### PR TITLE
Fix wrong count select statement for targetrolloutgroup

### DIFF
--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
@@ -245,8 +245,9 @@ public class RolloutGroupManagement {
                 JoinType.LEFT);
 
         final Root<RolloutTargetGroup> countQueryFrom = countQuery.distinct(true).from(RolloutTargetGroup.class);
-        countQuery
-                .select(cb.count(countQueryFrom.join(RolloutTargetGroup_.target).join(Target_.actions, JoinType.LEFT)))
+        countQueryFrom.join(RolloutTargetGroup_.target);
+        countQueryFrom.join(RolloutTargetGroup_.actions, JoinType.LEFT);
+        countQuery.select(cb.count(countQueryFrom))
                 .where(cb.equal(countQueryFrom.get(RolloutTargetGroup_.rolloutGroup), rolloutGroup));
         final Long totalCount = entityManager.createQuery(countQuery).getSingleResult();
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/footer/TargetFilterCountMessageLabel.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/footer/TargetFilterCountMessageLabel.java
@@ -29,6 +29,7 @@ import com.vaadin.shared.ui.label.ContentMode;
 import com.vaadin.spring.annotation.SpringComponent;
 import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Label;
+import com.vaadin.ui.UI;
 
 /**
  * @author Venugopal Boodidadinne(RBEI/BSJ)
@@ -75,7 +76,7 @@ public class TargetFilterCountMessageLabel extends Label {
                 || custFUIEvent == CustomFilterUIEvent.CREATE_NEW_FILTER_CLICK
                 || custFUIEvent == CustomFilterUIEvent.EXIT_CREATE_OR_UPDATE_FILTRER_VIEW
                 || custFUIEvent == CustomFilterUIEvent.FILTER_TARGET_BY_QUERY) {
-            this.getUI().access(() -> displayTargetFilterMessage());
+            UI.getCurrent().access(() -> displayTargetFilterMessage());
         }
     }
 


### PR DESCRIPTION
- the count select statement to retrieve the total count of targets within a rollout-group inclusive with action-status which is used by the UI is returning a wrong total count and therefore the UI breaks to try access to an element which does not exists in the container. 

The REST-API can still retrieve the groups thus it is not using the service method to retrieve the targets inclusive the current action status.