### PR TITLE
Annotation component must be removed

### DIFF
--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
@@ -10,14 +10,12 @@ package org.eclipse.hawkbit.amqp;
 
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 /**
  * Bean which holds the necessary properties for configuring the AMQP
  * connection.
  * 
  */
-@Component
 @ConfigurationProperties("hawkbit.dmf.rabbitmq")
 public class AmqpProperties {
     /**


### PR DESCRIPTION
* bean will otherwise registered twice because of EnableAutoConfiguration in the
AmqpConfiguration

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>