### PR TITLE
Create filter has different layout than rollout and the other widgets

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterHeader.java
@@ -78,9 +78,8 @@ public class TargetFilterHeader extends VerticalLayout {
     }
 
     private Label createHeaderCaption() {
-        final Label captionLabel = SPUIComponentProvider.getLabel(getHeaderCaption(),
+        return SPUIComponentProvider.getLabel(SPUIDefinitions.TARGET_FILTER_LIST_HEADER_CAPTION,
                 SPUILabelDefinitions.SP_WIDGET_CAPTION);
-        return captionLabel;
     }
 
     private void buildLayout() {
@@ -109,8 +108,8 @@ public class TargetFilterHeader extends VerticalLayout {
     }
 
     private Button createAddButton() {
-        final Button button = SPUIComponentProvider.getButton(getAddIconId(), "", "", null, false, FontAwesome.PLUS,
-                SPUIButtonStyleSmallNoBorder.class);
+        final Button button = SPUIComponentProvider.getButton(SPUIComponetIdProvider.TARGET_FILTER_ADD_ICON_ID, "", "",
+                null, false, FontAwesome.PLUS, SPUIButtonStyleSmallNoBorder.class);
         button.addClickListener(event -> addNewFilter());
         return button;
     }
@@ -185,11 +184,4 @@ public class TargetFilterHeader extends VerticalLayout {
         eventBus.publish(this, CustomFilterUIEvent.FILTER_BY_CUST_FILTER_TEXT_REMOVE);
     }
 
-    protected String getAddIconId() {
-        return SPUIComponetIdProvider.TARGET_FILTER_ADD_ICON_ID;
-    }
-
-    protected String getHeaderCaption() {
-        return SPUIDefinitions.TARGET_FILTER_LIST_HEADER_CAPTION;
-    }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterHeader.java
@@ -13,7 +13,6 @@ import javax.annotation.PostConstruct;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.components.SPUIButton;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
-import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmall;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmallNoBorder;
 import org.eclipse.hawkbit.ui.filtermanagement.event.CustomFilterUIEvent;
 import org.eclipse.hawkbit.ui.filtermanagement.state.FilterManagementUIState;
@@ -79,7 +78,7 @@ public class TargetFilterHeader extends VerticalLayout {
     }
 
     private Label createHeaderCaption() {
-        final Label captionLabel = SPUIComponentProvider.getLabel("Custom Filters",
+        final Label captionLabel = SPUIComponentProvider.getLabel(getHeaderCaption(),
                 SPUILabelDefinitions.SP_WIDGET_CAPTION);
         return captionLabel;
     }
@@ -110,10 +109,9 @@ public class TargetFilterHeader extends VerticalLayout {
     }
 
     private Button createAddButton() {
-        final Button button = SPUIComponentProvider.getButton("camp.search.add.Id", "Create Filter", "Create Filter",
-                "", false, null, SPUIButtonStyleSmall.class);
+        final Button button = SPUIComponentProvider.getButton(getAddIconId(), "", "", null, false, FontAwesome.PLUS,
+                SPUIButtonStyleSmallNoBorder.class);
         button.addClickListener(event -> addNewFilter());
-        button.addStyleName("on-focus-no-border link");
         return button;
     }
 
@@ -187,4 +185,11 @@ public class TargetFilterHeader extends VerticalLayout {
         eventBus.publish(this, CustomFilterUIEvent.FILTER_BY_CUST_FILTER_TEXT_REMOVE);
     }
 
+    protected String getAddIconId() {
+        return SPUIComponetIdProvider.TARGET_FILTER_ADD_ICON_ID;
+    }
+
+    protected String getHeaderCaption() {
+        return SPUIDefinitions.TARGET_FILTER_LIST_HEADER_CAPTION;
+    }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIComponetIdProvider.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIComponetIdProvider.java
@@ -76,6 +76,11 @@ public final class SPUIComponetIdProvider {
     public static final String TARGET_TEXT_FIELD = "target.search.textfield";
 
     /**
+     * ID for add target filter icon
+     */
+    public static final String TARGET_FILTER_ADD_ICON_ID = "target.filter.add.id";
+
+    /**
      * ID-Dist.
      */
     public static final String DIST_TABLE_ID = "dist.tableId";

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIDefinitions.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIDefinitions.java
@@ -923,6 +923,11 @@ public final class SPUIDefinitions {
     public static final String CUSTOM_FILTER_ASSIGNED_DS = "Assigned DS";
 
     /**
+     * TARGET_FILTER_MANAGEMENT - header caption .
+     */
+    public static final String TARGET_FILTER_LIST_HEADER_CAPTION = "Custom Filters";
+
+    /**
      * CUSTOM_FILTER_STATUS.
      */
     public static final String TARGET_FILTER_STATUS = "Status";
@@ -1000,7 +1005,6 @@ public final class SPUIDefinitions {
      * Rollout group started date column property.
      */
     public static final String ROLLOUT_GROUP_STARTED_DATE = "Started date";
-
 
     /**
      * Rollout group status column property.


### PR DESCRIPTION
The "create filter" icon in the target filter management view did not have the same look like in other views. Fixed that UI problem. In addition I added a constant for the header caption.

![create_filter_icon](https://cloud.githubusercontent.com/assets/18258708/14983455/d72e5168-113d-11e6-8aef-cdc8d71e6560.png)

Signed-off-by: Melanie Retter <melanie.retter@bosch-si.com>