### PR TITLE
Fixed wrong status content generation in mgmt API.

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionStatusFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionStatusFields.java
@@ -25,7 +25,7 @@ public enum ActionStatusFields implements FieldNameProvider {
     /**
      * The reportedAt field.
      */
-    REPORTED_AT("createdAt");
+    REPORTEDAT("createdAt");
 
     private final String fieldName;
 

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionStatusFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionStatusFields.java
@@ -20,7 +20,12 @@ public enum ActionStatusFields implements FieldNameProvider {
     /**
      * The id field.
      */
-    ID("id");
+    ID("id"),
+
+    /**
+     * The reportedAt field.
+     */
+    REPORTED_AT("createdAt");
 
     private final String fieldName;
 

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/ActionStatusRepository.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/ActionStatusRepository.java
@@ -51,13 +51,6 @@ public interface ActionStatusRepository
     Page<ActionStatus> findByAction(Pageable pageReq, Action action);
 
     /**
-     * @param pageReq
-     * @param action
-     * @return
-     */
-    Page<ActionStatus> findByActionOrderByIdDesc(Pageable pageReq, Action action);
-
-    /**
      * Finds all status updates for the defined action and target order by
      * {@link ActionStatus#getId()} desc including
      * {@link ActionStatus#getMessages()}.
@@ -71,6 +64,6 @@ public interface ActionStatusRepository
      * @return Page with found targets
      */
     @EntityGraph(value = "ActionStatus.withMessages", type = EntityGraphType.LOAD)
-    Page<ActionStatus> getByActionOrderByIdDesc(Pageable pageReq, Action action);
+    Page<ActionStatus> getByAction(Pageable pageReq, Action action);
 
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/ActionStatusRepository.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/ActionStatusRepository.java
@@ -21,38 +21,47 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * {@link ActionStatus} repository.
  *
- *
- *
- *
  */
 @Transactional(readOnly = true)
 public interface ActionStatusRepository
         extends BaseEntityRepository<ActionStatus, Long>, JpaSpecificationExecutor<ActionStatus> {
 
     /**
-     * @param target
+     * Counts {@link ActionStatus} entries of given {@link Action} in
+     * repository.
+     *
      * @param action
-     * @return
+     *            to count status entries
+     * @return number of actions in repository
      */
     Long countByAction(Action action);
 
     /**
+     * Counts {@link ActionStatus} entries of given {@link Action} with given
+     * {@link Status} in repository.
+     * 
      * @param action
-     * @param retrieved
-     * @return
+     *            to count status entries
+     * @param status
+     *            to filter for
+     * @return number of actions in repository
      */
-    Long countByActionAndStatus(Action action, Status retrieved);
+    Long countByActionAndStatus(Action action, Status status);
 
     /**
+     * Retrieves all {@link ActionStatus} entries from repository of given
+     * {@link Action}.
+     * 
      * @param pageReq
+     *            parameters
      * @param action
-     * @return
+     *            of the status entries
+     * @return pages list of {@link ActionStatus} entries
      */
     Page<ActionStatus> findByAction(Pageable pageReq, Action action);
 
     /**
-     * Finds all status updates for the defined action and target order by
-     * {@link ActionStatus#getId()} desc including
+     * Finds all status updates for the defined action and target including
      * {@link ActionStatus#getMessages()}.
      *
      * @param pageReq

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
@@ -925,7 +925,7 @@ public class DeploymentManagement {
 
     /**
      * retrieves all the {@link ActionStatus} entries of the given
-     * {@link Action} and {@link Target} in the order latest first.
+     * {@link Action} and {@link Target}.
      *
      * @param pageReq
      *            pagination parameter
@@ -937,12 +937,12 @@ public class DeploymentManagement {
      * @return the corresponding {@link Page} of {@link ActionStatus}
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
-    public Page<ActionStatus> findActionStatusMessagesByActionInDescOrder(final Pageable pageReq, final Action action,
+    public Page<ActionStatus> findActionStatusByAction(final Pageable pageReq, final Action action,
             final boolean withMessages) {
         if (withMessages) {
-            return actionStatusRepository.getByActionOrderByIdDesc(pageReq, action);
+            return actionStatusRepository.getByAction(pageReq, action);
         } else {
-            return actionStatusRepository.findByActionOrderByIdDesc(pageReq, action);
+            return actionStatusRepository.findByAction(pageReq, action);
         }
     }
 

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/ControllerManagementTest.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/ControllerManagementTest.java
@@ -70,8 +70,8 @@ public class ControllerManagementTest extends AbstractIntegrationTest {
                 .isEqualTo(TargetUpdateStatus.IN_SYNC);
 
         assertThat(actionStatusRepository.findAll(pageReq).getNumberOfElements()).isEqualTo(3);
-        assertThat(deploymentManagement.findActionStatusMessagesByActionInDescOrder(pageReq, savedAction, false)
-                .getNumberOfElements()).isEqualTo(3);
+        assertThat(deploymentManagement.findActionStatusByAction(pageReq, savedAction, false).getNumberOfElements())
+                .isEqualTo(3);
     }
 
     @Test

--- a/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/PagingUtility.java
+++ b/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/PagingUtility.java
@@ -102,7 +102,7 @@ public final class PagingUtility {
             sorting = new Sort(SortUtility.parse(ActionStatusFields.class, sortParam));
         } else {
             // default sort
-            sorting = new Sort(Direction.ASC, ActionStatusFields.ID.getFieldName());
+            sorting = new Sort(Direction.DESC, ActionStatusFields.ID.getFieldName());
         }
         return sorting;
     }

--- a/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/PagingUtility.java
+++ b/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/PagingUtility.java
@@ -23,11 +23,6 @@ import org.springframework.data.domain.Sort.Direction;
 /**
  * Utility class for for paged body generation.
  *
- *
- *
- *
- *
- *
  */
 public final class PagingUtility {
     /*
@@ -90,8 +85,9 @@ public final class PagingUtility {
         if (sortParam != null) {
             sorting = new Sort(SortUtility.parse(ActionFields.class, sortParam));
         } else {
-            // default sort
-            sorting = new Sort(Direction.ASC, ActionFields.ID.getFieldName());
+            // default sort is DESC in case of action to match behavior
+            // of management UI (last entry on top)
+            sorting = new Sort(Direction.DESC, ActionFields.ID.getFieldName());
         }
         return sorting;
     }
@@ -101,7 +97,8 @@ public final class PagingUtility {
         if (sortParam != null) {
             sorting = new Sort(SortUtility.parse(ActionStatusFields.class, sortParam));
         } else {
-            // default sort
+            // default sort is DESC in case of action status to match behavior
+            // of management UI (last entry on top)
             sorting = new Sort(Direction.DESC, ActionStatusFields.ID.getFieldName());
         }
         return sorting;

--- a/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/TargetMapper.java
+++ b/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/TargetMapper.java
@@ -297,8 +297,8 @@ final public class TargetMapper {
         final ActionStatusRest result = new ActionStatusRest();
 
         result.setMessages(actionStatus.getMessages());
-        result.setReportedAt(action.getCreatedAt());
-        result.setStatusId(action.getId());
+        result.setReportedAt(actionStatus.getCreatedAt());
+        result.setStatusId(actionStatus.getId());
         result.setType(getNameOfActionStatusType(actionStatus.getStatus()));
 
         return result;

--- a/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/TargetResource.java
+++ b/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/TargetResource.java
@@ -235,7 +235,7 @@ public class TargetResource implements TargetRestApi {
         final int sanitizedLimitParam = PagingUtility.sanitizePageLimitParam(pagingLimitParam);
         final Sort sorting = PagingUtility.sanitizeActionStatusSortParam(sortParam);
 
-        final Page<ActionStatus> statusList = this.deploymentManagement.findActionStatusMessagesByActionInDescOrder(
+        final Page<ActionStatus> statusList = this.deploymentManagement.findActionStatusByAction(
                 new OffsetBasedPageRequest(sanitizedOffsetParam, sanitizedLimitParam, sorting), action, true);
 
         return new ResponseEntity<>(

--- a/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
+++ b/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
@@ -887,7 +887,7 @@ public class TargetResourceTest extends AbstractIntegrationTest {
         // descending order
         mvc.perform(get(RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
                 + RestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS)
-                        .param(RestConstants.REQUEST_PARAMETER_SORTING, "REPORTED_AT:DESC"))
+                        .param(RestConstants.REQUEST_PARAMETER_SORTING, "REPORTEDAT:DESC"))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
@@ -903,7 +903,7 @@ public class TargetResourceTest extends AbstractIntegrationTest {
         // ascending order
         mvc.perform(get(RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
                 + RestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS)
-                        .param(RestConstants.REQUEST_PARAMETER_SORTING, "REPORTED_AT:ASC"))
+                        .param(RestConstants.REQUEST_PARAMETER_SORTING, "REPORTEDAT:ASC"))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(jsonPath("content.[1].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("canceling")))

--- a/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
+++ b/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
@@ -856,23 +856,20 @@ public class TargetResourceTest extends AbstractIntegrationTest {
     @Description("Verfies that the API returns the status list with expected content.")
     public void getMultipleActionStatus() throws Exception {
         final String knownTargetId = "targetId";
-        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
+        final Action action = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId).get(0);
+        final List<ActionStatus> actionStatus = action.getActionStatus().stream()
+                .sorted((e1, e2) -> Long.compare(e1.getId(), e2.getId())).collect(Collectors.toList());
 
-        mvc.perform(get(
-                RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + RestConstants.TARGET_V1_ACTIONS
-                        + "/" + actions.get(0).getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS))
+        mvc.perform(get(RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+                + RestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
-                .andExpect(
-                        jsonPath("content.[0].id", equalTo(actions.get(0).getActionStatus().get(1).getId().intValue())))
+                .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
                 .andExpect(jsonPath("content.[0].messages", hasItem("manual cancelation requested")))
-                .andExpect(jsonPath("content.[0].reportedAt",
-                        equalTo(actions.get(0).getActionStatus().get(1).getCreatedAt())))
-                .andExpect(
-                        jsonPath("content.[1].id", equalTo(actions.get(0).getActionStatus().get(0).getId().intValue())))
+                .andExpect(jsonPath("content.[0].reportedAt", equalTo(actionStatus.get(1).getCreatedAt())))
+                .andExpect(jsonPath("content.[1].id", equalTo(actionStatus.get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("running")))
-                .andExpect(jsonPath("content.[1].reportedAt",
-                        equalTo(actions.get(0).getActionStatus().get(0).getCreatedAt())))
+                .andExpect(jsonPath("content.[1].reportedAt", equalTo(actionStatus.get(0).getCreatedAt())))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)));
@@ -883,36 +880,32 @@ public class TargetResourceTest extends AbstractIntegrationTest {
     public void getMultipleActionStatusWithPagingLimitRequestParameter() throws Exception {
         final String knownTargetId = "targetId";
 
-        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
+        final Action action = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId).get(0);
+        final List<ActionStatus> actionStatus = action.getActionStatus().stream()
+                .sorted((e1, e2) -> Long.compare(e1.getId(), e2.getId())).collect(Collectors.toList());
 
         // Page 1
-        mvc.perform(get(
-                RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + RestConstants.TARGET_V1_ACTIONS
-                        + "/" + actions.get(0).getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS)
-                                .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1)))
+        mvc.perform(get(RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+                + RestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS)
+                        .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1)))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
-                .andExpect(
-                        jsonPath("content.[0].id", equalTo(actions.get(0).getActionStatus().get(1).getId().intValue())))
+                .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
                 .andExpect(jsonPath("content.[0].messages", hasItem("manual cancelation requested")))
-                .andExpect(jsonPath("content.[0].reportedAt",
-                        equalTo(actions.get(0).getActionStatus().get(1).getCreatedAt())))
+                .andExpect(jsonPath("content.[0].reportedAt", equalTo(actionStatus.get(1).getCreatedAt())))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(1)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(1)));
 
         // Page 2
-        mvc.perform(get(
-                RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + RestConstants.TARGET_V1_ACTIONS
-                        + "/" + actions.get(0).getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS)
-                                .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
-                                .param(RestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1)))
+        mvc.perform(get(RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+                + RestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS)
+                        .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
+                        .param(RestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1)))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
-                .andExpect(
-                        jsonPath("content.[0].id", equalTo(actions.get(0).getActionStatus().get(0).getId().intValue())))
+                .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("running")))
-                .andExpect(jsonPath("content.[0].reportedAt",
-                        equalTo(actions.get(0).getActionStatus().get(0).getCreatedAt())))
+                .andExpect(jsonPath("content.[0].reportedAt", equalTo(actionStatus.get(0).getCreatedAt())))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(1)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(1)));

--- a/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
+++ b/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
@@ -1026,8 +1026,8 @@ public class TargetResourceTest extends AbstractIntegrationTest {
         final List<Target> updatedTargets = deploymentManagement.assignDistributionSet(one, targets)
                 .getAssignedTargets();
         // 2nd update
-        // sleep 1ms to ensure that we can sort by reportedAt
-        Thread.sleep(1);
+        // sleep 10ms to ensure that we can sort by reportedAt
+        Thread.sleep(10);
         deploymentManagement.assignDistributionSet(two, updatedTargets);
 
         // two updates, one cancelation

--- a/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
+++ b/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
@@ -879,7 +879,7 @@ public class TargetResourceTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @Description("Verfies that the API resturns the status list with expected content split into two pages.")
+    @Description("Verfies that the API returns the status list with expected content split into two pages.")
     public void getMultipleActionStatusWithPagingLimitRequestParameter() throws Exception {
         final String knownTargetId = "targetId";
 

--- a/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
+++ b/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.rest.resource;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -229,7 +230,7 @@ public class TargetResourceTest extends AbstractIntegrationTest {
     @Test
     public void cancelActionOK() throws Exception {
         // prepare test
-        Target tA = createTargetAndStartAction();
+        final Target tA = createTargetAndStartAction();
 
         // test - cancel the active action
         mvc.perform(delete(RestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}",
@@ -252,7 +253,7 @@ public class TargetResourceTest extends AbstractIntegrationTest {
     @Test
     public void cancelAnCancelActionIsNotAllowed() throws Exception {
         // prepare test
-        Target tA = createTargetAndStartAction();
+        final Target tA = createTargetAndStartAction();
 
         // cancel the active action
         deploymentManagement.cancelAction(tA.getActions().get(0), tA);
@@ -272,7 +273,7 @@ public class TargetResourceTest extends AbstractIntegrationTest {
     @Description("Force Quit an Action, which is already canceled. Expected Result is an HTTP response code 204.")
     public void forceQuitAnCanceledActionReturnsOk() throws Exception {
 
-        Target tA = createTargetAndStartAction();
+        final Target tA = createTargetAndStartAction();
 
         // cancel the active action
         deploymentManagement.cancelAction(tA.getActions().get(0), tA);
@@ -293,7 +294,7 @@ public class TargetResourceTest extends AbstractIntegrationTest {
     @Description("Force Quit an Action, which is not canceled. Expected Result is an HTTP response code 405.")
     public void forceQuitAnNotCanceledActionReturnsMethodNotAllowed() throws Exception {
 
-        Target tA = createTargetAndStartAction();
+        final Target tA = createTargetAndStartAction();
 
         // test - cancel an cancel action returns forbidden
         mvc.perform(delete(RestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}?force=true",
@@ -852,6 +853,72 @@ public class TargetResourceTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @Description("Verfies that the API returns the status list with expected content.")
+    public void getMultipleActionStatus() throws Exception {
+        final String knownTargetId = "targetId";
+        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
+
+        mvc.perform(get(
+                RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + RestConstants.TARGET_V1_ACTIONS
+                        + "/" + actions.get(0).getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("content.[0].id", equalTo(actions.get(0).getActionStatus().get(1).getId().intValue())))
+                .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
+                .andExpect(jsonPath("content.[0].messages", hasItem("manual cancelation requested")))
+                .andExpect(jsonPath("content.[0].reportedAt",
+                        equalTo(actions.get(0).getActionStatus().get(1).getCreatedAt())))
+                .andExpect(
+                        jsonPath("content.[1].id", equalTo(actions.get(0).getActionStatus().get(0).getId().intValue())))
+                .andExpect(jsonPath("content.[1].type", equalTo("running")))
+                .andExpect(jsonPath("content.[1].reportedAt",
+                        equalTo(actions.get(0).getActionStatus().get(0).getCreatedAt())))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)));
+    }
+
+    @Test
+    @Description("Verfies that the API resturns the status list with expected content split into two pages.")
+    public void getMultipleActionStatusWithPagingLimitRequestParameter() throws Exception {
+        final String knownTargetId = "targetId";
+
+        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
+
+        // Page 1
+        mvc.perform(get(
+                RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + RestConstants.TARGET_V1_ACTIONS
+                        + "/" + actions.get(0).getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS)
+                                .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1)))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("content.[0].id", equalTo(actions.get(0).getActionStatus().get(1).getId().intValue())))
+                .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
+                .andExpect(jsonPath("content.[0].messages", hasItem("manual cancelation requested")))
+                .andExpect(jsonPath("content.[0].reportedAt",
+                        equalTo(actions.get(0).getActionStatus().get(1).getCreatedAt())))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(1)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(1)));
+
+        // Page 2
+        mvc.perform(get(
+                RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + RestConstants.TARGET_V1_ACTIONS
+                        + "/" + actions.get(0).getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS)
+                                .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
+                                .param(RestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1)))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("content.[0].id", equalTo(actions.get(0).getActionStatus().get(0).getId().intValue())))
+                .andExpect(jsonPath("content.[0].type", equalTo("running")))
+                .andExpect(jsonPath("content.[0].reportedAt",
+                        equalTo(actions.get(0).getActionStatus().get(0).getCreatedAt())))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(1)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(1)));
+    }
+
+    @Test
     public void getMultipleActionsWithPagingLimitRequestParameter() throws Exception {
         final String knownTargetId = "targetId";
         final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
@@ -874,6 +941,7 @@ public class TargetResourceTest extends AbstractIntegrationTest {
         mvc.perform(get(
                 RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + RestConstants.TARGET_V1_ACTIONS)
                         .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
+                        .param(RestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1))
                         .param(RestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1)))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actions.get(1).getId().intValue())))
@@ -1232,7 +1300,8 @@ public class TargetResourceTest extends AbstractIntegrationTest {
         // prepare test
         final DistributionSet dsA = TestDataUtil.generateDistributionSet("", softwareManagement,
                 distributionSetManagement);
-        Target tA = targetManagement.createTarget(TestDataUtil.buildTargetFixture("target-id-A", "first description"));
+        final Target tA = targetManagement
+                .createTarget(TestDataUtil.buildTargetFixture("target-id-A", "first description"));
         // assign a distribution set so we get an active update action
         deploymentManagement.assignDistributionSet(dsA, Lists.newArrayList(tA));
         // verify active action

--- a/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
+++ b/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
@@ -833,7 +833,8 @@ public class TargetResourceTest extends AbstractIntegrationTest {
         final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
 
         mvc.perform(get(
-                RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + RestConstants.TARGET_V1_ACTIONS))
+                RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + RestConstants.TARGET_V1_ACTIONS)
+                        .param(RestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(jsonPath("content.[1].id", equalTo(actions.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("update")))
@@ -960,7 +961,8 @@ public class TargetResourceTest extends AbstractIntegrationTest {
         // page 1: one entry
         mvc.perform(get(
                 RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + RestConstants.TARGET_V1_ACTIONS)
-                        .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1)))
+                        .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
+                        .param(RestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actions.get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("cancel")))
@@ -976,7 +978,8 @@ public class TargetResourceTest extends AbstractIntegrationTest {
                 RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + RestConstants.TARGET_V1_ACTIONS)
                         .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
                         .param(RestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1))
-                        .param(RestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1)))
+                        .param(RestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1))
+                        .param(RestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actions.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("update")))

--- a/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
+++ b/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/TargetResourceTest.java
@@ -35,6 +35,7 @@ import org.eclipse.hawkbit.TestDataUtil;
 import org.eclipse.hawkbit.WithUser;
 import org.eclipse.hawkbit.exception.SpServerError;
 import org.eclipse.hawkbit.im.authentication.SpPermission;
+import org.eclipse.hawkbit.repository.ActionFields;
 import org.eclipse.hawkbit.repository.ActionStatusFields;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.model.Action;
@@ -117,27 +118,24 @@ public class TargetResourceTest extends AbstractIntegrationTest {
                 new ActionStatus(actions.get(0), Status.FINISHED, System.currentTimeMillis(), "testmessage"),
                 actions.get(0));
 
-        final PageRequest pageRequest = new PageRequest(0, 1000, Direction.ASC, ActionStatusFields.ID.getFieldName());
+        final PageRequest pageRequest = new PageRequest(0, 1000, Direction.ASC, ActionFields.ID.getFieldName());
+        final ActionStatus status = deploymentManagement
+                .findActionsByTarget(pageRequest, targetManagement.findTargetByControllerID(knownTargetId)).getContent()
+                .get(0).getActionStatus().stream().sorted((e1, e2) -> Long.compare(e2.getId(), e1.getId()))
+                .collect(Collectors.toList()).get(0);
 
-        // limit to 1 - first page -> standard cancel message
-        final Long reportAt = deploymentManagement
-                .findActionsByTarget(pageRequest, targetManagement.findTargetByControllerID(knownTargetId)).getContent()
-                .get(0).getCreatedAt();
-        final Long id = deploymentManagement
-                .findActionsByTarget(pageRequest, targetManagement.findTargetByControllerID(knownTargetId)).getContent()
-                .get(0).getId();
         mvc.perform(get(RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
                 + RestConstants.TARGET_V1_ACTIONS + "/" + actions.get(0).getId() + "/status")
                         .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(limitSize))
-                        .param(RestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
+                        .param(RestConstants.REQUEST_PARAMETER_SORTING, "ID:DESC"))
                 .andExpect(status().isOk()).andDo(MockMvcResultPrinter.print())
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(3)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(limitSize)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(limitSize)))
-                .andExpect(jsonPath("content.[0].id", equalTo(id.intValue())))
+                .andExpect(jsonPath("content.[0].id", equalTo(status.getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("finished")))
                 .andExpect(jsonPath("content.[0].messages", hasSize(1)))
-                .andExpect(jsonPath("content.[0].reportedAt", equalTo(reportAt)))
+                .andExpect(jsonPath("content.[0].reportedAt", equalTo(status.getCreatedAt().longValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("canceling")));
     }
 
@@ -857,11 +855,38 @@ public class TargetResourceTest extends AbstractIntegrationTest {
     public void getMultipleActionStatus() throws Exception {
         final String knownTargetId = "targetId";
         final Action action = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId).get(0);
+        // retrieve list in default descending order for actionstaus entries
+        final List<ActionStatus> actionStatus = action.getActionStatus().stream()
+                .sorted((e1, e2) -> Long.compare(e2.getId(), e1.getId())).collect(Collectors.toList());
+
+        // sort is default descending order, latest status first
+        mvc.perform(get(RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+                + RestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(0).getId().intValue())))
+                .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
+                .andExpect(jsonPath("content.[0].messages", hasItem("manual cancelation requested")))
+                .andExpect(jsonPath("content.[0].reportedAt", equalTo(actionStatus.get(0).getCreatedAt())))
+                .andExpect(jsonPath("content.[1].id", equalTo(actionStatus.get(1).getId().intValue())))
+                .andExpect(jsonPath("content.[1].type", equalTo("running")))
+                .andExpect(jsonPath("content.[1].reportedAt", equalTo(actionStatus.get(1).getCreatedAt())))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)));
+    }
+
+    @Test
+    @Description("Verfies that the API returns the status list with expected content sorted by reportedAt field.")
+    public void getMultipleActionStatusSortedByReportedAt() throws Exception {
+        final String knownTargetId = "targetId";
+        final Action action = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId).get(0);
         final List<ActionStatus> actionStatus = action.getActionStatus().stream()
                 .sorted((e1, e2) -> Long.compare(e1.getId(), e2.getId())).collect(Collectors.toList());
 
+        // descending order
         mvc.perform(get(RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                + RestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS))
+                + RestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS)
+                        .param(RestConstants.REQUEST_PARAMETER_SORTING, "REPORTED_AT:DESC"))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
@@ -870,6 +895,22 @@ public class TargetResourceTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("content.[1].id", equalTo(actionStatus.get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("running")))
                 .andExpect(jsonPath("content.[1].reportedAt", equalTo(actionStatus.get(0).getCreatedAt())))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)));
+
+        // ascending order
+        mvc.perform(get(RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+                + RestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/" + RestConstants.TARGET_V1_ACTION_STATUS)
+                        .param(RestConstants.REQUEST_PARAMETER_SORTING, "REPORTED_AT:ASC"))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(jsonPath("content.[1].id", equalTo(actionStatus.get(1).getId().intValue())))
+                .andExpect(jsonPath("content.[1].type", equalTo("canceling")))
+                .andExpect(jsonPath("content.[1].messages", hasItem("manual cancelation requested")))
+                .andExpect(jsonPath("content.[1].reportedAt", equalTo(actionStatus.get(1).getCreatedAt())))
+                .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(0).getId().intValue())))
+                .andExpect(jsonPath("content.[0].type", equalTo("running")))
+                .andExpect(jsonPath("content.[0].reportedAt", equalTo(actionStatus.get(0).getCreatedAt())))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)));
@@ -963,7 +1004,8 @@ public class TargetResourceTest extends AbstractIntegrationTest {
                 + "?offset=0&limit=50&sort=id:DESC";
     }
 
-    private List<Action> generateTargetWithTwoUpdatesWithOneOverride(final String knownTargetId) {
+    private List<Action> generateTargetWithTwoUpdatesWithOneOverride(final String knownTargetId)
+            throws InterruptedException {
 
         final PageRequest pageRequest = new PageRequest(0, 100, Direction.ASC, ActionStatusFields.ID.getFieldName());
 
@@ -981,6 +1023,8 @@ public class TargetResourceTest extends AbstractIntegrationTest {
         final List<Target> updatedTargets = deploymentManagement.assignDistributionSet(one, targets)
                 .getAssignedTargets();
         // 2nd update
+        // sleep 1ms to ensure that we can sort by reportedAt
+        Thread.sleep(1);
         deploymentManagement.assignDistributionSet(two, updatedTargets);
 
         // two updates, one cancelation
@@ -1005,54 +1049,6 @@ public class TargetResourceTest extends AbstractIntegrationTest {
                                 + actions.get(1).getDistributionSet().getId())))
                 .andExpect(jsonPath("_links.status.href",
                         equalTo(generateStatusreferenceLink(knownTargetId, actions.get(1)))));
-    }
-
-    @Test
-    public void getActionStatusWithMultipleResultsWithPagingLimitRequestParameter() throws Exception {
-        final int limitSize = 1;
-        final String knownTargetId = "targetId";
-        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
-        actions.get(0).setStatus(Status.RUNNING);
-        controllerManagament.addUpdateActionStatus(
-                new ActionStatus(actions.get(0), Status.RUNNING, System.currentTimeMillis(), "testmessage"),
-                actions.get(0));
-
-        final PageRequest pageRequest = new PageRequest(0, 1000, Direction.ASC, ActionStatusFields.ID.getFieldName());
-
-        // limit to 1 - first page -> standard cancel message
-        Long reportAt = deploymentManagement
-                .findActionsByTarget(pageRequest, targetManagement.findTargetByControllerID(knownTargetId)).getContent()
-                .get(0).getCreatedAt();
-        Long id = deploymentManagement
-                .findActionsByTarget(pageRequest, targetManagement.findTargetByControllerID(knownTargetId)).getContent()
-                .get(0).getId();
-        mvc.perform(get(RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                + RestConstants.TARGET_V1_ACTIONS + "/" + actions.get(0).getId() + "/status")
-                        .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(limitSize)))
-                .andExpect(status().isOk()).andDo(MockMvcResultPrinter.print())
-                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(3)))
-                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(limitSize)))
-                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(limitSize)))
-                .andExpect(jsonPath("content.[0].id", equalTo(id.intValue())))
-                .andExpect(jsonPath("content.[0].type", equalTo("running")))
-                .andExpect(jsonPath("content.[0].messages", hasSize(1)))
-                .andExpect(jsonPath("content.[0].reportedAt", equalTo(reportAt)));
-
-        // limit to 1 - first page -> added custom message
-        reportAt = deploymentManagement
-                .findActionsByTarget(pageRequest, targetManagement.findTargetByControllerID(knownTargetId)).getContent()
-                .get(1).getCreatedAt();
-        id = deploymentManagement
-                .findActionsByTarget(pageRequest, targetManagement.findTargetByControllerID(knownTargetId)).getContent()
-                .get(1).getCreatedAt();
-
-        mvc.perform(get(RestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                + RestConstants.TARGET_V1_ACTIONS + "/" + actions.get(0).getId() + "/status")
-                        .param(RestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(limitSize))
-                        .param(RestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1)))
-                .andExpect(status().isOk()).andDo(MockMvcResultPrinter.print())
-                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(3)))
-                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(1)));
     }
 
     @Test

--- a/hawkbit-rest-resource/src/test/resources/log4j2.xml
+++ b/hawkbit-rest-resource/src/test/resources/log4j2.xml
@@ -17,7 +17,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="org.eclipse.hawkbit.MockMvcResultPrinter" level="debug" />
+        <Logger name="org.eclipse.hawkbit.MockMvcResultPrinter" level="error" />
 
         <Root level="error">
             <AppenderRef ref="Console"/>

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionHistoryTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionHistoryTable.java
@@ -16,6 +16,7 @@ import java.util.StringJoiner;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.eclipse.hawkbit.repository.ActionStatusFields;
 import org.eclipse.hawkbit.repository.DeploymentManagement;
 import org.eclipse.hawkbit.repository.exception.CancelActionNotAllowedException;
 import org.eclipse.hawkbit.repository.model.Action;
@@ -43,6 +44,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.vaadin.spring.events.EventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
@@ -417,9 +420,9 @@ public class ActionHistoryTable extends TreeTable implements Handler {
 
             final org.eclipse.hawkbit.repository.model.Action action = deploymentManagement
                     .findActionWithDetails(actionId);
-            final Pageable pageReq = new PageRequest(0, 1000);
+            final Pageable pageReq = new PageRequest(0, 1000, new Sort(Direction.ASC, ActionStatusFields.ID.getFieldName()));
             final Page<ActionStatus> actionStatusList = deploymentManagement
-                    .findActionStatusMessagesByActionInDescOrder(pageReq, action,
+                    .findActionStatusByAction(pageReq, action,
                             managementUIState.isActionHistoryMaximized());
             final List<ActionStatus> content = actionStatusList.getContent();
             /*

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionHistoryTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionHistoryTable.java
@@ -420,10 +420,10 @@ public class ActionHistoryTable extends TreeTable implements Handler {
 
             final org.eclipse.hawkbit.repository.model.Action action = deploymentManagement
                     .findActionWithDetails(actionId);
-            final Pageable pageReq = new PageRequest(0, 1000, new Sort(Direction.ASC, ActionStatusFields.ID.getFieldName()));
-            final Page<ActionStatus> actionStatusList = deploymentManagement
-                    .findActionStatusByAction(pageReq, action,
-                            managementUIState.isActionHistoryMaximized());
+            final Pageable pageReq = new PageRequest(0, 1000,
+                    new Sort(Direction.DESC, ActionStatusFields.ID.getFieldName()));
+            final Page<ActionStatus> actionStatusList = deploymentManagement.findActionStatusByAction(pageReq, action,
+                    managementUIState.isActionHistoryMaximized());
             final List<ActionStatus> content = actionStatusList.getContent();
             /*
              * Since the recent action status and messages are already


### PR DESCRIPTION
* Action status entries in management API show wrong ID and reportedAt. Currently we present ID and reportedAt not of the status entry itself, but of the related action which is obviously wrong.

* Fixed sorting of action status by ID. We used sorting params but actually fed this into a repo method with fixed desc sorting.

* While at it I added also sorting by reportAt.

* Changed default sort of actions in target resource also to descending. Makes more sense from usability point of view and matches behaviour of mgmt. UI.

Signed-off-by: Kai Zimmermann <kai.zimmermann@bosch-si.com>