### PR TITLE
Set new policy for central executor pool to avoid loosing data.

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/scheduling/ExecutorAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/scheduling/ExecutorAutoConfiguration.java
@@ -61,13 +61,11 @@ public class ExecutorAutoConfiguration {
     public ThreadPoolExecutor threadPoolExecutor() {
         final BlockingQueue<Runnable> blockingQueue = new ArrayBlockingQueue<>(
                 asyncConfigurerProperties.getQueuesize());
-        final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(asyncConfigurerProperties.getCorethreads(),
+        return new ThreadPoolExecutor(asyncConfigurerProperties.getCorethreads(),
                 asyncConfigurerProperties.getMaxthreads(), asyncConfigurerProperties.getIdletimeout(),
                 TimeUnit.MILLISECONDS, blockingQueue,
                 new ThreadFactoryBuilder().setNameFormat("central-executor-pool-%d").build(),
                 new PoolSizeExceededPolicy());
-
-        return threadPoolExecutor;
     }
 
     private static class PoolSizeExceededPolicy extends CallerRunsPolicy {


### PR DESCRIPTION
It may happen currently that we loose data in the central executor pool as it simply rejects tasks if the queue is full. That may result especially in DMF case that we get into an inconsistent state between our repository and the DMF connected systems.


Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>