### PR TITLE
Switch back Spring Boots default logger implementation logback

### DIFF
--- a/examples/hawkbit-device-simulator/pom.xml
+++ b/examples/hawkbit-device-simulator/pom.xml
@@ -82,16 +82,26 @@
       <dependency>
          <groupId>org.springframework.boot</groupId>
          <artifactId>spring-boot-starter</artifactId>
-         <exclusions>
-            <exclusion>
-               <groupId>org.springframework.boot</groupId>
-               <artifactId>spring-boot-starter-logging</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
+      <!-- Log4j API and Core implementation required for binding -->
       <dependency>
-         <groupId>org.springframework.boot</groupId>
-         <artifactId>spring-boot-starter-log4j2</artifactId>
+         <groupId>org.apache.logging.log4j</groupId>
+         <artifactId>log4j-api</artifactId>
+      </dependency>
+      <!-- Logging binding for java-util-logging e.g. Tomcat -->
+      <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>jul-to-slf4j</artifactId>
+      </dependency>
+      <!-- Logging binding for Jakarta Commons Logging -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+      </dependency>
+      <!-- Logging binding for Log4J Logging -->
+      <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>log4j-over-slf4j</artifactId>
       </dependency>
       <dependency>
          <groupId>com.vaadin</groupId>

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -149,6 +149,8 @@ public class DeviceSimulatorUpdater {
                     eventbus.post(new ProgressUpdate(device));
                     return;
                 }
+                // download is 80% of the game after all
+                device.setProgress(0.8);
             }
 
             final double newProgress = device.getProgress() + 0.2;
@@ -272,6 +274,10 @@ public class DeviceSimulatorUpdater {
         }
 
         private static String hideTokenDetails(final String targetToken) {
+            if (targetToken == null) {
+                return "<NULL!>";
+            }
+
             if (targetToken.isEmpty()) {
                 return "<EMTPTY!>";
             }

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulatorUpdater.java
@@ -264,7 +264,7 @@ public class DeviceSimulatorUpdater {
                 }
 
             } catch (IOException | KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
-                LOGGER.error("Failed to download {} with {}", url, e.getMessage());
+                LOGGER.error("Failed to download" + url, e);
                 return new UpdateStatus(ResponseStatus.ERROR, "Failed to download " + url + ": " + e.getMessage());
             }
 

--- a/examples/hawkbit-device-simulator/src/main/resources/logback.xml
+++ b/examples/hawkbit-device-simulator/src/main/resources/logback.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
 <configuration>
    <include resource="org/springframework/boot/logging/logback/base.xml" />
 

--- a/examples/hawkbit-device-simulator/src/main/resources/logback.xml
+++ b/examples/hawkbit-device-simulator/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+   <include resource="org/springframework/boot/logging/logback/base.xml" />
+
+   <logger name="org.eclipse.hawkbit.eventbus.DeadEventListener" level="WARN" />
+   <Logger name="org.springframework.boot.actuate.audit.listener.AuditListener" level="WARN" />
+
+   <Logger name="org.hibernate.validator.internal.util.Version" level="WARN" />
+
+   <Logger name="org.apache.coyote.http11.Http11NioProtocol" level="WARN" />
+   <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="WARN" />
+   <Logger name="org.apache.tomcat.jdbc.pool.ConnectionPool" level="DEBUG" />
+   <Logger name="org.apache.catalina.startup.DigesterFactory" level="ERROR" />   
+
+   <!-- Security Log with hints on potential attacks -->
+   <logger name="server-security" level="INFO" />
+
+   <Root level="INFO">
+      <AppenderRef ref="Console" />
+   </Root>
+
+</configuration>

--- a/examples/hawkbit-example-app/pom.xml
+++ b/examples/hawkbit-example-app/pom.xml
@@ -96,16 +96,26 @@
       <dependency>
          <groupId>org.springframework.boot</groupId>
          <artifactId>spring-boot-starter</artifactId>
-         <exclusions>
-            <exclusion>
-               <groupId>org.springframework.boot</groupId>
-               <artifactId>spring-boot-starter-logging</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
+      <!-- Log4j API and Core implementation required for binding -->
       <dependency>
-         <groupId>org.springframework.boot</groupId>
-         <artifactId>spring-boot-starter-log4j2</artifactId>
+         <groupId>org.apache.logging.log4j</groupId>
+         <artifactId>log4j-api</artifactId>
+      </dependency>
+      <!-- Logging binding for java-util-logging e.g. Tomcat -->
+      <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>jul-to-slf4j</artifactId>
+      </dependency>
+      <!-- Logging binding for Jakarta Commons Logging -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+      </dependency>
+      <!-- Logging binding for Log4J Logging -->
+      <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>log4j-over-slf4j</artifactId>
       </dependency>
       <dependency>
          <groupId>org.springframework.security</groupId>

--- a/examples/hawkbit-example-app/src/main/resources/logback.xml
+++ b/examples/hawkbit-example-app/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+   <include resource="org/springframework/boot/logging/logback/base.xml" />
+
+   <logger name="org.eclipse.hawkbit.eventbus.DeadEventListener" level="WARN" />
+   <Logger name="org.springframework.boot.actuate.audit.listener.AuditListener" level="WARN" />
+
+   <Logger name="org.hibernate.validator.internal.util.Version" level="WARN" />
+
+   <Logger name="org.apache.coyote.http11.Http11NioProtocol" level="WARN" />
+   <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="WARN" />
+   <Logger name="org.apache.tomcat.jdbc.pool.ConnectionPool" level="DEBUG" />
+   <Logger name="org.apache.catalina.startup.DigesterFactory" level="ERROR" />
+
+   <!-- Security Log with hints on potential attacks -->
+   <logger name="server-security" level="INFO" />
+
+   <Root level="INFO">
+      <AppenderRef ref="Console" />
+   </Root>
+
+</configuration>

--- a/examples/hawkbit-example-app/src/main/resources/logback.xml
+++ b/examples/hawkbit-example-app/src/main/resources/logback.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
 <configuration>
    <include resource="org/springframework/boot/logging/logback/base.xml" />
 

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/api/PropertyBasedArtifactUrlHandler.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/api/PropertyBasedArtifactUrlHandler.java
@@ -61,7 +61,7 @@ public class PropertyBasedArtifactUrlHandler implements ArtifactUrlHandler {
         for (final Entry<String, String> entry : entrySet) {
             if (entry.getKey().equals(PORT_PLACEHOLDER)) {
                 urlPattern = urlPattern.replace(":{" + entry.getKey() + "}",
-                        Strings.isNullOrEmpty(entry.getValue()) ? "" : ":" + entry.getValue());
+                        Strings.isNullOrEmpty(entry.getValue()) ? "" : (":" + entry.getValue()));
             } else {
                 urlPattern = urlPattern.replace("{" + entry.getKey() + "}", entry.getValue());
             }

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
@@ -100,6 +100,7 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTestWit
         amqpMessageDispatcherService.targetAssignDistributionSet(targetAssignDistributionSetEvent);
         final Message sendMessage = createArgumentCapture(targetAssignDistributionSetEvent.getTargetAdress());
         final DownloadAndUpdateRequest downloadAndUpdateRequest = assertDownloadAndInstallMessage(sendMessage);
+        assertThat(downloadAndUpdateRequest.getTargetSecurityToken()).isEqualTo(TEST_TOKEN);
         assertTrue("No softwaremmodule should be contained in the request",
                 downloadAndUpdateRequest.getSoftwareModules().isEmpty());
     }
@@ -116,6 +117,7 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTestWit
         final DownloadAndUpdateRequest downloadAndUpdateRequest = assertDownloadAndInstallMessage(sendMessage);
         assertEquals("Expecting a size of 3 software modules in the reuqest", 3,
                 downloadAndUpdateRequest.getSoftwareModules().size());
+        assertThat(downloadAndUpdateRequest.getTargetSecurityToken()).isEqualTo(TEST_TOKEN);
         for (final org.eclipse.hawkbit.dmf.json.model.SoftwareModule softwareModule : downloadAndUpdateRequest
                 .getSoftwareModules()) {
             assertTrue("Artifact list for softwaremodule should be empty", softwareModule.getArtifacts().isEmpty());
@@ -155,6 +157,8 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTestWit
         final DownloadAndUpdateRequest downloadAndUpdateRequest = assertDownloadAndInstallMessage(sendMessage);
         assertEquals("DownloadAndUpdateRequest event should contains 3 software modules", 3,
                 downloadAndUpdateRequest.getSoftwareModules().size());
+        assertThat(downloadAndUpdateRequest.getTargetSecurityToken()).isEqualTo(TEST_TOKEN);
+
         for (final org.eclipse.hawkbit.dmf.json.model.SoftwareModule softwareModule : downloadAndUpdateRequest
                 .getSoftwareModules()) {
             if (!softwareModule.getModuleId().equals(module.getId())) {

--- a/pom.xml
+++ b/pom.xml
@@ -445,39 +445,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
             <version>${spring.boot.version}</version>
-            <exclusions>
-               <exclusion>
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot-starter-logging</artifactId>
-               </exclusion>
-            </exclusions>
-         </dependency>
-         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-log4j2</artifactId>
-            <version>${spring.boot.version}</version>
          </dependency>
          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring.boot.version}</version>
-            <exclusions>
-               <exclusion>
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot-starter-logging</artifactId>
-               </exclusion>
-            </exclusions>
          </dependency>
          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
             <version>${spring.boot.version}</version>
-            <exclusions>
-               <exclusion>
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot-starter-logging</artifactId>
-               </exclusion>
-            </exclusions>
          </dependency>
          <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
The log4j2 usage was introduced in the past as we expected better JUL integration. However, turned out logback is doing that as well as log4j2. In addition logback allows easier configuration through boots property mechanism.

I fixed also a small simulator glitch and added a few test asserts into DMF tests.