### PR TITLE
exclude .sonar directory from license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,8 @@
                   <exclude>eclipse_codeformatter.xml</exclude>
                   <exclude>**/addons.scss</exclude>
                   <exclude>**/VAADIN/widgetsets/**</exclude>
+                  <exclude>.sonar</exclude>
+                  <exclude>**/.sonar/**</exclude>
                </excludes>
                <mapping>
                   <scss>JAVADOC_STYLE</scss>


### PR DESCRIPTION
`.sonar` directory with `report-task.txt` files might be written during sonarqube runner and will cause an failure build on the license check of this file. This should be excluded from the licence-check.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>