### PR TITLE
remove singleton instance wihthin TenantConfigurationManagement

### DIFF
--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/RepositoryApplicationConfiguration.java
@@ -19,6 +19,7 @@ import org.eclipse.hawkbit.repository.model.helper.CacheManagerHolder;
 import org.eclipse.hawkbit.repository.model.helper.SecurityTokenGeneratorHolder;
 import org.eclipse.hawkbit.repository.model.helper.SystemManagementHolder;
 import org.eclipse.hawkbit.repository.model.helper.TenantAwareHolder;
+import org.eclipse.hawkbit.repository.model.helper.TenantConfigurationManagementHolder;
 import org.eclipse.hawkbit.security.SecurityTokenGenerator;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -54,8 +55,8 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
      *         directly, e.g. JPA entities.
      */
     @Bean
-    public TenantConfigurationManagement tenantConfigurationManagement() {
-        return TenantConfigurationManagement.getInstance();
+    public TenantConfigurationManagementHolder tenantConfigurationManagementHolder() {
+        return TenantConfigurationManagementHolder.getInstance();
     }
 
     /**

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/TenantConfigurationManagement.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/TenantConfigurationManagement.java
@@ -24,6 +24,7 @@ import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.env.Environment;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
@@ -32,9 +33,8 @@ import org.springframework.validation.annotation.Validated;
  */
 @Transactional(readOnly = true)
 @Validated
+@Service
 public class TenantConfigurationManagement implements EnvironmentAware {
-
-    private static final TenantConfigurationManagement INSTANCE = new TenantConfigurationManagement();
 
     @Autowired
     private TenantConfigurationRepository tenantConfigurationRepository;
@@ -45,16 +45,6 @@ public class TenantConfigurationManagement implements EnvironmentAware {
     private final ConfigurableConversionService conversionService = new DefaultConversionService();
 
     private Environment environment;
-
-    /**
-     * Get Singleton instance, needed for classes which are not managed in
-     * Spring context
-     * 
-     * @return singleton instance of TenantConfigurationManagement
-     */
-    public static TenantConfigurationManagement getInstance() {
-        return INSTANCE;
-    }
 
     /**
      * Retrieves a configuration value from the e.g. tenant overwritten

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/TargetInfo.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/TargetInfo.java
@@ -38,7 +38,7 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
-import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.repository.model.helper.TenantConfigurationManagementHolder;
 import org.eclipse.hawkbit.tenancy.configuration.DurationHelper;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
 import org.eclipse.persistence.annotations.CascadeOnDelete;
@@ -246,11 +246,12 @@ public class TargetInfo implements Persistable<Long>, Serializable {
             return null;
         }
 
-        final Duration pollTime = DurationHelper.formattedStringToDuration(TenantConfigurationManagement.getInstance()
-                .getConfigurationValue(TenantConfigurationKey.POLLING_TIME_INTERVAL, String.class).getValue());
-        final Duration overdueTime = DurationHelper.formattedStringToDuration(TenantConfigurationManagement
-                .getInstance().getConfigurationValue(TenantConfigurationKey.POLLING_OVERDUE_TIME_INTERVAL, String.class)
-                .getValue());
+        final Duration pollTime = DurationHelper.formattedStringToDuration(
+                TenantConfigurationManagementHolder.getInstance().getTenantConfigurationManagement()
+                        .getConfigurationValue(TenantConfigurationKey.POLLING_TIME_INTERVAL, String.class).getValue());
+        final Duration overdueTime = DurationHelper.formattedStringToDuration(TenantConfigurationManagementHolder
+                .getInstance().getTenantConfigurationManagement()
+                .getConfigurationValue(TenantConfigurationKey.POLLING_OVERDUE_TIME_INTERVAL, String.class).getValue());
         final LocalDateTime currentDate = LocalDateTime.now();
         final LocalDateTime lastPollDate = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastTargetQuery),
                 ZoneId.systemDefault());

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/helper/TenantConfigurationManagementHolder.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/helper/TenantConfigurationManagementHolder.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.model.helper;
+
+import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * A singleton bean which holds {@link TenantConfigurationManagement} service
+ * and makes it accessible to beans which are not managed by spring, e.g. JPA
+ * entities.
+ */
+public final class TenantConfigurationManagementHolder {
+
+    private static final TenantConfigurationManagementHolder INSTANCE = new TenantConfigurationManagementHolder();
+
+    @Autowired
+    private TenantConfigurationManagement tenantConfiguration;
+
+    private TenantConfigurationManagementHolder() {
+    }
+
+    /**
+     * @return the singleton {@link TenantConfigurationManagementHolder}
+     *         instance
+     */
+    public static TenantConfigurationManagementHolder getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * @return the {@link TenantConfigurationManagement} service
+     */
+    public TenantConfigurationManagement getTenantConfigurationManagement() {
+        return tenantConfiguration;
+    }
+
+}


### PR DESCRIPTION
Remove the inner singleton instance of `TenantConfigurationManagement` there is no possible solution for the spring-framework to create a proxy instance over a manually created bean.
```
private static final TenantConfigurationManagement INSTANCE = new TenantConfigurationManagement();
```
This bean is not managed by spring and so no proxy for caching is created!

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>