### PR TITLE
Set the event strategy transient

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/HawkbitUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/HawkbitUI.java
@@ -61,7 +61,7 @@ public class HawkbitUI extends DefaultHawkbitUI implements DetachListener {
 
     private static final String EMPTY_VIEW = "";
 
-    private EventPushStrategy pushStrategy;
+    private transient EventPushStrategy pushStrategy;
 
     @Autowired
     private SpringViewProvider viewProvider;


### PR DESCRIPTION
Set the event strategy transient, because it is not serializable 

Signed-off-by: SirWayne <dennis.melzer@bosch-si.com>