### PR TITLE
Migrated sonar false positives from sonarqube server into code.

### DIFF
--- a/examples/hawkbit-custom-theme-example/src/main/java/org/eclipse/hawkbit/app/Start.java
+++ b/examples/hawkbit-custom-theme-example/src/main/java/org/eclipse/hawkbit/app/Start.java
@@ -22,14 +22,17 @@ import org.springframework.context.annotation.Import;
 @SpringBootApplication
 @Import({ RepositoryApplicationConfiguration.class })
 @EnableHawkbitManagedSecurityConfiguration
+// Exception squid:S1118 - Spring boot standard behavior
+@SuppressWarnings({ "squid:S1118" })
 public class Start {
-
     /**
      * Main method to start the spring-boot application.
      *
      * @param args
      *            the VM arguments.
      */
+    // Exception squid:S2095 - Spring boot standard behavior
+    @SuppressWarnings({ "squid:S2095" })
     public static void main(final String[] args) {
         SpringApplication.run(Start.class, args);
     }

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulator.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulator.java
@@ -21,8 +21,6 @@ import com.vaadin.spring.annotation.EnableVaadin;
 /**
  * The main-method to start the Spring-Boot application.
  *
- *
- *
  */
 @SpringBootApplication
 @EnableVaadin
@@ -46,6 +44,8 @@ public class DeviceSimulator {
      * @param args
      *            the args
      */
+    // Exception squid:S2095 - Spring boot standard behavior
+    @SuppressWarnings({ "squid:S2095" })
     public static void main(final String[] args) {
         SpringApplication.run(DeviceSimulator.class, args);
     }

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/SpReceiverService.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/SpReceiverService.java
@@ -88,6 +88,8 @@ public class SpReceiverService extends ReceiverService {
         if (eventHeader == null) {
             logAndThrowMessageError(message, "Event Topic is not set");
         }
+        // Exception squid:S2259 - Checked before
+        @SuppressWarnings({ "squid:S2259" })
         final EventTopic eventTopic = EventTopic.valueOf(eventHeader.toString());
         switch (eventTopic) {
         case DOWNLOAD_AND_INSTALL:

--- a/examples/hawkbit-example-app/src/main/java/org/eclipse/hawkbit/app/Start.java
+++ b/examples/hawkbit-example-app/src/main/java/org/eclipse/hawkbit/app/Start.java
@@ -26,6 +26,8 @@ import org.springframework.context.annotation.Import;
 @EnableHawkbitManagedSecurityConfiguration
 @EnableRestResources
 @EnableDirectDeviceApi
+// Exception squid:S1118 - Spring boot standard behavior
+@SuppressWarnings({ "squid:S1118" })
 public class Start {
 
     /**
@@ -34,6 +36,8 @@ public class Start {
      * @param args
      *            the VM arguments.
      */
+    // Exception squid:S2095 - Spring boot standard behavior
+    @SuppressWarnings({ "squid:S2095" })
     public static void main(final String[] args) {
         SpringApplication.run(Start.class, args);
     }

--- a/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/DistributionSetBuilder.java
+++ b/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/DistributionSetBuilder.java
@@ -18,8 +18,9 @@ import com.google.common.collect.Lists;
 /**
  * Builder pattern for building {@link DistributionSetRequestBodyPost}.
  */
+// Exception squid:S1701 - builder pattern
+@SuppressWarnings({ "squid:S1701" })
 public class DistributionSetBuilder {
-
     private String name;
     private String version;
     private String type;

--- a/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/DistributionSetTypeBuilder.java
+++ b/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/DistributionSetTypeBuilder.java
@@ -21,8 +21,9 @@ import com.google.common.collect.Lists;
  * Builder pattern for building {@link DistributionSetTypeRequestBodyPost}.
  *
  */
+// Exception squid:S1701 - builder pattern
+@SuppressWarnings({ "squid:S1701" })
 public class DistributionSetTypeBuilder {
-
     private String key;
     private String name;
     private final List<SoftwareModuleTypeAssigmentRest> mandatorymodules = Lists.newArrayList();

--- a/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/RolloutBuilder.java
+++ b/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/RolloutBuilder.java
@@ -17,6 +17,8 @@ import org.eclipse.hawkbit.rest.resource.model.rollout.RolloutRestRequestBody;
  * Builder pattern for building {@link RolloutRestRequestBody}.
  *
  */
+// Exception squid:S1701 - builder pattern
+@SuppressWarnings({ "squid:S1701" })
 public class RolloutBuilder {
 
     private String name;

--- a/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/SoftwareModuleBuilder.java
+++ b/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/SoftwareModuleBuilder.java
@@ -21,6 +21,8 @@ import com.google.common.collect.Lists;
  * Builder pattern for building {@link SoftwareModuleRequestBodyPost}.
  *
  */
+// Exception squid:S1701 - builder pattern
+@SuppressWarnings({ "squid:S1701" })
 public class SoftwareModuleBuilder {
 
     private String name;

--- a/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/SoftwareModuleTypeBuilder.java
+++ b/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/SoftwareModuleTypeBuilder.java
@@ -21,6 +21,8 @@ import com.google.common.collect.Lists;
  * Builder pattern for building {@link SoftwareModuleRequestBodyPost}.
  *
  */
+// Exception squid:S1701 - builder pattern
+@SuppressWarnings({ "squid:S1701" })
 public class SoftwareModuleTypeBuilder {
 
     private String key;

--- a/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TagBuilder.java
+++ b/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TagBuilder.java
@@ -19,6 +19,8 @@ import com.google.common.collect.Lists;
  * Builder pattern for building {@link TagRequestBodyPut}.
  *
  */
+// Exception squid:S1701 - builder pattern
+@SuppressWarnings({ "squid:S1701" })
 public class TagBuilder {
 
     private String name;

--- a/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetBuilder.java
+++ b/examples/hawkbit-mgmt-api-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetBuilder.java
@@ -21,6 +21,8 @@ import com.google.common.collect.Lists;
  * Builder pattern for building {@link TargetRequestBody}.
  *
  */
+// Exception squid:S1701 - builder pattern
+@SuppressWarnings({ "squid:S1701" })
 public class TargetBuilder {
 
     private String controllerId;

--- a/hawkbit-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoConfiguration.java
+++ b/hawkbit-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoConfiguration.java
@@ -71,6 +71,8 @@ public class MongoConfiguration extends AbstractMongoConfiguration {
     @Override
     @Bean
     @ConditionalOnMissingBean
+    // Closed by pre-destroy
+    @SuppressWarnings({ "squid:S2095" })
     public Mongo mongo() throws UnknownHostException {
         final MongoClientURI uri = new MongoClientURI(properties.getUri(), createBuilderOutOfOptions(options));
 

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/DistributedResourceBundleMessageSource.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/DistributedResourceBundleMessageSource.java
@@ -22,11 +22,10 @@ import org.springframework.core.io.support.ResourcePatternResolver;
  * This resource bundles using specified basenames, to resource loading. This
  * MessageSource implementation supports more than 1 properties file with the
  * same name. All properties files will be merged.
- * 
- *
- *
  */
 public class DistributedResourceBundleMessageSource extends ReloadableResourceBundleMessageSource {
+    // Follows our upper case convention
+    @SuppressWarnings({ "squid:S2387" })
     private static final Logger LOGGER = LoggerFactory.getLogger(DistributedResourceBundleMessageSource.class);
     private static final String PROPERTIES_SUFFIX = ".properties";
     private ResourceLoader resourceLoader;

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/DistributedResourceBundleMessageSource.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/DistributedResourceBundleMessageSource.java
@@ -24,7 +24,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
  * same name. All properties files will be merged.
  */
 public class DistributedResourceBundleMessageSource extends ReloadableResourceBundleMessageSource {
-    // Follows our upper case convention
+    // Exception squid:S2387 - Follows our upper case convention
     @SuppressWarnings({ "squid:S2387" })
     private static final Logger LOGGER = LoggerFactory.getLogger(DistributedResourceBundleMessageSource.class);
     private static final String PROPERTIES_SUFFIX = ".properties";

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/tenancy/configuration/validator/TenantConfigurationPollingDurationValidator.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/tenancy/configuration/validator/TenantConfigurationPollingDurationValidator.java
@@ -39,6 +39,8 @@ public class TenantConfigurationPollingDurationValidator implements TenantConfig
     }
 
     @Override
+    // Exception squid:S1166 - Hide origin exception
+    @SuppressWarnings({ "squid:S1166" })
     public void validate(final Object tenantConfigurationObject) {
         TenantConfigurationValidator.super.validate(tenantConfigurationObject);
         final String tenantConfigurationString = (String) tenantConfigurationObject;

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/aspects/ExceptionMappingAspectHandler.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/aspects/ExceptionMappingAspectHandler.java
@@ -90,6 +90,8 @@ public class ExceptionMappingAspectHandler implements Ordered {
             + " || execution( * org.eclipse.hawkbit.controller.*.*(..)) "
             + " || execution( * org.eclipse.hawkbit.rest.resource.*.*(..)) "
             + " || execution( * org.eclipse.hawkbit.service.*.*(..)) )", throwing = "ex")
+    // Exception squid:S00112 - Is aspectJ proxy
+    @SuppressWarnings({ "squid:S00112" })
     public void catchAndWrapJpaExceptionsService(final Exception ex) throws Throwable {
         LOG.trace("exception occured", ex);
         Exception translatedAccessException = translateEclipseLinkExceptionIfPossible(ex);

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/eventbus/EntityChangeEventListener.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/eventbus/EntityChangeEventListener.java
@@ -20,9 +20,9 @@ import org.eclipse.hawkbit.eventbus.event.TargetDeletedEvent;
 import org.eclipse.hawkbit.eventbus.event.TargetInfoUpdateEvent;
 import org.eclipse.hawkbit.executor.AfterTransactionCommitExecutor;
 import org.eclipse.hawkbit.repository.TargetRepository;
-import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetInfo;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -67,6 +67,8 @@ public class EntityChangeEventListener {
      *             {@link ProceedingJoinPoint#proceed()}
      */
     @Around("execution(* org.eclipse.hawkbit.repository.TargetInfoRepository.save(..))")
+    // Exception squid:S00112 - Is aspectJ proxy
+    @SuppressWarnings({ "squid:S00112" })
     public Object targetCreated(final ProceedingJoinPoint joinpoint) throws Throwable {
         final boolean isNew = isTargetInfoNew(joinpoint.getArgs()[0]);
         final Object result = joinpoint.proceed();
@@ -92,6 +94,8 @@ public class EntityChangeEventListener {
      *             {@link ProceedingJoinPoint#proceed()}
      */
     @Around("execution(* org.eclipse.hawkbit.repository.TargetRepository.deleteByIdIn(..))")
+    // Exception squid:S00112 - Is aspectJ proxy
+    @SuppressWarnings({ "squid:S00112" })
     public Object targetDeletedById(final ProceedingJoinPoint joinpoint) throws Throwable {
         final String currentTenant = tenantAware.getCurrentTenant();
         final Object result = joinpoint.proceed();
@@ -111,8 +115,9 @@ public class EntityChangeEventListener {
      *             in case exception happens in the
      *             {@link ProceedingJoinPoint#proceed()}
      */
-    @SuppressWarnings("unchecked")
     @Around("execution(* org.eclipse.hawkbit.repository.TargetRepository.delete(..))")
+ // Exception squid:S00112 - Is aspectJ proxy
+    @SuppressWarnings({ "squid:S00112", "unchecked" })
     public Object targetDeleted(final ProceedingJoinPoint joinpoint) throws Throwable {
         final String currentTenant = tenantAware.getCurrentTenant();
         final Object result = joinpoint.proceed();

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/executor/AfterTransactionCommitDefaultServiceExecutor.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/executor/AfterTransactionCommitDefaultServiceExecutor.java
@@ -29,6 +29,8 @@ public class AfterTransactionCommitDefaultServiceExecutor extends TransactionSyn
     private static final ThreadLocal<List<Runnable>> THREAD_LOCAL_RUNNABLES = new ThreadLocal<>();
 
     @Override
+    // Exception squid:S1217 - Is aspectJ proxy
+    @SuppressWarnings({ "squid:S1217" })
     public void afterCommit() {
         final List<Runnable> afterCommitRunnables = THREAD_LOCAL_RUNNABLES.get();
         LOGGER.debug("Transaction successfully committed, executing {} runnables", afterCommitRunnables.size());
@@ -60,6 +62,7 @@ public class AfterTransactionCommitDefaultServiceExecutor extends TransactionSyn
     }
 
     @Override
+    @SuppressWarnings({ "squid:S1217" })
     public void afterCompletion(final int status) {
         final String transactionStatus = status == STATUS_COMMITTED ? "COMMITTED" : "ROLLEDBACK";
         LOGGER.debug("Transaction completed after commit with status {}", transactionStatus);

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
@@ -198,6 +198,9 @@ public class DeploymentManagement {
     @Transactional
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_REPOSITORY_AND_UPDATE_TARGET)
     @CacheEvict(value = { "distributionUsageAssigned" }, allEntries = true)
+    // Exception squid:S2095: see
+    // https://jira.sonarsource.com/browse/SONARJAVA-1478
+    @SuppressWarnings({ "squid:S2095" })
     public DistributionSetAssignmentResult assignDistributionSet(@NotNull final Long dsID, final ActionType actionType,
             final long forcedTimestamp, @NotEmpty final String... targetIDs) {
         return assignDistributionSet(dsID, Arrays.stream(targetIDs)

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/SystemManagement.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/SystemManagement.java
@@ -341,6 +341,8 @@ public class SystemManagement {
      */
     private class CurrentTenantKeyGenerator implements KeyGenerator {
         @Override
+        // Exception squid:S923 - override
+        @SuppressWarnings({ "squid:S923" })
         public Object generate(final Object target, final Method method, final Object... params) {
             final String initialTenantCreation = createInitialTenant.get();
             if (initialTenantCreation == null) {

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/rsql/RSQLUtility.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/rsql/RSQLUtility.java
@@ -66,10 +66,6 @@ import cz.jirutka.rsql.parser.ast.RSQLVisitor;
  * <li>name==targetId1,description==plugAndPlay,updateStatus==UNKNOWN</li>
  * <li>name==targetId1 or description==plugAndPlay or updateStatus==UNKNOWN</li>
  * </ul>
- * 
- *
- *
- *
  */
 public final class RSQLUtility {
 
@@ -279,6 +275,9 @@ public final class RSQLUtility {
         }
 
         @Override
+        // Exception squid:S2095 - see
+        // https://jira.sonarsource.com/browse/SONARJAVA-1478
+        @SuppressWarnings({ "squid:S2095" })
         public List<Predicate> visit(final ComparisonNode node, final String param) {
             A fieldName = null;
             try {
@@ -304,6 +303,9 @@ public final class RSQLUtility {
             return mapToPredicate(node, fieldPath, node.getArguments(), transformedValue, fieldName);
         }
 
+        // Exception squid:S2095 - see
+        // https://jira.sonarsource.com/browse/SONARJAVA-1478
+        @SuppressWarnings({ "squid:S2095" })
         private List<String> getExpectedFieldList() {
             final List<String> expectedFieldList = Arrays.stream(enumType.getEnumConstants())
                     .filter(enumField -> enumField.getSubEntityAttributes().isEmpty()).map(enumField -> {
@@ -390,7 +392,9 @@ public final class RSQLUtility {
             }
         }
 
-        @SuppressWarnings({ "rawtypes", "unchecked" })
+        // Exception squid:S2095 - see
+        // https://jira.sonarsource.com/browse/SONARJAVA-1478
+        @SuppressWarnings({ "rawtypes", "unchecked", "squid:S2095" })
         private Object transformEnumValue(final ComparisonNode node, final String value,
                 final Class<? extends Object> javaType) {
             final Class<? extends Enum> tmpEnumType = (Class<? extends Enum>) javaType;

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/TenantUserPasswordAuthenticationToken.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/TenantUserPasswordAuthenticationToken.java
@@ -19,12 +19,10 @@ import org.springframework.security.core.GrantedAuthority;
  *
  */
 public class TenantUserPasswordAuthenticationToken extends UsernamePasswordAuthenticationToken {
-
-    /**
-    *
-    */
     private static final long serialVersionUID = 1L;
 
+    // Exception squid:S1948 - no need to be Serializable
+    @SuppressWarnings({ "squid:S1948" })
     final Object tenant;
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
@@ -37,6 +37,8 @@ public class UiProperties {
         /**
          * Demo user password.
          */
+        // Exception squid:S2068 - Empty password
+        @SuppressWarnings({ "squid:S2068" })
         private String password = "";
 
         public String getPassword() {
@@ -64,6 +66,7 @@ public class UiProperties {
         }
 
     }
+
     /**
      * Links to potentially other systems (e.g. support, user management,
      * documentation etc.).
@@ -227,6 +230,7 @@ public class UiProperties {
         }
 
     }
+
     /**
      * Configuration of login view.
      *

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadHandler.java
@@ -37,20 +37,12 @@ import com.vaadin.ui.Upload.SucceededListener;
  * {@link StreamVariable} upload variants.
  *
  * The handler manages the output to the user and at the same time ensures that
- * the upload does not exceed the configued max file size.
- *
- *
- *
- *
- *
+ * the upload does not exceed the configured max file size.
  *
  */
 public class UploadHandler implements StreamVariable, Receiver, SucceededListener, FailedListener, FinishedListener,
         ProgressListener, StartedListener {
 
-    /**
-    *
-    */
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOG = LoggerFactory.getLogger(UploadHandler.class);
@@ -108,7 +100,7 @@ public class UploadHandler implements StreamVariable, Receiver, SucceededListene
     public OutputStream receiveUpload(final String fileName, final String mimeType) {
         this.fileName = fileName;
         this.mimeType = mimeType;
-        //reset has directory flag before upload
+        // reset has directory flag before upload
         view.setHasDirectory(false);
         try {
             if (view.checkIfSoftwareModuleIsSelected()) {
@@ -343,11 +335,6 @@ public class UploadHandler implements StreamVariable, Receiver, SucceededListene
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -356,11 +343,6 @@ public class UploadHandler implements StreamVariable, Receiver, SucceededListene
         return result;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(final Object obj) {
         if (this == obj) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/UserDetailsFormatter.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/UserDetailsFormatter.java
@@ -170,6 +170,8 @@ public final class UserDetailsFormatter {
         return trimmedDetail;
     }
 
+    // Exception squid:S1166 - exception has to be hidden
+    @SuppressWarnings({ "squid:S1166" })
     private static UserDetails loadUserByUsername(final String username) {
         final UserDetailsService userDetailsService = SpringContextHelper.getBean(UserDetailsService.class);
         try {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/FilterQueryValidation.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/FilterQueryValidation.java
@@ -31,10 +31,7 @@ import cz.jirutka.rsql.parser.RSQLParserException;
  * 
  * Validates the target filter query.
  * 
- *
- *
  */
-
 public final class FilterQueryValidation {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FilterQueryValidation.class);
@@ -103,6 +100,9 @@ public final class FilterQueryValidation {
      * @param expectedTokens
      * @return
      */
+    // Exception squid:S2095 - see
+    // https://jira.sonarsource.com/browse/SONARJAVA-1478
+    @SuppressWarnings({ "squid:S2095" })
     public static List<String> processExpectedTokens(final List<Integer> expectedTokens) {
         final List<String> expectToken = new ArrayList<>();
         if (expectedTokens.size() == 2 && expectedTokens.contains(9) && expectedTokens.contains(4)) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
@@ -43,10 +43,6 @@ import com.vaadin.ui.themes.ValoTheme;
 @SpringComponent
 @VaadinSessionScope
 public class CreateUpdateDistributionTagLayoutWindow extends CreateUpdateTagLayout {
-
-    /**
-    * 
-    */
     private static final long serialVersionUID = 444276149954167545L;
 
     @Autowired
@@ -288,16 +284,22 @@ public class CreateUpdateDistributionTagLayoutWindow extends CreateUpdateTagLayo
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagCreatedBulkEvent(final DistributionSetTagCreatedBulkEvent event) {
         populateTagNameCombo();
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagDeletedEvent(final DistributionSetTagDeletedEvent event) {
         populateTagNameCombo();
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagUpdateEvent(final DistributionSetTagUpdateEvent event) {
         populateTagNameCombo();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtons.java
@@ -61,16 +61,22 @@ public class DistributionTagButtons extends AbstractFilterButtons {
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagCreatedBulkEvent(final DistributionSetTagCreatedBulkEvent event) {
         refreshTagTable();
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagDeletedEvent(final DistributionSetTagDeletedEvent event) {
         refreshTagTable();
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagUpdateEvent(final DistributionSetTagUpdateEvent event) {
         refreshTagTable();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CreateUpdateTargetTagLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CreateUpdateTargetTagLayout.java
@@ -85,16 +85,22 @@ public class CreateUpdateTargetTagLayout extends CreateUpdateTagLayout {
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onEventTargetTagCreated(final TargetTagCreatedBulkEvent event) {
         populateTagNameCombo();
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onEventTargetDeletedEvent(final TargetTagDeletedEvent event) {
         populateTagNameCombo();
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onEventTargetTagUpdateEvent(final TargetTagUpdateEvent event) {
         populateTagNameCombo();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterButtons.java
@@ -267,16 +267,22 @@ public class TargetTagFilterButtons extends AbstractFilterButtons {
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onEvent(final TargetTagUpdateEvent event) {
         refreshContainer();
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onEventTargetTagCreated(final TargetTagCreatedBulkEvent event) {
         refreshContainer();
     }
 
     @EventBusListenerMethod(scope = EventScope.SESSION)
+    // Exception squid:S1172 - event not needed
+    @SuppressWarnings({ "squid:S1172" })
     void onEventTargetDeletedEvent(final TargetTagDeletedEvent event) {
         refreshContainer();
     }


### PR DESCRIPTION
We have decided to migrate the false positives out of the qube DB into the code itself. That makes discussions on pull requests easier and allows better use of the more and more popular sonar lint.