### PR TITLE
Add target security token to DMF update message

### DIFF
--- a/examples/hawkbit-device-simulator/pom.xml
+++ b/examples/hawkbit-device-simulator/pom.xml
@@ -134,11 +134,6 @@
          <optional>true</optional>
       </dependency>
       <dependency>
-         <groupId>org.scala-lang</groupId>
-         <artifactId>scala-library</artifactId>
-         <version>2.10.4</version>
-      </dependency>
-      <dependency>
          <groupId>org.apache.httpcomponents</groupId>
          <artifactId>httpclient</artifactId>
       </dependency>

--- a/examples/hawkbit-device-simulator/pom.xml
+++ b/examples/hawkbit-device-simulator/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <!--
 
     Copyright (c) 2015 Bosch Software Innovations GmbH and others.
@@ -9,7 +8,8 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <modelVersion>4.0.0</modelVersion>
    <parent>
@@ -132,6 +132,15 @@
          <groupId>org.springframework.boot</groupId>
          <artifactId>spring-boot-configuration-processor</artifactId>
          <optional>true</optional>
+      </dependency>
+      <dependency>
+         <groupId>org.scala-lang</groupId>
+         <artifactId>scala-library</artifactId>
+         <version>2.10.4</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.httpcomponents</groupId>
+         <artifactId>httpclient</artifactId>
       </dependency>
    </dependencies>
    <dependencyManagement>

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/AbstractSimulatedDevice.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/AbstractSimulatedDevice.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.hawkbit.simulator;
 
+import org.eclipse.hawkbit.simulator.UpdateStatus.ResponseStatus;
+
 /**
  * The bean of a simulated device which can be stored in the
  * {@link DeviceSimulatorRepository} or shown in the UI.
@@ -22,16 +24,15 @@ public abstract class AbstractSimulatedDevice {
     private Status status;
     private double progress;
     private String swversion = "unknown";
-    private ResponseStatus responseStatus = ResponseStatus.SUCCESSFUL;
+    private UpdateStatus updateStatus = new UpdateStatus(ResponseStatus.SUCCESSFUL, "Simulation complete!");
     private Protocol protocol = Protocol.DMF_AMQP;
+    private String targetSecurityToken;
 
     private int nextPollCounterSec;
 
     /**
      * Enum definition of the protocol to be used for the simulated device.
      * 
-     * @author Michael Hirsch
-     *
      */
     public enum Protocol {
         /**
@@ -65,24 +66,6 @@ public abstract class AbstractSimulatedDevice {
         FINISH,
         /**
          * device has been updated with an error.
-         */
-        ERROR;
-    }
-
-    /**
-     * The status to response to the hawkbit update server if an simulated
-     * update process should be respond with successful or failure update.
-     * 
-     * @author Michael Hirsch
-     *
-     */
-    public enum ResponseStatus {
-        /**
-         * updated has been successful and response the successful update.
-         */
-        SUCCESSFUL,
-        /**
-         * updated has been not successful and response the error update.
          */
         ERROR;
     }
@@ -158,12 +141,12 @@ public abstract class AbstractSimulatedDevice {
         this.swversion = swversion;
     }
 
-    public ResponseStatus getResponseStatus() {
-        return responseStatus;
+    public UpdateStatus getUpdateStatus() {
+        return updateStatus;
     }
 
-    public void setResponseStatus(final ResponseStatus responseStatus) {
-        this.responseStatus = responseStatus;
+    public void setUpdateStatus(final UpdateStatus updateStatus) {
+        this.updateStatus = updateStatus;
     }
 
     public Protocol getProtocol() {
@@ -177,4 +160,13 @@ public abstract class AbstractSimulatedDevice {
     public void setNextPollCounterSec(final int nextPollDelayInSec) {
         this.nextPollCounterSec = nextPollDelayInSec;
     }
+
+    public String getTargetSecurityToken() {
+        return targetSecurityToken;
+    }
+
+    public void setTargetSecurityToken(final String targetSecurityToken) {
+        this.targetSecurityToken = targetSecurityToken;
+    }
+
 }

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DMFSimulatedDevice.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DMFSimulatedDevice.java
@@ -9,10 +9,7 @@
 package org.eclipse.hawkbit.simulator;
 
 /**
- * An simulated device using the DMF API of the hawkbit update server.
- * 
- * @author Michael Hirsch
- *
+ * A simulated device using the DMF API of the hawkBit update server.
  */
 public class DMFSimulatedDevice extends AbstractSimulatedDevice {
 

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -138,7 +138,7 @@ public class DeviceSimulatorUpdater {
         public void run() {
             if (device.getProgress() <= 0 && modules != null) {
                 device.setUpdateStatus(simulateDownloads(device.getTargetSecurityToken()));
-                if (device.getUpdateStatus().getResponseStatus().equals(ResponseStatus.ERROR)) {
+                if (isErrorResponse(device.getUpdateStatus())) {
                     callback.updateFinished(device, actionId);
                     eventbus.post(new ProgressUpdate(device));
                     return;
@@ -169,7 +169,7 @@ public class DeviceSimulatorUpdater {
             result.getStatusMessages().add("Simulation complete!");
             status.forEach(download -> {
                 result.getStatusMessages().addAll(download.getStatusMessages());
-                if (download.getResponseStatus().equals(ResponseStatus.ERROR)) {
+                if (isErrorResponse(download)) {
                     result.setResponseStatus(ResponseStatus.ERROR);
                 }
             });
@@ -177,6 +177,14 @@ public class DeviceSimulatorUpdater {
             LOGGER.info("Download simulations complete for {}", device.getId());
 
             return result;
+        }
+
+        private boolean isErrorResponse(final UpdateStatus status) {
+            if (status == null) {
+                return false;
+            }
+
+            return ResponseStatus.ERROR.equals(status.getResponseStatus());
         }
 
         private static void handleArtifacts(final String targetToken, final List<UpdateStatus> status,
@@ -195,7 +203,7 @@ public class DeviceSimulatorUpdater {
         }
 
         private static UpdateStatus downloadUrl(final String url, final String targetToken, final String sha1Hash) {
-            LOGGER.debug("Downloading " + url);
+            LOGGER.debug("Downloading {}", url);
 
             long overallread = 0;
             try {
@@ -245,7 +253,7 @@ public class DeviceSimulatorUpdater {
     /**
      * Callback interface which is called when the simulated update process has
      * been finished and the caller of starting the simulated update process can
-     * send the result to the hawkBit update server back. *
+     * send the result back to the hawkBit update server.
      */
     @FunctionalInterface
     public interface UpdaterCallback {

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -8,27 +8,52 @@
  */
 package org.eclipse.hawkbit.simulator;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.DigestOutputStream;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.eclipse.hawkbit.dmf.json.model.Artifact;
+import org.eclipse.hawkbit.dmf.json.model.SoftwareModule;
 import org.eclipse.hawkbit.simulator.AbstractSimulatedDevice.Protocol;
+import org.eclipse.hawkbit.simulator.UpdateStatus.ResponseStatus;
 import org.eclipse.hawkbit.simulator.amqp.SpSenderService;
 import org.eclipse.hawkbit.simulator.event.InitUpdate;
 import org.eclipse.hawkbit.simulator.event.ProgressUpdate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.google.common.eventbus.EventBus;
+import com.google.common.io.BaseEncoding;
+import com.google.common.io.ByteStreams;
 
 /**
- * @author Michael Hirsch
+ * Update simulation handler.
  *
  */
 @Service
 public class DeviceSimulatorUpdater {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeviceSimulatorUpdater.class);
 
     private static final ScheduledExecutorService threadPool = Executors.newScheduledThreadPool(4);
 
@@ -54,14 +79,18 @@ public class DeviceSimulatorUpdater {
      * @param actionId
      *            the actionId from the hawkbit update server to start the
      *            update.
-     * @param swVersion
+     * @param modules
      *            the software module version from the hawkbit update server
+     * @param swVersion
+     *            the software version as static value in case modules is null
+     * @param targetSecurityToken
+     *            the target security token for download authentication
      * @param callback
      *            the callback which gets called when the simulated update
      *            process has been finished
      */
     public void startUpdate(final String tenant, final String id, final long actionId, final String swVersion,
-            final UpdaterCallback callback) {
+            final List<SoftwareModule> modules, final String targetSecurityToken, final UpdaterCallback callback) {
         AbstractSimulatedDevice device = repository.get(tenant, id);
 
         // plug and play - non existing device will be auto created
@@ -70,11 +99,18 @@ public class DeviceSimulatorUpdater {
         }
 
         device.setProgress(0.0);
-        device.setSwversion(swVersion);
+
+        if (modules == null) {
+            device.setSwversion(swVersion);
+        } else {
+            device.setSwversion(modules.stream().map(sm -> sm.getModuleVersion()).collect(Collectors.joining(", ")));
+        }
+        device.setTargetSecurityToken(targetSecurityToken);
         eventbus.post(new InitUpdate(device));
 
-        threadPool.schedule(new DeviceSimulatorUpdateThread(device, spSenderService, actionId, eventbus, callback),
-                2_000, TimeUnit.MILLISECONDS);
+        threadPool.schedule(
+                new DeviceSimulatorUpdateThread(device, spSenderService, actionId, eventbus, callback, modules), 2_000,
+                TimeUnit.MILLISECONDS);
     }
 
     private static final class DeviceSimulatorUpdateThread implements Runnable {
@@ -85,38 +121,130 @@ public class DeviceSimulatorUpdater {
         private final long actionId;
         private final EventBus eventbus;
         private final UpdaterCallback callback;
+        private final List<SoftwareModule> modules;
 
         private DeviceSimulatorUpdateThread(final AbstractSimulatedDevice device, final SpSenderService spSenderService,
-                final long actionId, final EventBus eventbus, final UpdaterCallback callback) {
+                final long actionId, final EventBus eventbus, final UpdaterCallback callback,
+                final List<SoftwareModule> modules) {
             this.device = device;
             this.spSenderService = spSenderService;
             this.actionId = actionId;
             this.eventbus = eventbus;
             this.callback = callback;
+            this.modules = modules;
         }
 
         @Override
         public void run() {
+            if (device.getProgress() <= 0 && modules != null) {
+                device.setUpdateStatus(simulateDownloads(device.getTargetSecurityToken()));
+                if (device.getUpdateStatus().getResponseStatus().equals(ResponseStatus.ERROR)) {
+                    callback.updateFinished(device, actionId);
+                    eventbus.post(new ProgressUpdate(device));
+                    return;
+                }
+            }
+
             final double newProgress = device.getProgress() + 0.2;
             device.setProgress(newProgress);
             if (newProgress < 1.0) {
                 threadPool.schedule(
-                        new DeviceSimulatorUpdateThread(device, spSenderService, actionId, eventbus, callback),
+                        new DeviceSimulatorUpdateThread(device, spSenderService, actionId, eventbus, callback, modules),
                         rndSleep.nextInt(5_000), TimeUnit.MILLISECONDS);
             } else {
                 callback.updateFinished(device, actionId);
             }
             eventbus.post(new ProgressUpdate(device));
         }
+
+        private UpdateStatus simulateDownloads(final String targetToken) {
+            final List<UpdateStatus> status = new ArrayList<>();
+
+            LOGGER.info("Simulate downloads for {}", device.getId());
+
+            modules.forEach(module -> module.getArtifacts()
+                    .forEach(artifact -> handleArtifacts(targetToken, status, artifact)));
+
+            final UpdateStatus result = new UpdateStatus(ResponseStatus.SUCCESSFUL);
+            result.getStatusMessages().add("Simulation complete!");
+            status.forEach(download -> {
+                result.getStatusMessages().addAll(download.getStatusMessages());
+                if (download.getResponseStatus().equals(ResponseStatus.ERROR)) {
+                    result.setResponseStatus(ResponseStatus.ERROR);
+                }
+            });
+
+            LOGGER.info("Download simulations complete for {}", device.getId());
+
+            return result;
+        }
+
+        private static void handleArtifacts(final String targetToken, final List<UpdateStatus> status,
+                final Artifact artifact) {
+            artifact.getUrls().entrySet().forEach(entry -> {
+                switch (entry.getKey()) {
+                case HTTPS:
+                    status.add(downloadUrl(entry.getValue(), targetToken, artifact.getHashes().getSha1()));
+                    break;
+                default:
+                    // not supported yet
+                    break;
+                }
+            });
+        }
+
+        private static UpdateStatus downloadUrl(final String url, final String targetToken, final String sha1Hash) {
+            LOGGER.debug("Downloading " + url);
+
+            long overallread = 0;
+            try {
+                final CloseableHttpClient httpclient = createHttpClientThatAcceptsAllServerCerts();
+                final HttpGet request = new HttpGet(url);
+                request.addHeader("TargetToken", targetToken);
+
+                final String sha1HashResult;
+                try (final CloseableHttpResponse response = httpclient.execute(request)) {
+                    final File tempFile = File.createTempFile("uploadFile", null);
+                    final MessageDigest md = MessageDigest.getInstance("SHA-1");
+
+                    try (final DigestOutputStream dos = new DigestOutputStream(new FileOutputStream(tempFile), md)) {
+                        overallread = ByteStreams.copy(response.getEntity().getContent(), dos);
+                        sha1HashResult = BaseEncoding.base16().lowerCase().encode(md.digest());
+                    } finally {
+                        tempFile.delete();
+                    }
+                }
+
+                if (!sha1Hash.equals(sha1HashResult)) {
+                    final String message = "Download " + url + " failed with SHA1 hash missmatch (Expected: " + sha1Hash
+                            + " but got: " + sha1HashResult + ")";
+                    LOGGER.debug(message);
+                    return new UpdateStatus(ResponseStatus.ERROR, message);
+                }
+
+            } catch (IOException | KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
+                LOGGER.error("Failed to download {}", url, e);
+                return new UpdateStatus(ResponseStatus.ERROR, "Failed to download " + url + ": " + e.getMessage());
+            }
+
+            final String message = "Downloaded " + url + " (" + overallread + " bytes)";
+            LOGGER.debug(message);
+            return new UpdateStatus(ResponseStatus.SUCCESSFUL, message);
+        }
+
+        private static CloseableHttpClient createHttpClientThatAcceptsAllServerCerts()
+                throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+            final SSLContextBuilder builder = new SSLContextBuilder();
+            builder.loadTrustMaterial(null, (chain, authType) -> true);
+            final SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build());
+            return HttpClients.custom().setSSLSocketFactory(sslsf).build();
+        }
     }
 
     /**
      * Callback interface which is called when the simulated update process has
      * been finished and the caller of starting the simulated update process can
-     * send the result to the hawkbit update server back.
-     *
-     * @author Michael Hirsch
-     *
+     * send the result to the hawkBit update server back. *
      */
     @FunctionalInterface
     public interface UpdaterCallback {

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -100,7 +100,7 @@ public class DeviceSimulatorUpdater {
 
         device.setProgress(0.0);
 
-        if (modules == null) {
+        if (modules == null || modules.isEmpty()) {
             device.setSwversion(swVersion);
         } else {
             device.setSwversion(modules.stream().map(sm -> sm.getModuleVersion()).collect(Collectors.joining(", ")));

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -183,6 +183,7 @@ public class DeviceSimulatorUpdater {
                 final Artifact artifact) {
             artifact.getUrls().entrySet().forEach(entry -> {
                 switch (entry.getKey()) {
+                case HTTP:
                 case HTTPS:
                     status.add(downloadUrl(entry.getValue(), targetToken, artifact.getHashes().getSha1()));
                     break;

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/NextPollTimeController.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/NextPollTimeController.java
@@ -26,9 +26,6 @@ import com.google.common.eventbus.EventBus;
 /**
  * Poll time trigger which executes the {@link DDISimulatedDevice#poll()} every
  * second.
- *
- * @author Michael Hirsch
- *
  */
 @Component
 public class NextPollTimeController {
@@ -59,16 +56,15 @@ public class NextPollTimeController {
 
             devices.forEach(device -> {
                 int nextCounter = device.getNextPollCounterSec() - 1;
-                if (nextCounter < 0) {
-                    if (device instanceof DDISimulatedDevice) {
-                        try {
-                            pollService.submit(() -> ((DDISimulatedDevice) device).poll());
-                        } catch (final IllegalStateException e) {
-                            LOGGER.trace("Device could not be polled", e);
-                        }
-                        nextCounter = ((DDISimulatedDevice) device).getPollDelaySec();
+                if (nextCounter < 0 && device instanceof DDISimulatedDevice) {
+                    try {
+                        pollService.submit(() -> ((DDISimulatedDevice) device).poll());
+                    } catch (final IllegalStateException e) {
+                        LOGGER.trace("Device could not be polled", e);
                     }
+                    nextCounter = ((DDISimulatedDevice) device).getPollDelaySec();
                 }
+
                 device.setNextPollCounterSec(nextCounter);
             });
             eventBus.post(new NextPollCounterUpdate(devices));

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatedDeviceFactory.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatedDeviceFactory.java
@@ -9,8 +9,6 @@
 package org.eclipse.hawkbit.simulator;
 
 import java.net.URL;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.hawkbit.simulator.AbstractSimulatedDevice.Protocol;
 import org.eclipse.hawkbit.simulator.http.ControllerResource;
@@ -24,15 +22,9 @@ import feign.Logger;
 /**
  * The simulated device factory to create either {@link DMFSimulatedDevice} or
  * {@link DDISimulatedDevice#}.
- * 
- * @author Michael Hirsch
- *
  */
 @Service
 public class SimulatedDeviceFactory {
-
-    private static final ScheduledExecutorService pollThreadPool = Executors.newScheduledThreadPool(4);
-
     @Autowired
     private DeviceSimulatorUpdater deviceUpdater;
 
@@ -47,7 +39,8 @@ public class SimulatedDeviceFactory {
      *            the protocol of the device
      * @return the created simulated device
      */
-    public AbstractSimulatedDevice createSimulatedDevice(final String id, final String tenant, final Protocol protocol) {
+    public AbstractSimulatedDevice createSimulatedDevice(final String id, final String tenant,
+            final Protocol protocol) {
         return createSimulatedDevice(id, tenant, protocol, 30, null, null);
     }
 
@@ -80,7 +73,7 @@ public class SimulatedDeviceFactory {
             final ControllerResource controllerResource = Feign.builder().logger(new Logger.ErrorLogger())
                     .requestInterceptor(new GatewayTokenInterceptor(gatewayToken)).logLevel(Logger.Level.BASIC)
                     .target(ControllerResource.class, baseEndpoint.toString());
-            return new DDISimulatedDevice(id, tenant, pollDelaySec, controllerResource, pollThreadPool, deviceUpdater);
+            return new DDISimulatedDevice(id, tenant, pollDelaySec, controllerResource, deviceUpdater);
         default:
             throw new IllegalArgumentException("Protocol " + protocol + " unknown");
         }

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/UpdateStatus.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/UpdateStatus.java
@@ -16,15 +16,30 @@ import java.util.List;
  *
  */
 public class UpdateStatus {
-    private ResponseStatus responseStatus = ResponseStatus.SUCCESSFUL;
-    private final List<String> statusMessages = new ArrayList<>();
+    private ResponseStatus responseStatus;
+    private List<String> statusMessages;
 
+    /**
+     * Constructor.
+     * 
+     * @param responseStatus
+     *            of the update
+     */
     public UpdateStatus(final ResponseStatus responseStatus) {
         this.responseStatus = responseStatus;
     }
 
+    /**
+     * Constructor including status message.
+     * 
+     * @param responseStatus
+     *            of the update
+     * @param message
+     *            of the update status
+     */
     public UpdateStatus(final ResponseStatus responseStatus, final String message) {
         this(responseStatus);
+        statusMessages = new ArrayList<>();
         statusMessages.add(message);
     }
 
@@ -37,6 +52,10 @@ public class UpdateStatus {
     }
 
     public List<String> getStatusMessages() {
+        if (statusMessages == null) {
+            statusMessages = new ArrayList<>();
+        }
+
         return statusMessages;
     }
 
@@ -46,11 +65,12 @@ public class UpdateStatus {
      */
     public enum ResponseStatus {
         /**
-         * updated has been successful and response the successful update.
+         * Update has been successful and response the successful update.
          */
         SUCCESSFUL,
+
         /**
-         * updated has been not successful and response the error update.
+         * Update has been not successful and response the error update.
          */
         ERROR;
     }

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/UpdateStatus.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/UpdateStatus.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.simulator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Update status of the simulated update.
+ *
+ */
+public class UpdateStatus {
+    private ResponseStatus responseStatus = ResponseStatus.SUCCESSFUL;
+    private final List<String> statusMessages = new ArrayList<>();
+
+    public UpdateStatus(final ResponseStatus responseStatus) {
+        this.responseStatus = responseStatus;
+    }
+
+    public UpdateStatus(final ResponseStatus responseStatus, final String message) {
+        this(responseStatus);
+        statusMessages.add(message);
+    }
+
+    public ResponseStatus getResponseStatus() {
+        return responseStatus;
+    }
+
+    public void setResponseStatus(final ResponseStatus responseStatus) {
+        this.responseStatus = responseStatus;
+    }
+
+    public List<String> getStatusMessages() {
+        return statusMessages;
+    }
+
+    /**
+     * The status to response to the hawkBit update server if an simulated
+     * update process should be respond with successful or failure update.
+     */
+    public enum ResponseStatus {
+        /**
+         * updated has been successful and response the successful update.
+         */
+        SUCCESSFUL,
+        /**
+         * updated has been not successful and response the error update.
+         */
+        ERROR;
+    }
+
+}

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/SpReceiverService.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/SpReceiverService.java
@@ -25,6 +25,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 
+import com.google.common.collect.Lists;
+
 /**
  * Handle all incoming Messages from hawkBit update server.
  *
@@ -109,7 +111,7 @@ public class SpReceiverService extends ReceiverService {
         final Long actionId = convertMessage(message, Long.class);
 
         final SimulatedUpdate update = new SimulatedUpdate(tenant, thingId, actionId);
-        spSenderService.finishUpdateProcess(update, "Simulation canceled");
+        spSenderService.finishUpdateProcess(update, Lists.newArrayList("Simulation canceled"));
     }
 
     private void handleUpdateProcess(final Message message, final String thingId) {
@@ -120,19 +122,20 @@ public class SpReceiverService extends ReceiverService {
         final DownloadAndUpdateRequest downloadAndUpdateRequest = convertMessage(message,
                 DownloadAndUpdateRequest.class);
         final Long actionId = downloadAndUpdateRequest.getActionId();
+        final String targetSecurityToken = downloadAndUpdateRequest.getTargetSecurityToken();
 
-        deviceUpdater.startUpdate(tenant, thingId, actionId,
-                downloadAndUpdateRequest.getSoftwareModules().get(0).getModuleVersion(), (device, actionId1) -> {
-                    switch (device.getResponseStatus()) {
+        deviceUpdater.startUpdate(tenant, thingId, actionId, null, downloadAndUpdateRequest.getSoftwareModules(),
+                targetSecurityToken, (device, actionId1) -> {
+                    switch (device.getUpdateStatus().getResponseStatus()) {
                     case SUCCESSFUL:
                         spSenderService.finishUpdateProcess(
                                 new SimulatedUpdate(device.getTenant(), device.getId(), actionId1),
-                                "Simulation complete!");
+                                device.getUpdateStatus().getStatusMessages());
                         break;
                     case ERROR:
                         spSenderService.finishUpdateProcessWithError(
                                 new SimulatedUpdate(device.getTenant(), device.getId(), actionId1),
-                                "Simulation complete with error!");
+                                device.getUpdateStatus().getStatusMessages());
                         break;
                     default:
                         break;

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/event/ProgressUpdate.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/event/ProgressUpdate.java
@@ -13,8 +13,6 @@ import org.eclipse.hawkbit.simulator.AbstractSimulatedDevice;
 /**
  * Event definition object which is published if the simulated device updated
  * its update progress.
- * 
- * @author Michael Hirsch
  *
  */
 public class ProgressUpdate {

--- a/examples/hawkbit-example-app/src/main/resources/application-cloudsandbox.properties
+++ b/examples/hawkbit-example-app/src/main/resources/application-cloudsandbox.properties
@@ -8,3 +8,7 @@
 #
 
 vaadin.servlet.productionMode=true
+
+hawkbit.artifact.url.coap.enabled=false
+hawkbit.artifact.url.http.enabled=false
+hawkbit.artifact.url.https.enabled=true

--- a/examples/hawkbit-example-app/src/main/resources/application-cloudsandbox.properties
+++ b/examples/hawkbit-example-app/src/main/resources/application-cloudsandbox.properties
@@ -12,3 +12,5 @@ vaadin.servlet.productionMode=true
 hawkbit.artifact.url.coap.enabled=false
 hawkbit.artifact.url.http.enabled=false
 hawkbit.artifact.url.https.enabled=true
+hawkbit.artifact.url.https.pattern={protocol}://{hostname}/{tenant}/controller/v1/{targetId}/softwaremodules/{softwareModuleId}/artifacts/{artifactFileName}
+hawkbit.artifact.url.https.hostname=hawkbit.eu-gb.mybluemix.net

--- a/examples/hawkbit-example-app/src/main/resources/application.properties
+++ b/examples/hawkbit-example-app/src/main/resources/application.properties
@@ -7,15 +7,22 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #
 
+# DDI authentication configuration
 hawkbit.server.ddi.security.authentication.anonymous.enabled=true
-hawkbit.server.ddi.security.authentication.targettoken.enabled=false
-hawkbit.server.ddi.security.authentication.gatewaytoken.enabled=false
+hawkbit.server.ddi.security.authentication.targettoken.enabled=true
+hawkbit.server.ddi.security.authentication.gatewaytoken.enabled=true
 
-spring.profiles.active=amqp
+# Download URL generation config
+hawkbit.artifact.url.coap.enabled=false
+hawkbit.artifact.url.http.enabled=true
+hawkbit.artifact.url.http.port=8080
+hawkbit.artifact.url.https.enabled=false
 
+## Vaadin configuration
 vaadin.servlet.productionMode=false
 
-## Configuration for RabbitMQ integration
+## Configuration for DMF/RabbitMQ integration
+spring.profiles.active=amqp
 spring.rabbitmq.username=guest
 spring.rabbitmq.password=guest
 spring.rabbitmq.virtualHost=/

--- a/examples/hawkbit-mgmt-api-client/pom.xml
+++ b/examples/hawkbit-mgmt-api-client/pom.xml
@@ -18,7 +18,7 @@
    </parent>
    <packaging>jar</packaging>
    <artifactId>hawkbit-mgmt-api-client</artifactId>
-   <name>hawkBit Management API example client</name>
+   <name>hawkBit :: Management API example client</name>
 
    <build>
       <plugins>

--- a/hawkbit-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactStore.java
+++ b/hawkbit-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactStore.java
@@ -200,9 +200,9 @@ public class ArtifactStore implements ArtifactRepository {
         String sha1Hash;
         // compute digest
         final MessageDigest md = MessageDigest.getInstance("SHA-1");
-        final DigestOutputStream dos = new DigestOutputStream(os, md);
-        ByteStreams.copy(stream, dos);
-        dos.close();
+        try (final DigestOutputStream dos = new DigestOutputStream(os, md)) {
+            ByteStreams.copy(stream, dos);
+        }
         sha1Hash = BaseEncoding.base16().lowerCase().encode(md.digest());
         if (providedSHA1Sum != null && !providedSHA1Sum.equalsIgnoreCase(sha1Hash)) {
             throw new HashNotMatchException(

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/api/ArtifactUrlHandler.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/api/ArtifactUrlHandler.java
@@ -13,7 +13,6 @@ package org.eclipse.hawkbit.api;
  * URLs to specific artifacts.
  *
  */
-@FunctionalInterface
 public interface ArtifactUrlHandler {
 
     /**
@@ -34,4 +33,11 @@ public interface ArtifactUrlHandler {
      */
     String getUrl(String controllerId, final Long softwareModuleId, final String filename, final String sha1Hash,
             final UrlProtocol protocol);
+
+    /**
+     * @param protocol
+     *            to check support for
+     * @return <code>true</code> of the handler supports given protocol.
+     */
+    boolean protocolSupported(UrlProtocol protocol);
 }

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/api/ArtifactUrlHandlerProperties.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/api/ArtifactUrlHandlerProperties.java
@@ -78,6 +78,12 @@ public class ArtifactUrlHandlerProperties {
          * @return the pattern to build the URL.
          */
         String getPattern();
+
+        /**
+         * @return <code>true</code> if the {@link ProtocolProperties} is
+         *         enabled.
+         */
+        boolean isEnabled();
     }
 
     /**
@@ -92,6 +98,20 @@ public class ArtifactUrlHandlerProperties {
          * have specific artifact placeholder.
          */
         private String pattern = "{protocol}://{hostname}:{port}/{tenant}/controller/v1/{targetId}/softwaremodules/{softwareModuleId}/artifacts/{artifactFileName}";
+
+        /**
+         * Enables HTTP URI generation in DDI and DMF.
+         */
+        private boolean enabled = true;
+
+        @Override
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(final boolean enabled) {
+            this.enabled = enabled;
+        }
 
         @Override
         public String getHostname() {
@@ -143,6 +163,20 @@ public class ArtifactUrlHandlerProperties {
          */
         private String pattern = "{protocol}://{hostname}:{port}/{tenant}/controller/v1/{targetId}/softwaremodules/{softwareModuleId}/artifacts/{artifactFileName}";
 
+        /**
+         * Enables HTTPS URI generation in DDI and DMF.
+         */
+        private boolean enabled = true;
+
+        @Override
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(final boolean enabled) {
+            this.enabled = enabled;
+        }
+
         @Override
         public String getHostname() {
             return hostname;
@@ -192,6 +226,20 @@ public class ArtifactUrlHandlerProperties {
          * have specific artifact placeholder.
          */
         private String pattern = "{protocol}://{ip}:{port}/fw/{tenant}/{targetId}/sha1/{artifactSHA1}";
+
+        /**
+         * Enables CoAP URI generation in DMF.
+         */
+        private boolean enabled = true;
+
+        @Override
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(final boolean enabled) {
+            this.enabled = enabled;
+        }
 
         @Override
         public String getHostname() {

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/api/PropertyBasedArtifactUrlHandler.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/api/PropertyBasedArtifactUrlHandler.java
@@ -84,4 +84,15 @@ public class PropertyBasedArtifactUrlHandler implements ArtifactUrlHandler {
         return replaceMap;
     }
 
+    @Override
+    public boolean protocolSupported(final UrlProtocol protocol) {
+        final String protocolString = protocol.name().toLowerCase();
+        final ProtocolProperties properties = urlHandlerProperties.getProperties(protocolString);
+        if (properties == null || properties.getPattern() == null) {
+            return false;
+        }
+
+        return properties.isEnabled();
+    }
+
 }

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
@@ -82,6 +82,7 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
                 .getSoftwareModules();
         final DownloadAndUpdateRequest downloadAndUpdateRequest = new DownloadAndUpdateRequest();
         downloadAndUpdateRequest.setActionId(targetAssignDistributionSetEvent.getActionId());
+        downloadAndUpdateRequest.setTargetToken(targetAssignDistributionSetEvent.getTargetToken());
 
         for (final org.eclipse.hawkbit.repository.model.SoftwareModule softwareModule : modules) {
             final SoftwareModule amqpSoftwareModule = convertToAmqpSoftwareModule(controllerId, softwareModule);

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
@@ -82,7 +82,7 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
                 .getSoftwareModules();
         final DownloadAndUpdateRequest downloadAndUpdateRequest = new DownloadAndUpdateRequest();
         downloadAndUpdateRequest.setActionId(targetAssignDistributionSetEvent.getActionId());
-        downloadAndUpdateRequest.setTargetToken(targetAssignDistributionSetEvent.getTargetToken());
+        downloadAndUpdateRequest.setTargetSecurityToken(targetAssignDistributionSetEvent.getTargetToken());
 
         for (final org.eclipse.hawkbit.repository.model.SoftwareModule softwareModule : modules) {
             final SoftwareModule amqpSoftwareModule = convertToAmqpSoftwareModule(controllerId, softwareModule);

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
@@ -155,18 +155,26 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
     private Artifact convertArtifact(final String targetId, final LocalArtifact localArtifact) {
         final Artifact artifact = new Artifact();
 
-        artifact.getUrls().put(Artifact.UrlProtocol.COAP,
-                artifactUrlHandler.getUrl(targetId, localArtifact.getSoftwareModule().getId(),
-                        localArtifact.getFilename(), localArtifact.getSha1Hash(), UrlProtocol.COAP));
-        artifact.getUrls().put(Artifact.UrlProtocol.HTTP,
-                artifactUrlHandler.getUrl(targetId, localArtifact.getSoftwareModule().getId(),
-                        localArtifact.getFilename(), localArtifact.getSha1Hash(), UrlProtocol.HTTP));
-        artifact.getUrls().put(Artifact.UrlProtocol.HTTPS,
-                artifactUrlHandler.getUrl(targetId, localArtifact.getSoftwareModule().getId(),
-                        localArtifact.getFilename(), localArtifact.getSha1Hash(), UrlProtocol.HTTPS));
+        if (artifactUrlHandler.protocolSupported(UrlProtocol.COAP)) {
+            artifact.getUrls().put(Artifact.UrlProtocol.COAP,
+                    artifactUrlHandler.getUrl(targetId, localArtifact.getSoftwareModule().getId(),
+                            localArtifact.getFilename(), localArtifact.getSha1Hash(), UrlProtocol.COAP));
+        }
+
+        if (artifactUrlHandler.protocolSupported(UrlProtocol.HTTP)) {
+            artifact.getUrls().put(Artifact.UrlProtocol.HTTP,
+                    artifactUrlHandler.getUrl(targetId, localArtifact.getSoftwareModule().getId(),
+                            localArtifact.getFilename(), localArtifact.getSha1Hash(), UrlProtocol.HTTP));
+        }
+
+        if (artifactUrlHandler.protocolSupported(UrlProtocol.HTTPS)) {
+            artifact.getUrls().put(Artifact.UrlProtocol.HTTPS,
+                    artifactUrlHandler.getUrl(targetId, localArtifact.getSoftwareModule().getId(),
+                            localArtifact.getFilename(), localArtifact.getSha1Hash(), UrlProtocol.HTTPS));
+        }
 
         artifact.setFilename(localArtifact.getFilename());
-        artifact.setHashes(new ArtifactHash(localArtifact.getSha1Hash(), null));
+        artifact.setHashes(new ArtifactHash(localArtifact.getSha1Hash(), localArtifact.getMd5Hash()));
         artifact.setSize(localArtifact.getSize());
         return artifact;
     }

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -337,9 +337,8 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
         final Action action = checkActionExist(message, actionUpdateStatus);
 
         final ActionStatus actionStatus = new ActionStatus();
-        final List<String> messageText = actionUpdateStatus.getMessage();
-        final String messageString = String.join(", ", messageText);
-        actionStatus.addMessage(messageString);
+        actionUpdateStatus.getMessage().forEach(actionStatus::addMessage);
+
         actionStatus.setAction(action);
         actionStatus.setOccurredAt(System.currentTimeMillis());
 

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -305,7 +305,8 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
         final List<SoftwareModule> softwareModuleList = controllerManagement
                 .findSoftwareModulesByDistributionSet(distributionSet);
         eventBus.post(new TargetAssignDistributionSetEvent(target.getOptLockRevision(), target.getTenant(),
-                target.getControllerId(), action.getId(), softwareModuleList, target.getTargetInfo().getAddress()));
+                target.getControllerId(), action.getId(), softwareModuleList, target.getTargetInfo().getAddress(),
+                target.getSecurityToken()));
 
     }
 

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
@@ -192,7 +192,7 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTestWit
                 downloadAndUpdateRequest.getActionId(), Long.valueOf(1));
         assertEquals("The topic of the event shuold contain DOWNLOAD_AND_INSTALL", EventTopic.DOWNLOAD_AND_INSTALL,
                 sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.TOPIC));
-        assertEquals("Security token of target", downloadAndUpdateRequest.getTargetToken(), TEST_TOKEN);
+        assertEquals("Security token of target", downloadAndUpdateRequest.getTargetSecurityToken(), TEST_TOKEN);
 
         return downloadAndUpdateRequest;
 

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
@@ -58,6 +58,12 @@ import ru.yandex.qatools.allure.annotations.Stories;
 @Stories("AmqpMessage Dispatcher Service Test")
 public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTestWithMongoDB {
 
+    private static final String TENANT = "default";
+
+    private static final URI AMQP_URI = IpUtil.createAmqpUri("vHost", "mytest");
+
+    private static final String TEST_TOKEN = "testToken";
+
     private AmqpMessageDispatcherService amqpMessageDispatcherService;
 
     private RabbitTemplate rabbitTemplate;
@@ -89,8 +95,7 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTestWit
     @Description("Verfies that download and install event with no software modul works")
     public void testSendDownloadRequesWithEmptySoftwareModules() {
         final TargetAssignDistributionSetEvent targetAssignDistributionSetEvent = new TargetAssignDistributionSetEvent(
-                1L, "default", CONTROLLER_ID, 1l, new ArrayList<SoftwareModule>(),
-                IpUtil.createAmqpUri("vHost", "mytest"));
+                1L, TENANT, CONTROLLER_ID, 1L, new ArrayList<SoftwareModule>(), AMQP_URI, TEST_TOKEN);
         amqpMessageDispatcherService.targetAssignDistributionSet(targetAssignDistributionSetEvent);
         final Message sendMessage = createArgumentCapture(targetAssignDistributionSetEvent.getTargetAdress());
         final DownloadAndUpdateRequest downloadAndUpdateRequest = assertDownloadAndInstallMessage(sendMessage);
@@ -104,7 +109,7 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTestWit
         final DistributionSet dsA = TestDataUtil.generateDistributionSet("", softwareManagement,
                 distributionSetManagement);
         final TargetAssignDistributionSetEvent targetAssignDistributionSetEvent = new TargetAssignDistributionSetEvent(
-                1L, "default", CONTROLLER_ID, 1l, dsA.getModules(), IpUtil.createAmqpUri("vHost", "mytest"));
+                1L, TENANT, CONTROLLER_ID, 1L, dsA.getModules(), AMQP_URI, TEST_TOKEN);
         amqpMessageDispatcherService.targetAssignDistributionSet(targetAssignDistributionSetEvent);
         final Message sendMessage = createArgumentCapture(targetAssignDistributionSetEvent.getTargetAdress());
         final DownloadAndUpdateRequest downloadAndUpdateRequest = assertDownloadAndInstallMessage(sendMessage);
@@ -143,7 +148,7 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTestWit
         Mockito.when(rabbitTemplate.convertSendAndReceive(any())).thenReturn(receivedList);
 
         final TargetAssignDistributionSetEvent targetAssignDistributionSetEvent = new TargetAssignDistributionSetEvent(
-                1L, "default", CONTROLLER_ID, 1l, dsA.getModules(), IpUtil.createAmqpUri("vHost", "mytest"));
+                1L, TENANT, CONTROLLER_ID, 1L, dsA.getModules(), AMQP_URI, TEST_TOKEN);
         amqpMessageDispatcherService.targetAssignDistributionSet(targetAssignDistributionSetEvent);
         final Message sendMessage = createArgumentCapture(targetAssignDistributionSetEvent.getTargetAdress());
         final DownloadAndUpdateRequest downloadAndUpdateRequest = assertDownloadAndInstallMessage(sendMessage);
@@ -162,7 +167,7 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTestWit
     @Description("Verfies that send cancel event works")
     public void testSendCancelRequest() {
         final CancelTargetAssignmentEvent cancelTargetAssignmentDistributionSetEvent = new CancelTargetAssignmentEvent(
-                1L, "default", CONTROLLER_ID, 1l, IpUtil.createAmqpUri("vHost", "mytest"));
+                1L, TENANT, CONTROLLER_ID, 1L, AMQP_URI);
         amqpMessageDispatcherService
                 .targetCancelAssignmentToDistributionSet(cancelTargetAssignmentDistributionSetEvent);
         final Message sendMessage = createArgumentCapture(cancelTargetAssignmentDistributionSetEvent.getTargetAdress());
@@ -187,13 +192,12 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTestWit
                 downloadAndUpdateRequest.getActionId(), Long.valueOf(1));
         assertEquals("The topic of the event shuold contain DOWNLOAD_AND_INSTALL", EventTopic.DOWNLOAD_AND_INSTALL,
                 sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.TOPIC));
+        assertEquals("Security token of target", downloadAndUpdateRequest.getTargetToken(), TEST_TOKEN);
+
         return downloadAndUpdateRequest;
 
     }
 
-    /**
-     * @param sendMessage
-     */
     private void assertEventMessage(final Message sendMessage) {
         assertNotNull("The message should not be null", sendMessage);
 

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -339,14 +339,14 @@ public class AmqpMessageHandlerServiceTest {
 
     @Test
     @Description("Tests TODO")
-    public void lookupNextUpdateActionAfterFinished() throws IllegalArgumentException, IllegalAccessException {
+    public void lookupNextUpdateActionAfterFinished() throws IllegalAccessException {
 
         // Mock
         final Action action = createActionWithTarget(22L, Status.FINISHED);
         when(controllerManagementMock.findActionWithDetails(Matchers.any())).thenReturn(action);
         when(controllerManagementMock.addUpdateActionStatus(Matchers.any(), Matchers.any())).thenReturn(action);
         // for the test the same action can be used
-        final List<Action> actionList = new ArrayList<Action>();
+        final List<Action> actionList = new ArrayList<>();
         actionList.add(action);
         when(controllerManagementMock.findActionByTargetAndActive(Matchers.any())).thenReturn(actionList);
 
@@ -372,6 +372,8 @@ public class AmqpMessageHandlerServiceTest {
 
         assertThat(targetAssignDistributionSetEvent.getControllerId()).as("event has wrong controller id")
                 .isEqualTo("target1");
+        assertThat(targetAssignDistributionSetEvent.getTargetToken()).as("targetoken not filled correctly")
+                .isEqualTo(action.getTarget().getSecurityToken());
         assertThat(targetAssignDistributionSetEvent.getActionId()).as("event has wrong action id").isEqualTo(22L);
         assertThat(targetAssignDistributionSetEvent.getSoftwareModules()).as("event has wrong sofware modules")
                 .isEqualTo(softwareModuleList);
@@ -411,8 +413,7 @@ public class AmqpMessageHandlerServiceTest {
         return softwareModuleList;
     }
 
-    private Action createActionWithTarget(final Long targetId, final Status status)
-            throws IllegalArgumentException, IllegalAccessException {
+    private Action createActionWithTarget(final Long targetId, final Status status) throws IllegalAccessException {
         // is needed for the creation of targets
         initalizeSecurityTokenGenerator();
 

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -333,6 +333,8 @@ public class AmqpMessageHandlerServiceTest {
         assertThat(downloadResponse.getResponseCode()).as("Message body response code is wrong")
                 .isEqualTo(HttpStatus.OK.value());
         assertThat(downloadResponse.getArtifact().getSize()).as("Wrong artifact size in message body").isEqualTo(1L);
+        assertThat(downloadResponse.getArtifact().getHashes().getSha1()).as("Wrong sha1 hash").isEqualTo("sha1");
+        assertThat(downloadResponse.getArtifact().getHashes().getMd5()).as("Wrong md5 hash").isEqualTo("md5");
         assertThat(downloadResponse.getDownloadUrl()).as("download url is wrong")
                 .startsWith("http://localhost/api/v1/downloadserver/downloadId/");
     }
@@ -381,7 +383,7 @@ public class AmqpMessageHandlerServiceTest {
     }
 
     private ActionUpdateStatus createActionUpdateStatus(final ActionStatus status) {
-        return createActionUpdateStatus(status, 2l);
+        return createActionUpdateStatus(status, 2L);
     }
 
     private ActionUpdateStatus createActionUpdateStatus(final ActionStatus status, final Long id) {
@@ -406,7 +408,7 @@ public class AmqpMessageHandlerServiceTest {
     }
 
     private List<SoftwareModule> createSoftwareModuleList() {
-        final List<SoftwareModule> softwareModuleList = new ArrayList<SoftwareModule>();
+        final List<SoftwareModule> softwareModuleList = new ArrayList<>();
         final SoftwareModule softwareModule = new SoftwareModule();
         softwareModule.setId(777L);
         softwareModuleList.add(softwareModule);
@@ -428,7 +430,7 @@ public class AmqpMessageHandlerServiceTest {
         return action;
     }
 
-    private void initalizeSecurityTokenGenerator() throws IllegalArgumentException, IllegalAccessException {
+    private void initalizeSecurityTokenGenerator() throws IllegalAccessException {
         final SecurityTokenGeneratorHolder instance = SecurityTokenGeneratorHolder.getInstance();
         final Field[] fields = instance.getClass().getDeclaredFields();
         for (final Field field : fields) {

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/BaseAmqpServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/BaseAmqpServiceTest.java
@@ -52,6 +52,8 @@ public class BaseAmqpServiceTest {
         final ActionUpdateStatus actionUpdateStatus = new ActionUpdateStatus();
         actionUpdateStatus.setActionId(1L);
         actionUpdateStatus.setSoftwareModuleId(2L);
+        actionUpdateStatus.getMessage().add("Message 1");
+        actionUpdateStatus.getMessage().add("Message 2");
 
         final Message message = rabbitTemplate.getMessageConverter().toMessage(actionUpdateStatus,
                 new MessageProperties());

--- a/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/ArtifactHash.java
+++ b/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/ArtifactHash.java
@@ -13,10 +13,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * JSON representation of artifact hash.
- * 
- *
- *
- *
  */
 public class ArtifactHash {
 

--- a/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DownloadAndUpdateRequest.java
+++ b/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DownloadAndUpdateRequest.java
@@ -19,15 +19,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * JSON representation of download and update request.
  *
- *
- *
- *
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DownloadAndUpdateRequest {
     @JsonProperty
     private Long actionId;
+
+    @JsonProperty
+    private String targetToken;
+
     @JsonProperty
     private final List<SoftwareModule> softwareModules = new LinkedList<>();
 
@@ -37,6 +38,14 @@ public class DownloadAndUpdateRequest {
 
     public void setActionId(final Long correlator) {
         this.actionId = correlator;
+    }
+
+    public String getTargetToken() {
+        return targetToken;
+    }
+
+    public void setTargetToken(final String targetToken) {
+        this.targetToken = targetToken;
     }
 
     public List<SoftwareModule> getSoftwareModules() {

--- a/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DownloadAndUpdateRequest.java
+++ b/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DownloadAndUpdateRequest.java
@@ -27,7 +27,7 @@ public class DownloadAndUpdateRequest {
     private Long actionId;
 
     @JsonProperty
-    private String targetToken;
+    private String targetSecurityToken;
 
     @JsonProperty
     private final List<SoftwareModule> softwareModules = new LinkedList<>();
@@ -40,12 +40,12 @@ public class DownloadAndUpdateRequest {
         this.actionId = correlator;
     }
 
-    public String getTargetToken() {
-        return targetToken;
+    public String getTargetSecurityToken() {
+        return targetSecurityToken;
     }
 
-    public void setTargetToken(final String targetToken) {
-        this.targetToken = targetToken;
+    public void setTargetSecurityToken(final String targetSecurityToken) {
+        this.targetSecurityToken = targetSecurityToken;
     }
 
     public List<SoftwareModule> getSoftwareModules() {

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/eventbus/event/TargetAssignDistributionSetEvent.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/eventbus/event/TargetAssignDistributionSetEvent.java
@@ -16,8 +16,6 @@ import org.eclipse.hawkbit.repository.model.SoftwareModule;
 /**
  * Event that gets sent when a distribution set gets assigned to a target.
  *
- *
- *
  */
 public class TargetAssignDistributionSetEvent extends AbstractEvent {
 
@@ -25,6 +23,7 @@ public class TargetAssignDistributionSetEvent extends AbstractEvent {
     private final String controllerId;
     private final Long actionId;
     private final URI targetAdress;
+    private final String targetToken;
 
     /**
      * Creates a new {@link TargetAssignDistributionSetEvent}.
@@ -41,14 +40,18 @@ public class TargetAssignDistributionSetEvent extends AbstractEvent {
      *            the software modules which have been assigned to the target
      * @param targetAdress
      *            the targetAdress of the target
+     * @param targetToken
+     *            the authentication token of the target
      */
     public TargetAssignDistributionSetEvent(final long revision, final String tenant, final String controllerId,
-            final Long actionId, final Collection<SoftwareModule> softwareModules, final URI targetAdress) {
+            final Long actionId, final Collection<SoftwareModule> softwareModules, final URI targetAdress,
+            final String targetToken) {
         super(revision, tenant);
         this.controllerId = controllerId;
         this.actionId = actionId;
         this.softwareModules = softwareModules;
         this.targetAdress = targetAdress;
+        this.targetToken = targetToken;
     }
 
     /**
@@ -77,4 +80,7 @@ public class TargetAssignDistributionSetEvent extends AbstractEvent {
         return targetAdress;
     }
 
+    public String getTargetToken() {
+        return targetToken;
+    }
 }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -63,6 +63,8 @@ public class ControllerManagement {
     private static final Logger LOG = LoggerFactory.getLogger(ControllerManagement.class);
     private static final Logger LOG_DOS = LoggerFactory.getLogger("server-security.dos");
 
+    public static final String SERVER_MESSAGE_PREFIX = "Update Server: ";
+
     @Autowired
     private EntityManager entityManager;
 
@@ -341,13 +343,14 @@ public class ControllerManagement {
             break;
         case CANCELED:
         case FINISHED:
-            // in case of successful cancelation we also report the success at
+            // in case of successful cancellation we also report the success at
             // the canceled action itself.
-            actionStatus.addMessage("Cancelation completion is finished sucessfully.");
+            actionStatus.addMessage(
+                    ControllerManagement.SERVER_MESSAGE_PREFIX + "Cancellation completion is finished sucessfully.");
             deploymentManagement.successCancellation(action);
             break;
         case RETRIEVED:
-            actionStatus.addMessage("Cancelation request retrieved");
+            actionStatus.addMessage(ControllerManagement.SERVER_MESSAGE_PREFIX + "Cancellation request retrieved.");
             break;
         default:
         }

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
@@ -389,8 +389,8 @@ public class DeploymentManagement {
                         softwareModules));
     }
 
-    private Action createTargetAction(final Map<String, TargetWithActionType> targetsWithActionMap, final Target target,
-            final DistributionSet set, final Rollout rollout, final RolloutGroup rolloutGroup) {
+    private static Action createTargetAction(final Map<String, TargetWithActionType> targetsWithActionMap,
+            final Target target, final DistributionSet set, final Rollout rollout, final RolloutGroup rolloutGroup) {
         final Action actionForTarget = new Action();
         final TargetWithActionType targetWithActionType = targetsWithActionMap.get(target.getControllerId());
         actionForTarget.setActionType(targetWithActionType.getActionType());
@@ -421,13 +421,14 @@ public class DeploymentManagement {
         afterCommit.afterCommit(() -> {
             eventBus.post(new TargetInfoUpdateEvent(target.getTargetInfo()));
             eventBus.post(new TargetAssignDistributionSetEvent(target.getOptLockRevision(), target.getTenant(),
-                    target.getControllerId(), actionId, softwareModules, target.getTargetInfo().getAddress()));
+                    target.getControllerId(), actionId, softwareModules, target.getTargetInfo().getAddress(),
+                    target.getSecurityToken()));
         });
     }
 
     /**
      * Removes {@link UpdateAction}s that are no longer necessary and sends
-     * cancelations to the controller.
+     * cancellations to the controller.
      *
      * @param myTarget
      *            to override {@link UpdateAction}s

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/TestConfiguration.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/TestConfiguration.java
@@ -79,7 +79,7 @@ public class TestConfiguration implements AsyncConfigurer {
     }
 
     /**
-     * Bean for the downlod id cache.
+     * Bean for the download id cache.
      * 
      * @return the cache
      */

--- a/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/controller/ArtifactStoreController.java
+++ b/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/controller/ArtifactStoreController.java
@@ -143,9 +143,11 @@ public class ArtifactStoreController {
         actionStatus.setStatus(Status.DOWNLOAD);
 
         if (range != null) {
-            actionStatus.addMessage("It is a partial download request: " + range);
+            actionStatus.addMessage(ControllerManagement.SERVER_MESSAGE_PREFIX + "Target downloads range " + range
+                    + " of: " + request.getRequestURI());
         } else {
-            actionStatus.addMessage("Target downloads");
+            actionStatus.addMessage(
+                    ControllerManagement.SERVER_MESSAGE_PREFIX + "Target downloads: " + request.getRequestURI());
         }
         controllerManagement.addActionStatusMessage(actionStatus);
         return action;

--- a/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/controller/RootController.java
+++ b/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/controller/RootController.java
@@ -220,7 +220,7 @@ public class RootController {
                     + " of: " + request.getRequestURI());
         } else {
             statusMessage.addMessage(
-                    ControllerManagement.SERVER_MESSAGE_PREFIX + "Target downloads: " + request.getRequestURI());
+                    ControllerManagement.SERVER_MESSAGE_PREFIX + "Target downloads " + request.getRequestURI());
         }
         controllerManagement.addActionStatusMessage(statusMessage);
         return action;
@@ -390,7 +390,7 @@ public class RootController {
             LOG.debug("Controller confirmed cancel (actionid: {}, targetid: {}) as we got {} report.", actionid,
                     targetid, feedback.getStatus().getExecution());
             actionStatus.setStatus(Status.CANCELED);
-            actionStatus.addMessage(ControllerManagement.SERVER_MESSAGE_PREFIX + "Target confirmed cancelation");
+            actionStatus.addMessage(ControllerManagement.SERVER_MESSAGE_PREFIX + "Target confirmed cancelation.");
             break;
         case REJECTED:
             LOG.info("Controller reported internal error (actionid: {}, targetid: {}) as we got {} report.", actionid,
@@ -424,7 +424,7 @@ public class RootController {
                 targetid, feedback.getStatus().getExecution());
         actionStatus.setStatus(Status.RUNNING);
         actionStatus.addMessage(
-                ControllerManagement.SERVER_MESSAGE_PREFIX + "Target reported: " + feedback.getStatus().getExecution());
+                ControllerManagement.SERVER_MESSAGE_PREFIX + "Target reported " + feedback.getStatus().getExecution());
     }
 
     private static void handleClosedUpdateStatus(final ActionFeedback feedback, final String targetid,

--- a/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/controller/RootController.java
+++ b/hawkbit-rest-resource/src/main/java/org/eclipse/hawkbit/controller/RootController.java
@@ -216,9 +216,11 @@ public class RootController {
         statusMessage.setStatus(Status.DOWNLOAD);
 
         if (range != null) {
-            statusMessage.addMessage("It is a partial download request: " + range);
+            statusMessage.addMessage(ControllerManagement.SERVER_MESSAGE_PREFIX + "Target downloads range " + range
+                    + " of: " + request.getRequestURI());
         } else {
-            statusMessage.addMessage("Controller downloads");
+            statusMessage.addMessage(
+                    ControllerManagement.SERVER_MESSAGE_PREFIX + "Target downloads: " + request.getRequestURI());
         }
         controllerManagement.addActionStatusMessage(statusMessage);
         return action;
@@ -388,13 +390,13 @@ public class RootController {
             LOG.debug("Controller confirmed cancel (actionid: {}, targetid: {}) as we got {} report.", actionid,
                     targetid, feedback.getStatus().getExecution());
             actionStatus.setStatus(Status.CANCELED);
-            actionStatus.addMessage("Controller confirmed cancelation");
+            actionStatus.addMessage(ControllerManagement.SERVER_MESSAGE_PREFIX + "Target confirmed cancelation");
             break;
         case REJECTED:
             LOG.info("Controller reported internal error (actionid: {}, targetid: {}) as we got {} report.", actionid,
                     targetid, feedback.getStatus().getExecution());
             actionStatus.setStatus(Status.WARNING);
-            actionStatus.addMessage("Controller reported internal ERROR and REJECTED update.");
+            actionStatus.addMessage(ControllerManagement.SERVER_MESSAGE_PREFIX + "Target REJECTED update.");
             break;
         case CLOSED:
             handleClosedUpdateStatus(feedback, targetid, actionid, actionStatus);
@@ -421,7 +423,8 @@ public class RootController {
         LOG.debug("Controller reported intermediate status (actionid: {}, targetid: {}) as we got {} report.", actionid,
                 targetid, feedback.getStatus().getExecution());
         actionStatus.setStatus(Status.RUNNING);
-        actionStatus.addMessage("Controller reported: " + feedback.getStatus().getExecution());
+        actionStatus.addMessage(
+                ControllerManagement.SERVER_MESSAGE_PREFIX + "Target reported: " + feedback.getStatus().getExecution());
     }
 
     private static void handleClosedUpdateStatus(final ActionFeedback feedback, final String targetid,
@@ -430,10 +433,10 @@ public class RootController {
                 feedback.getStatus().getExecution());
         if (feedback.getStatus().getResult().getFinished() == FinalResult.FAILURE) {
             actionStatus.setStatus(Status.ERROR);
-            actionStatus.addMessage("Controller reported CLOSED with ERROR!");
+            actionStatus.addMessage(ControllerManagement.SERVER_MESSAGE_PREFIX + "Target reported CLOSED with ERROR!");
         } else {
             actionStatus.setStatus(Status.FINISHED);
-            actionStatus.addMessage("Controller reported CLOSED with OK!");
+            actionStatus.addMessage(ControllerManagement.SERVER_MESSAGE_PREFIX + "Target reported CLOSED with OK!");
         }
     }
 


### PR DESCRIPTION
The DMF API update message so far does not contain the target security token. As a result users have to use either gateway token or for every update can mgmt API to get the token for device authentication for artefact download. Adding the token to the message should make things a lot easier.

I needed a way to test this so I enabled the device simulator to download artefacts in DMF case leveraging the targetToken.

During testing I saw a couple of bugs in DMF API (not providing MD5 hash and handling multi line update results incorrectly) and improved on the readability of the server generated messages.

I also introduced the possibility to enable/disabled the different download URI generations in DDI and DMF. I think in the long run we should make this more flexible. This hard configured URL generation is not a very flexible solution imho.

Final result looks like this:
![screen shot 2016-05-03 at 18 32 48](https://cloud.githubusercontent.com/assets/9153035/14990582/7e4206c4-115d-11e6-9b36-26fa6bde9b43.png)
