### PR TITLE
update vaadin-bom to 7.6.3 version

### DIFF
--- a/examples/hawkbit-device-simulator/pom.xml
+++ b/examples/hawkbit-device-simulator/pom.xml
@@ -126,7 +126,7 @@
          <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-bom</artifactId>
-            <version>7.5.5</version>
+            <version>7.6.3</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>


### PR DESCRIPTION
* 7.5 version is not working with updated vaadin 7.6 in hawkbit, this will cause an Websocket XHR not found.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>