### PR TITLE
Remove transitive compile dependency objenesis 

### DIFF
--- a/hawkbit-repository/pom.xml
+++ b/hawkbit-repository/pom.xml
@@ -94,6 +94,12 @@
       <dependency>
          <groupId>org.springframework.hateoas</groupId>
          <artifactId>spring-hateoas</artifactId>
+         <exclusions>
+            <exclusion>
+               <groupId>org.objenesis</groupId>
+               <artifactId>objenesis</artifactId>
+            </exclusion>
+         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.flywaydb</groupId>

--- a/hawkbit-rest-api/pom.xml
+++ b/hawkbit-rest-api/pom.xml
@@ -29,6 +29,12 @@
       <dependency>
          <groupId>org.springframework.hateoas</groupId>
          <artifactId>spring-hateoas</artifactId>
+         <exclusions>
+            <exclusion>
+               <groupId>org.objenesis</groupId>
+               <artifactId>objenesis</artifactId>
+            </exclusion>
+         </exclusions>
       </dependency>
       <dependency>
          <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
…as it contains problematic classes license wise.

see CQ https://dev.eclipse.org/ipzilla/show_bug.cgi?id=10624