### PR TITLE
Upgraded eclipse link weave maven plugin to 2.6.2

### DIFF
--- a/hawkbit-repository/pom.xml
+++ b/hawkbit-repository/pom.xml
@@ -215,7 +215,7 @@
          <plugin>
             <groupId>com.ethlo.persistence.tools</groupId>
             <artifactId>eclipselink-maven-plugin</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.6.2</version>
             <executions>
                <execution>
                   <phase>process-classes</phase>


### PR DESCRIPTION
Finally a released version we can use.