### PR TITLE
Fix improve space usage for tag type names

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
@@ -42,11 +42,11 @@ import com.vaadin.ui.themes.ValoTheme;
 public abstract class AbstractFilterButtons extends Table {
 
     private static final long serialVersionUID = 7783305719009746375L;
-    
+
     private static final String DEFAULT_GREEN = "rgb(44,151,32)";
 
     protected static final String FILTER_BUTTON_COLUMN = "filterButton";
-    
+
     @Autowired
     protected transient EventBus.SessionEventBus eventBus;
 
@@ -63,7 +63,7 @@ public abstract class AbstractFilterButtons extends Table {
         createTable();
         eventBus.subscribe(this);
     }
-    
+
     @PreDestroy
     void destroy() {
         eventBus.unsubscribe(this);
@@ -120,6 +120,7 @@ public abstract class AbstractFilterButtons extends Table {
                         ? item.getItemProperty(SPUILabelDefinitions.VAR_COLOR).getValue().toString() : DEFAULT_GREEN;
         final Button typeButton = createFilterButton(id, name, desc, color, itemId);
         typeButton.addClickListener(event -> filterButtonClickBehaviour.processFilterButtonClick(event));
+        typeButton.addStyleName("generatedColumnPadding");
         if (typeButton.getData().equals(SPUIDefinitions.NO_TAG_BUTTON_ID) && isNoTagSateSelected()) {
             filterButtonClickBehaviour.setDefaultClickedButton(typeButton);
         } else if (id != null && isClickedByDefault(name)) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
@@ -156,6 +156,7 @@ public abstract class AbstractFilterButtons extends Table {
         columnIds.add(FILTER_BUTTON_COLUMN);
         setVisibleColumns(columnIds.toArray());
         setColumnHeaderMode(ColumnHeaderMode.HIDDEN);
+        setColumnWidth(FILTER_BUTTON_COLUMN, 137);
     }
 
     private Button createFilterButton(final Long id, final String name, final String description, final String color,

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
@@ -182,7 +182,6 @@ public abstract class AbstractFilterButtons extends Table {
         }
         button.setData(id == null ? SPUIDefinitions.NO_TAG_BUTTON_ID : itemId);
 
-        button.addStyleName("generatedColumnPadding");
         return button;
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
@@ -120,7 +120,6 @@ public abstract class AbstractFilterButtons extends Table {
                         ? item.getItemProperty(SPUILabelDefinitions.VAR_COLOR).getValue().toString() : DEFAULT_GREEN;
         final Button typeButton = createFilterButton(id, name, desc, color, itemId);
         typeButton.addClickListener(event -> filterButtonClickBehaviour.processFilterButtonClick(event));
-        typeButton.addStyleName("generatedColumnPadding");
         if (typeButton.getData().equals(SPUIDefinitions.NO_TAG_BUTTON_ID) && isNoTagSateSelected()) {
             filterButtonClickBehaviour.setDefaultClickedButton(typeButton);
         } else if (id != null && isClickedByDefault(name)) {
@@ -181,6 +180,8 @@ public abstract class AbstractFilterButtons extends Table {
             button.setDescription(name);
         }
         button.setData(id == null ? SPUIDefinitions.NO_TAG_BUTTON_ID : itemId);
+
+        button.addStyleName("generatedColumnPadding");
         return button;
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/decorators/SPUITagButtonStyle.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/decorators/SPUITagButtonStyle.java
@@ -30,8 +30,9 @@ public class SPUITagButtonStyle implements SPUIButtonDecorator {
             button.setCaption(buttonCaption.substring(0, SPUIButtonDefinitions.BUTTON_CAPTION_LENGTH) + "...");
         }
         button.setImmediate(true);
-        button.addStyleName("button-no-border" + " " + ValoTheme.BUTTON_BORDERLESS + " " + ValoTheme.BUTTON_TINY + " "
+        button.addStyleName("generatedColumnPadding button-no-border" + " " + ValoTheme.BUTTON_BORDERLESS + " "
                 + "button-tag-no-border");
+
         // Set Style
         if (null != style) {
             if (setStyle) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/decorators/SPUITagButtonStyle.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/decorators/SPUITagButtonStyle.java
@@ -8,8 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.decorators;
 
-import org.eclipse.hawkbit.ui.utils.SPUIButtonDefinitions;
-
 import com.vaadin.server.Resource;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.themes.ValoTheme;
@@ -22,13 +20,6 @@ public class SPUITagButtonStyle implements SPUIButtonDecorator {
     @Override
     public Button decorate(final Button button, final String style, final boolean setStyle, final Resource icon) {
 
-        /**
-         * Add ... for long name
-         */
-        final String buttonCaption = button.getCaption();
-        if (buttonCaption != null && buttonCaption.length() > SPUIButtonDefinitions.BUTTON_CAPTION_LENGTH) {
-            button.setCaption(buttonCaption.substring(0, SPUIButtonDefinitions.BUTTON_CAPTION_LENGTH) + "...");
-        }
         button.setImmediate(true);
         button.addStyleName("generatedColumnPadding button-no-border" + " " + ValoTheme.BUTTON_BORDERLESS + " "
                 + "button-tag-no-border");

--- a/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/table-common.scss
+++ b/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/table-common.scss
@@ -181,4 +181,8 @@
     visibility: hidden;
     float: right;
   }
+  
+  .v-button-generatedColumnPadding .v-button-tiny {
+  	padding: 0 0px;
+  }
 }

--- a/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/table-common.scss
+++ b/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/table-common.scss
@@ -182,7 +182,8 @@
     float: right;
   }
   
-  .v-button-generatedColumnPadding .v-button-tiny {
-  	padding: 0 0px;
+  .v-button-generatedColumnPadding .v-button-tiny-generatedColumnPadding {
+  	padding: 0px 0px !important;
   }
+  
 }

--- a/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/table-common.scss
+++ b/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/table-common.scss
@@ -184,7 +184,7 @@
   
   .v-button-generatedColumnPadding {
   	height: 28px;
-	padding: 0 0px !important;
+	padding: 0 6px !important;
 	font-size: 12px;
 	border-radius: 4px;
   }

--- a/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/table-common.scss
+++ b/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/table-common.scss
@@ -182,8 +182,12 @@
     float: right;
   }
   
-  .v-button-generatedColumnPadding .v-button-tiny-generatedColumnPadding {
-  	padding: 0px 0px !important;
+  .v-button-generatedColumnPadding {
+  	height: 28px;
+	padding: 0 0px !important;
+	font-size: 12px;
+	border-radius: 4px;
   }
+  
   
 }


### PR DESCRIPTION
The space usage of the simple filter tag view is improved. The padding on the left and right side is reduced, so there is more space for the tag text. If the tag text is longer than the available space, the text is visually cut. The full text is always available as a tooltip.

![improve_space_usage](https://cloud.githubusercontent.com/assets/18258708/15855045/8a2e6110-2cad-11e6-8d9c-8a159fb20098.png)
