### PR TITLE
Device simulator improvements

### DIFF
--- a/examples/hawkbit-device-simulator/README.md
+++ b/examples/hawkbit-device-simulator/README.md
@@ -13,7 +13,7 @@ run org.eclipse.hawkbit.simulator.DeviceSimulator
 
 ## Notes
 
-The simulator has user authentication enabled by default. Default credentials:
+The simulator has user authentication enabled in **cloud profile**. Default credentials:
 *  username : admin
 *  passwd : admin
 
@@ -29,8 +29,6 @@ The UI can be accessed via the URL:
 http://localhost:8083
 ```
 
-`Basic Authentication Credentials are admin / admin`
-
  ![](src/main/images/generateScreenshot.png)
  
  ![](src/main/images/updateProcessScreenshot.png)
@@ -45,6 +43,10 @@ Optional parameters:
 * name : name prefix simulated devices (default: "dmfSimulated"), followed by counter
 * amount : number of simulated devices (default: 20, capped at: 4000)
 * tenant : in a multi-tenenat ready hawkBit installation (default: "DEFAULT")
+* api : the API which should be used for the simulated device either `dmf` or `ddi` (default: "ddi")
+* endpoint :  URL which defines the hawkbit DDI base endpoint (deffault: "http://localhost:8080")
+* polldelay : number in milliseconds of the delay when DDI simulated devices should poll the endpoint (default: "30")
+* gatewaytoken : an hawkbit gateway token to be used in case hawkbit does not allow anonymous access for DDI devices (default: "")
 
 
 Example: for 20 simulated devices (default)
@@ -55,4 +57,9 @@ http://localhost:8083/start
 Example: for 10 simulated devices that start with the name prefix "activeSim": 
 ```
 http://localhost:8083/start?amount=10&name=activeSim
+```
+
+Example: for 5 simulated devices that start with the name prefix "ddi" using the Direct Device Integration API (http): 
+```
+http://localhost:8083/start?amount=5&name=ddi?api=ddi
 ```

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationController.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationController.java
@@ -46,6 +46,17 @@ public class SimulationController {
      *            the amount of devices to be created
      * @param tenant
      *            the tenant to create the device to
+     * @param api
+     *            the api-protocol to be used either {@code dmf} or {@code ddi}
+     * @param endpoint
+     *            the URL endpoint to be used of the hawkbit-update-server for
+     *            DDI devices
+     * @param pollDelay
+     *            number of delay in milliseconds to delay polling of DDI
+     *            devices
+     * @param gatewayToken
+     *            the hawkbit-update-server gatwaytoken in case authentication
+     *            is enforced in hawkbit
      * @return a response string that devices has been created
      * @throws MalformedURLException
      */

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationController.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationController.java
@@ -8,9 +8,13 @@
  */
 package org.eclipse.hawkbit.simulator;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.eclipse.hawkbit.simulator.AbstractSimulatedDevice.Protocol;
 import org.eclipse.hawkbit.simulator.amqp.SpSenderService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,18 +47,37 @@ public class SimulationController {
      * @param tenant
      *            the tenant to create the device to
      * @return a response string that devices has been created
+     * @throws MalformedURLException
      */
     @RequestMapping("/start")
-    String start(@RequestParam(value = "name", defaultValue = "dmfSimulated") final String name,
+    ResponseEntity<String> start(@RequestParam(value = "name", defaultValue = "simulated") final String name,
             @RequestParam(value = "amount", defaultValue = "20") final int amount,
-            @RequestParam(value = "tenant", defaultValue = "DEFAULT") final String tenant) {
+            @RequestParam(value = "tenant", defaultValue = "DEFAULT") final String tenant,
+            @RequestParam(value = "api", defaultValue = "dmf") final String api,
+            @RequestParam(value = "endpoint", defaultValue = "http://localhost:8080") final String endpoint,
+            @RequestParam(value = "polldelay", defaultValue = "30") final int pollDelay,
+            @RequestParam(value = "gatewaytoken", defaultValue = "") final String gatewayToken)
+                    throws MalformedURLException {
+
+        final Protocol protocol;
+        switch (api.toLowerCase()) {
+        case "dmf":
+            protocol = Protocol.DMF_AMQP;
+            break;
+        case "ddi":
+            protocol = Protocol.DDI_HTTP;
+            break;
+        default:
+            return ResponseEntity.badRequest().body("query param api only allows value of 'dmf' or 'ddi'");
+        }
 
         for (int i = 0; i < amount; i++) {
             final String deviceId = name + i;
-            repository.add(deviceFactory.createSimulatedDevice(deviceId, tenant, Protocol.DMF_AMQP));
+            repository.add(deviceFactory.createSimulatedDevice(deviceId, tenant, protocol, pollDelay, new URL(endpoint),
+                    gatewayToken));
             spSenderService.createOrUpdateThing(tenant, deviceId);
         }
 
-        return "Updated " + amount + " DMF connected targets!";
+        return ResponseEntity.ok("Updated " + amount + " DMF connected targets!");
     }
 }

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/ui/GenerateDialog.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/ui/GenerateDialog.java
@@ -83,8 +83,8 @@ public class GenerateDialog extends Window {
         tf5.setIcon(FontAwesome.FLAG_O);
         tf5.setRequired(true);
         tf5.setVisible(false);
-        tf5.addValidator(new RegexpValidator(
-                "^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]", "is not an URL"));
+        tf5.addValidator(new RegexpValidator("^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]",
+                "is not an URL"));
 
         final TextField tf6 = new TextField("gateway token", "");
         tf6.setColumns(50);
@@ -125,7 +125,8 @@ public class GenerateDialog extends Window {
             @Override
             public void buttonClick(final ClickEvent event) {
                 try {
-                    callback.okButton(tf1.getValue(), tf3.getValue(), Integer.valueOf(tf2.getValue().replace(".", "")),
+                    callback.okButton(tf1.getValue(), tf3.getValue(),
+                            Integer.valueOf(tf2.getValue().replace(".", "").replace(",", "")),
                             Integer.valueOf(tf4.getValue().replace(".", "")), new URL(tf5.getValue()), tf6.getValue(),
                             (Protocol) protocolGroup.getValue());
                 } catch (final NumberFormatException e) {

--- a/examples/hawkbit-device-simulator/src/main/resources/application-cloud.properties
+++ b/examples/hawkbit-device-simulator/src/main/resources/application-cloud.properties
@@ -1,3 +1,12 @@
+#
+# Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+
 # SECURITY (SecurityProperties)
 security.basic.enabled=true
 security.user.name=${BASIC_USERNAME:admin}

--- a/examples/hawkbit-device-simulator/src/main/resources/application-cloud.properties
+++ b/examples/hawkbit-device-simulator/src/main/resources/application-cloud.properties
@@ -1,0 +1,19 @@
+# SECURITY (SecurityProperties)
+security.basic.enabled=true
+security.user.name=${BASIC_USERNAME:admin}
+security.user.password=${BASIC_PASSWORD:admin}
+security.user.role=USER
+security.require-ssl=false
+security.enable-csrf=false
+security.basic.enabled=true
+security.basic.realm=DeviceSimulator
+security.basic.path= /**
+security.basic.authorize-mode=ROLE
+security.filter-order=0
+security.headers.xss=false
+security.headers.cache=false
+security.headers.frame=false
+security.headers.content-type=false
+security.headers.hsts=all
+security.sessions=stateless
+security.ignored=/VAADIN/**

--- a/examples/hawkbit-device-simulator/src/main/resources/application.properties
+++ b/examples/hawkbit-device-simulator/src/main/resources/application.properties
@@ -27,23 +27,5 @@ spring.rabbitmq.port=5672
 spring.rabbitmq.dynamic=true
 spring.rabbitmq.listener.prefetch=100
 
-# SECURITY (SecurityProperties)
-security.user.name=${BASIC_USERNAME:admin}
-security.user.password=${BASIC_PASSWORD:admin}
-security.user.role=USER
-security.require-ssl=false
-security.enable-csrf=false
-security.basic.enabled=true
-security.basic.realm=DeviceSimulator
-security.basic.path= /**
-security.basic.authorize-mode=ROLE
-security.filter-order=0
-security.headers.xss=false
-security.headers.cache=false
-security.headers.frame=false
-security.headers.content-type=false
-security.headers.hsts=all
-security.sessions=stateless
-security.ignored=/VAADIN/**
-
+security.basic.enabled=false
 server.port=8083


### PR DESCRIPTION
- extend simulator rest-api for simulating also DDI devices
- adapt readme.md to document new simulator rest-api
- remove basic-auth from standard application properties and introduce an extra cloud-profile which includes basic-auth-security parameters for easier use locally
- fix dialog for amount with 4 digit and comma charachter