### PR TITLE
re-order tenant lazy initialization filter after authentication chain

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
@@ -83,6 +83,7 @@ import org.springframework.security.web.header.writers.frameoptions.StaticAllowF
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter.XFrameOptionsMode;
 import org.springframework.security.web.session.HttpSessionEventPublisher;
+import org.springframework.security.web.session.SessionManagementFilter;
 import org.vaadin.spring.security.VaadinSecurityContext;
 import org.vaadin.spring.security.annotation.EnableVaadinSecurity;
 import org.vaadin.spring.security.web.VaadinDefaultRedirectStrategy;
@@ -333,7 +334,7 @@ public class SecurityManagedConfiguration {
             }, RequestHeaderAuthenticationFilter.class)
                     .addFilterAfter(
                             new AuthenticationSuccessTenantMetadataCreationFilter(tenantAware, systemManagement),
-                            RequestHeaderAuthenticationFilter.class)
+                            SessionManagementFilter.class)
                     .authorizeRequests().anyRequest().authenticated()
                     .antMatchers(MgmtRestConstants.BASE_SYSTEM_MAPPING + "/admin/**")
                     .hasAnyAuthority(SpPermission.SYSTEM_ADMIN)


### PR DESCRIPTION
push back the `AuthenticationSuccessTenantMetadataCreationFilter` in the security-filter-chain after the spring authentication providers. Otherwise the first login attemp and doing a entity write request e.g. like posting tenant configuration the first time will lead in 
```
{"exceptionClass":"org.eclipse.hawkbit.repository.exception.TenantNotExistException","errorCode":"hawkbit.server.error.repo.tenantNotExists","message":"Tenant SPE2ETEST does not exists, cannot create entity class org.eclipse.hawkbit.repository.jpa.model.JpaTenantConfiguration with id null"}
```
Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>