### PR TITLE
Removed N+1 query from UI that came in with the DS tooltip.

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CreateOrUpdateFilterTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CreateOrUpdateFilterTable.java
@@ -8,7 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.filtermanagement;
 
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -202,10 +201,7 @@ public class CreateOrUpdateFilterTable extends Table {
                 new TableColumn(SPUILabelDefinitions.VAR_LAST_MODIFIED_DATE, i18n.get("header.modifiedDate"), 0.1F));
         columnList.add(new TableColumn(SPUILabelDefinitions.VAR_DESC, i18n.get("header.description"), 0.1F));
         columnList.add(new TableColumn(SPUILabelDefinitions.STATUS_ICON, i18n.get("header.status"), 0.1F));
-        columnList.add(new TableColumn(SPUILabelDefinitions.ASSIGNED_DISTRIBUTION_NAME_VER,
-                i18n.get("header.assigned.ds"), 0.125F));
-        columnList.add(new TableColumn(SPUILabelDefinitions.INSTALLED_DISTRIBUTION_NAME_VER,
-                i18n.get("header.installed.ds"), 0.125F));
+
         return columnList;
     }
 
@@ -258,5 +254,5 @@ public class CreateOrUpdateFilterTable extends Table {
         populateTableData();
         eventBus.publish(this, CustomFilterUIEvent.UPDATE_TARGET_FILTER_SEARCH_ICON);
     }
-   
+
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CustomTargetBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CustomTargetBeanQuery.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.hawkbit.repository.TargetManagement;
-import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.ui.common.UserDetailsFormatter;
 import org.eclipse.hawkbit.ui.components.ProxyTarget;
@@ -121,20 +120,7 @@ public class CustomTargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
             prxyTarget.setCreatedAt(targ.getCreatedAt());
             prxyTarget.setCreatedByUser(UserDetailsFormatter.loadAndFormatCreatedBy(targ));
             prxyTarget.setModifiedByUser(UserDetailsFormatter.loadAndFormatLastModifiedBy(targ));
-            final Target target = getTargetManagement().findTargetByControllerIDWithDetails(targ.getControllerId());
-            final DistributionSet installedDistributionSet = target.getTargetInfo().getInstalledDistributionSet();
-            prxyTarget.setInstalledDistributionSet(installedDistributionSet);
-            final DistributionSet assignedDistributionSet = target.getAssignedDistributionSet();
-            prxyTarget.setAssignedDistributionSet(assignedDistributionSet);
 
-            if (null != assignedDistributionSet) {
-                prxyTarget.setAssignedDistNameVersion(HawkbitCommonUtil.getFormattedNameVersion(
-                        assignedDistributionSet.getName(), assignedDistributionSet.getVersion()));
-            }
-            if (null != installedDistributionSet) {
-                prxyTarget.setInstalledDistNameVersion(HawkbitCommonUtil.getFormattedNameVersion(
-                        installedDistributionSet.getName(), installedDistributionSet.getVersion()));
-            }
             prxyTarget.setUpdateStatus(targ.getTargetInfo().getUpdateStatus());
             prxyTarget.setLastTargetQuery(targ.getTargetInfo().getLastTargetQuery());
             prxyTarget.setTargetInfo(targ.getTargetInfo());

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBeanQuery.java
@@ -134,21 +134,17 @@ public class TargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
             prxyTarget.setCreatedByUser(UserDetailsFormatter.loadAndFormatCreatedBy(targ));
             prxyTarget.setModifiedByUser(UserDetailsFormatter.loadAndFormatLastModifiedBy(targ));
 
-            final Target target = getTargetManagement().findTargetByControllerIDWithDetails(targ.getControllerId());
-            final DistributionSet installedDistributionSet = target.getTargetInfo().getInstalledDistributionSet();
-            final DistributionSet assignedDistributionSet = target.getAssignedDistributionSet();
-
-            prxyTarget.setInstalledDistributionSet(installedDistributionSet);
-            prxyTarget.setAssignedDistributionSet(assignedDistributionSet);
-
-            if (installedDistributionSet != null) {
-                prxyTarget.setInstalledDistNameVersion(HawkbitCommonUtil.getFormattedNameVersion(
-                        installedDistributionSet.getName(), installedDistributionSet.getVersion()));
+            if (pinnedDistId == null) {
+                prxyTarget.setInstalledDistributionSet(null);
+                prxyTarget.setAssignedDistributionSet(null);
+            } else {
+                final Target target = getTargetManagement().findTargetByControllerIDWithDetails(targ.getControllerId());
+                final DistributionSet installedDistributionSet = target.getTargetInfo().getInstalledDistributionSet();
+                prxyTarget.setInstalledDistributionSet(installedDistributionSet);
+                final DistributionSet assignedDistributionSet = target.getAssignedDistributionSet();
+                prxyTarget.setAssignedDistributionSet(assignedDistributionSet);
             }
-            if (assignedDistributionSet != null) {
-                prxyTarget.setAssignedDistNameVersion(HawkbitCommonUtil.getFormattedNameVersion(
-                        assignedDistributionSet.getName(), assignedDistributionSet.getVersion()));
-            }
+
             prxyTarget.setUpdateStatus(targ.getTargetInfo().getUpdateStatus());
             prxyTarget.setLastTargetQuery(targ.getTargetInfo().getLastTargetQuery());
             prxyTarget.setTargetInfo(targ.getTargetInfo());

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
@@ -24,9 +24,7 @@ import org.eclipse.hawkbit.eventbus.event.TargetInfoUpdateEvent;
 import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.TargetManagement;
-import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetIdName;
-import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.eclipse.hawkbit.repository.model.TargetIdName;
@@ -113,7 +111,6 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> implements 
     private static final int PROPERTY_DEPT = 3;
     private static final String ACTION_NOT_ALLOWED_MSG = "message.action.not.allowed";
 
-   
     @Autowired
     private transient TargetManagement targetManagement;
 
@@ -335,11 +332,6 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> implements 
         if (!isMaximized()) {
             columnList.add(new TableColumn(SPUIDefinitions.TARGET_STATUS_POLL_TIME, "", 0.0F));
             columnList.add(new TableColumn(SPUIDefinitions.TARGET_STATUS_PIN_TOGGLE_ICON, "", 0.0F));
-        }else{
-            columnList.add(new TableColumn(SPUILabelDefinitions.ASSIGNED_DISTRIBUTION_NAME_VER,
-                    i18n.get("header.assigned.ds"), 0.1F));
-            columnList.add(new TableColumn(SPUILabelDefinitions.INSTALLED_DISTRIBUTION_NAME_VER,
-                    i18n.get("header.installed.ds"), 0.1F));
         }
         return columnList;
 


### PR DESCRIPTION
https://github.com/eclipse/hawkbit/pull/159 introduced an N+1(extra query per target) into target table. Unfortunately it slipped through review.

I removed this for now to have a working master again. But this needs to be refactored in general to have proper performance.

Signed-off-by: Kai Zimmermann <kai.zimmermann@bosch-si.com>