### PR TITLE
make use of the existencechecking annotation for targetrolloutgroup

### DIFF
--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/RolloutTargetGroup.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/RolloutTargetGroup.java
@@ -28,8 +28,9 @@ import org.eclipse.persistence.annotations.ExistenceChecking;
 import org.eclipse.persistence.annotations.ExistenceType;
 
 /**
- * @author Michael Hirsch
- *
+ * Entity with JPA annotation to store the information which {@link Target} is
+ * in a specific {@link RolloutGroup}.
+ * 
  */
 @IdClass(RolloutTargetGroupId.class)
 @Entity

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/RolloutTargetGroup.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/RolloutTargetGroup.java
@@ -24,6 +24,9 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
+import org.eclipse.persistence.annotations.ExistenceChecking;
+import org.eclipse.persistence.annotations.ExistenceType;
+
 /**
  * @author Michael Hirsch
  *
@@ -31,6 +34,7 @@ import javax.persistence.Table;
 @IdClass(RolloutTargetGroupId.class)
 @Entity
 @Table(name = "sp_rollouttargetgroup")
+@ExistenceChecking(ExistenceType.ASSUME_NON_EXISTENCE)
 public class RolloutTargetGroup implements Serializable {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
During `Rollout` creation we insert all `Target`s of an `RolloutGroup` into a table which are a lot of inserts in case of a big `Rollout`. To avoid that JPA is doing an extra selection before inserting into the `sp_rollouttargetgroup` table you can use the eclipse-link annotation `@ExistenceChecking`. We don't need a pessimistic check on the database in this case of creation. We are actually sure that this combination of `Target`-ID and `RolloutGroup`-ID is unique because we just create the newly `RolloutGruop`. We can avoid all these select-statements for each insert.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>