### PR TITLE
Reduce logging of checking running rollouts

### DIFF
--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
@@ -552,7 +552,7 @@ public class RolloutManagement {
         if (updated == 0) {
             // nothing to check, maybe another instance already checked in
             // between
-            LOGGER.info("No rolloutcheck necessary for current scheduled check {}, next check at {}", lastCheck,
+            LOGGER.debug("No rolloutcheck necessary for current scheduled check {}, next check at {}", lastCheck,
                     lastCheck + delayBetweenChecks);
             return;
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/footer/TargetFilterCountMessageLabel.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/footer/TargetFilterCountMessageLabel.java
@@ -29,6 +29,7 @@ import com.vaadin.shared.ui.label.ContentMode;
 import com.vaadin.spring.annotation.SpringComponent;
 import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Label;
+import com.vaadin.ui.UI;
 
 /**
  * @author Venugopal Boodidadinne(RBEI/BSJ)
@@ -75,7 +76,7 @@ public class TargetFilterCountMessageLabel extends Label {
                 || custFUIEvent == CustomFilterUIEvent.CREATE_NEW_FILTER_CLICK
                 || custFUIEvent == CustomFilterUIEvent.EXIT_CREATE_OR_UPDATE_FILTRER_VIEW
                 || custFUIEvent == CustomFilterUIEvent.FILTER_TARGET_BY_QUERY) {
-            this.getUI().access(() -> displayTargetFilterMessage());
+            UI.getCurrent().access(() -> displayTargetFilterMessage());
         }
     }
 


### PR DESCRIPTION
change logging from info to debug if there is no rollout to check, this will be logged for each tenant and the log will be dumped full with these info logs otherwise