### PR TITLE
Fixed broken sorting for SM/DS type in mgmt API

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/FieldNameProvider.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/FieldNameProvider.java
@@ -20,7 +20,7 @@ import java.util.Map;
  */
 public interface FieldNameProvider {
     /**
-     * Seperator for the sub attributes
+     * Separator for the sub attributes
      */
     public static final String SUB_ATTRIBUTE_SEPERATOR = ".";
 

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/SoftwareModuleTypeFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/SoftwareModuleTypeFields.java
@@ -36,7 +36,7 @@ public enum SoftwareModuleTypeFields implements FieldNameProvider {
     /**
      * The max ds assignments field.
      */
-    MAX("maxAssignments");
+    MAXASSIGNMENTS("maxAssignments");
 
     private final String fieldName;
 

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/rsql/RSQLSoftwareModuleTypeFieldsTest.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/rsql/RSQLSoftwareModuleTypeFieldsTest.java
@@ -55,7 +55,7 @@ public class RSQLSoftwareModuleTypeFieldsTest extends AbstractIntegrationTest {
     @Test
     @Description("Test filter software module test type by max")
     public void testFilterByMaxAssignment() {
-        assertRSQLQuery(SoftwareModuleTypeFields.MAX.name() + "==1", 3);
+        assertRSQLQuery(SoftwareModuleTypeFields.MAXASSIGNMENTS.name() + "==1", 3);
     }
 
     private void assertRSQLQuery(final String rsqlParam, final long excpectedEntity) {

--- a/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/DistributionSetTypeResource.java
+++ b/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/DistributionSetTypeResource.java
@@ -64,7 +64,7 @@ public class DistributionSetTypeResource implements DistributionSetTypeRestApi {
 
         final int sanitizedOffsetParam = PagingUtility.sanitizeOffsetParam(pagingOffsetParam);
         final int sanitizedLimitParam = PagingUtility.sanitizePageLimitParam(pagingLimitParam);
-        final Sort sorting = PagingUtility.sanitizeSoftwareModuleSortParam(sortParam);
+        final Sort sorting = PagingUtility.sanitizeDistributionSetTypeSortParam(sortParam);
 
         final Pageable pageable = new OffsetBasedPageRequest(sanitizedOffsetParam, sanitizedLimitParam, sorting);
 

--- a/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/PagingUtility.java
+++ b/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/PagingUtility.java
@@ -12,10 +12,12 @@ import org.eclipse.hawkbit.repository.ActionFields;
 import org.eclipse.hawkbit.repository.ActionStatusFields;
 import org.eclipse.hawkbit.repository.DistributionSetFields;
 import org.eclipse.hawkbit.repository.DistributionSetMetadataFields;
+import org.eclipse.hawkbit.repository.DistributionSetTypeFields;
 import org.eclipse.hawkbit.repository.RolloutFields;
 import org.eclipse.hawkbit.repository.RolloutGroupFields;
 import org.eclipse.hawkbit.repository.SoftwareModuleFields;
 import org.eclipse.hawkbit.repository.SoftwareModuleMetadataFields;
+import org.eclipse.hawkbit.repository.SoftwareModuleTypeFields;
 import org.eclipse.hawkbit.repository.TargetFields;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -69,6 +71,17 @@ public final class PagingUtility {
         return sorting;
     }
 
+    static Sort sanitizeSoftwareModuleTypeSortParam(final String sortParam) {
+        final Sort sorting;
+        if (sortParam != null) {
+            sorting = new Sort(SortUtility.parse(SoftwareModuleTypeFields.class, sortParam));
+        } else {
+            // default sort
+            sorting = new Sort(Direction.ASC, SoftwareModuleTypeFields.NAME.getFieldName());
+        }
+        return sorting;
+    }
+
     static Sort sanitizeDistributionSetSortParam(final String sortParam) {
         final Sort sorting;
         if (sortParam != null) {
@@ -76,6 +89,17 @@ public final class PagingUtility {
         } else {
             // default sort
             sorting = new Sort(Direction.ASC, DistributionSetFields.NAME.getFieldName());
+        }
+        return sorting;
+    }
+
+    static Sort sanitizeDistributionSetTypeSortParam(final String sortParam) {
+        final Sort sorting;
+        if (sortParam != null) {
+            sorting = new Sort(SortUtility.parse(DistributionSetTypeFields.class, sortParam));
+        } else {
+            // default sort
+            sorting = new Sort(Direction.ASC, DistributionSetTypeFields.NAME.getFieldName());
         }
         return sorting;
     }

--- a/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/PagingUtility.java
+++ b/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/PagingUtility.java
@@ -50,125 +50,92 @@ public final class PagingUtility {
     }
 
     static Sort sanitizeTargetSortParam(final String sortParam) {
-        final Sort sorting;
-        if (sortParam != null) {
-            sorting = new Sort(SortUtility.parse(TargetFields.class, sortParam));
-        } else {
-            // default sort
-            sorting = new Sort(Direction.ASC, TargetFields.NAME.getFieldName());
+        if (sortParam == null) {
+            // default
+            return new Sort(Direction.ASC, TargetFields.NAME.getFieldName());
         }
-        return sorting;
+        return new Sort(SortUtility.parse(TargetFields.class, sortParam));
     }
 
     static Sort sanitizeSoftwareModuleSortParam(final String sortParam) {
-        final Sort sorting;
-        if (sortParam != null) {
-            sorting = new Sort(SortUtility.parse(SoftwareModuleFields.class, sortParam));
-        } else {
-            // default sort
-            sorting = new Sort(Direction.ASC, SoftwareModuleFields.NAME.getFieldName());
+        if (sortParam == null) {
+            // default
+            return new Sort(Direction.ASC, SoftwareModuleFields.NAME.getFieldName());
         }
-        return sorting;
+        return new Sort(SortUtility.parse(SoftwareModuleFields.class, sortParam));
     }
 
     static Sort sanitizeSoftwareModuleTypeSortParam(final String sortParam) {
-        final Sort sorting;
-        if (sortParam != null) {
-            sorting = new Sort(SortUtility.parse(SoftwareModuleTypeFields.class, sortParam));
-        } else {
-            // default sort
-            sorting = new Sort(Direction.ASC, SoftwareModuleTypeFields.NAME.getFieldName());
+        if (sortParam == null) {
+            // default
+            return new Sort(Direction.ASC, SoftwareModuleTypeFields.NAME.getFieldName());
         }
-        return sorting;
+        return new Sort(SortUtility.parse(SoftwareModuleTypeFields.class, sortParam));
     }
 
     static Sort sanitizeDistributionSetSortParam(final String sortParam) {
-        final Sort sorting;
-        if (sortParam != null) {
-            sorting = new Sort(SortUtility.parse(DistributionSetFields.class, sortParam));
-        } else {
-            // default sort
-            sorting = new Sort(Direction.ASC, DistributionSetFields.NAME.getFieldName());
+        if (sortParam == null) {
+            // default
+            return new Sort(Direction.ASC, DistributionSetFields.NAME.getFieldName());
         }
-        return sorting;
+        return new Sort(SortUtility.parse(DistributionSetFields.class, sortParam));
     }
 
     static Sort sanitizeDistributionSetTypeSortParam(final String sortParam) {
-        final Sort sorting;
-        if (sortParam != null) {
-            sorting = new Sort(SortUtility.parse(DistributionSetTypeFields.class, sortParam));
-        } else {
-            // default sort
-            sorting = new Sort(Direction.ASC, DistributionSetTypeFields.NAME.getFieldName());
+        if (sortParam == null) {
+            // default
+            return new Sort(Direction.ASC, DistributionSetTypeFields.NAME.getFieldName());
         }
-        return sorting;
+        return new Sort(SortUtility.parse(DistributionSetTypeFields.class, sortParam));
     }
 
     static Sort sanitizeActionSortParam(final String sortParam) {
-        final Sort sorting;
-        if (sortParam != null) {
-            sorting = new Sort(SortUtility.parse(ActionFields.class, sortParam));
-        } else {
+        if (sortParam == null) {
             // default sort is DESC in case of action to match behavior
             // of management UI (last entry on top)
-            sorting = new Sort(Direction.DESC, ActionFields.ID.getFieldName());
+            return new Sort(Direction.DESC, ActionFields.ID.getFieldName());
         }
-        return sorting;
+        return new Sort(SortUtility.parse(ActionFields.class, sortParam));
     }
 
     static Sort sanitizeActionStatusSortParam(final String sortParam) {
-        final Sort sorting;
-        if (sortParam != null) {
-            sorting = new Sort(SortUtility.parse(ActionStatusFields.class, sortParam));
-        } else {
+        if (sortParam == null) {
             // default sort is DESC in case of action status to match behavior
             // of management UI (last entry on top)
-            sorting = new Sort(Direction.DESC, ActionStatusFields.ID.getFieldName());
+            return new Sort(Direction.DESC, ActionStatusFields.ID.getFieldName());
         }
-        return sorting;
+        return new Sort(SortUtility.parse(ActionStatusFields.class, sortParam));
     }
 
     static Sort sanitizeDistributionSetMetadataSortParam(final String sortParam) {
-        final Sort sorting;
-        if (sortParam != null) {
-            sorting = new Sort(SortUtility.parse(DistributionSetMetadataFields.class, sortParam));
-        } else {
-            // default sort
-            sorting = new Sort(Direction.ASC, DistributionSetMetadataFields.KEY.getFieldName());
+        if (sortParam == null) {
+            // default
+            return new Sort(Direction.ASC, DistributionSetMetadataFields.KEY.getFieldName());
         }
-        return sorting;
+        return new Sort(SortUtility.parse(DistributionSetMetadataFields.class, sortParam));
     }
 
     static Sort sanitizeSoftwareModuleMetadataSortParam(final String sortParam) {
-        final Sort sorting;
-        if (sortParam != null) {
-            sorting = new Sort(SortUtility.parse(SoftwareModuleMetadataFields.class, sortParam));
-        } else {
-            // default sort
-            sorting = new Sort(Direction.ASC, SoftwareModuleMetadataFields.KEY.getFieldName());
+        if (sortParam == null) {
+            // default
+            return new Sort(Direction.ASC, SoftwareModuleMetadataFields.KEY.getFieldName());
         }
-        return sorting;
+        return new Sort(SortUtility.parse(SoftwareModuleMetadataFields.class, sortParam));
     }
 
     static Sort sanitizeRolloutSortParam(final String sortParam) {
-        final Sort sorting;
-        if (sortParam != null) {
-            sorting = new Sort(SortUtility.parse(RolloutFields.class, sortParam));
-        } else {
-            // default sort
-            sorting = new Sort(Direction.ASC, RolloutFields.NAME.getFieldName());
+        if (sortParam == null) {
+            // default
+            return new Sort(Direction.ASC, RolloutFields.NAME.getFieldName());
         }
-        return sorting;
+        return new Sort(SortUtility.parse(RolloutFields.class, sortParam));
     }
 
     static Sort sanitizeRolloutGroupSortParam(final String sortParam) {
-        final Sort sorting;
-        if (sortParam != null) {
-            sorting = new Sort(SortUtility.parse(RolloutGroupFields.class, sortParam));
-        } else {
-            // default sort
-            sorting = new Sort(Direction.ASC, RolloutGroupFields.NAME.getFieldName());
+        if (sortParam == null) {
+            // default
+            return new Sort(Direction.ASC, RolloutGroupFields.NAME.getFieldName());
         }
-        return sorting;
+        return new Sort(SortUtility.parse(RolloutGroupFields.class, sortParam));
     }
 }

--- a/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/SoftwareModuleTypeResource.java
+++ b/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/rest/resource/SoftwareModuleTypeResource.java
@@ -48,7 +48,7 @@ public class SoftwareModuleTypeResource implements SoftwareModuleTypeRestApi {
 
         final int sanitizedOffsetParam = PagingUtility.sanitizeOffsetParam(pagingOffsetParam);
         final int sanitizedLimitParam = PagingUtility.sanitizePageLimitParam(pagingLimitParam);
-        final Sort sorting = PagingUtility.sanitizeSoftwareModuleSortParam(sortParam);
+        final Sort sorting = PagingUtility.sanitizeSoftwareModuleTypeSortParam(sortParam);
 
         final Pageable pageable = new OffsetBasedPageRequest(sanitizedOffsetParam, sanitizedLimitParam, sorting);
 

--- a/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/DistributionSetTypeResourceTest.java
+++ b/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/DistributionSetTypeResourceTest.java
@@ -91,6 +91,43 @@ public class DistributionSetTypeResourceTest extends AbstractIntegrationTest {
 
     @Test
     @WithUser(principal = "uploadTester", allSpPermissions = true)
+    @Description("Checks the correct behaviour of /rest/v1/distributionsettypes GET requests with sorting by KEY.")
+    public void getDistributionSetTypesSortedByKey() throws Exception {
+
+        DistributionSetType testType = distributionSetManagement
+                .createDistributionSetType(new DistributionSetType("zzzzz", "TestName123", "Desc123"));
+        testType.setDescription("Desc1234");
+        testType = distributionSetManagement.updateDistributionSetType(testType);
+
+        // descending
+        mvc.perform(get("/rest/v1/distributionsettypes").accept(MediaType.APPLICATION_JSON)
+                .param(RestConstants.REQUEST_PARAMETER_SORTING, "KEY:DESC")).andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$content.[0].id", equalTo(testType.getId().intValue())))
+                .andExpect(jsonPath("$content.[0].name", equalTo("TestName123")))
+                .andExpect(jsonPath("$content.[0].description", equalTo("Desc1234")))
+                .andExpect(jsonPath("$content.[0].createdBy", equalTo("uploadTester")))
+                .andExpect(jsonPath("$content.[0].createdAt", equalTo(testType.getCreatedAt())))
+                .andExpect(jsonPath("$content.[0].lastModifiedBy", equalTo("uploadTester")))
+                .andExpect(jsonPath("$content.[0].lastModifiedAt", equalTo(testType.getLastModifiedAt())))
+                .andExpect(jsonPath("$content.[0].key", equalTo("zzzzz"))).andExpect(jsonPath("$total", equalTo(4)));
+
+        // ascending
+        mvc.perform(get("/rest/v1/distributionsettypes").accept(MediaType.APPLICATION_JSON)
+                .param(RestConstants.REQUEST_PARAMETER_SORTING, "KEY:ASC")).andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$content.[3].id", equalTo(testType.getId().intValue())))
+                .andExpect(jsonPath("$content.[3].name", equalTo("TestName123")))
+                .andExpect(jsonPath("$content.[3].description", equalTo("Desc1234")))
+                .andExpect(jsonPath("$content.[3].createdBy", equalTo("uploadTester")))
+                .andExpect(jsonPath("$content.[3].createdAt", equalTo(testType.getCreatedAt())))
+                .andExpect(jsonPath("$content.[3].lastModifiedBy", equalTo("uploadTester")))
+                .andExpect(jsonPath("$content.[3].lastModifiedAt", equalTo(testType.getLastModifiedAt())))
+                .andExpect(jsonPath("$content.[3].key", equalTo("zzzzz"))).andExpect(jsonPath("$total", equalTo(4)));
+    }
+
+    @Test
+    @WithUser(principal = "uploadTester", allSpPermissions = true)
     @Description("Checks the correct behaviour of /rest/v1/distributionsettypes POST requests.")
     public void createDistributionSetTypes() throws JSONException, Exception {
 

--- a/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/SoftwareModuleTypeResourceTest.java
+++ b/hawkbit-rest-resource/src/test/java/org/eclipse/hawkbit/rest/resource/SoftwareModuleTypeResourceTest.java
@@ -92,6 +92,46 @@ public class SoftwareModuleTypeResourceTest extends AbstractIntegrationTest {
 
     @Test
     @WithUser(principal = "uploadTester", allSpPermissions = true)
+    @Description("Checks the correct behaviour of /rest/v1/softwaremoduletypes GET requests with sorting by MAXASSIGNMENTS field.")
+    public void getSoftwareModuleTypesSortedByMaxAssignments() throws Exception {
+        SoftwareModuleType testType = softwareManagement
+                .createSoftwareModuleType(new SoftwareModuleType("test123", "TestName123", "Desc123", 5));
+        testType.setDescription("Desc1234");
+        testType = softwareManagement.updateSoftwareModuleType(testType);
+
+        // descending
+        mvc.perform(get("/rest/v1/softwaremoduletypes").accept(MediaType.APPLICATION_JSON)
+                .param(RestConstants.REQUEST_PARAMETER_SORTING, "MAXASSIGNMENTS:DESC"))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$content.[0].id", equalTo(testType.getId().intValue())))
+                .andExpect(jsonPath("$content.[0].name", equalTo("TestName123")))
+                .andExpect(jsonPath("$content.[0].description", equalTo("Desc1234")))
+                .andExpect(jsonPath("$content.[0].createdBy", equalTo("uploadTester")))
+                .andExpect(jsonPath("$content.[0].createdAt", equalTo(testType.getCreatedAt())))
+                .andExpect(jsonPath("$content.[0].lastModifiedBy", equalTo("uploadTester")))
+                .andExpect(jsonPath("$content.[0].lastModifiedAt", equalTo(testType.getLastModifiedAt())))
+                .andExpect(jsonPath("$content.[0].maxAssignments", equalTo(5)))
+                .andExpect(jsonPath("$content.[0].key", equalTo("test123"))).andExpect(jsonPath("$total", equalTo(4)));
+
+        // ascending
+        mvc.perform(get("/rest/v1/softwaremoduletypes").accept(MediaType.APPLICATION_JSON)
+                .param(RestConstants.REQUEST_PARAMETER_SORTING, "MAXASSIGNMENTS:ASC"))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$content.[3].id", equalTo(testType.getId().intValue())))
+                .andExpect(jsonPath("$content.[3].name", equalTo("TestName123")))
+                .andExpect(jsonPath("$content.[3].description", equalTo("Desc1234")))
+                .andExpect(jsonPath("$content.[3].createdBy", equalTo("uploadTester")))
+                .andExpect(jsonPath("$content.[3].createdAt", equalTo(testType.getCreatedAt())))
+                .andExpect(jsonPath("$content.[3].lastModifiedBy", equalTo("uploadTester")))
+                .andExpect(jsonPath("$content.[3].lastModifiedAt", equalTo(testType.getLastModifiedAt())))
+                .andExpect(jsonPath("$content.[3].maxAssignments", equalTo(5)))
+                .andExpect(jsonPath("$content.[3].key", equalTo("test123"))).andExpect(jsonPath("$total", equalTo(4)));
+    }
+
+    @Test
+    @WithUser(principal = "uploadTester", allSpPermissions = true)
     @Description("Checks the correct behaviour of /rest/v1/softwaremoduletypes POST requests.")
     public void createSoftwareModuleTypes() throws JSONException, Exception {
 


### PR DESCRIPTION
* Sorting for the two types did not work at all…blame on me it seems I messed that up somewhere last year :smile: 
* SM type field MAXASSIGNMENTS was in filter/sort actually called differently ("MAX"). I fixed that also as sort filter params should always have the same name as the field in the mgmt. API payloads. I mean how should an API use ever figure this out if we use different names.