### PR TITLE
Filter icon (succes/error) not centered

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
@@ -150,7 +150,7 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
 
     private void buildLayout() {
         final HorizontalLayout nameEditLayout = new HorizontalLayout();
-        nameEditLayout.setWidth(100.0f, Unit.PERCENTAGE);
+        nameEditLayout.setWidth(100.0F, Unit.PERCENTAGE);
         nameEditLayout.addComponent(caption);
         nameEditLayout.setComponentAlignment(caption, Alignment.TOP_LEFT);
         if (hasEditPermission()) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
@@ -157,7 +157,7 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
             nameEditLayout.addComponent(editButton);
             nameEditLayout.setComponentAlignment(editButton, Alignment.TOP_RIGHT);
         }
-        nameEditLayout.setExpandRatio(caption, 1.0f);
+        nameEditLayout.setExpandRatio(caption, 1.0F);
         nameEditLayout.addStyleName(SPUIStyleDefinitions.WIDGET_TITLE);
 
         addComponent(nameEditLayout);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
@@ -152,18 +152,18 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
         final HorizontalLayout nameEditLayout = new HorizontalLayout();
         nameEditLayout.setWidth(100.0f, Unit.PERCENTAGE);
         nameEditLayout.addComponent(caption);
-        nameEditLayout.setComponentAlignment(caption, Alignment.MIDDLE_LEFT);
+        nameEditLayout.setComponentAlignment(caption, Alignment.TOP_LEFT);
         if (hasEditPermission()) {
             nameEditLayout.addComponent(editButton);
-            nameEditLayout.setComponentAlignment(editButton, Alignment.MIDDLE_RIGHT);
+            nameEditLayout.setComponentAlignment(editButton, Alignment.TOP_RIGHT);
         }
         nameEditLayout.setExpandRatio(caption, 1.0f);
         nameEditLayout.addStyleName(SPUIStyleDefinitions.WIDGET_TITLE);
 
         addComponent(nameEditLayout);
-        setComponentAlignment(nameEditLayout, Alignment.MIDDLE_CENTER);
+        setComponentAlignment(nameEditLayout, Alignment.TOP_CENTER);
         addComponent(detailsTab);
-        setComponentAlignment(nameEditLayout, Alignment.MIDDLE_CENTER);
+        setComponentAlignment(nameEditLayout, Alignment.TOP_CENTER);
 
         setSizeFull();
         setHeightUndefined();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableHeader.java
@@ -44,7 +44,7 @@ import com.vaadin.ui.VerticalLayout;
 public abstract class AbstractTableHeader extends VerticalLayout {
 
     private static final long serialVersionUID = 4881626370291837175L;
-    
+
     @Autowired
     protected I18N i18n;
 
@@ -53,7 +53,6 @@ public abstract class AbstractTableHeader extends VerticalLayout {
 
     @Autowired
     protected transient EventBus.SessionEventBus eventbus;
-    
 
     private Label headerCaption;
 
@@ -83,7 +82,7 @@ public abstract class AbstractTableHeader extends VerticalLayout {
         restoreState();
         eventbus.subscribe(this);
     }
-    
+
     @PreDestroy
     void destroy() {
         eventbus.unsubscribe(this);
@@ -195,7 +194,7 @@ public abstract class AbstractTableHeader extends VerticalLayout {
             dropHintDropFilterLayout.setExpandRatio(dropFilterLayout, 1.0f);
         }
         addComponent(dropHintDropFilterLayout);
-        setComponentAlignment(dropHintDropFilterLayout, Alignment.MIDDLE_CENTER);
+        setComponentAlignment(dropHintDropFilterLayout, Alignment.TOP_CENTER);
         addStyleName("bordered-layout");
         addStyleName("no-border-bottom");
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableHeader.java
@@ -170,8 +170,8 @@ public abstract class AbstractTableHeader extends VerticalLayout {
         }
         titleFilterIconsLayout.addComponent(maxMinIcon);
         titleFilterIconsLayout.setComponentAlignment(maxMinIcon, Alignment.TOP_RIGHT);
-        titleFilterIconsLayout.setExpandRatio(headerCaption, 0.4f);
-        titleFilterIconsLayout.setExpandRatio(searchField, 0.6f);
+        titleFilterIconsLayout.setExpandRatio(headerCaption, 0.4F);
+        titleFilterIconsLayout.setExpandRatio(searchField, 0.6F);
 
         addComponent(titleFilterIconsLayout);
 
@@ -191,7 +191,7 @@ public abstract class AbstractTableHeader extends VerticalLayout {
 
             dropHintDropFilterLayout.addComponent(dropFilterLayout);
             dropHintDropFilterLayout.setComponentAlignment(dropFilterLayout, Alignment.TOP_CENTER);
-            dropHintDropFilterLayout.setExpandRatio(dropFilterLayout, 1.0f);
+            dropHintDropFilterLayout.setExpandRatio(dropFilterLayout, 1.0F);
         }
         addComponent(dropHintDropFilterLayout);
         setComponentAlignment(dropHintDropFilterLayout, Alignment.TOP_CENTER);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CreateOrUpdateFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CreateOrUpdateFilterHeader.java
@@ -290,7 +290,7 @@ public class CreateOrUpdateFilterHeader extends VerticalLayout implements Button
         searchLayout.setSpacing(false);
         searchLayout.addComponents(validationIcon, queryTextField);
         searchLayout.addStyleName("custom-search-layout");
-        searchLayout.setComponentAlignment(validationIcon, Alignment.MIDDLE_CENTER);
+        searchLayout.setComponentAlignment(validationIcon, Alignment.TOP_CENTER);
 
         final HorizontalLayout iconLayout = new HorizontalLayout();
         iconLayout.setSizeUndefined();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
@@ -115,7 +115,7 @@ public final class DashboardMenu extends CustomComponent {
         final VerticalLayout links = buildLinksAndVersion();
         menus.addComponent(links);
         menus.setComponentAlignment(links, Alignment.BOTTOM_CENTER);
-        menus.setExpandRatio(links, 1.0f);
+        menus.setExpandRatio(links, 1.0F);
         menuContent.addComponent(menus);
         menuContent.setExpandRatio(menus, 1.0F);
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
@@ -139,7 +139,7 @@ public final class DashboardMenu extends CustomComponent {
         final Label logo = new Label("<strong>" + i18n.get("menu.title") + "</strong>", ContentMode.HTML);
         logo.setSizeUndefined();
         final HorizontalLayout logoWrapper = new HorizontalLayout(logo);
-        logoWrapper.setComponentAlignment(logo, Alignment.MIDDLE_CENTER);
+        logoWrapper.setComponentAlignment(logo, Alignment.TOP_CENTER);
         logoWrapper.addStyleName("valo-menu-title");
         return logoWrapper;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
@@ -117,7 +117,7 @@ public final class DashboardMenu extends CustomComponent {
         menus.setComponentAlignment(links, Alignment.BOTTOM_CENTER);
         menus.setExpandRatio(links, 1.0f);
         menuContent.addComponent(menus);
-        menuContent.setExpandRatio(menus, 1.0f);
+        menuContent.setExpandRatio(menus, 1.0F);
 
         dashboardMenuLayout.addComponent(menuContent);
         return dashboardMenuLayout;
@@ -264,7 +264,7 @@ public final class DashboardMenu extends CustomComponent {
     private VerticalLayout buildMenuItems() {
         final VerticalLayout menuItemsLayout = new VerticalLayout();
         menuItemsLayout.addStyleName("valo-menuitems");
-        menuItemsLayout.setHeight(100.0f, Unit.PERCENTAGE);
+        menuItemsLayout.setHeight(100.0F, Unit.PERCENTAGE);
 
         final List<DashboardMenuItem> accessibleViews = getAccessibleViews();
         if (accessibleViews.isEmpty()) {

--- a/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/target-filter-query.scss
+++ b/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/target-filter-query.scss
@@ -28,12 +28,12 @@
 
 .error-icon{
 	color:$success-icon-color !important;
-	padding:2px;
+	padding-left:2px !important;
 }
 
 .success-icon{
 	color:$error-icon-color !important;
-	padding:2px;
+	padding-left:2px !important;
 }
 
 .on-focus-no-border:focus::after{


### PR DESCRIPTION
The error/success icon in the "target filter management - create filter" view is centered now.
![filter_icon_not_centered](https://cloud.githubusercontent.com/assets/18258708/14984329/67887302-1142-11e6-8f60-b246e32320a9.png)

Furthermore I changed the position of some table headers because they were in the center neither.
