### PR TITLE
Fix missing run as secruity context for header filter

### DIFF
--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilter.java
@@ -144,8 +144,8 @@ public class ControllerPreAuthenticatedSecurityHeaderFilter extends AbstractCont
     private final class GetSecurityAuthorityNameTenantRunner implements TenantAware.TenantRunner<String> {
         @Override
         public String run() {
-            return tenantConfigurationManagement.getConfigurationValue(
-                    TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_AUTHORITY_NAME, String.class).getValue();
+            return systemSecurityContext.runAsSystem(() -> tenantConfigurationManagement.getConfigurationValue(
+                    TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_AUTHORITY_NAME, String.class).getValue());
         }
     }
 }


### PR DESCRIPTION
Fix missing run as secruity context for header filter

Signed-off-by: SirWayne <dennis.melzer@bosch-si.com>