### PR TITLE
Update 3rd party library list for 0.2 CQs

### DIFF
--- a/3rd-dependencies/compile.txt
+++ b/3rd-dependencies/compile.txt
@@ -1,74 +1,95 @@
    aopalliance:aopalliance:jar:1.0:compile
-   com.fasterxml.jackson.core:jackson-annotations:jar:2.5.0:compile
-   com.fasterxml.jackson.core:jackson-core:jar:2.5.0:compile
-   com.fasterxml.jackson.core:jackson-databind:jar:2.5.0:compile
-   com.fasterxml:classmate:jar:1.3.0:compile
-   com.google.guava:guava:jar:18.0:compile
-   com.h2database:h2:jar:1.4.186:compile
+   ch.qos.logback:logback-classic:jar:1.1.3:compile
+   ch.qos.logback:logback-core:jar:1.1.3:compile
+   com.fasterxml.jackson.core:jackson-annotations:jar:2.5.5:compile
+   com.fasterxml.jackson.core:jackson-core:jar:2.5.5:compile
+   com.fasterxml.jackson.core:jackson-databind:jar:2.5.5:compile
+   com.fasterxml:classmate:jar:1.1.0:compile
+   com.fasterxml:classmate:jar:1.2.0:compile
+   com.google.collections:google-collections:jar:1.0-rc2:compile
+   com.google.guava:guava:jar:19.0:compile
+   com.h2database:h2:jar:1.4.190:compile
+   com.jayway.jsonpath:json-path:jar:0.9.1:compile
+   com.netflix.feign:feign-core:jar:8.12.1:compile
+   com.netflix.feign:feign-core:jar:8.14.2:compile
+   com.netflix.feign:feign-jackson:jar:8.14.1:compile
+   com.netflix.feign:feign-ribbon:jar:8.1.1:compile
+   com.netflix.feign:feign-slf4j:jar:8.1.1:compile
+   com.netflix.ribbon:ribbon-core:jar:2.0.0:compile
+   com.netflix.ribbon:ribbon-httpclient:jar:2.0.0:compile
+   com.netflix.ribbon:ribbon-loadbalancer:jar:2.0.0:compile
+   com.netflix.ribbon:ribbon:jar:2.0.0:compile
    com.rabbitmq:amqp-client:jar:3.5.5:compile
    com.vaadin.external.atmosphere:atmosphere-runtime:jar:2.2.7.vaadin1:compile
    com.vaadin.external.flute:flute:jar:1.3.0.gg2:compile
    com.vaadin.external.google:guava:jar:16.0.1.vaadin1:compile
    com.vaadin.external.slf4j:vaadin-slf4j-jdk14:jar:1.6.1:compile
    com.vaadin.external.streamhtmlparser:streamhtmlparser-jsilver:jar:0.0.10.vaadin1:compile
-   com.vaadin:vaadin-push:jar:7.5.7:compile
-   com.vaadin:vaadin-sass-compiler:jar:0.9.12:compile
-   com.vaadin:vaadin-server:jar:7.5.7:compile
-   com.vaadin:vaadin-shared:jar:7.5.7:compile
+   com.vaadin:vaadin-client-compiled:jar:7.6.3:compile
+   com.vaadin:vaadin-push:jar:7.6.3:compile
+   com.vaadin:vaadin-sass-compiler:jar:0.9.13:compile
+   com.vaadin:vaadin-server:jar:7.6.3:compile
+   com.vaadin:vaadin-shared:jar:7.6.3:compile
+   com.vaadin:vaadin-spring-boot-starter:jar:1.0.0:compile
    com.vaadin:vaadin-spring-boot:jar:1.0.0:compile
    com.vaadin:vaadin-spring:jar:1.0.0:compile
-   com.vaadin:vaadin-themes:jar:7.5.7:compile
+   com.vaadin:vaadin-themes:jar:7.6.3:compile
+   com.yahoo.platform.yui:yuicompressor:jar:2.4.8:compile
    commons-io:commons-io:jar:2.4:compile
    cz.jirutka.rsql:rsql-parser:jar:2.0.0:compile
+   io.reactivex:rxjava:jar:1.0.11:compile
    io.springfox:springfox-core:jar:2.0.3:compile
-   io.springfox:springfox-schema:jar:2.0.3:compile
-   io.springfox:springfox-spi:jar:2.0.3:compile
-   io.springfox:springfox-spring-web:jar:2.0.3:compile
-   io.springfox:springfox-swagger-common:jar:2.0.3:compile
-   io.springfox:springfox-swagger2:jar:2.0.3:compile
-   io.swagger:swagger-annotations:jar:1.5.0:compile
-   io.swagger:swagger-models:jar:1.5.0:compile
    javax.servlet:javax.servlet-api:jar:3.1.0:compile
    javax.transaction:javax.transaction-api:jar:1.2:compile
    javax.validation:validation-api:jar:1.1.0.Final:compile
    joda-time:joda-time:jar:2.5:compile
    net._01001111:jlorem:jar:1.1:compile
+   net.minidev:json-smart:jar:1.2:compile
    org.apache.commons:commons-lang3:jar:3.4:compile
    org.apache.commons:commons-pool2:jar:2.2:compile
    org.apache.logging.log4j:log4j-api:jar:2.1:compile
    org.apache.logging.log4j:log4j-core:jar:2.1:compile
    org.apache.logging.log4j:log4j-slf4j-impl:jar:2.1:compile
-   org.apache.tomcat:tomcat-jdbc:jar:8.0.28:compile
-   org.apache.tomcat:tomcat-juli:jar:8.0.28:compile
+   org.apache.tomcat:tomcat-jdbc:jar:8.0.30:compile
+   org.apache.tomcat:tomcat-juli:jar:8.0.30:compile
    org.aspectj:aspectjrt:jar:1.8.5:compile
    org.aspectj:aspectjweaver:jar:1.8.5:compile
-   org.eclipse.persistence:javax.persistence:jar:2.1.0:compile
-   org.eclipse.persistence:org.eclipse.persistence.antlr:jar:2.6.0:compile
-   org.eclipse.persistence:org.eclipse.persistence.asm:jar:2.6.0:compile
-   org.eclipse.persistence:org.eclipse.persistence.core:jar:2.6.0:compile
-   org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:jar:2.6.0:compile
-   org.eclipse.persistence:org.eclipse.persistence.jpa:jar:2.6.0:compile
+   org.eclipse.persistence:javax.persistence:jar:2.1.1:compile
+   org.eclipse.persistence:org.eclipse.persistence.antlr:jar:2.6.2:compile
+   org.eclipse.persistence:org.eclipse.persistence.asm:jar:2.6.2:compile
+   org.eclipse.persistence:org.eclipse.persistence.core:jar:2.6.2:compile
+   org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:jar:2.6.2:compile
+   org.eclipse.persistence:org.eclipse.persistence.jpa:jar:2.6.2:compile
    org.flywaydb:flyway-core:jar:3.1:compile
    org.glassfish:javax.json:jar:1.0.4:compile
-   org.hibernate:hibernate-validator:jar:5.2.2.Final:compile
+   org.hibernate:hibernate-validator:jar:5.2.4.Final:compile
    org.jboss.logging:jboss-logging:jar:3.2.1.Final:compile
-   org.jsoup:jsoup:jar:1.8.1:compile
-   org.mapstruct:mapstruct:jar:1.0.0.Beta4:compile
-   org.mongodb:mongo-java-driver:jar:3.0.2:compile
+   org.json:json:jar:20141113:compile
+   org.jsoup:jsoup:jar:1.8.3:compile
+   org.mongodb:mongo-java-driver:jar:3.2.2:compile
    org.objenesis:objenesis:jar:2.1:compile
-   org.slf4j:jcl-over-slf4j:jar:1.7.12:compile
-   org.slf4j:jul-to-slf4j:jar:1.7.12:compile
-   org.slf4j:slf4j-api:jar:1.7.7:compile
+   org.slf4j:jcl-over-slf4j:jar:1.7.13:compile
+   org.slf4j:jul-to-slf4j:jar:1.7.13:compile
+   org.slf4j:log4j-over-slf4j:jar:1.7.13:compile
+   org.slf4j:slf4j-api:jar:1.7.13:compile
    org.springframework.amqp:spring-amqp:jar:1.4.6.RELEASE:compile
    org.springframework.amqp:spring-rabbit:jar:1.4.6.RELEASE:compile
-   org.springframework.boot:spring-boot-autoconfigure:jar:1.2.7.RELEASE:compile
-   org.springframework.boot:spring-boot-starter-aop:jar:1.2.7.RELEASE:compile
-   org.springframework.boot:spring-boot-starter-data-jpa:jar:1.2.7.RELEASE:compile
-   org.springframework.boot:spring-boot-starter-jdbc:jar:1.2.7.RELEASE:compile
-   org.springframework.boot:spring-boot-starter-log4j2:jar:1.2.7.RELEASE:compile
-   org.springframework.boot:spring-boot-starter-web:jar:1.2.7.RELEASE:compile
-   org.springframework.boot:spring-boot-starter:jar:1.2.7.RELEASE:compile
-   org.springframework.boot:spring-boot:jar:1.2.7.RELEASE:compile
+   org.springframework.boot:spring-boot-autoconfigure:jar:1.2.8.RELEASE:compile
+   org.springframework.boot:spring-boot-configuration-processor:jar:1.2.8.RELEASE:compile
+   org.springframework.boot:spring-boot-starter-aop:jar:1.2.8.RELEASE:compile
+   org.springframework.boot:spring-boot-starter-data-jpa:jar:1.2.8.RELEASE:compile
+   org.springframework.boot:spring-boot-starter-jdbc:jar:1.2.8.RELEASE:compile
+   org.springframework.boot:spring-boot-starter-log4j2:jar:1.2.8.RELEASE:compile
+   org.springframework.boot:spring-boot-starter-logging:jar:1.2.8.RELEASE:compile
+   org.springframework.boot:spring-boot-starter-web:jar:1.2.8.RELEASE:compile
+   org.springframework.boot:spring-boot-starter:jar:1.2.8.RELEASE:compile
+   org.springframework.boot:spring-boot:jar:1.2.8.RELEASE:compile
+   org.springframework.cloud:spring-cloud-commons:jar:1.0.5.RELEASE:compile
+   org.springframework.cloud:spring-cloud-context:jar:1.0.5.RELEASE:compile
+   org.springframework.cloud:spring-cloud-netflix-core:jar:1.0.7.RELEASE:compile
+   org.springframework.cloud:spring-cloud-starter-feign:jar:1.0.6.RELEASE:compile
+   org.springframework.cloud:spring-cloud-starter-ribbon:jar:1.0.6.RELEASE:compile
+   org.springframework.cloud:spring-cloud-starter:jar:1.0.5.RELEASE:compile
    org.springframework.data:spring-data-commons:jar:1.10.1.RELEASE:compile
    org.springframework.data:spring-data-jpa:jar:1.8.1.RELEASE:compile
    org.springframework.data:spring-data-mongodb:jar:1.7.1.RELEASE:compile
@@ -77,29 +98,33 @@
    org.springframework.plugin:spring-plugin-core:jar:1.1.0.RELEASE:compile
    org.springframework.plugin:spring-plugin-metadata:jar:1.2.0.RELEASE:compile
    org.springframework.retry:spring-retry:jar:1.1.2.RELEASE:compile
-   org.springframework.security:spring-security-aspects:jar:3.2.8.RELEASE:compile
-   org.springframework.security:spring-security-config:jar:3.2.8.RELEASE:compile
-   org.springframework.security:spring-security-core:jar:3.2.8.RELEASE:compile
-   org.springframework.security:spring-security-web:jar:3.2.8.RELEASE:compile
-   org.springframework:spring-aop:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-aspects:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-beans:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-context-support:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-context:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-core:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-expression:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-jdbc:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-messaging:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-orm:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-tx:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-web:jar:4.1.8.RELEASE:compile
-   org.springframework:spring-webmvc:jar:4.1.8.RELEASE:compile
+   org.springframework.security:spring-security-aspects:jar:3.2.9.RELEASE:compile
+   org.springframework.security:spring-security-config:jar:3.2.9.RELEASE:compile
+   org.springframework.security:spring-security-core:jar:3.2.9.RELEASE:compile
+   org.springframework.security:spring-security-crypto:jar:3.2.9.RELEASE:compile
+   org.springframework.security:spring-security-web:jar:3.2.9.RELEASE:compile
+   org.springframework:spring-aop:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-aspects:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-beans:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-context-support:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-context:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-core:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-expression:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-jdbc:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-messaging:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-orm:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-tx:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-web:jar:4.1.9.RELEASE:compile
+   org.springframework:spring-webmvc:jar:4.1.9.RELEASE:compile
    org.vaadin.addons.lazyquerycontainer:vaadin-lazyquerycontainer:jar:7.4.0.1:compile
+   org.vaadin.addons:contextmenu:jar:4.5:compile
    org.vaadin.addons:flexibleoptiongroup:jar:2.2.0:compile
    org.vaadin.addons:tokenfield:jar:7.0.1:compile
+   org.vaadin.alump.distributionbar:dbar-addon:jar:1.2.0:compile
    org.vaadin.spring.addons:vaadin-spring-addon-eventbus:jar:0.0.6.RELEASE:compile
    org.vaadin.spring.extensions:vaadin-spring-ext-core:jar:0.0.6.RELEASE:compile
    org.vaadin.spring.extensions:vaadin-spring-ext-security:jar:0.0.6.RELEASE:compile
    org.w3c.css:sac:jar:1.3:compile
    org.yaml:snakeyaml:jar:1.14:compile
    redis.clients:jedis:jar:2.5.2:compile
+   rhino:js:jar:1.7R2:compile

--- a/3rd-dependencies/listDeps.sh
+++ b/3rd-dependencies/listDeps.sh
@@ -6,3 +6,6 @@ find . -name dependencies.txt|while read i; do cat $i;done|grep '.*:.*:test'|sor
 find . -name dependencies.txt|while read i; do cat $i;done|grep '.*:.*:provided'|sort|uniq > 3rd-dependencies/provided.txt
 find . -name dependencies.txt|while read i; do rm $i;done
 cd 3rd-dependencies/
+cat compile.txt provided.txt|cut -d':' -f1-4|while read i; do grep -h $i test.txt;done|sort|uniq|while read x; do sed -i.bak -e s/$x// test.txt ;done
+sed -i.bak '/^[[:space:]]*$/d' test.txt
+rm *.bak

--- a/3rd-dependencies/provided.txt
+++ b/3rd-dependencies/provided.txt
@@ -1,6 +1,6 @@
    javax.servlet:javax.servlet-api:jar:3.1.0:provided
-   org.apache.tomcat.embed:tomcat-embed-core:jar:8.0.28:provided
-   org.apache.tomcat.embed:tomcat-embed-el:jar:8.0.28:provided
-   org.apache.tomcat.embed:tomcat-embed-logging-juli:jar:8.0.28:provided
-   org.apache.tomcat.embed:tomcat-embed-websocket:jar:8.0.28:provided
-   org.springframework.boot:spring-boot-starter-tomcat:jar:1.2.7.RELEASE:provided
+   org.apache.tomcat.embed:tomcat-embed-core:jar:8.0.30:provided
+   org.apache.tomcat.embed:tomcat-embed-el:jar:8.0.30:provided
+   org.apache.tomcat.embed:tomcat-embed-logging-juli:jar:8.0.30:provided
+   org.apache.tomcat.embed:tomcat-embed-websocket:jar:8.0.30:provided
+   org.springframework.boot:spring-boot-starter-tomcat:jar:1.2.8.RELEASE:provided

--- a/3rd-dependencies/test.txt
+++ b/3rd-dependencies/test.txt
@@ -1,55 +1,36 @@
-   com.fasterxml.jackson.core:jackson-core:jar:2.5.0:test
-   com.fasterxml.jackson.core:jackson-databind:jar:2.5.0:test
    com.github.fge:btf:jar:1.2:test
    com.github.fge:jackson-coreutils:jar:1.6:test
    com.github.fge:json-patch:jar:1.7:test
    com.github.fge:msg-simple:jar:1.1:test
    com.google.code.findbugs:jsr305:jar:2.0.1:test
-   com.h2database:h2:jar:1.4.186:test
-   com.jayway.jsonpath:json-path:jar:0.9.1:test
+   com.sun.jersey:jersey-client:jar:1.18.1:test
+   com.sun.jersey:jersey-core:jar:1.13:test
    commons-beanutils:commons-beanutils-core:jar:1.8.3:test
-   commons-io:commons-io:jar:2.4:test
    commons-logging:commons-logging:jar:1.1.1:test
-   de.flapdoodle.embed:de.flapdoodle.embed.mongo:jar:1.50.0:test
-   de.flapdoodle.embed:de.flapdoodle.embed.process:jar:1.50.0:test
-   io.swagger:swagger-annotations:jar:1.5.0:test
+   de.flapdoodle.embed:de.flapdoodle.embed.mongo:jar:1.50.2:test
+   de.flapdoodle.embed:de.flapdoodle.embed.process:jar:1.50.1:test
    javax.el:javax.el-api:jar:2.2.4:test
    junit:junit:jar:4.12:test
    net.java.dev.jna:jna-platform:jar:4.0.0:test
-   net.java.dev.jna:jna:jar:3.3.0:test
    net.java.dev.jna:jna:jar:4.0.0:test
-   net.java.dev.jna:jna:jar:platform:3.3.0:test
-   net.minidev:json-smart:jar:1.2:test
    org.apache.commons:commons-compress:jar:1.3:test
-   org.apache.commons:commons-lang3:jar:3.1:test
    org.apache.tika:tika-core:jar:1.7:test
-   org.aspectj:aspectjrt:jar:1.8.5:test
    org.atteo:evo-inflector:jar:1.2.1:test
    org.easytesting:fest-assert-core:jar:2.0M10:test
    org.easytesting:fest-assert:jar:1.4:test
    org.easytesting:fest-util:jar:1.2.5:test
    org.hamcrest:hamcrest-core:jar:1.3:test
    org.hamcrest:hamcrest-library:jar:1.3:test
-   org.json:json:jar:20141113:test
    org.jvnet.jaxb2_commons:jaxb2-basics-runtime:jar:0.9.3:test
-   org.mariadb.jdbc:mariadb-java-client:jar:1.2.3:test
+   org.mariadb.jdbc:mariadb-java-client:jar:1.3.5:test
    org.mockito:mockito-core:jar:1.10.19:test
-   org.objenesis:objenesis:jar:2.1:test
-   org.springframework.boot:spring-boot-starter-test:jar:1.2.7.RELEASE:test
+   org.springframework.boot:spring-boot-starter-test:jar:1.2.8.RELEASE:test
    org.springframework.data:spring-data-rest-core:jar:2.3.1.RELEASE:test
    org.springframework.data:spring-data-rest-webmvc:jar:2.3.1.RELEASE:test
-   org.springframework.hateoas:spring-hateoas:jar:0.16.0.RELEASE:test
-   org.springframework.plugin:spring-plugin-core:jar:1.1.0.RELEASE:test
-   org.springframework.security:spring-security-aspects:jar:3.2.8.RELEASE:test
-   org.springframework.security:spring-security-config:jar:3.2.8.RELEASE:test
-   org.springframework.security:spring-security-web:jar:3.2.8.RELEASE:test
-   org.springframework:spring-context-support:jar:4.1.8.RELEASE:test
-   org.springframework:spring-test:jar:4.1.8.RELEASE:test
-   org.springframework:spring-web:jar:4.1.8.RELEASE:test
-   org.springframework:spring-webmvc:jar:4.1.8.RELEASE:test
-   ru.yandex.qatools.allure:allure-java-adaptor-api:jar:1.4.15:test
-   ru.yandex.qatools.allure:allure-java-annotations:jar:1.4.15:test
-   ru.yandex.qatools.allure:allure-java-aspects:jar:1.4.15:test
-   ru.yandex.qatools.allure:allure-junit-adaptor:jar:1.4.15:test
-   ru.yandex.qatools.allure:allure-model:jar:1.4.15:test
+   org.springframework:spring-test:jar:4.1.9.RELEASE:test
+   ru.yandex.qatools.allure:allure-java-adaptor-api:jar:1.4.22:test
+   ru.yandex.qatools.allure:allure-java-annotations:jar:1.4.22:test
+   ru.yandex.qatools.allure:allure-java-aspects:jar:1.4.22:test
+   ru.yandex.qatools.allure:allure-junit-adaptor:jar:1.4.22:test
+   ru.yandex.qatools.allure:allure-model:jar:1.4.22:test
    ru.yandex.qatools.properties:properties-loader:jar:1.5:test

--- a/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/ClientConfigurationProperties.java
+++ b/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/ClientConfigurationProperties.java
@@ -9,14 +9,12 @@
 package org.eclipse.hawkbit.mgmt.client;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 /**
  * Configuration bean which holds the configuration of the client e.g. the base
  * URL of the hawkbit-server and the credentials to use the RESTful Management
  * API.
  */
-@Component
 @ConfigurationProperties(prefix = "hawkbit")
 public class ClientConfigurationProperties {
 

--- a/examples/hawkbit-mgmt-api-client/src/main/resources/logback.xml
+++ b/examples/hawkbit-mgmt-api-client/src/main/resources/logback.xml
@@ -1,6 +1,3 @@
-<!-- Copyright (c) 2015 Bosch Software Innovations GmbH and others. All rights reserved. This program and the accompanying 
-   materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and 
-   is available at http://www.eclipse.org/legal/epl-v10.html -->
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 


### PR DESCRIPTION
- Removed libraries out of 3rd-lib test generation that where already covered by compile and provided.
- Upgraded for current 0.2 snapshot