### PR TITLE
Feature security adaptions

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
@@ -272,20 +272,6 @@ public class SecurityManagedConfiguration {
     }
 
     /**
-     * Security configuration for the REST management API of the health url.
-     */
-    @Configuration
-    @Order(310)
-    public static class HealthSecurityConfigurationAdapter extends WebSecurityConfigurerAdapter {
-
-        @Override
-        protected void configure(final HttpSecurity http) throws Exception {
-            http.regexMatcher("/system/health").csrf().disable().httpBasic().and().sessionManagement()
-                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        }
-    }
-
-    /**
      * Security configuration for the REST management API.
      */
     @Configuration
@@ -310,7 +296,7 @@ public class SecurityManagedConfiguration {
             final BasicAuthenticationEntryPoint basicAuthEntryPoint = new BasicAuthenticationEntryPoint();
             basicAuthEntryPoint.setRealmName(springSecurityProperties.getBasic().getRealm());
 
-            HttpSecurity httpSec = http.regexMatcher("\\/rest.*|\\/system.*").csrf().disable();
+            HttpSecurity httpSec = http.regexMatcher("\\/rest.*|\\/system/admin.*").csrf().disable();
             if (springSecurityProperties.isRequireSsl()) {
                 httpSec = httpSec.requiresChannel().anyRequest().requiresSecure().and();
             }
@@ -337,9 +323,7 @@ public class SecurityManagedConfiguration {
                             SessionManagementFilter.class)
                     .authorizeRequests().anyRequest().authenticated()
                     .antMatchers(MgmtRestConstants.BASE_SYSTEM_MAPPING + "/admin/**")
-                    .hasAnyAuthority(SpPermission.SYSTEM_ADMIN)
-                    .antMatchers(MgmtRestConstants.BASE_SYSTEM_MAPPING + "/**")
-                    .hasAnyAuthority(SpPermission.SYSTEM_DIAG);
+                    .hasAnyAuthority(SpPermission.SYSTEM_ADMIN);
 
             httpSec.httpBasic().and().exceptionHandling().authenticationEntryPoint(basicAuthEntryPoint);
         }

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/PermissionUtils.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/PermissionUtils.java
@@ -36,6 +36,9 @@ public final class PermissionUtils {
 
         for (final String role : roles) {
             authorities.add(new SimpleGrantedAuthority(role));
+            // add spring security ROLE authority which is indicated by the
+            // `ROLE_` prefix
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
         }
 
         return authorities;

--- a/hawkbit-security-core/src/test/java/org/eclipse/hawkbit/im/authentication/PermissionTest.java
+++ b/hawkbit-security-core/src/test/java/org/eclipse/hawkbit/im/authentication/PermissionTest.java
@@ -36,7 +36,8 @@ public final class PermissionTest {
         final Collection<String> allAuthorities = SpPermission.getAllAuthorities();
         final List<GrantedAuthority> allAuthoritiesList = PermissionUtils.createAllAuthorityList();
         assertThat(allAuthorities).hasSize(allPermission);
-        assertThat(allAuthoritiesList).hasSize(allPermission);
+        // times 2 because we add also all authorities as prefix 'ROLE_';
+        assertThat(allAuthoritiesList).hasSize(allPermission * 2);
         assertThat(allAuthoritiesList.stream().map(authority -> authority.getAuthority()).collect(Collectors.toList()))
                 .containsAll(allAuthorities);
 
@@ -46,7 +47,8 @@ public final class PermissionTest {
                 .getAllAuthorities(SpPermission.SYSTEM_ADMIN, SpPermission.SYSTEM_DIAG, SpPermission.SYSTEM_MONITOR));
 
         assertThat(authoritiesWithoutSystem).hasSize(permissionWithoutSystem);
-        assertThat(authoritiesListWithoutSystem).hasSize(permissionWithoutSystem);
+        // times 2 because we add also all authorities as prefix 'ROLE_';
+        assertThat(authoritiesListWithoutSystem).hasSize(permissionWithoutSystem * 2);
         assertThat(authoritiesListWithoutSystem.stream().map(authority -> authority.getAuthority())
                 .collect(Collectors.toList())).containsAll(authoritiesWithoutSystem);
 


### PR DESCRIPTION
* Removing the special handling of the `system/health` security configuration of the `SecurityManagedConfiguration` because this should not be configured. Spring actuator is able to configure the security and paths etc via configuration properties. It's not necessary configure this at all in the security configuration.

* Spring Security configuration like spring acuator (management configuration) is based on security-roles and not on authoritiy. So adding all authorities also with the spring security `ROLE_` prefix so the spring eval-language `hasRole()` works as well.