### PR TITLE
Fix null handling for all drag and drop table

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/footer/SMDeleteActionsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/footer/SMDeleteActionsLayout.java
@@ -8,16 +8,15 @@
  */
 package org.eclipse.hawkbit.ui.artifacts.footer;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.hawkbit.ui.artifacts.event.UploadArtifactUIEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.UploadViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.artifacts.state.ArtifactUploadState;
 import org.eclipse.hawkbit.ui.common.footer.AbstractDeleteActionsLayout;
+import org.eclipse.hawkbit.ui.common.table.AbstractTable;
 import org.eclipse.hawkbit.ui.management.event.DragEvent;
 import org.eclipse.hawkbit.ui.utils.SPUIComponetIdProvider;
-import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventScope;
@@ -155,13 +154,9 @@ public class SMDeleteActionsLayout extends AbstractDeleteActionsLayout {
 
     private void addToDeleteList(final Table sourceTable, final TableTransferable transferable) {
         @SuppressWarnings("unchecked")
-        final Set<Long> swModuleSelected = (Set<Long>) sourceTable.getValue();
-        final Set<Long> swModuleIdNameSet = new HashSet<>();
-        if (!swModuleSelected.contains(transferable.getData(SPUIDefinitions.ITEMID))) {
-            swModuleIdNameSet.add((Long) transferable.getData(SPUIDefinitions.ITEMID));
-        } else {
-            swModuleIdNameSet.addAll(swModuleSelected);
-        }
+        final AbstractTable<?, Long> swTable = (AbstractTable<?, Long>) sourceTable;
+        final Set<Long> swModuleIdNameSet = swTable.getDeletedEntityByTransferable(transferable);
+
         swModuleIdNameSet.forEach(id -> {
             final String swModuleName = (String) sourceTable.getContainerDataSource().getItem(id)
                     .getItemProperty(SPUILabelDefinitions.NAME_VERSION).getValue();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTable.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.ui.common.table;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -229,6 +230,30 @@ public abstract class AbstractTable<E extends NamedEntity, I> extends Table {
         } else if (BaseEntityEventType.NEW_ENTITY == event.getEventType()) {
             UI.getCurrent().access(() -> addEntity(event.getEntity()));
         }
+    }
+
+    /**
+     * Return the entity which should be deleted by a transferable
+     * 
+     * @param transferable
+     *            the table transferable
+     * @return set of entities id which will deleted
+     */
+    @SuppressWarnings("unchecked")
+    public Set<I> getDeletedEntityByTransferable(final TableTransferable transferable) {
+        final Set<I> selectedEntities = (Set<I>) getTableValue(this);
+        final Set<I> ids = new HashSet<>();
+        final Object tranferableData = transferable.getData(SPUIDefinitions.ITEMID);
+        if (tranferableData == null) {
+            return ids;
+        }
+
+        if (!selectedEntities.contains(tranferableData)) {
+            ids.add((I) tranferableData);
+        } else {
+            ids.addAll(selectedEntities);
+        }
+        return ids;
     }
 
     protected abstract E findEntityByTableValue(I lastSelectedId);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
@@ -209,9 +209,9 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         };
     }
 
-    @SuppressWarnings("unchecked")
     private void onDrop(final DragAndDropEvent event) {
         final TableTransferable transferable = (TableTransferable) event.getTransferable();
+        @SuppressWarnings("unchecked")
         final AbstractTable<?, Long> source = (AbstractTable<SoftwareModule, Long>) transferable.getSourceComponent();
         final Set<Long> softwareModulesIdList = source.getDeletedEntityByTransferable(transferable);
 
@@ -224,11 +224,6 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         }
     }
 
-    /**
-     * @param source
-     * @param softwareModulesIdList
-     * @param item
-     */
     private void handleDropEvent(final Table source, final Set<Long> softwareModulesIdList, final Item item) {
         final Long distId = (Long) item.getItemProperty("id").getValue();
         final String distName = (String) item.getItemProperty("name").getValue();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
@@ -29,6 +29,7 @@ import org.eclipse.hawkbit.repository.model.SoftwareModuleIdName;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent.SoftwareModuleEventType;
 import org.eclipse.hawkbit.ui.common.table.AbstractNamedVersionTable;
+import org.eclipse.hawkbit.ui.common.table.AbstractTable;
 import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionsUIEvent;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionsViewAcceptCriteria;
@@ -208,17 +209,11 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         };
     }
 
+    @SuppressWarnings("unchecked")
     private void onDrop(final DragAndDropEvent event) {
         final TableTransferable transferable = (TableTransferable) event.getTransferable();
-        final Table source = transferable.getSourceComponent();
-        final Set<Long> softwareModuleSelected = (Set<Long>) source.getValue();
-        final Set<Long> softwareModulesIdList = new HashSet<>();
-
-        if (!softwareModuleSelected.contains(transferable.getData("itemId"))) {
-            softwareModulesIdList.add((Long) transferable.getData("itemId"));
-        } else {
-            softwareModulesIdList.addAll(softwareModuleSelected);
-        }
+        final AbstractTable<?, Long> source = (AbstractTable<SoftwareModule, Long>) transferable.getSourceComponent();
+        final Set<Long> softwareModulesIdList = source.getDeletedEntityByTransferable(transferable);
 
         final AbstractSelectTargetDetails dropData = (AbstractSelectTargetDetails) event.getTargetDetails();
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/footer/DSDeleteActionsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/footer/DSDeleteActionsLayout.java
@@ -20,6 +20,7 @@ import org.eclipse.hawkbit.repository.model.DistributionSetIdName;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleIdName;
 import org.eclipse.hawkbit.ui.common.footer.AbstractDeleteActionsLayout;
+import org.eclipse.hawkbit.ui.common.table.AbstractTable;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionsUIEvent;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionsViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.distributions.event.DragEvent;
@@ -188,13 +189,8 @@ public class DSDeleteActionsLayout extends AbstractDeleteActionsLayout {
 
     private void addInDeleteDistributionList(final Table sourceTable, final TableTransferable transferable) {
         @SuppressWarnings("unchecked")
-        final Set<DistributionSetIdName> distSelected = (Set<DistributionSetIdName>) sourceTable.getValue();
-        final Set<DistributionSetIdName> distributionIdNameSet = new HashSet<>();
-        if (!distSelected.contains(transferable.getData(SPUIDefinitions.ITEMID))) {
-            distributionIdNameSet.add((DistributionSetIdName) transferable.getData(SPUIDefinitions.ITEMID));
-        } else {
-            distributionIdNameSet.addAll(distSelected);
-        }
+        final AbstractTable<?, DistributionSetIdName> table = (AbstractTable<?, DistributionSetIdName>) sourceTable;
+        final Set<DistributionSetIdName> distributionIdNameSet = table.getDeletedEntityByTransferable(transferable);
         /*
          * Flags to identify whether all dropped distributions are already in
          * the deleted list (or) some distributions are already in the deleted
@@ -224,15 +220,10 @@ public class DSDeleteActionsLayout extends AbstractDeleteActionsLayout {
     }
 
     private void addToSWDeleteList(final Table sourceTable, final TableTransferable transferable) {
-
         @SuppressWarnings("unchecked")
-        final Set<Long> swModuleSelected = (Set<Long>) sourceTable.getValue();
-        final Set<Long> swModuleIdNameSet = new HashSet<>();
-        if (!swModuleSelected.contains(transferable.getData(SPUIDefinitions.ITEMID))) {
-            swModuleIdNameSet.add((Long) transferable.getData(SPUIDefinitions.ITEMID));
-        } else {
-            swModuleIdNameSet.addAll(swModuleSelected);
-        }
+        final AbstractTable<?, Long> swTable = (AbstractTable<?, Long>) sourceTable;
+        final Set<Long> swModuleIdNameSet = swTable.getDeletedEntityByTransferable(transferable);
+
         swModuleIdNameSet.forEach(id -> {
             final String swModuleName = (String) sourceTable.getContainerDataSource().getItem(id)
                     .getItemProperty(SPUILabelDefinitions.NAME_VERSION).getValue();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTable.java
@@ -26,6 +26,7 @@ import org.eclipse.hawkbit.repository.model.DistributionSetTagAssignmentResult;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetIdName;
 import org.eclipse.hawkbit.ui.common.table.AbstractNamedVersionTable;
+import org.eclipse.hawkbit.ui.common.table.AbstractTable;
 import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.management.event.DistributionTableEvent;
@@ -350,17 +351,12 @@ public class DistributionTable extends AbstractNamedVersionTable<DistributionSet
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void assignTargetToDs(final DragAndDropEvent event) {
         final TableTransferable transferable = (TableTransferable) event.getTransferable();
-        final Table source = transferable.getSourceComponent();
-        final Set<TargetIdName> targetsSelected = getTableValue(source);
-        final Set<TargetIdName> targetDetailsList = new HashSet<>();
-
-        if (!targetsSelected.contains(transferable.getData("itemId"))) {
-            targetDetailsList.add((TargetIdName) transferable.getData("itemId"));
-        } else {
-            targetDetailsList.addAll(targetsSelected);
-        }
+        final AbstractTable<?, TargetIdName> source = (AbstractTable<?, TargetIdName>) transferable
+                .getSourceComponent();
+        final Set<TargetIdName> targetDetailsList = source.getDeletedEntityByTransferable(transferable);
 
         final AbstractSelectTargetDetails dropData = (AbstractSelectTargetDetails) event.getTargetDetails();
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/event/DistributionTagDropEvent.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/event/DistributionTagDropEvent.java
@@ -8,7 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.management.event;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -17,6 +16,7 @@ import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.model.DistributionSetIdName;
 import org.eclipse.hawkbit.repository.model.DistributionSetTagAssignmentResult;
+import org.eclipse.hawkbit.ui.common.table.AbstractTable;
 import org.eclipse.hawkbit.ui.management.state.DistributionTableFilters;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.I18N;
@@ -127,28 +127,25 @@ public class DistributionTagDropEvent implements DropHandler {
         return true;
     }
 
+    @SuppressWarnings("unchecked")
     private void processDistributionDrop(final DragAndDropEvent event) {
 
         final com.vaadin.event.dd.TargetDetails targetDetails = event.getTargetDetails();
 
         final TableTransferable transferable = (TableTransferable) event.getTransferable();
-        final Table source = transferable.getSourceComponent();
+        final AbstractTable<?, DistributionSetIdName> source = (AbstractTable<?, DistributionSetIdName>) transferable
+                .getSourceComponent();
 
-        @SuppressWarnings("unchecked")
-        final Set<DistributionSetIdName> distSelected = (Set<DistributionSetIdName>) source.getValue();
-        final Set<Long> distributionList = new HashSet<>();
-        if (!distSelected.contains(transferable.getData(ITEMID))) {
-            distributionList.add(((DistributionSetIdName) transferable.getData(ITEMID)).getId());
-        } else {
-            distributionList.addAll(distSelected.stream().map(t -> t.getId()).collect(Collectors.toList()));
-        }
+        final Set<DistributionSetIdName> distSelected = source.getDeletedEntityByTransferable(transferable);
+        final Set<Long> distributionList = distSelected.stream().map(entity -> entity.getId())
+                .collect(Collectors.toSet());
 
         final String distTagName = HawkbitCommonUtil.removePrefix(targetDetails.getTarget().getId(),
                 SPUIDefinitions.DISTRIBUTION_TAG_ID_PREFIXS);
 
         final List<String> tagsClickedList = distFilterParameters.getDistSetTags();
-        final DistributionSetTagAssignmentResult result = distributionSetManagement.toggleTagAssignment(distributionList,
-                distTagName);
+        final DistributionSetTagAssignmentResult result = distributionSetManagement
+                .toggleTagAssignment(distributionList, distTagName);
 
         notification.displaySuccess(HawkbitCommonUtil.createAssignmentMessage(distTagName, result, i18n));
         if (result.getUnassigned() >= 1 && !tagsClickedList.isEmpty()) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/event/DistributionTagDropEvent.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/event/DistributionTagDropEvent.java
@@ -68,8 +68,6 @@ public class DistributionTagDropEvent implements DropHandler {
     @Autowired
     private ManagementViewAcceptCriteria managementViewAcceptCriteria;
 
-    private static final String ITEMID = "itemId";
-
     @Override
     public void drop(final DragAndDropEvent event) {
         if (validate(event) && isNoTagAssigned(event)) {
@@ -127,12 +125,12 @@ public class DistributionTagDropEvent implements DropHandler {
         return true;
     }
 
-    @SuppressWarnings("unchecked")
     private void processDistributionDrop(final DragAndDropEvent event) {
 
         final com.vaadin.event.dd.TargetDetails targetDetails = event.getTargetDetails();
 
         final TableTransferable transferable = (TableTransferable) event.getTransferable();
+        @SuppressWarnings("unchecked")
         final AbstractTable<?, DistributionSetIdName> source = (AbstractTable<?, DistributionSetIdName>) transferable
                 .getSourceComponent();
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/DeleteActionsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/DeleteActionsLayout.java
@@ -278,14 +278,27 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
         managementUIState.getDeletedDistributionList().addAll(distributionIdNameSet);
         final int newDeletedDistributionsSize = managementUIState.getDeletedDistributionList().size();
 
-        if (newDeletedDistributionsSize == existingDeletedDistributionsSize) {
-            notification.displayValidationError(i18n.get("message.targets.already.deleted"));
+        showAlreadyDeletedDistributionSetNotfication(existingDeletedDistributionsSize, newDeletedDistributionsSize,
+                "message.dists.already.deleted");
+        showPendingDeletedNotifaction(distributionIdNameSet, existingDeletedDistributionsSize,
+                newDeletedDistributionsSize, "message.dist.deleted.pending");
+    }
+
+    private void showPendingDeletedNotifaction(final Set<?> currentValues, final int existingDeletedSize,
+            final int newDeletedSize, final String messageKey) {
+        if (newDeletedSize - existingDeletedSize == currentValues.size()) {
             return;
         }
+        notification.displayValidationError(i18n.get(messageKey));
+    }
 
-        if (newDeletedDistributionsSize - existingDeletedDistributionsSize != distributionIdNameSet.size()) {
-            notification.displayValidationError(i18n.get("message.dist.deleted.pending"));
+    private void showAlreadyDeletedDistributionSetNotfication(final int existingDeletedSize, final int newDeletedSize,
+            final String messageKey) {
+
+        if (newDeletedSize != existingDeletedSize) {
+            return;
         }
+        notification.displayValidationError(i18n.get(messageKey));
     }
 
     private boolean isDsInUseInBulkUpload(final Set<DistributionSetIdName> distributionIdNameSet,
@@ -311,15 +324,11 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
         managementUIState.getDeletedTargetList().addAll(targetIdNameSet);
         final int newDeletedTargetsSize = managementUIState.getDeletedTargetList().size();
 
-        if (newDeletedTargetsSize == existingDeletedTargetsSize) {
-            notification.displayValidationError(i18n.get("message.targets.already.deleted"));
-            return;
-        }
+        showAlreadyDeletedDistributionSetNotfication(existingDeletedTargetsSize, newDeletedTargetsSize,
+                "message.targets.already.deleted");
 
-        if (newDeletedTargetsSize - existingDeletedTargetsSize != targetIdNameSet.size()) {
-            notification.displayValidationError(i18n.get("message.target.deleted.pending"));
-            return;
-        }
+        showPendingDeletedNotifaction(targetIdNameSet, existingDeletedTargetsSize, newDeletedTargetsSize,
+                "message.target.deleted.pending");
     }
 
     private void updateActionCount() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/DeleteActionsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/DeleteActionsLayout.java
@@ -256,8 +256,8 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void addInDeleteDistributionList(final Table sourceTable, final TableTransferable transferable) {
+        @SuppressWarnings("unchecked")
         final AbstractTable<?, DistributionSetIdName> distTable = (AbstractTable<?, DistributionSetIdName>) sourceTable;
         final Set<DistributionSetIdName> distributionIdNameSet = distTable.getDeletedEntityByTransferable(transferable);
 
@@ -305,8 +305,8 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
         return false;
     }
 
-    @SuppressWarnings("unchecked")
     private void addInDeleteTargetList(final Table sourceTable, final TableTransferable transferable) {
+        @SuppressWarnings("unchecked")
         final AbstractTable<?, TargetIdName> targetTable = (AbstractTable<?, TargetIdName>) sourceTable;
         final Set<TargetIdName> targetIdNameSet = targetTable.getDeletedEntityByTransferable(transferable);
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/DeleteActionsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/DeleteActionsLayout.java
@@ -270,27 +270,20 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
         if (distributionIdNameSet.isEmpty()) {
             return;
         }
-        /*
-         * Flags to identify whether all dropped distributions are already in
-         * the deleted list (or) some distributions are already in the deleted
-         * distribution list.
-         */
+        checkDeletedDistributionSets(distributionIdNameSet);
+    }
+
+    private void checkDeletedDistributionSets(final Set<DistributionSetIdName> distributionIdNameSet) {
         final int existingDeletedDistributionsSize = managementUIState.getDeletedDistributionList().size();
         managementUIState.getDeletedDistributionList().addAll(distributionIdNameSet);
         final int newDeletedDistributionsSize = managementUIState.getDeletedDistributionList().size();
+
         if (newDeletedDistributionsSize == existingDeletedDistributionsSize) {
-            /*
-             * No new distributions are added, all distributions dropped now are
-             * already available in the delete list. Hence display warning
-             * message accordingly.
-             */
             notification.displayValidationError(i18n.get("message.targets.already.deleted"));
-        } else if (newDeletedDistributionsSize - existingDeletedDistributionsSize != distributionIdNameSet.size()) {
-            /*
-             * Not the all distributions dropped now are added to the delete
-             * list. There are some distributions are already there in the
-             * delete list. Hence display warning message accordingly.
-             */
+            return;
+        }
+
+        if (newDeletedDistributionsSize - existingDeletedDistributionsSize != distributionIdNameSet.size()) {
             notification.displayValidationError(i18n.get("message.dist.deleted.pending"));
         }
     }
@@ -310,28 +303,22 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
         final AbstractTable<?, TargetIdName> targetTable = (AbstractTable<?, TargetIdName>) sourceTable;
         final Set<TargetIdName> targetIdNameSet = targetTable.getDeletedEntityByTransferable(transferable);
 
-        /*
-         * Flags to identify whether all dropped targets are already in the
-         * deleted list (or) some target are already in the deleted distribution
-         * list.
-         */
+        checkDeletedTargets(targetIdNameSet);
+    }
+
+    private void checkDeletedTargets(final Set<TargetIdName> targetIdNameSet) {
         final int existingDeletedTargetsSize = managementUIState.getDeletedTargetList().size();
         managementUIState.getDeletedTargetList().addAll(targetIdNameSet);
         final int newDeletedTargetsSize = managementUIState.getDeletedTargetList().size();
+
         if (newDeletedTargetsSize == existingDeletedTargetsSize) {
-            /*
-             * No new targets are added, all targets dropped now are already
-             * available in the delete list. Hence display warning message
-             * accordingly.
-             */
             notification.displayValidationError(i18n.get("message.targets.already.deleted"));
-        } else if (newDeletedTargetsSize - existingDeletedTargetsSize != targetIdNameSet.size()) {
-            /*
-             * Not the all targets dropped now are added to the delete list.
-             * There are some targets are already there in the delete list.
-             * Hence display warning message accordingly.
-             */
+            return;
+        }
+
+        if (newDeletedTargetsSize - existingDeletedTargetsSize != targetIdNameSet.size()) {
             notification.displayValidationError(i18n.get("message.target.deleted.pending"));
+            return;
         }
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/DeleteActionsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/DeleteActionsLayout.java
@@ -8,7 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.management.footer;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.hawkbit.repository.TagManagement;
@@ -257,15 +256,10 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void addInDeleteDistributionList(final Table sourceTable, final TableTransferable transferable) {
-        final Set<DistributionSetIdName> distSelected = AbstractTable.getTableValue(sourceTable);
-        final Set<DistributionSetIdName> distributionIdNameSet = new HashSet<>();
-
-        if (!distSelected.contains(transferable.getData(SPUIDefinitions.ITEMID))) {
-            distributionIdNameSet.add((DistributionSetIdName) transferable.getData(SPUIDefinitions.ITEMID));
-        } else {
-            distributionIdNameSet.addAll(distSelected);
-        }
+        final AbstractTable<?, DistributionSetIdName> distTable = (AbstractTable<?, DistributionSetIdName>) sourceTable;
+        final Set<DistributionSetIdName> distributionIdNameSet = distTable.getDeletedEntityByTransferable(transferable);
 
         final DistributionSetIdName dsInBulkUpload = managementUIState.getTargetTableFilters().getBulkUpload()
                 .getDsNameAndVersion();
@@ -273,31 +267,31 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
             distributionIdNameSet.remove(dsInBulkUpload);
         }
 
-        if (!distributionIdNameSet.isEmpty()) {
-
+        if (distributionIdNameSet.isEmpty()) {
+            return;
+        }
+        /*
+         * Flags to identify whether all dropped distributions are already in
+         * the deleted list (or) some distributions are already in the deleted
+         * distribution list.
+         */
+        final int existingDeletedDistributionsSize = managementUIState.getDeletedDistributionList().size();
+        managementUIState.getDeletedDistributionList().addAll(distributionIdNameSet);
+        final int newDeletedDistributionsSize = managementUIState.getDeletedDistributionList().size();
+        if (newDeletedDistributionsSize == existingDeletedDistributionsSize) {
             /*
-             * Flags to identify whether all dropped distributions are already
-             * in the deleted list (or) some distributions are already in the
-             * deleted distribution list.
+             * No new distributions are added, all distributions dropped now are
+             * already available in the delete list. Hence display warning
+             * message accordingly.
              */
-            final int existingDeletedDistributionsSize = managementUIState.getDeletedDistributionList().size();
-            managementUIState.getDeletedDistributionList().addAll(distributionIdNameSet);
-            final int newDeletedDistributionsSize = managementUIState.getDeletedDistributionList().size();
-            if (newDeletedDistributionsSize == existingDeletedDistributionsSize) {
-                /*
-                 * No new distributions are added, all distributions dropped now
-                 * are already available in the delete list. Hence display
-                 * warning message accordingly.
-                 */
-                notification.displayValidationError(i18n.get("message.targets.already.deleted"));
-            } else if (newDeletedDistributionsSize - existingDeletedDistributionsSize != distributionIdNameSet.size()) {
-                /*
-                 * Not the all distributions dropped now are added to the delete
-                 * list. There are some distributions are already there in the
-                 * delete list. Hence display warning message accordingly.
-                 */
-                notification.displayValidationError(i18n.get("message.dist.deleted.pending"));
-            }
+            notification.displayValidationError(i18n.get("message.targets.already.deleted"));
+        } else if (newDeletedDistributionsSize - existingDeletedDistributionsSize != distributionIdNameSet.size()) {
+            /*
+             * Not the all distributions dropped now are added to the delete
+             * list. There are some distributions are already there in the
+             * delete list. Hence display warning message accordingly.
+             */
+            notification.displayValidationError(i18n.get("message.dist.deleted.pending"));
         }
     }
 
@@ -311,15 +305,10 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
         return false;
     }
 
+    @SuppressWarnings("unchecked")
     private void addInDeleteTargetList(final Table sourceTable, final TableTransferable transferable) {
-        final Set<TargetIdName> targetSelected = AbstractTable.getTableValue(sourceTable);
-
-        final Set<TargetIdName> targetIdNameSet = new HashSet<>();
-        if (!targetSelected.contains(transferable.getData(SPUIDefinitions.ITEMID))) {
-            targetIdNameSet.add((TargetIdName) transferable.getData(SPUIDefinitions.ITEMID));
-        } else {
-            targetIdNameSet.addAll(targetSelected);
-        }
+        final AbstractTable<?, TargetIdName> targetTable = (AbstractTable<?, TargetIdName>) sourceTable;
+        final Set<TargetIdName> targetIdNameSet = targetTable.getDeletedEntityByTransferable(transferable);
 
         /*
          * Flags to identify whether all dropped targets are already in the

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
@@ -107,7 +107,6 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> implements 
     private static final long serialVersionUID = -2300392868806614568L;
 
     private static final int PROPERTY_DEPT = 3;
-    private static final String ITEMID = "itemId";
     private static final String ACTION_NOT_ALLOWED_MSG = "message.action.not.allowed";
 
     @Autowired
@@ -632,9 +631,9 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> implements 
         return true;
     }
 
-    @SuppressWarnings("unchecked")
     private static Set<DistributionSetIdName> getDraggedDistributionSet(final TableTransferable transferable,
             final Table source) {
+        @SuppressWarnings("unchecked")
         final AbstractTable<?, DistributionSetIdName> distTable = (AbstractTable<?, DistributionSetIdName>) source;
         return distTable.getDeletedEntityByTransferable(transferable);
     }
@@ -853,6 +852,7 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> implements 
         eventBus.publish(this, new TargetTableEvent(TargetComponentEvent.REFRESH_TARGETS));
     }
 
+    @SuppressWarnings("unchecked")
     private void updateVisibleItemOnEvent(final TargetInfo targetInfo, final Target target,
             final TargetIdName targetIdName) {
         final LazyQueryContainer targetContainer = (LazyQueryContainer) getContainerDataSource();
@@ -875,8 +875,8 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> implements 
      * @param targetInfoUpdateEvents
      *            list of target info update event
      */
-    @SuppressWarnings("unchecked")
     private void onTargetInfoUpdateEvents(final List<TargetInfoUpdateEvent> targetInfoUpdateEvents) {
+        @SuppressWarnings("unchecked")
         final List<Object> visibleItemIds = (List<Object>) getVisibleItemIds();
         boolean shoulTargetsUpdated = false;
         Target lastSelectedTarget = null;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
@@ -632,16 +632,11 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> implements 
         return true;
     }
 
+    @SuppressWarnings("unchecked")
     private static Set<DistributionSetIdName> getDraggedDistributionSet(final TableTransferable transferable,
             final Table source) {
-        final Set<DistributionSetIdName> distSelected = getTableValue(source);
-        final Set<DistributionSetIdName> distributionIdSet = new HashSet<>();
-        if (!distSelected.contains(transferable.getData(ITEMID))) {
-            distributionIdSet.add((DistributionSetIdName) transferable.getData(ITEMID));
-        } else {
-            distributionIdSet.addAll(distSelected);
-        }
-        return distributionIdSet;
+        final AbstractTable<?, DistributionSetIdName> distTable = (AbstractTable<?, DistributionSetIdName>) source;
+        return distTable.getDeletedEntityByTransferable(transferable);
     }
 
     private Boolean validateDragAndDropWrapper(final Component compsource) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
@@ -8,7 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.management.targettable;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.hawkbit.repository.model.DistributionSetIdName;
@@ -378,8 +377,8 @@ public class TargetTableHeader extends AbstractTableHeader {
         return isValid;
     }
 
-    @SuppressWarnings("unchecked")
     private Set<DistributionSetIdName> getDropppedDistributionDetails(final TableTransferable transferable) {
+        @SuppressWarnings("unchecked")
         final AbstractTable<?, DistributionSetIdName> distTable = (AbstractTable<?, DistributionSetIdName>) transferable.getSourceComponent();
         return distTable.getDeletedEntityByTransferable(transferable);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
@@ -378,16 +378,10 @@ public class TargetTableHeader extends AbstractTableHeader {
         return isValid;
     }
 
+    @SuppressWarnings("unchecked")
     private Set<DistributionSetIdName> getDropppedDistributionDetails(final TableTransferable transferable) {
-        final Set<DistributionSetIdName> distSelected = AbstractTable.getTableValue(transferable.getSourceComponent());
-        final Set<DistributionSetIdName> distributionIdSet = new HashSet<>();
-        if (!distSelected.contains(transferable.getData("itemId"))) {
-            distributionIdSet.add((DistributionSetIdName) transferable.getData("itemId"));
-        } else {
-            distributionIdSet.addAll(distSelected);
-        }
-
-        return distributionIdSet;
+        final AbstractTable<?, DistributionSetIdName> distTable = (AbstractTable<?, DistributionSetIdName>) transferable.getSourceComponent();
+        return distTable.getDeletedEntityByTransferable(transferable);
     }
 
     private void addFilterTextField(final DistributionSetIdName distributionSetIdName) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterButtons.java
@@ -78,8 +78,6 @@ public class TargetTagFilterButtons extends AbstractFilterButtons {
     @Autowired
     private transient TargetManagement targetManagement;
 
-    private static final String ITEMID = "itemId";
-
     TargetTagFilterButtonClick filterButtonClickBehaviour;
 
     /**
@@ -211,10 +209,10 @@ public class TargetTagFilterButtons extends AbstractFilterButtons {
         return true;
     }
 
-    @SuppressWarnings("unchecked")
     private void processTargetDrop(final DragAndDropEvent event) {
         final com.vaadin.event.dd.TargetDetails targetDetails = event.getTargetDetails();
         final TableTransferable transferable = (TableTransferable) event.getTransferable();
+        @SuppressWarnings("unchecked")
         final AbstractTable<?, TargetIdName> targetTable = (AbstractTable<?, TargetIdName>) transferable
                 .getSourceComponent();
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterButtons.java
@@ -8,7 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.management.targettag;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -212,36 +211,32 @@ public class TargetTagFilterButtons extends AbstractFilterButtons {
         return true;
     }
 
+    @SuppressWarnings("unchecked")
     private void processTargetDrop(final DragAndDropEvent event) {
-
         final com.vaadin.event.dd.TargetDetails targetDetails = event.getTargetDetails();
         final TableTransferable transferable = (TableTransferable) event.getTransferable();
-        final Table source = transferable.getSourceComponent();
+        final AbstractTable<?, TargetIdName> targetTable = (AbstractTable<?, TargetIdName>) transferable
+                .getSourceComponent();
 
-        final Set<TargetIdName> targetSelected = AbstractTable.getTableValue(source);
-        final Set<String> targetList = new HashSet<>();
-        if (transferable.getData(ITEMID) != null) {
-            if (!targetSelected.contains(transferable.getData(ITEMID))) {
-                targetList.add(((TargetIdName) transferable.getData(ITEMID)).getControllerId());
-            } else {
-                targetList.addAll(targetSelected.stream().map(t -> t.getControllerId()).collect(Collectors.toList()));
-            }
+        final Set<TargetIdName> targetSelected = targetTable.getDeletedEntityByTransferable(transferable);
+        final Set<String> targetList = targetSelected.stream().map(t -> t.getControllerId())
+                .collect(Collectors.toSet());
 
-            final String targTagName = HawkbitCommonUtil.removePrefix(targetDetails.getTarget().getId(),
-                    SPUIDefinitions.TARGET_TAG_ID_PREFIXS);
+        final String targTagName = HawkbitCommonUtil.removePrefix(targetDetails.getTarget().getId(),
+                SPUIDefinitions.TARGET_TAG_ID_PREFIXS);
 
-            final List<String> tagsClickedList = managementUIState.getTargetTableFilters().getClickedTargetTags();
+        final List<String> tagsClickedList = managementUIState.getTargetTableFilters().getClickedTargetTags();
 
-            final TargetTagAssignmentResult result = targetManagement.toggleTagAssignment(targetList, targTagName);
-            notification.displaySuccess(HawkbitCommonUtil.createAssignmentMessage(targTagName, result, i18n));
+        final TargetTagAssignmentResult result = targetManagement.toggleTagAssignment(targetList, targTagName);
+        notification.displaySuccess(HawkbitCommonUtil.createAssignmentMessage(targTagName, result, i18n));
 
-            if (result.getAssigned() >= 1 && managementUIState.getTargetTableFilters().isNoTagSelected()) {
-                eventBus.publish(this, ManagementUIEvent.ASSIGN_TARGET_TAG);
-            }
-            if (result.getUnassigned() >= 1 && !tagsClickedList.isEmpty() && tagsClickedList.contains(targTagName)) {
-                eventBus.publish(this, ManagementUIEvent.UNASSIGN_TARGET_TAG);
-            }
+        if (result.getAssigned() >= 1 && managementUIState.getTargetTableFilters().isNoTagSelected()) {
+            eventBus.publish(this, ManagementUIEvent.ASSIGN_TARGET_TAG);
         }
+        if (result.getUnassigned() >= 1 && !tagsClickedList.isEmpty() && tagsClickedList.contains(targTagName)) {
+            eventBus.publish(this, ManagementUIEvent.UNASSIGN_TARGET_TAG);
+        }
+
     }
 
     private boolean validateIfSourceisTargetTable(final Table source) {


### PR DESCRIPTION
The TableTransferable could contain null values. Now this is checked by the abstract table.

Depends on: #124

Signed-off-by: SirWayne dennis.melzer@bosch-si.com