### PR TITLE
add spring security eval expression for system_monitor permission

### DIFF
--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
@@ -396,6 +396,12 @@ public final class SpPermission {
         public static final String HAS_AUTH_TENANT_CONFIGURATION = HAS_AUTH_PREFIX + TENANT_CONFIGURATION
                 + HAS_AUTH_SUFFIX;
 
+        /**
+         * Spring security eval hasAuthority expression to check if spring
+         * context contains {@link SpPermission#SYSTEM_MONITOR}
+         */
+        public static final String HAS_AUTH_SYSTEM_MONITOR = HAS_AUTH_PREFIX + SYSTEM_MONITOR + HAS_AUTH_SUFFIX;
+
         private SpringEvalExpressions() {
             // utility class
         }


### PR DESCRIPTION
add spring security eval expression in the `SpPermission` class to check if the context contains the `SYSTEM_MONITOR` permission.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>