### PR TITLE
Rename deadletter queue and exchange

### DIFF
--- a/hawkbit-autoconfigure/src/main/resources/hawkbitdefaults.properties
+++ b/hawkbit-autoconfigure/src/main/resources/hawkbitdefaults.properties
@@ -38,6 +38,6 @@ hawkbit.controller.pollingTime=00:05:00
 hawkbit.controller.pollingOverdueTime=00:05:00
 
 ## Configuration for RabbitMQ integration
-hawkbit.dmf.rabbitmq.deadLetterQueue=dmf_receiver_deadletter
-hawkbit.dmf.rabbitmq.deadLetterExchange=dmf.receiver.deadletter
+hawkbit.dmf.rabbitmq.deadLetterQueue=dmf_connector_deadletter
+hawkbit.dmf.rabbitmq.deadLetterExchange=dmf.connector.deadletter
 hawkbit.dmf.rabbitmq.receiverQueue=dmf_receiver

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
@@ -21,12 +21,12 @@ public class AmqpProperties {
     /**
      * DMF API dead letter queue.
      */
-    private String deadLetterQueue = "dmf_receiver_deadletter";
+    private String deadLetterQueue = "dmf_connector_deadletter";
 
     /**
      * DMF API dead letter exchange.
      */
-    private String deadLetterExchange = "dmf.receiver.deadletter";
+    private String deadLetterExchange = "dmf.connector.deadletter";
 
     /**
      * DMF API receiving queue.


### PR DESCRIPTION
Rename deadletter queue and exchange, because cannot exists 2 deadletter queues for 1 queue

Signed-off-by: SirWayne <dennis.melzer@bosch-si.com>