### PR TITLE
remove current tenant null check 

### DIFF
--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/MultiTenantJpaTransactionManager.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/MultiTenantJpaTransactionManager.java
@@ -11,7 +11,6 @@ package org.eclipse.hawkbit;
 import javax.persistence.EntityManager;
 import javax.transaction.Transaction;
 
-import org.eclipse.hawkbit.repository.exception.TenantNotExistException;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,11 +40,8 @@ public class MultiTenantJpaTransactionManager extends JpaTransactionManager {
         final EntityManager em = emHolder.getEntityManager();
 
         final String currentTenant = tenantAware.getCurrentTenant();
-        if (currentTenant == null) {
-            throw new TenantNotExistException("Tenant Unknown. Canceling transaction.");
+        if (currentTenant != null) {
+            em.setProperty(PersistenceUnitProperties.MULTITENANT_PROPERTY_DEFAULT, currentTenant.toUpperCase());
         }
-
-        em.setProperty(PersistenceUnitProperties.MULTITENANT_PROPERTY_DEFAULT, currentTenant.toUpperCase());
-
     }
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/MultiTenantJpaTransactionManager.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/MultiTenantJpaTransactionManager.java
@@ -35,12 +35,11 @@ public class MultiTenantJpaTransactionManager extends JpaTransactionManager {
     protected void doBegin(final Object transaction, final TransactionDefinition definition) {
         super.doBegin(transaction, definition);
 
-        final EntityManagerHolder emHolder = (EntityManagerHolder) TransactionSynchronizationManager
-                .getResource(getEntityManagerFactory());
-        final EntityManager em = emHolder.getEntityManager();
-
         final String currentTenant = tenantAware.getCurrentTenant();
         if (currentTenant != null) {
+            final EntityManagerHolder emHolder = (EntityManagerHolder) TransactionSynchronizationManager
+                    .getResource(getEntityManagerFactory());
+            final EntityManager em = emHolder.getEntityManager();
             em.setProperty(PersistenceUnitProperties.MULTITENANT_PROPERTY_DEFAULT, currentTenant.toUpperCase());
         }
     }


### PR DESCRIPTION
The `currentTenant` null check in the `MultiTenantJpaTransactionManager` should be removed after the changes of https://github.com/eclipse/hawkbit/pull/132 because not all queries have current tenant and must not all queries must set the current tenant e.g. for independent queries like in 'SystemManagement'. 

To call `findTenants()` in the `SystemManagement` class you don't need to a `currentTenant` like the `RolloutScheduler` is doing to find all tenants. Queries e.g. against the entity `TenantMetadata` do make use of the `TenantAwareBaseEntity` with the annotation `@Multitenant(MultitenantType.SINGLE_TABLE)`.

So calling e.g. `findTenants()` a new transaction will be created (if none exists) and if then no current tenant is set, it will crash in the `MultiTenantJpaTransactionManager` which is not necessary because the queries which will be executed is tenant independent and the eclipse tenant property must not set then.

In case a transaction is already open there should be no problem when calling `findTenants()` because this query does not care if the eclipse tenant property is set or not. And the `MultiTenantJpaTransactionManager` is only called if a new transaction is created.

So the fix here is to remove the `TenantNotExistException` in case no current tenant is set because there are scenarios where no current tenant must be set in the transaction e.g. for queries not related to the `TenantAwareBaseEntity`

This will fix the exception in the `RolloutScheduler` which looks like this:
```
web_1 | [2016-04-28 17:56:13.266] boot - 7 ERROR [pool-10-thread-1] --- TaskUtils$LoggingErrorHandler: Unexpected error occurred in scheduled task. web_1 | org.eclipse.hawkbit.repository.exception.TenantNotExistException: Tenant Unknown. Canceling transaction. web_1 | at org.eclipse.hawkbit.MultiTenantJpaTransactionManager.doBegin(MultiTenantJpaTransactionManager.java:45) ~[hawkbit-repository-0.2.0-SNAPSHOT.jar!/:0.2.0-SNAPSHOT] web_1 | 
```
Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>