### PR TITLE
Reonnect queues to vhost

### DIFF
--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
@@ -139,6 +139,7 @@ public class AmqpConfiguration {
         final SimpleRabbitListenerContainerFactory containerFactory = new SimpleRabbitListenerContainerFactory();
         containerFactory.setDefaultRequeueRejected(false);
         containerFactory.setConnectionFactory(connectionFactory);
+        containerFactory.setMissingQueuesFatal(amqpProperties.isMissingQueuesFatal());
         return containerFactory;
     }
 

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.amqp;
 
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -24,6 +25,26 @@ public class AmqpProperties {
     private String deadLetterQueue = "dmf_connector_deadletter";
     private String deadLetterExchange = "dmf.connector.deadletter";
     private String receiverQueue = "dmf_receiver";
+    private boolean missingQueuesFatal = false;
+
+    /**
+     * Is missingQueuesFatal enabled
+     * 
+     * @see SimpleMessageListenerContainer#setMissingQueuesFatal
+     * @return the missingQueuesFatal <true> enabled <false> disabled
+     */
+    public boolean isMissingQueuesFatal() {
+        return missingQueuesFatal;
+    }
+
+    /**
+     * @param missingQueuesFatal
+     *            the missingQueuesFatal to set.
+     * @see SimpleMessageListenerContainer#setMissingQueuesFatal
+     */
+    public void setMissingQueuesFatal(final boolean missingQueuesFatal) {
+        this.missingQueuesFatal = missingQueuesFatal;
+    }
 
     /**
      * Returns the dead letter exchange.


### PR DESCRIPTION
If the RabbitMQ goes down, all queues will loose connection. The queue will stop trying to reconnect after 3 failures. Now the queues will try to reconnect all the time. To Disable the feature set the property missing.queues.fatal=true