### PR TITLE
Fixed problem where correlation data is null.

### DIFF
--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
@@ -135,12 +135,10 @@ public class AmqpConfiguration {
 
         rabbitTemplate.setConfirmCallback((correlationData, ack, cause) -> {
             if (ack) {
-                LOGGER.debug("Message with correlation ID {} confirmed by broker.", correlationData.getId());
+                LOGGER.debug("Message with {} confirmed by broker.", correlationData);
             } else {
-                LOGGER.error("Broker is unable to handle message with correlation ID {} : {}", correlationData.getId(),
-                        cause);
+                LOGGER.error("Broker is unable to handle message with {} : {}", correlationData, cause);
             }
-
         });
 
         return rabbitTemplate;


### PR DESCRIPTION
We have to make sure that we do not fail on publisher confirm if correlation id has not been provided by sender.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>