### PR TITLE
run getting polling configuration in system-code

### DIFF
--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/RepositoryApplicationConfiguration.java
@@ -18,9 +18,11 @@ import org.eclipse.hawkbit.repository.model.helper.AfterTransactionCommitExecuto
 import org.eclipse.hawkbit.repository.model.helper.CacheManagerHolder;
 import org.eclipse.hawkbit.repository.model.helper.SecurityTokenGeneratorHolder;
 import org.eclipse.hawkbit.repository.model.helper.SystemManagementHolder;
+import org.eclipse.hawkbit.repository.model.helper.SystemSecurityContextHolder;
 import org.eclipse.hawkbit.repository.model.helper.TenantAwareHolder;
 import org.eclipse.hawkbit.repository.model.helper.TenantConfigurationManagementHolder;
 import org.eclipse.hawkbit.security.SecurityTokenGenerator;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration;
@@ -48,6 +50,16 @@ import org.springframework.validation.beanvalidation.MethodValidationPostProcess
 @ComponentScan
 @EnableAutoConfiguration
 public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
+
+    /**
+     * @return the {@link SystemSecurityContext} singleton bean which make it
+     *         accessible in beans which cannot access the service directly,
+     *         e.g. JPA entities.
+     */
+    @Bean
+    public SystemSecurityContextHolder systemSecurityContextHolder() {
+        return SystemSecurityContextHolder.getInstance();
+    }
 
     /**
      * @return the {@link TenantConfigurationManagement} singleton bean which

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/TenantConfigurationManagement.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/TenantConfigurationManagement.java
@@ -150,7 +150,8 @@ public class TenantConfigurationManagement implements EnvironmentAware {
      *             if the property cannot be converted to the given
      *             {@code propertyType}
      */
-    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
+    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION + SpringEvalExpressions.HAS_AUTH_OR
+            + SpringEvalExpressions.IS_SYSTEM_CODE)
     public TenantConfigurationValue<?> getConfigurationValue(final TenantConfigurationKey configurationKey) {
         return getConfigurationValue(configurationKey, configurationKey.getDataType());
     }
@@ -175,7 +176,8 @@ public class TenantConfigurationManagement implements EnvironmentAware {
      *             if the property cannot be converted to the given
      *             {@code propertyType}
      */
-    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
+    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION + SpringEvalExpressions.HAS_AUTH_OR
+            + SpringEvalExpressions.IS_SYSTEM_CODE)
     public <T> T getGlobalConfigurationValue(final TenantConfigurationKey configurationKey,
             final Class<T> propertyType) {
 

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/TargetInfo.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/TargetInfo.java
@@ -38,6 +38,7 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
+import org.eclipse.hawkbit.repository.model.helper.SystemSecurityContextHolder;
 import org.eclipse.hawkbit.repository.model.helper.TenantConfigurationManagementHolder;
 import org.eclipse.hawkbit.tenancy.configuration.DurationHelper;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
@@ -245,19 +246,21 @@ public class TargetInfo implements Persistable<Long>, Serializable {
         if (lastTargetQuery == null) {
             return null;
         }
-
-        final Duration pollTime = DurationHelper.formattedStringToDuration(
-                TenantConfigurationManagementHolder.getInstance().getTenantConfigurationManagement()
-                        .getConfigurationValue(TenantConfigurationKey.POLLING_TIME_INTERVAL, String.class).getValue());
-        final Duration overdueTime = DurationHelper.formattedStringToDuration(TenantConfigurationManagementHolder
-                .getInstance().getTenantConfigurationManagement()
-                .getConfigurationValue(TenantConfigurationKey.POLLING_OVERDUE_TIME_INTERVAL, String.class).getValue());
-        final LocalDateTime currentDate = LocalDateTime.now();
-        final LocalDateTime lastPollDate = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastTargetQuery),
-                ZoneId.systemDefault());
-        final LocalDateTime nextPollDate = lastPollDate.plus(pollTime);
-        final LocalDateTime overdueDate = nextPollDate.plus(overdueTime);
-        return new PollStatus(lastPollDate, nextPollDate, overdueDate, currentDate);
+        return SystemSecurityContextHolder.getInstance().getSystemSecurityContext().runAsSystem(() -> {
+            final Duration pollTime = DurationHelper.formattedStringToDuration(TenantConfigurationManagementHolder
+                    .getInstance().getTenantConfigurationManagement()
+                    .getConfigurationValue(TenantConfigurationKey.POLLING_TIME_INTERVAL, String.class).getValue());
+            final Duration overdueTime = DurationHelper.formattedStringToDuration(
+                    TenantConfigurationManagementHolder.getInstance().getTenantConfigurationManagement()
+                            .getConfigurationValue(TenantConfigurationKey.POLLING_OVERDUE_TIME_INTERVAL, String.class)
+                            .getValue());
+            final LocalDateTime currentDate = LocalDateTime.now();
+            final LocalDateTime lastPollDate = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastTargetQuery),
+                    ZoneId.systemDefault());
+            final LocalDateTime nextPollDate = lastPollDate.plus(pollTime);
+            final LocalDateTime overdueDate = nextPollDate.plus(overdueTime);
+            return new PollStatus(lastPollDate, nextPollDate, overdueDate, currentDate);
+        });
     }
 
     /**

--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/helper/SystemSecurityContextHolder.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/helper/SystemSecurityContextHolder.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.model.helper;
+
+import org.eclipse.hawkbit.security.SystemSecurityContext;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * A singleton bean which holds {@link SystemSecurityContext} service and makes
+ * it accessible to beans which are not managed by spring, e.g. JPA entities.
+ */
+public final class SystemSecurityContextHolder {
+
+    private static final SystemSecurityContextHolder INSTANCE = new SystemSecurityContextHolder();
+
+    @Autowired
+    private SystemSecurityContext systemSecurityContext;
+
+    private SystemSecurityContextHolder() {
+    }
+
+    /**
+     * @return the singleton {@link SystemSecurityContextHolder} instance
+     */
+    public static SystemSecurityContextHolder getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * @return the {@link SystemSecurityContext} service
+     */
+    public SystemSecurityContext getSystemSecurityContext() {
+        return systemSecurityContext;
+    }
+}

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/TargetManagementTest.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/TargetManagementTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,6 +30,7 @@ import javax.validation.ConstraintViolationException;
 
 import org.eclipse.hawkbit.AbstractIntegrationTest;
 import org.eclipse.hawkbit.TestDataUtil;
+import org.eclipse.hawkbit.WithSpringAuthorityRule;
 import org.eclipse.hawkbit.WithUser;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.TenantNotExistException;
@@ -722,6 +724,22 @@ public class TargetManagementTest extends AbstractIntegrationTest {
 
         assertThat(50).as("Total targets").isEqualTo(targetManagement.findAllTargetIds().size());
         assertThat(25).as("Targets with no tag").isEqualTo(targetsListWithNoTag.size());
+
+    }
+
+    @Test
+    @Description("Tests the a target can be read with only the read target permission")
+    public void targetCanBeReadWithOnlyReadTargetPermission() throws Exception {
+        final String knownTargetControllerId = "readTarget";
+        controllerManagament.findOrRegisterTargetIfItDoesNotexist(knownTargetControllerId, new URI("http://127.0.0.1"));
+
+        securityRule.runAs(WithSpringAuthorityRule.withUser("bumlux", "READ_TARGET"), () -> {
+            final Target findTargetByControllerID = targetManagement.findTargetByControllerID(knownTargetControllerId);
+            assertThat(findTargetByControllerID).isNotNull();
+            assertThat(findTargetByControllerID.getTargetInfo()).isNotNull();
+            assertThat(findTargetByControllerID.getTargetInfo().getPollStatus()).isNotNull();
+            return null;
+        });
 
     }
 }


### PR DESCRIPTION
After fixing the tenant configuration ( https://github.com/eclipse/hawkbit/pull/168 ) to be a spring-managed bean the security checks on the `TenantConfigurationManagement` is working again and if the security context does not contain the `TENANT_CONFIGURATION` permission now, the target cannot be loaded because the TargetInfo needs the polling configuration values.

So run this code as system-code because it's not about user-permission to calculate the polling. Polling-Configuration is not security relevant.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>