### PR TITLE
fix the lookup of artifacts which exists multiple times with same lookup key e.g. SHA1

### DIFF
--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -166,7 +166,7 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
             final LocalArtifact localArtifact = findLocalArtifactByFileResource(fileResource);
 
             if (localArtifact == null) {
-                LOG.info("target {} requested file resource which does not exists to download",
+                LOG.info("target {} requested file resource {} which does not exists to download",
                         secruityToken.getControllerId(), fileResource);
                 throw new EntityNotFoundException();
             }

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -227,7 +227,8 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
         LOG.debug("no anonymous download request, doing authentication check for target {} and artifact {}",
                 controllerId, localArtifact);
         if (!controllerManagement.hasTargetArtifactAssigned(controllerId, localArtifact)) {
-            LOG.info("target {} tried to download artifact {} which is not assigned to the target");
+            LOG.info("target {} tried to download artifact {} which is not assigned to the target", controllerId,
+                    localArtifact);
             throw new EntityNotFoundException();
         }
         LOG.info("download security check for target {} and artifact {} granted", controllerId, localArtifact);

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -313,11 +313,9 @@ public class AmqpMessageHandlerServiceTest {
 
         // mock
         final LocalArtifact localArtifactMock = mock(LocalArtifact.class);
-        final Action actionMock = mock(Action.class);
         final DbArtifact dbArtifactMock = mock(DbArtifact.class);
         when(artifactManagementMock.findFirstLocalArtifactsBySHA1(anyString())).thenReturn(localArtifactMock);
-        when(controllerManagementMock.getActionForDownloadByTargetAndSoftwareModule(anyObject(), anyObject()))
-                .thenReturn(actionMock);
+        when(controllerManagementMock.hasTargetArtifactAssigned(anyObject(), anyObject())).thenReturn(true);
         when(artifactManagementMock.loadLocalArtifactBinary(localArtifactMock)).thenReturn(dbArtifactMock);
         when(dbArtifactMock.getArtifactId()).thenReturn("artifactId");
         when(dbArtifactMock.getSize()).thenReturn(1L);

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -315,7 +315,8 @@ public class AmqpMessageHandlerServiceTest {
         final LocalArtifact localArtifactMock = mock(LocalArtifact.class);
         final DbArtifact dbArtifactMock = mock(DbArtifact.class);
         when(artifactManagementMock.findFirstLocalArtifactsBySHA1(anyString())).thenReturn(localArtifactMock);
-        when(controllerManagementMock.hasTargetArtifactAssigned(anyObject(), anyObject())).thenReturn(true);
+        when(controllerManagementMock.hasTargetArtifactAssigned(securityToken.getControllerId(), localArtifactMock))
+                .thenReturn(true);
         when(artifactManagementMock.loadLocalArtifactBinary(localArtifactMock)).thenReturn(dbArtifactMock);
         when(dbArtifactMock.getArtifactId()).thenReturn("artifactId");
         when(dbArtifactMock.getSize()).thenReturn(1L);

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -28,12 +28,14 @@ import org.eclipse.hawkbit.repository.model.Action.Status;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.repository.model.ActionStatus_;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.LocalArtifact;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetInfo;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.eclipse.hawkbit.repository.model.Target_;
 import org.eclipse.hawkbit.repository.model.TenantConfiguration;
+import org.eclipse.hawkbit.repository.specifications.ActionSpecifications;
 import org.eclipse.hawkbit.security.HawkbitSecurityProperties;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -164,6 +166,31 @@ public class ControllerManagement {
         }
 
         return action.get(0);
+    }
+
+    /**
+     * Checks if a given target has currently or has even been assigned to the
+     * given artifact through the action history list. This can e.g. indicate if
+     * a target is allowed to download a given artifact because it has currently
+     * assigned or had ever been assigned to the target and so it's visible to a
+     * specific target e.g. for downloading.
+     * 
+     * @param targetId
+     *            the ID of the target to check
+     * @param localArtifact
+     *            the artifact to verify if the given target had even been
+     *            assigned to
+     * @return {@code true} if the given target has currently or had ever a
+     *         relation to the given artifact through the action history,
+     *         otherwise {@code false}
+     */
+    public boolean hasTargetArtifactAssigned(@NotNull final String targetId,
+            @NotNull final LocalArtifact localArtifact) {
+        final Target target = targetRepository.findByControllerId(targetId);
+        if (target == null) {
+            return false;
+        }
+        return actionRepository.count(ActionSpecifications.hasTargetArtifactAssigned(target, localArtifact)) > 0;
     }
 
     /**

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -190,7 +190,7 @@ public class ControllerManagement {
         if (target == null) {
             return false;
         }
-        return actionRepository.count(ActionSpecifications.hasTargetArtifactAssigned(target, localArtifact)) > 0;
+        return actionRepository.count(ActionSpecifications.hasTargetAssignedArtifact(target, localArtifact)) > 0;
     }
 
     /**

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/specifications/ActionSpecifications.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/specifications/ActionSpecifications.java
@@ -47,14 +47,14 @@ public class ActionSpecifications {
      *            assigned
      * @return a specification to use with spring JPA
      */
-    public static Specification<Action> hasTargetArtifactAssigned(final Target target,
+    public static Specification<Action> hasTargetAssignedArtifact(final Target target,
             final LocalArtifact localArtifact) {
-        return (actionRoot, query, cb) -> {
+        return (actionRoot, query, criteriaBuilder) -> {
             final Join<Action, DistributionSet> dsJoin = actionRoot.join(Action_.distributionSet);
             final SetJoin<DistributionSet, SoftwareModule> modulesJoin = dsJoin.join(DistributionSet_.modules);
             final ListJoin<SoftwareModule, LocalArtifact> artifactsJoin = modulesJoin.join(SoftwareModule_.artifacts);
-            return cb.and(cb.equal(artifactsJoin.get(LocalArtifact_.id), localArtifact.getId()),
-                    cb.equal(actionRoot.get(Action_.target), target));
+            return criteriaBuilder.and(criteriaBuilder.equal(artifactsJoin.get(LocalArtifact_.id), localArtifact.getId()),
+                    criteriaBuilder.equal(actionRoot.get(Action_.target), target));
         };
     }
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/specifications/ActionSpecifications.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/specifications/ActionSpecifications.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.specifications;
+
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.ListJoin;
+import javax.persistence.criteria.SetJoin;
+
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.Action_;
+import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.DistributionSet_;
+import org.eclipse.hawkbit.repository.model.LocalArtifact;
+import org.eclipse.hawkbit.repository.model.LocalArtifact_;
+import org.eclipse.hawkbit.repository.model.SoftwareModule;
+import org.eclipse.hawkbit.repository.model.SoftwareModule_;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.springframework.data.jpa.domain.Specification;
+
+/**
+ * Utility class for {@link Action}s {@link Specification}s. The class provides
+ * Spring Data JPQL Specifications.
+ *
+ */
+public class ActionSpecifications {
+
+    private ActionSpecifications() {
+        // utility class
+    }
+
+    /**
+     * Specification which joins all necessary tables to retrieve the dependency
+     * between a target and a local file assignment through the assigen action
+     * of the target. All actions are included, not only active actions.
+     * 
+     * @param target
+     *            the target to verfiy if the given artifact is currently
+     *            assigned or had been assigned
+     * @param localArtifact
+     *            the local artifact to check wherever the target had ever been
+     *            assigned
+     * @return a specification to use with spring JPA
+     */
+    public static Specification<Action> hasTargetArtifactAssigned(final Target target,
+            final LocalArtifact localArtifact) {
+        return (actionRoot, query, cb) -> {
+            final Join<Action, DistributionSet> dsJoin = actionRoot.join(Action_.distributionSet);
+            final SetJoin<DistributionSet, SoftwareModule> modulesJoin = dsJoin.join(DistributionSet_.modules);
+            final ListJoin<SoftwareModule, LocalArtifact> artifactsJoin = modulesJoin.join(SoftwareModule_.artifacts);
+            return cb.and(cb.equal(artifactsJoin.get(LocalArtifact_.id), localArtifact.getId()),
+                    cb.equal(actionRoot.get(Action_.target), target));
+        };
+    }
+}


### PR DESCRIPTION
Artifacts can assigned to multiple software modules which leads that when we trying to find a artifact e.g. based on filename or SHA1 hashes which are not unique in the system we cannot determine the correct software module to it to verify if the current target is permitted to download this artifact or not. 

Current code just takes the first found `LocalArtifact` and checks against this `SoftwareModule` which will lead in case the artifact exists multiple times in different `SoftwareModule`s the current check to verify if this `SoftwareModule` is assigned to the target will fail, because it could be another `SoftwareModule` but with the same artifact.

To avoid this check, we can check if the requested artifact had been ever assigned to the target based on the action history and check all actions and their `SoftwareModule`s and if in these `SoftwareModule`s exists the request artifact.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>