### PR TITLE
Removed runtime dependencies to sass compiler package

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPUIComponentProvider.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPUIComponentProvider.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.ui.components;
 import java.util.Arrays;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonDecorator;
 import org.eclipse.hawkbit.ui.decorators.SPUIComboBoxDecorator;
@@ -23,7 +24,6 @@ import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.sass.internal.util.StringUtil;
 import com.vaadin.server.ExternalResource;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.server.Resource;
@@ -109,7 +109,7 @@ public final class SPUIComponentProvider {
         // Do we really need this???
         HorizontalLayout hLayout = getHorizontalLayout(new SPUIHorizontalLayout().getUiHorizontalLayout().getClass());
         try {
-            SPUIHeaderLayoutDecorator layoutDecorator = null;
+            SPUIHeaderLayoutDecorator layoutDecorator;
             if (tableHeaderLayoutDecorator != null) {
                 layoutDecorator = tableHeaderLayoutDecorator.newInstance();
                 hLayout = layoutDecorator.decorate(hLayout);
@@ -324,7 +324,7 @@ public final class SPUIComponentProvider {
      * @return Label
      */
     public static Label createNameValueLabel(final String label, final String... values) {
-        final String valueStr = StringUtil.collectionToDelimitedString(Arrays.asList(values), " ");
+        final String valueStr = StringUtils.join(Arrays.asList(values), " ");
         final Label nameValueLabel = new Label(getBoldHTMLText(label) + valueStr, ContentMode.HTML);
         nameValueLabel.setSizeFull();
         nameValueLabel.addStyleName(SPUIDefinitions.TEXT_STYLE);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPUIComponentProvider.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPUIComponentProvider.java
@@ -108,16 +108,16 @@ public final class SPUIComponentProvider {
             final Class<? extends SPUIHeaderLayoutDecorator> tableHeaderLayoutDecorator) {
         // Do we really need this???
         HorizontalLayout hLayout = getHorizontalLayout(new SPUIHorizontalLayout().getUiHorizontalLayout().getClass());
+
+        if (tableHeaderLayoutDecorator == null) {
+            return hLayout;
+        }
+
         try {
-            SPUIHeaderLayoutDecorator layoutDecorator;
-            if (tableHeaderLayoutDecorator != null) {
-                layoutDecorator = tableHeaderLayoutDecorator.newInstance();
-                hLayout = layoutDecorator.decorate(hLayout);
-            }
-        } catch (final InstantiationException exception) {
-            LOG.error("Error occured while creating horizontal decorator " + SPUIHeaderLayoutDecorator.class,
-                    exception);
-        } catch (final IllegalAccessException exception) {
+            final SPUIHeaderLayoutDecorator layoutDecorator = tableHeaderLayoutDecorator.newInstance();
+            hLayout = layoutDecorator.decorate(hLayout);
+
+        } catch (final InstantiationException | IllegalAccessException exception) {
             LOG.error("Error occured while creating horizontal decorator " + SPUIHeaderLayoutDecorator.class,
                     exception);
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
@@ -73,8 +73,8 @@ import org.vaadin.spring.events.EventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
-import com.google.gwt.thirdparty.guava.common.base.Strings;
 import com.vaadin.data.Container;
 import com.vaadin.data.Item;
 import com.vaadin.event.Action;
@@ -103,6 +103,8 @@ import com.vaadin.ui.themes.ValoTheme;
 @SpringComponent
 @ViewScope
 public class TargetTable extends AbstractTable implements Handler {
+
+    private static final String TARGET_PINNED = "targetPinned";
 
     private static final long serialVersionUID = -2300392868806614568L;
 
@@ -271,7 +273,7 @@ public class TargetTable extends AbstractTable implements Handler {
         final Map<String, Object> queryConfig = prepareQueryConfigFilters();
 
         // Create TargetBeanQuery factory with the query config.
-        final BeanQueryFactory<TargetBeanQuery> targetQF = new BeanQueryFactory<TargetBeanQuery>(TargetBeanQuery.class);
+        final BeanQueryFactory<TargetBeanQuery> targetQF = new BeanQueryFactory<>(TargetBeanQuery.class);
         targetQF.setQueryConfiguration(queryConfig);
 
         // create lazy query container with lazy defination and query
@@ -394,7 +396,7 @@ public class TargetTable extends AbstractTable implements Handler {
      */
     @Override
     protected List<TableColumn> getTableVisibleColumns() {
-        final List<TableColumn> columnList = new ArrayList<TableColumn>();
+        final List<TableColumn> columnList = new ArrayList<>();
         if (isMaximized()) {
             columnList.add(new TableColumn(SPUILabelDefinitions.VAR_NAME, i18n.get("header.name"), 0.2f));
             columnList.add(new TableColumn(SPUILabelDefinitions.VAR_CREATED_BY, i18n.get("header.createdBy"), 0.1f));
@@ -469,7 +471,7 @@ public class TargetTable extends AbstractTable implements Handler {
     }
 
     private Map<String, Object> prepareQueryConfigFilters() {
-        final Map<String, Object> queryConfig = new HashMap<String, Object>();
+        final Map<String, Object> queryConfig = new HashMap<>();
         managementUIState.getTargetTableFilters().getSearchText()
                 .ifPresent(value -> queryConfig.put(SPUIDefinitions.FILTER_BY_TEXT, value));
         managementUIState.getTargetTableFilters().getDistributionSet()
@@ -481,7 +483,7 @@ public class TargetTable extends AbstractTable implements Handler {
         queryConfig.put(SPUIDefinitions.FILTER_BY_NO_TAG, managementUIState.getTargetTableFilters().isNoTagSelected());
 
         if (isFilteredByTags()) {
-            final List<String> list = new ArrayList<String>();
+            final List<String> list = new ArrayList<>();
             list.addAll(managementUIState.getTargetTableFilters().getClickedTargetTags());
             queryConfig.put(SPUIDefinitions.FILTER_BY_TAG, list.toArray(new String[list.size()]));
         }
@@ -522,7 +524,7 @@ public class TargetTable extends AbstractTable implements Handler {
         pinBtn.setId(SPUIComponetIdProvider.TARGET_PIN_ICON + "." + itemId);
         pinBtn.addClickListener(event -> addPinClickListener(event));
         if (isPinned(((TargetIdName) itemId).getControllerId())) {
-            pinBtn.addStyleName("targetPinned");
+            pinBtn.addStyleName(TARGET_PINNED);
             isTargetPinned = Boolean.TRUE;
             targetPinnedBtn = pinBtn;
             eventBus.publish(this, PinUnpinEvent.PIN_TARGET);
@@ -533,7 +535,7 @@ public class TargetTable extends AbstractTable implements Handler {
     }
 
     private boolean isPinned(final String targetId) {
-        boolean result = false;
+        boolean result;
         if (managementUIState.getDistributionTableFilters().getPinnedTargetId().isPresent()
                 && targetId.equals(managementUIState.getDistributionTableFilters().getPinnedTargetId().get())) {
             result = true;
@@ -594,7 +596,7 @@ public class TargetTable extends AbstractTable implements Handler {
         eventBus.publish(this, PinUnpinEvent.PIN_TARGET);
         /* change target table styling */
         styleTargetTable();
-        eventBtn.addStyleName("targetPinned");
+        eventBtn.addStyleName(TARGET_PINNED);
         isTargetPinned = Boolean.FALSE;
     }
 
@@ -605,7 +607,7 @@ public class TargetTable extends AbstractTable implements Handler {
     }
 
     private void resetPinStyle(final Button pinBtn) {
-        pinBtn.removeStyleName("targetPinned");
+        pinBtn.removeStyleName(TARGET_PINNED);
         pinBtn.addStyleName(SPUIStyleDefinitions.TARGET_STATUS_PIN_TOGGLE);
         HawkbitCommonUtil.applyStatusLblStyle(this, pinBtn, pinBtn.getData());
     }
@@ -644,7 +646,7 @@ public class TargetTable extends AbstractTable implements Handler {
         final com.vaadin.event.dd.TargetDetails taregtDet = event.getTargetDetails();
         final Table targetTable = (Table) taregtDet.getTarget();
         final Set<TargetIdName> targetSelected = HawkbitCommonUtil.getSelectedTargetDetails(targetTable);
-        final Set<String> targetList = new HashSet<String>();
+        final Set<String> targetList = new HashSet<>();
         final AbstractSelectTargetDetails dropData = (AbstractSelectTargetDetails) event.getTargetDetails();
         final Object targetItemId = dropData.getItemIdOver();
         if (!targetSelected.contains(targetItemId)) {
@@ -701,9 +703,8 @@ public class TargetTable extends AbstractTable implements Handler {
 
     private static Set<DistributionSetIdName> getDraggedDistributionSet(final TableTransferable transferable,
             final Table source) {
-        @SuppressWarnings("unchecked")
         final Set<DistributionSetIdName> distSelected = HawkbitCommonUtil.getSelectedDSDetails(source);
-        final Set<DistributionSetIdName> distributionIdSet = new HashSet<DistributionSetIdName>();
+        final Set<DistributionSetIdName> distributionIdSet = new HashSet<>();
         if (!distSelected.contains(transferable.getData(ITEMID))) {
             distributionIdSet.add((DistributionSetIdName) transferable.getData(ITEMID));
         } else {
@@ -828,15 +829,11 @@ public class TargetTable extends AbstractTable implements Handler {
         }
     }
 
-    /**
-     * @param filterEvent
-     * @return
-     */
-    private boolean checkFilterEvent(final TargetFilterEvent filterEvent) {
-        boolean isFilterEvent = false;
-        boolean isFilter = false;
-        boolean isRemoveFilters = false;
-        boolean isStatusFilter = false;
+    private static boolean checkFilterEvent(final TargetFilterEvent filterEvent) {
+        boolean isFilterEvent;
+        boolean isFilter;
+        boolean isRemoveFilters;
+        boolean isStatusFilter;
         isFilter = filterEvent == TargetFilterEvent.FILTER_BY_TEXT || filterEvent == TargetFilterEvent.FILTER_BY_TAG
                 || filterEvent == TargetFilterEvent.FILTER_BY_DISTRIBUTION
                 || filterEvent == TargetFilterEvent.FILTER_BY_TARGET_FILTER_QUERY;
@@ -1020,11 +1017,11 @@ public class TargetTable extends AbstractTable implements Handler {
     private List<TargetIdName> getTargetIdsBySimpleFilters(final PageRequest pageRequest) {
         final Long filterByDistId = managementUIState.getTargetTableFilters().getDistributionSet().isPresent()
                 ? managementUIState.getTargetTableFilters().getDistributionSet().get().getId() : null;
-        final List<TargetUpdateStatus> statusList = new ArrayList<TargetUpdateStatus>();
+        final List<TargetUpdateStatus> statusList = new ArrayList<>();
         if (isFilteredByStatus()) {
             statusList.addAll(managementUIState.getTargetTableFilters().getClickedStatusTargetTags());
         }
-        final List<String> tagList = new ArrayList<String>();
+        final List<String> tagList = new ArrayList<>();
         if (isFilteredByTags()) {
             tagList.addAll(managementUIState.getTargetTableFilters().getClickedTargetTags());
         }
@@ -1081,7 +1078,7 @@ public class TargetTable extends AbstractTable implements Handler {
         String[] targetTags = null;
         Long distributionId = null;
         String searchText = null;
-        Boolean noTagClicked = Boolean.FALSE;
+        Boolean noTagClicked;
         Long pinnedDistId = null;
 
         if (isFilteredByTags()) {
@@ -1129,13 +1126,13 @@ public class TargetTable extends AbstractTable implements Handler {
                 && !Strings.isNullOrEmpty(managementUIState.getTargetTableFilters().getSearchText().get());
     }
 
-    private Boolean anyFilterSelected(final Collection<TargetUpdateStatus> status, final Long distributionId,
+    private static Boolean anyFilterSelected(final Collection<TargetUpdateStatus> status, final Long distributionId,
             final Boolean noTagClicked, final String[] targetTags, final String searchText) {
         return status == null && distributionId == null && Strings.isNullOrEmpty(searchText)
                 && !isTagSelected(targetTags, noTagClicked);
     }
 
-    private Boolean isTagSelected(final String[] targetTags, final Boolean noTagClicked) {
+    private static Boolean isTagSelected(final String[] targetTags, final Boolean noTagClicked) {
         return targetTags == null && !noTagClicked;
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/AbstractSimpleTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/AbstractSimpleTableHeader.java
@@ -15,7 +15,7 @@ import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 
-import com.google.gwt.thirdparty.guava.common.base.Strings;
+import com.google.common.base.Strings;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.ui.AbstractTextField.TextChangeEventMode;
 import com.vaadin.ui.Alignment;

--- a/pom.xml
+++ b/pom.xml
@@ -363,30 +363,6 @@
             <artifactId>vaadin-push</artifactId>
             <version>${vaadin.version}</version>
          </dependency>
-         <!-- Needed when using the widgetset optimizer (custom ConnectorBundleLoaderFactory).
-            For widgetset compilation, vaadin-client-compiler is automatically added
-            on the compilation classpath by vaadin-maven-plugin so normally there is
-            no need for an explicit dependency. -->
-         <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-client-compiler</artifactId>
-            <version>${vaadin.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-               <exclusion>
-                  <groupId>org.eclipse.jetty</groupId>
-                  <artifactId>jetty-servlets</artifactId>
-               </exclusion>
-               <exclusion>
-                  <groupId>org.eclipse.jetty</groupId>
-                  <artifactId>jetty-annotations</artifactId>
-               </exclusion>
-               <exclusion>
-                  <groupId>org.eclipse.jetty</groupId>
-                  <artifactId>jetty-util</artifactId>
-               </exclusion>
-            </exclusions>
-         </dependency>
          <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-themes</artifactId>


### PR DESCRIPTION
Fixed accidental introduced runtime dependencies to sass compiler. Allows applications to remove sass compiler from delivery.
Fixed a few sonar issues on the way.