### PR TITLE
move widgetset to src/main/resources and remove cleaning of widgeset

### DIFF
--- a/hawkbit-ui/pom.xml
+++ b/hawkbit-ui/pom.xml
@@ -1,15 +1,6 @@
-<!--
-
-    Copyright (c) 2015 Bosch Software Innovations GmbH and others.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
-
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!-- Copyright (c) 2015 Bosch Software Innovations GmbH and others. All rights reserved. This program and the accompanying materials are made available 
+   under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <parent>
       <groupId>org.eclipse.hawkbit</groupId>
@@ -28,8 +19,8 @@
             <configuration>
                <extraJvmArgs>-Xmx1g -Xss1024k</extraJvmArgs>
                <!-- We are doing "inplace" gwt compilation but into subdir VAADIN/widgetsets -->
-               <webappDirectory>${project.build.directory}/classes/VAADIN/widgetsets</webappDirectory>
-               <hostedWebapp>${project.build.directory}/classes/VAADIN/widgetsets</hostedWebapp>
+               <webappDirectory>src/main/resources/VAADIN/widgetsets</webappDirectory>
+               <hostedWebapp>src/main/resources/VAADIN/widgetsets</hostedWebapp>
                <warSourceDirectory>src/main/resources</warSourceDirectory>
                <noServer>true</noServer>
                <!-- Remove draftCompile when project is ready -->
@@ -43,12 +34,12 @@
             </configuration>
             <executions>
                <execution>
+               <phase>process-classes</phase>
                   <configuration>
                      <!-- if you don't specify any modules, the plugin will find them -->
                      <!-- <modules> <module>com.vaadin.demo.mobilemail.gwt.ColorPickerWidgetSet</module> </modules> -->
                   </configuration>
                   <goals>
-                     <goal>clean</goal>
                      <goal>resources</goal>
                      <goal>update-theme</goal>
                      <goal>update-widgetset</goal>
@@ -58,29 +49,47 @@
                </execution>
             </executions>
          </plugin>
-		 <plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-jar-plugin</artifactId>
-			<configuration>
-				<archive>
-					<index>true</index>
-					<manifest>
-						<addClasspath>true</addClasspath>
-						<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-					</manifest>
-					<manifestEntries>
-						<Implementation-Title>CustomRenderers</Implementation-Title>
-						<Vaadin-Package-Version>1</Vaadin-Package-Version>
-						<Vaadin-Widgetsets>org.eclipse.hawkbit.ui.customrenderers.CustomRendererWidgetSet</Vaadin-Widgetsets>
-					</manifestEntries>
-				</archive>
-			</configuration>
-		</plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+               <execution>
+                  <phase>process-classes</phase>
+                  <configuration>
+                     <target>
+                        <copy todir="${project.build.directory}/classes/VAADIN/widgetsets">
+                           <fileset dir="${basedir}/src/main/resources/VAADIN/widgetsets" includes="**/*" />
+                        </copy>
+                     </target>
+                  </configuration>
+                  <goals>
+                     <goal>run</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+               <archive>
+                  <index>true</index>
+                  <manifest>
+                     <addClasspath>true</addClasspath>
+                     <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                  </manifest>
+                  <manifestEntries>
+                     <Implementation-Title>CustomRenderers</Implementation-Title>
+                     <Vaadin-Package-Version>1</Vaadin-Package-Version>
+                     <Vaadin-Widgetsets>org.eclipse.hawkbit.ui.customrenderers.CustomRendererWidgetSet</Vaadin-Widgetsets>
+                  </manifestEntries>
+               </archive>
+            </configuration>
+         </plugin>
       </plugins>
       <pluginManagement>
          <plugins>
-            <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven 
-               build itself. -->
+            <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself. -->
             <plugin>
                <groupId>org.eclipse.m2e</groupId>
                <artifactId>lifecycle-mapping</artifactId>
@@ -171,11 +180,11 @@
          <groupId>com.vaadin</groupId>
          <artifactId>vaadin-server</artifactId>
       </dependency>
-	  <dependency>
-		 <groupId>com.vaadin</groupId>
-		 <artifactId>vaadin-client</artifactId>
-	  </dependency>
-	  <dependency>
+      <dependency>
+         <groupId>com.vaadin</groupId>
+         <artifactId>vaadin-client</artifactId>
+      </dependency>
+      <dependency>
          <groupId>com.vaadin</groupId>
          <artifactId>vaadin-push</artifactId>
       </dependency>

--- a/hawkbit-ui/pom.xml
+++ b/hawkbit-ui/pom.xml
@@ -1,5 +1,13 @@
-<!-- Copyright (c) 2015 Bosch Software Innovations GmbH and others. All rights reserved. This program and the accompanying materials are made available 
-   under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html -->
+<!--
+
+    Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@
                   <exclude>**/*.sql</exclude>
                   <exclude>eclipse_codeformatter.xml</exclude>
                   <exclude>**/addons.scss</exclude>
+                  <exclude>**/VAADIN/widgetsets/**</exclude>
                </excludes>
                <mapping>
                   <scss>JAVADOC_STYLE</scss>


### PR DESCRIPTION
When switching branches eclipse-maven cleans the target folder and removes the compiled widgetset with it. So you'll need always to recompile the widgetset again in these case. This is annoying and time consuming.

The widgetset is not something which is changed very frequently so it might make sense to generate it to `src/main/resouces/VAADIN` where it won't be deleted and if you need to re-build hawkBit the widgetset does not need to compiled again during a normal `clean install` maven build phase.

Re-compiling hawkbit with `clean install -DskipTests` you currently will safe round about `1:30min` for a complete hawkBit build (without tests)

1. First build with necessary widget compilation
```
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:41 min
[INFO] Finished at: 2016-05-20T13:42:41+02:00
[INFO] Final Memory: 124M/1170M
[INFO] ------------------------------------------------------------------------
```

2. Second build without widget compilation necessary
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:02 min
[INFO] Finished at: 2016-05-20T13:44:07+02:00
[INFO] Final Memory: 123M/1179M
[INFO] ------------------------------------------------------------------------
```

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>