### PR TITLE
use vaadin-version placeholder in case of hard-coded vaadin version

### DIFF
--- a/examples/hawkbit-device-simulator/pom.xml
+++ b/examples/hawkbit-device-simulator/pom.xml
@@ -139,7 +139,7 @@
          <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-bom</artifactId>
-            <version>7.6.3</version>
+            <version>${vaadin.version}</version>
             <type>pom</type>
             <scope>import</scope>
          </dependency>


### PR DESCRIPTION
Vaadin version has been updated to 7.6.5 and the device-simulator used an older version which leaded to a NoSuchMethodException
```
java.lang.NoSuchMethodError: com.vaadin.shared.ui.MarginInfo.<init>(ZZ)V
	at com.vaadin.ui.FormLayout.<init>(FormLayout.java:39)
	at org.eclipse.hawkbit.simulator.ui.GenerateDialog.<init>(GenerateDialog.java:44)
```

The example-simulator should make use of the `<version>${vaadin.version}</version>` placeholder

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>