### PR TITLE
Consolidate equals hashcode

### DIFF
--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
@@ -52,7 +52,7 @@ import org.eclipse.persistence.annotations.CascadeOnDelete;
         @NamedEntityGraph(name = "Action.all", attributeNodes = { @NamedAttributeNode("distributionSet"),
                 @NamedAttributeNode(value = "target", subgraph = "target.ds") }, subgraphs = @NamedSubgraph(name = "target.ds", attributeNodes = @NamedAttributeNode("assignedDistributionSet"))) })
 @Entity
-public class Action extends TenantAwareBaseEntity implements Comparable<Action> {
+public class Action extends TenantAwareBaseEntity {
     private static final long serialVersionUID = 1L;
 
     /**
@@ -198,14 +198,6 @@ public class Action extends TenantAwareBaseEntity implements Comparable<Action> 
         this.rollout = rollout;
     }
 
-    @Override
-    public int compareTo(final Action o) {
-        if (super.getId() == null || o == null || o.getId() == null) {
-            return 0;
-        }
-        return super.getId().compareTo(o.getId());
-    }
-
     /**
      * checks if the {@link #forcedTime} is hit by the given
      * {@code hitTimeMillis}, by means if the given milliseconds are greater
@@ -252,26 +244,6 @@ public class Action extends TenantAwareBaseEntity implements Comparable<Action> 
     @Override
     public String toString() {
         return "Action [distributionSet=" + distributionSet + ", getId()=" + getId() + "]";
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof Action)) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/ActionStatus.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/ActionStatus.java
@@ -140,24 +140,4 @@ public class ActionStatus extends TenantAwareBaseEntity {
         this.status = status;
     }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof ActionStatus)) {
-            return false;
-        }
-
-        return true;
-    }
-
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Artifact.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Artifact.java
@@ -53,24 +53,4 @@ public abstract class Artifact extends TenantAwareBaseEntity {
     public void setSize(final Long size) {
         this.size = size;
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof Artifact)) {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/BaseEntity.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/BaseEntity.java
@@ -108,6 +108,11 @@ public abstract class BaseEntity implements Serializable, Identifiable<Long> {
         return optLockRevision;
     }
 
+    // for test purposes only
+    void setOptLockRevision(final long optLockRevision) {
+        this.optLockRevision = optLockRevision;
+    }
+
     @Override
     public Long getId() {
         return id;
@@ -135,6 +140,7 @@ public abstract class BaseEntity implements Serializable, Identifiable<Long> {
         int result = 1;
         result = prime * result + (id == null ? 0 : id.hashCode());
         result = prime * result + (int) (optLockRevision ^ optLockRevision >>> 32);
+        result = prime * result + this.getClass().getName().hashCode();
         return result;
     }
 
@@ -154,7 +160,7 @@ public abstract class BaseEntity implements Serializable, Identifiable<Long> {
         if (obj == null) {
             return false;
         }
-        if (!(obj instanceof BaseEntity)) {
+        if (!(this.getClass().isInstance(obj))) {
             return false;
         }
         final BaseEntity other = (BaseEntity) obj;

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSet.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSet.java
@@ -150,26 +150,6 @@ public class DistributionSet extends NamedVersionedEntity {
         return actions;
     }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof DistributionSet)) {
-            return false;
-        }
-
-        return true;
-    }
-
     public boolean isRequiredMigrationStep() {
         return requiredMigrationStep;
     }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetType.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetType.java
@@ -285,24 +285,4 @@ public class DistributionSetType extends NamedEntity {
         return "DistributionSetType [key=" + key + ", isDeleted()=" + isDeleted() + ", getId()=" + getId() + "]";
     }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof DistributionSetType)) {
-            return false;
-        }
-
-        return true;
-    }
-
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/ExternalArtifactProvider.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/ExternalArtifactProvider.java
@@ -73,24 +73,4 @@ public class ExternalArtifactProvider extends NamedEntity {
         this.defaultSuffix = defaultSuffix;
     }
 
-    @Override
-    public int hashCode() { // NOSONAR - as this is generated
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) { // NOSONAR - as this is generated
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof ExternalArtifactProvider)) {
-            return false;
-        }
-
-        return true;
-    }
-
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/NamedEntity.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/NamedEntity.java
@@ -60,24 +60,4 @@ public abstract class NamedEntity extends TenantAwareBaseEntity {
     public void setName(final String name) {
         this.name = name;
     }
-
-    @Override
-    public int hashCode() { // NOSONAR - as this is generated
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) { // NOSONAR - as this is generated
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof NamedEntity)) {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/NamedVersionedEntity.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/NamedVersionedEntity.java
@@ -47,25 +47,4 @@ public abstract class NamedVersionedEntity extends NamedEntity {
     public void setVersion(final String version) {
         this.version = version;
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof NamedVersionedEntity)) {
-            return false;
-        }
-
-        return true;
-    }
-
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Rollout.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Rollout.java
@@ -231,24 +231,4 @@ public class Rollout extends NamedEntity {
          */
         ERROR_STARTING;
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof Rollout)) {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/RolloutGroup.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/RolloutGroup.java
@@ -476,25 +476,4 @@ public class RolloutGroup extends NamedEntity {
             return this;
         }
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof RolloutGroup)) {
-            return false;
-        }
-
-        return true;
-    }
-
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/SoftwareModule.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/SoftwareModule.java
@@ -233,26 +233,6 @@ public class SoftwareModule extends NamedVersionedEntity {
                 + ", revision=" + getOptLockRevision() + ", Id=" + getId() + ", type=" + getType().getName() + "]";
     }
 
-    @Override
-    public int hashCode() { // NOSONAR - as this is generated
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) { // NOSONAR - as this is generated
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof SoftwareModule)) {
-            return false;
-        }
-
-        return true;
-    }
-
     /**
      * @return the assignedTo
      */

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/SoftwareModuleType.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/SoftwareModuleType.java
@@ -114,24 +114,4 @@ public class SoftwareModuleType extends NamedEntity {
     public String toString() {
         return "SoftwareModuleType [key=" + key + ", getName()=" + getName() + ", getId()=" + getId() + "]";
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof SoftwareModuleType)) {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Tag.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Tag.java
@@ -56,24 +56,4 @@ public abstract class Tag extends NamedEntity implements Identifiable<Long> {
     public String toString() {
         return "Tag [getOptLockRevision()=" + getOptLockRevision() + ", getId()=" + getId() + "]";
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof Tag)) {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
@@ -131,31 +131,6 @@ public class Target extends NamedEntity implements Persistable<Long> {
         securityToken = null;
     }
 
-    /**
-     * Note: For Target we extended the general strategy by adding controllerId
-     * as well.
-     * 
-     * @see org.eclipse.hawkbit.repository.model.BaseEntity#equals(java.lang.Object)
-     */
-    @Override
-    public boolean equals(final Object obj) {// NOSONAR - as this is generated
-        if (obj == null) {
-            return false;
-        }
-        if (!(obj instanceof Target)) {
-            return false;
-        }
-        final Target other = (Target) obj;
-        if (controllerId == null) {
-            if (other.controllerId != null) {
-                return false;
-            }
-        } else if (!controllerId.equals(other.controllerId)) {
-            return false;
-        }
-        return true;
-    }
-
     public DistributionSet getAssignedDistributionSet() {
         return assignedDistributionSet;
     }
@@ -166,14 +141,6 @@ public class Target extends NamedEntity implements Persistable<Long> {
 
     public Set<TargetTag> getTags() {
         return tags;
-    }
-
-    @Override
-    public int hashCode() { // NOSONAR - as this is generated
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (controllerId == null ? 0 : controllerId.hashCode());
-        return result;
     }
 
     public void setAssignedDistributionSet(final DistributionSet assignedDistributionSet) {

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/TargetFilterQuery.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/TargetFilterQuery.java
@@ -55,24 +55,4 @@ public class TargetFilterQuery extends TenantAwareBaseEntity {
     public void setQuery(final String query) {
         this.query = query;
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof TargetFilterQuery)) {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/TenantAwareBaseEntity.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/TenantAwareBaseEntity.java
@@ -99,9 +99,6 @@ public abstract class TenantAwareBaseEntity extends BaseEntity {
         if (!super.equals(obj)) {
             return false;
         }
-        if (!(obj instanceof TenantAwareBaseEntity)) {
-            return false;
-        }
         final TenantAwareBaseEntity other = (TenantAwareBaseEntity) obj;
         if (tenant == null) {
             if (other.tenant != null) {

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/TenantConfiguration.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/TenantConfiguration.java
@@ -52,54 +52,20 @@ public class TenantConfiguration extends TenantAwareBaseEntity implements Serial
 
     }
 
-    /**
-     * @return the key
-     */
     public String getKey() {
         return key;
     }
 
-    /**
-     * @param key
-     *            the key to set
-     */
     public void setKey(final String key) {
         this.key = key;
     }
 
-    /**
-     * @return the value
-     */
     public String getValue() {
         return value;
     }
 
-    /**
-     * @param value
-     *            the value to set
-     */
     public void setValue(final String value) {
         this.value = value;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + this.getClass().getName().hashCode();
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof TenantConfiguration)) {
-            return false;
-        }
-
-        return true;
     }
 
 }

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/DeploymentManagementTest.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/DeploymentManagementTest.java
@@ -611,8 +611,8 @@ public class DeploymentManagementTest extends AbstractIntegrationTest {
         final List<Target> deployResWithDsBTargets = targetManagement.findTargetByControllerID(deployResWithDsB
                 .getDeployedTargets().stream().map(target -> target.getControllerId()).collect(Collectors.toList()));
 
-        assertThat(deployed2DS).as("deployed ds is wrong").containsAll(deployResWithDsB.getDeployedTargets());
-        assertThat(deployed2DS).as("deployed ds is wrong").hasSameSizeAs(deployResWithDsB.getDeployedTargets());
+        assertThat(deployed2DS).as("deployed ds is wrong").containsAll(deployResWithDsBTargets);
+        assertThat(deployed2DS).as("deployed ds is wrong").hasSameSizeAs(deployResWithDsBTargets);
 
         for (final Target t_ : deployed2DS) {
             final Target t = targetManagement.findTargetByControllerID(t_.getControllerId());

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/DeploymentManagementTest.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/DeploymentManagementTest.java
@@ -18,6 +18,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.AbstractIntegrationTest;
 import org.eclipse.hawkbit.Constants;
@@ -386,7 +387,7 @@ public class DeploymentManagementTest extends AbstractIntegrationTest {
                 .createTargets(TestDataUtil.buildTargetFixtures(10, myCtrlIDPref, "first description"));
 
         final String myDeployedCtrlIDPref = "myDeployedCtrlID";
-        final List<Target> savedDeployedTargets = targetManagement
+        List<Target> savedDeployedTargets = targetManagement
                 .createTargets(TestDataUtil.buildTargetFixtures(20, myDeployedCtrlIDPref, "first description"));
 
         final DistributionSet ds = TestDataUtil.generateDistributionSet("", softwareManagement,
@@ -398,6 +399,10 @@ public class DeploymentManagementTest extends AbstractIntegrationTest {
         assertThat(actionRepository.findAll(pageReq).getNumberOfElements()).as("wrong size of actions").isEqualTo(20);
 
         final Iterable<Target> allFoundTargets = targetManagement.findTargetsAll(pageReq).getContent();
+
+        // get final updated version of targets
+        savedDeployedTargets = targetManagement.findTargetByControllerID(
+                savedDeployedTargets.stream().map(target -> target.getControllerId()).collect(Collectors.toList()));
 
         assertThat(allFoundTargets).as("founded targets are wrong").containsAll(savedDeployedTargets)
                 .containsAll(savedNakedTargets);
@@ -601,6 +606,10 @@ public class DeploymentManagementTest extends AbstractIntegrationTest {
         final Iterable<Target> deployed2DS = deploymentManagement
                 .assignDistributionSet(dsA, deployResWithDsB.getDeployedTargets()).getAssignedTargets();
         actionRepository.findByDistributionSet(pageRequest, dsA).getContent().get(1);
+
+        // get final updated version of targets
+        final List<Target> deployResWithDsBTargets = targetManagement.findTargetByControllerID(deployResWithDsB
+                .getDeployedTargets().stream().map(target -> target.getControllerId()).collect(Collectors.toList()));
 
         assertThat(deployed2DS).as("deployed ds is wrong").containsAll(deployResWithDsB.getDeployedTargets());
         assertThat(deployed2DS).as("deployed ds is wrong").hasSameSizeAs(deployResWithDsB.getDeployedTargets());

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/TargetManagementSearchTest.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/TargetManagementSearchTest.java
@@ -109,6 +109,14 @@ public class TargetManagementSearchTest extends AbstractIntegrationTest {
         both.add(TargetUpdateStatus.UNKNOWN);
         both.add(TargetUpdateStatus.PENDING);
 
+        // get final updated version of targets
+        targAs = targetManagement.findTargetByControllerID(
+                targAs.stream().map(target -> target.getControllerId()).collect(Collectors.toList()));
+        targBs = targetManagement.findTargetByControllerID(
+                targBs.stream().map(target -> target.getControllerId()).collect(Collectors.toList()));
+        targCs = targetManagement.findTargetByControllerID(
+                targCs.stream().map(target -> target.getControllerId()).collect(Collectors.toList()));
+
         // try to find several targets with different filter settings
         verifyThatRepositoryContains400Targets();
         verifyThat200TargetsHaveTagD(targTagW, concat(targBs, targCs));
@@ -708,10 +716,13 @@ public class TargetManagementSearchTest extends AbstractIntegrationTest {
         final DistributionSet assignedSet = TestDataUtil.generateDistributionSet("", softwareManagement,
                 distributionSetManagement);
         targetManagement.createTargets(TestDataUtil.generateTargets(10, "unassigned"));
-        final List<Target> assignedtargets = targetManagement
-                .createTargets(TestDataUtil.generateTargets(10, "assigned"));
+        List<Target> assignedtargets = targetManagement.createTargets(TestDataUtil.generateTargets(10, "assigned"));
 
         deploymentManagement.assignDistributionSet(assignedSet, assignedtargets);
+
+        // get final updated version of targets
+        assignedtargets = targetManagement.findTargetByControllerID(
+                assignedtargets.stream().map(target -> target.getControllerId()).collect(Collectors.toList()));
 
         assertThat(targetManagement.findTargetByAssignedDistributionSet(assignedSet.getId(), pageReq))
                 .as("Contains the assigned targets").containsAll(assignedtargets)
@@ -727,8 +738,7 @@ public class TargetManagementSearchTest extends AbstractIntegrationTest {
         final DistributionSet installedSet = TestDataUtil.generateDistributionSet("another", softwareManagement,
                 distributionSetManagement);
         targetManagement.createTargets(TestDataUtil.generateTargets(10, "unassigned"));
-        final List<Target> assignedtargets = targetManagement
-                .createTargets(TestDataUtil.generateTargets(10, "assigned"));
+        List<Target> assignedtargets = targetManagement.createTargets(TestDataUtil.generateTargets(10, "assigned"));
 
         // set on installed and assign another one
         deploymentManagement.assignDistributionSet(installedSet, assignedtargets).getActions().forEach(actionId -> {
@@ -739,11 +749,13 @@ public class TargetManagementSearchTest extends AbstractIntegrationTest {
         });
         deploymentManagement.assignDistributionSet(assignedSet, assignedtargets);
 
+        assignedtargets = targetManagement.findTargetByControllerID(
+                assignedtargets.stream().map(target -> target.getControllerId()).collect(Collectors.toList()));
+
         assertThat(targetManagement.findTargetByAssignedDistributionSet(assignedSet.getId(),
                 TargetSpecifications.hasInstalledDistributionSet(installedSet.getId()), pageReq))
                         .as("Contains the assigned targets").containsAll(assignedtargets)
                         .as("and that means the following expected amount").hasSize(10);
-
     }
 
     @Test
@@ -754,8 +766,7 @@ public class TargetManagementSearchTest extends AbstractIntegrationTest {
         final DistributionSet installedSet = TestDataUtil.generateDistributionSet("another", softwareManagement,
                 distributionSetManagement);
         targetManagement.createTargets(TestDataUtil.generateTargets(10, "unassigned"));
-        final List<Target> installedtargets = targetManagement
-                .createTargets(TestDataUtil.generateTargets(10, "assigned"));
+        List<Target> installedtargets = targetManagement.createTargets(TestDataUtil.generateTargets(10, "assigned"));
 
         // set on installed and assign another one
         deploymentManagement.assignDistributionSet(installedSet, installedtargets).getActions().forEach(actionId -> {
@@ -765,6 +776,10 @@ public class TargetManagementSearchTest extends AbstractIntegrationTest {
                     new ActionStatus(action, Status.FINISHED, System.currentTimeMillis(), "message"), action);
         });
         deploymentManagement.assignDistributionSet(assignedSet, installedtargets);
+
+        // get final updated version of targets
+        installedtargets = targetManagement.findTargetByControllerID(
+                installedtargets.stream().map(target -> target.getControllerId()).collect(Collectors.toList()));
 
         assertThat(targetManagement.findTargetByInstalledDistributionSet(installedSet.getId(), pageReq))
                 .as("Contains the assigned targets").containsAll(installedtargets)
@@ -780,8 +795,7 @@ public class TargetManagementSearchTest extends AbstractIntegrationTest {
         final DistributionSet installedSet = TestDataUtil.generateDistributionSet("another", softwareManagement,
                 distributionSetManagement);
         targetManagement.createTargets(TestDataUtil.generateTargets(10, "unassigned"));
-        final List<Target> installedtargets = targetManagement
-                .createTargets(TestDataUtil.generateTargets(10, "assigned"));
+        List<Target> installedtargets = targetManagement.createTargets(TestDataUtil.generateTargets(10, "assigned"));
 
         // set on installed and assign another one
         deploymentManagement.assignDistributionSet(installedSet, installedtargets).getActions().forEach(actionId -> {
@@ -791,6 +805,10 @@ public class TargetManagementSearchTest extends AbstractIntegrationTest {
                     new ActionStatus(action, Status.FINISHED, System.currentTimeMillis(), "message"), action);
         });
         deploymentManagement.assignDistributionSet(assignedSet, installedtargets);
+
+        // get final updated version of targets
+        installedtargets = targetManagement.findTargetByControllerID(
+                installedtargets.stream().map(target -> target.getControllerId()).collect(Collectors.toList()));
 
         assertThat(targetManagement.findTargetByInstalledDistributionSet(installedSet.getId(),
                 TargetSpecifications.hasAssignedDistributionSet(assignedSet.getId()), pageReq))

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/model/ModelEqualsHashcodeTest.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/model/ModelEqualsHashcodeTest.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.hawkbit.repository.model;
 
 import static org.fest.assertions.api.Assertions.assertThat;

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/model/ModelEqualsHashcodeTest.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/model/ModelEqualsHashcodeTest.java
@@ -56,7 +56,8 @@ public class ModelEqualsHashcodeTest extends AbstractIntegrationTest {
     public void changedEntitiesAreNotEqual() {
         final SoftwareModuleType type = softwareManagement
                 .createSoftwareModuleType(new SoftwareModuleType("test", "test", "test", 1));
-        assertThat(type).isNotEqualTo(new SoftwareModuleType("test", "test", "test", 1));
+        assertThat(type).as("persited entity is not equal to regular object")
+                .isNotEqualTo(new SoftwareModuleType("test", "test", "test", 1));
 
         type.setDescription("another");
         final SoftwareModuleType updated = softwareManagement.updateSoftwareModuleType(type);
@@ -84,7 +85,8 @@ public class ModelEqualsHashcodeTest extends AbstractIntegrationTest {
     public void updatedEntitiesHaveDifferentHashcodes() {
         final SoftwareModuleType type = softwareManagement
                 .createSoftwareModuleType(new SoftwareModuleType("test", "test", "test", 1));
-        assertThat(type.hashCode()).isNotEqualTo(new SoftwareModuleType("test", "test", "test", 1).hashCode());
+        assertThat(type.hashCode()).as("persited entity does not have same hashcode as regular object")
+                .isNotEqualTo(new SoftwareModuleType("test", "test", "test", 1).hashCode());
 
         final int beforeChange = type.hashCode();
         type.setDescription("another");

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/model/ModelEqualsHashcodeTest.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/model/ModelEqualsHashcodeTest.java
@@ -1,0 +1,92 @@
+package org.eclipse.hawkbit.repository.model;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import org.eclipse.hawkbit.AbstractIntegrationTest;
+import org.junit.Test;
+
+import ru.yandex.qatools.allure.annotations.Description;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Stories;
+
+@Features("Unit Tests - Repository")
+@Stories("Repository Model")
+public class ModelEqualsHashcodeTest extends AbstractIntegrationTest {
+
+    @Test
+    @Description("Verfies that different objects even with identical primary key, version and tenant "
+            + "return different hash codes.")
+    public void differentEntitiesReturnDifferentHashCodes() {
+        assertThat(new Action().hashCode()).as("action should have different hashcode than action status")
+                .isNotEqualTo(new ActionStatus().hashCode());
+        assertThat(new DistributionSet().hashCode())
+                .as("Distribution set should have different hashcode than software module")
+                .isNotEqualTo(new SoftwareModule().hashCode());
+        assertThat(new DistributionSet().hashCode())
+                .as("Distribution set should have different hashcode than action status")
+                .isNotEqualTo(new ActionStatus().hashCode());
+        assertThat(new DistributionSetType().hashCode())
+                .as("Distribution set type should have different hashcode than action status")
+                .isNotEqualTo(new ActionStatus().hashCode());
+    }
+
+    @Test
+    @Description("Verfies that different object even with identical primary key, version and tenant "
+            + "are not equal.")
+    public void differentEntitiesAreNotEqual() {
+        assertThat(new Action().equals(new ActionStatus())).as("action equals action status").isFalse();
+        assertThat(new DistributionSet().equals(new SoftwareModule())).as("Distribution set equals software module")
+                .isFalse();
+        assertThat(new DistributionSet().equals(new ActionStatus())).as("Distribution set equals action status")
+                .isFalse();
+        assertThat(new DistributionSetType().equals(new ActionStatus()))
+                .as("Distribution set type equals action status").isFalse();
+    }
+
+    @Test
+    @Description("Verfies that updated entities are not equal.")
+    public void changedEntitiesAreNotEqual() {
+        final SoftwareModuleType type = softwareManagement
+                .createSoftwareModuleType(new SoftwareModuleType("test", "test", "test", 1));
+        assertThat(type).isNotEqualTo(new SoftwareModuleType("test", "test", "test", 1));
+
+        type.setDescription("another");
+        final SoftwareModuleType updated = softwareManagement.updateSoftwareModuleType(type);
+        assertThat(type).as("Changed entity is not equal to the previous version").isNotEqualTo(updated);
+    }
+
+    @Test
+    @Description("Verify that no proxy of the entity manager has an influence on the equals or hashcode result.")
+    public void managedEntityIsEqualToUnamangedObjectWithSameKey() {
+        final SoftwareModuleType type = softwareManagement
+                .createSoftwareModuleType(new SoftwareModuleType("test", "test", "test", 1));
+
+        final SoftwareModuleType mock = new SoftwareModuleType("test", "test", "test", 1);
+        mock.setId(type.getId());
+        mock.setOptLockRevision(type.getOptLockRevision());
+        mock.setTenant(type.getTenant());
+
+        assertThat(type).as("managed entity is equal to regular object with same content").isEqualTo(mock);
+        assertThat(type.hashCode()).as("managed entity has same hash code as regular object with same content")
+                .isEqualTo(mock.hashCode());
+    }
+
+    @Test
+    @Description("Verfies that updated entities do not have the same hashcode.")
+    public void updatedEntitiesHaveDifferentHashcodes() {
+        final SoftwareModuleType type = softwareManagement
+                .createSoftwareModuleType(new SoftwareModuleType("test", "test", "test", 1));
+        assertThat(type.hashCode()).isNotEqualTo(new SoftwareModuleType("test", "test", "test", 1).hashCode());
+
+        final int beforeChange = type.hashCode();
+        type.setDescription("another");
+        assertThat(type.hashCode())
+                .as("Changed entity has no different hashcode than the previous version until updated in repository")
+                .isEqualTo(beforeChange);
+
+        final SoftwareModuleType updated = softwareManagement.updateSoftwareModuleType(type);
+        assertThat(type.hashCode()).as("Updated entity has different hashcode than the previous version")
+                .isNotEqualTo(updated.hashCode());
+    }
+
+}


### PR DESCRIPTION
- Equals and dashcode of baseentities consolidated by means that an override is only necessary if there is an actual business requirement.
- Removed a comparable that is no longer necessary

Signed-off-by: Kai Zimmermann <kai.zimmermann@bosch-si.com>