### PR TITLE
fix mgmt client startup with xml problem and not unique bean exception

### DIFF
--- a/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/ClientConfigurationProperties.java
+++ b/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/ClientConfigurationProperties.java
@@ -9,14 +9,12 @@
 package org.eclipse.hawkbit.mgmt.client;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 /**
  * Configuration bean which holds the configuration of the client e.g. the base
  * URL of the hawkbit-server and the credentials to use the RESTful Management
  * API.
  */
-@Component
 @ConfigurationProperties(prefix = "hawkbit")
 public class ClientConfigurationProperties {
 

--- a/examples/hawkbit-mgmt-api-client/src/main/resources/logback.xml
+++ b/examples/hawkbit-mgmt-api-client/src/main/resources/logback.xml
@@ -1,6 +1,3 @@
-<!-- Copyright (c) 2015 Bosch Software Innovations GmbH and others. All rights reserved. This program and the accompanying 
-   materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and 
-   is available at http://www.eclipse.org/legal/epl-v10.html -->
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 


### PR DESCRIPTION
* The `logback.xml` got messed up with the license header
* Removing the double registration of the bean `ClientConfigurationProperties` by removing the `@Component` annotation

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>