### PR TITLE
allow the getTargetSecurityToken can be called as system code

### DIFF
--- a/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
+++ b/hawkbit-repository/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
@@ -38,6 +38,7 @@ import javax.validation.constraints.Size;
 import org.eclipse.hawkbit.im.authentication.SpPermission;
 import org.eclipse.hawkbit.repository.model.helper.SecurityChecker;
 import org.eclipse.hawkbit.repository.model.helper.SecurityTokenGeneratorHolder;
+import org.eclipse.hawkbit.repository.model.helper.SystemSecurityContextHolder;
 import org.eclipse.persistence.annotations.CascadeOnDelete;
 import org.springframework.data.domain.Persistable;
 
@@ -193,10 +194,14 @@ public class Target extends NamedEntity implements Persistable<Long> {
     }
 
     /**
-     * @return the securityToken
+     * @return the securityToken if the current security context contains the
+     *         necessary permission {@link SpPermission#READ_TARGET_SEC_TOKEN}
+     *         or the current context is executed as system code, otherwise
+     *         {@code null}.
      */
     public String getSecurityToken() {
-        if (SecurityChecker.hasPermission(SpPermission.READ_TARGET_SEC_TOKEN)) {
+        if (SystemSecurityContextHolder.getInstance().getSystemSecurityContext().isCurrentThreadSystemCode()
+                || SecurityChecker.hasPermission(SpPermission.READ_TARGET_SEC_TOKEN)) {
             return securityToken;
         }
         return null;

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/AbstractIntegrationTest.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/AbstractIntegrationTest.java
@@ -48,6 +48,7 @@ import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 import org.eclipse.hawkbit.repository.utils.RepositoryDataGenerator.DatabaseCleanupUtil;
 import org.eclipse.hawkbit.security.DosFilter;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -181,10 +182,9 @@ public abstract class AbstractIntegrationTest implements EnvironmentAware {
 
     @Autowired
     protected TenantAwareCacheManager cacheManager;
-    
+
     @Autowired
     protected TenantConfigurationManagement tenantConfigurationManagement;
-
 
     @Autowired
     protected RolloutManagement rolloutManagement;
@@ -197,6 +197,9 @@ public abstract class AbstractIntegrationTest implements EnvironmentAware {
 
     @Autowired
     protected RolloutRepository rolloutRepository;
+
+    @Autowired
+    protected SystemSecurityContext systemSecurityContext;
 
     protected MockMvc mvc;
 

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/WithSpringAuthorityRule.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/WithSpringAuthorityRule.java
@@ -160,19 +160,23 @@ public class WithSpringAuthorityRule implements TestRule {
     }
 
     public static WithUser withUser(final String principal, final String... authorities) {
-        return withUserAndTenant(principal, "default", true, authorities);
+        return withUserAndTenant(principal, "default", true, true, authorities);
+    }
+    
+    public static WithUser withUser(final String principal, final boolean allSpPermision, final String... authorities) {
+        return withUserAndTenant(principal, "default", true, allSpPermision, authorities);
     }
 
     public static WithUser withUser(final boolean autoCreateTenant) {
-        return withUserAndTenant("bumlux", "default", autoCreateTenant, new String[] {});
+        return withUserAndTenant("bumlux", "default", autoCreateTenant, true, new String[] {});
     }
 
     public static WithUser withUserAndTenant(final String principal, final String tenant, final String... authorities) {
-        return withUserAndTenant(principal, tenant, true, new String[] {});
+        return withUserAndTenant(principal, tenant, true, true, new String[] {});
     }
 
     public static WithUser withUserAndTenant(final String principal, final String tenant,
-            final boolean autoCreateTenant, final String... authorities) {
+            final boolean autoCreateTenant, final boolean allSpPermission, final String... authorities) {
         return new WithUser() {
 
             @Override
@@ -197,7 +201,7 @@ public class WithSpringAuthorityRule implements TestRule {
 
             @Override
             public boolean allSpPermissions() {
-                return true;
+                return allSpPermission;
             }
 
             @Override

--- a/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/TargetManagementTest.java
+++ b/hawkbit-repository/src/test/java/org/eclipse/hawkbit/repository/TargetManagementTest.java
@@ -32,6 +32,7 @@ import org.eclipse.hawkbit.AbstractIntegrationTest;
 import org.eclipse.hawkbit.TestDataUtil;
 import org.eclipse.hawkbit.WithSpringAuthorityRule;
 import org.eclipse.hawkbit.WithUser;
+import org.eclipse.hawkbit.im.authentication.SpPermission;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.TenantNotExistException;
 import org.eclipse.hawkbit.repository.model.Action;
@@ -55,6 +56,36 @@ import ru.yandex.qatools.allure.annotations.Stories;
 @Features("Component Tests - Repository")
 @Stories("Target Management")
 public class TargetManagementTest extends AbstractIntegrationTest {
+
+    @Test
+    @Description("Ensures that retrieving the target security is only permitted with the necessary permissions.")
+    public void getTargetSecurityTokenOnlyWithCorrectPermission() throws Exception {
+        final Target createdTarget = targetManagement.createTarget(new Target("targetWithSecurityToken"));
+
+        // retrieve security token only with READ_TARGET_SEC_TOKEN permission
+        final String securityTokenWithReadPermission = securityRule.runAs(WithSpringAuthorityRule
+                .withUser("OnlyTargetReadPermission", false, SpPermission.READ_TARGET_SEC_TOKEN.toString()), () -> {
+                    return createdTarget.getSecurityToken();
+                });
+
+        // retrieve security token as system code execution
+        final String securityTokenAsSystemCode = systemSecurityContext.runAsSystem(() -> {
+            return createdTarget.getSecurityToken();
+        });
+
+        // retrieve security token without any permissions
+        final String securityTokenWithoutPermission = securityRule
+                .runAs(WithSpringAuthorityRule.withUser("NoPermission", false), () -> {
+                    return createdTarget.getSecurityToken();
+                });
+
+        assertThat(createdTarget.getSecurityToken()).isNotNull();
+        assertThat(securityTokenWithReadPermission).isNotNull();
+        assertThat(securityTokenAsSystemCode).isNotNull();
+
+        assertThat(securityTokenWithoutPermission).isNull();
+
+    }
 
     @Test
     @Description("Ensures that targets cannot be created e.g. in plug'n play scenarios when tenant does not exists.")

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SystemSecurityContext.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SystemSecurityContext.java
@@ -49,6 +49,21 @@ public class SystemSecurityContext {
         this.tenantAware = tenantAware;
     }
 
+    /**
+     * Runs a given {@link Callable} within a system security context, which is
+     * permitted to call secured system code. Often the system needs to call
+     * secured methods by it's own without relying on the current security
+     * context e.g. if the current security context does not contain the
+     * necessary permission it's necessary to execute code as system code to
+     * execute necessary methods and functionality.
+     * 
+     * The security context will be switched to the system code and back after
+     * the callable is called.
+     * 
+     * @param callable
+     *            the callable to call within the system security context
+     * @return the return value of the {@link Callable#call()} method.
+     */
     public <T> T runAsSystem(final Callable<T> callable) {
         final SecurityContext oldContext = SecurityContextHolder.getContext();
         try {
@@ -66,6 +81,17 @@ public class SystemSecurityContext {
             SecurityContextHolder.setContext(oldContext);
             logger.debug("leaving system code execution");
         }
+    }
+
+    /**
+     * @return {@code true} if the current running code is running as system
+     *         code block.
+     */
+    public boolean isCurrentThreadSystemCode() {
+        if (SecurityContextHolder.getContext().getAuthentication() instanceof SystemCodeAuthentication) {
+            return true;
+        }
+        return false;
     }
 
     private static void setSystemContext() {

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SystemSecurityContext.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SystemSecurityContext.java
@@ -88,10 +88,7 @@ public class SystemSecurityContext {
      *         code block.
      */
     public boolean isCurrentThreadSystemCode() {
-        if (SecurityContextHolder.getContext().getAuthentication() instanceof SystemCodeAuthentication) {
-            return true;
-        }
-        return false;
+        return SecurityContextHolder.getContext().getAuthentication() instanceof SystemCodeAuthentication;
     }
 
     private static void setSystemContext() {


### PR DESCRIPTION
Allow that the `org.eclipse.hawkbit.repository.model.Target.getSecurityToken()` can be called as system-code. 

Because since we are sending the target-security-token to the DMF-API, it shouldn't be up-to the current security-context of the user which does the assignment to read the token. 

I'm explicit against the idea to move the security check out of the `Target` entity because then you'll need to be aware of the security check in every API which exposes the security-token as well as on the UI. This will lead to distributed security checks through the code.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>