### PR TITLE
Fixed auth problem in device simulator. Fixed equals ignore case in MD5 check.

### DIFF
--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -265,12 +265,12 @@ public class DeviceSimulatorUpdater {
                 return "<EMTPTY!>";
             }
 
-            if (targetToken.length() <= 3) {
+            if (targetToken.length() <= 6) {
                 return "***";
             }
 
-            return targetToken.substring(0, 3) + "***"
-                    + targetToken.substring(targetToken.length() - 3, targetToken.length());
+            return targetToken.substring(0, 2) + "***"
+                    + targetToken.substring(targetToken.length() - 2, targetToken.length());
         }
 
         private static String wrongHash(final String url, final String sha1Hash, final long overallread,

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -43,6 +43,7 @@ import org.eclipse.hawkbit.simulator.event.ProgressUpdate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -117,6 +118,11 @@ public class DeviceSimulatorUpdater {
     }
 
     private static final class DeviceSimulatorUpdateThread implements Runnable {
+        /**
+         * 
+         */
+        private static final int MINIMUM_TOKENLENGTH_FOR_HINT = 6;
+
         private static final Random rndSleep = new SecureRandom();
 
         private final AbstractSimulatedDevice device;
@@ -215,7 +221,7 @@ public class DeviceSimulatorUpdater {
             try {
                 final CloseableHttpClient httpclient = createHttpClientThatAcceptsAllServerCerts();
                 final HttpGet request = new HttpGet(url);
-                request.addHeader("Authorization", "TargetToken " + targetToken);
+                request.addHeader(HttpHeaders.AUTHORIZATION, "TargetToken " + targetToken);
 
                 final String sha1HashResult;
                 try (final CloseableHttpResponse response = httpclient.execute(request)) {
@@ -273,7 +279,7 @@ public class DeviceSimulatorUpdater {
                 return "<EMTPTY!>";
             }
 
-            if (targetToken.length() <= 6) {
+            if (targetToken.length() <= MINIMUM_TOKENLENGTH_FOR_HINT) {
                 return "***";
             }
 

--- a/hawkbit-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactStore.java
+++ b/hawkbit-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactStore.java
@@ -185,7 +185,8 @@ public class ArtifactStore implements ArtifactRepository {
             throw new ArtifactStoreException(e.getMessage(), e);
         }
 
-        if (hash != null && hash.getMd5() != null && !storedArtifact.getHashes().getMd5().equals(hash.getMd5())) {
+        if (hash != null && hash.getMd5() != null
+                && !storedArtifact.getHashes().getMd5().equalsIgnoreCase(hash.getMd5())) {
             throw new HashNotMatchException("The given md5 hash " + hash.getMd5()
                     + " not matching the calculated md5 hash " + storedArtifact.getHashes().getMd5(),
                     HashNotMatchException.MD5);


### PR DESCRIPTION
* Fixed auth problem in device simulator. 
* Fixed equals ignore case in MD5 check.
* Improved error handling of simulator in download sim.
* Improved SHA-1 gen performance by using buffered streams.

Signed-off-by: Kai Zimmermann <kai.zimmermann@bosch-si.com>