### PR TITLE
introduce a conditional property to disable startup generation devices

### DIFF
--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatorStartup.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatorStartup.java
@@ -16,6 +16,7 @@ import org.eclipse.hawkbit.simulator.amqp.SpSenderService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
@@ -25,6 +26,7 @@ import org.springframework.stereotype.Component;
  *
  */
 @Component
+@ConditionalOnProperty(prefix = "com.bosch.hawkbit.simulator", name = "generateOnStartup", matchIfMissing = true)
 public class SimulatorStartup implements ApplicationListener<ContextRefreshedEvent> {
     private static final Logger LOGGER = LoggerFactory.getLogger(SimulatorStartup.class);
 

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatorStartup.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatorStartup.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
  *
  */
 @Component
-@ConditionalOnProperty(prefix = "com.bosch.hawkbit.simulator", name = "generateOnStartup", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "hawkbit.device.simulator", name = "autostart", matchIfMissing = true)
 public class SimulatorStartup implements ApplicationListener<ContextRefreshedEvent> {
     private static final Logger LOGGER = LoggerFactory.getLogger(SimulatorStartup.class);
 


### PR DESCRIPTION
It is not possible to replace the property defined in the `application.properties` 
```
## Configuration for simulations
hawkbit.device.simulator.autostarts.[0].tenant=DEFAULT
```
via e.g. environment variables. It is not possible to make the list empty by overriding this property. So the only solution to disable the simulator to generate targets at startup is to add a property additionally to disable this feature.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>