### PR TITLE
removing spring-context-support dependency because it's not necessary.

### DIFF
--- a/hawkbit-autoconfigure/pom.xml
+++ b/hawkbit-autoconfigure/pom.xml
@@ -68,9 +68,5 @@
          <version>${project.version}</version>
          <optional>true</optional>
       </dependency>
-        <dependency>
-         <groupId>org.springframework</groupId>
-         <artifactId>spring-context-support</artifactId>
-      </dependency>
    </dependencies>
 </project>


### PR DESCRIPTION
* remove spring-context-support dependency because the dependency seems not necessary for hawkbit.