### PR TITLE
retrieve target-security-token with system-context permission

### DIFF
--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -47,6 +47,7 @@ import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.LocalArtifact;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.util.IpUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,6 +105,9 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
 
     @Autowired
     private EntityFactory entityFactory;
+
+    @Autowired
+    private SystemSecurityContext systemSecurityContext;
 
     /**
      * Constructor.
@@ -313,9 +317,10 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
         final DistributionSet distributionSet = action.getDistributionSet();
         final List<SoftwareModule> softwareModuleList = controllerManagement
                 .findSoftwareModulesByDistributionSet(distributionSet);
+        final String targetSecurityToken = systemSecurityContext.runAsSystem(() -> target.getSecurityToken());
         eventBus.post(new TargetAssignDistributionSetEvent(target.getOptLockRevision(), target.getTenant(),
                 target.getControllerId(), action.getId(), softwareModuleList, target.getTargetInfo().getAddress(),
-                target.getSecurityToken()));
+                targetSecurityToken));
 
     }
 

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -478,4 +478,7 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
         this.entityFactory = entityFactory;
     }
 
+    void setSystemSecurityContext(final SystemSecurityContext systemSecurityContext) {
+        this.systemSecurityContext = systemSecurityContext;
+    }
 }

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -52,6 +52,7 @@ import org.eclipse.hawkbit.repository.model.LocalArtifact;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.TargetInfo;
 import org.eclipse.hawkbit.security.SecurityTokenGenerator;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -112,6 +113,9 @@ public class AmqpMessageHandlerServiceTest {
     @Mock
     private RabbitTemplate rabbitTemplate;
 
+    @Mock
+    private SystemSecurityContext systemSecurityContextMock;
+
     @Before
     public void before() throws Exception {
         messageConverter = new Jackson2JsonMessageConverter();
@@ -124,6 +128,7 @@ public class AmqpMessageHandlerServiceTest {
         amqpMessageHandlerService.setHostnameResolver(hostnameResolverMock);
         amqpMessageHandlerService.setEventBus(eventBus);
         amqpMessageHandlerService.setEntityFactory(entityFactoryMock);
+        amqpMessageHandlerService.setSystemSecurityContext(systemSecurityContextMock);
 
     }
 
@@ -366,6 +371,8 @@ public class AmqpMessageHandlerServiceTest {
         final List<SoftwareModule> softwareModuleList = createSoftwareModuleList();
         when(controllerManagementMock.findSoftwareModulesByDistributionSet(Matchers.any()))
                 .thenReturn(softwareModuleList);
+
+        when(systemSecurityContextMock.runAsSystem(anyObject())).thenReturn("securityToken");
 
         final MessageProperties messageProperties = createMessageProperties(MessageType.EVENT);
         messageProperties.setHeader(MessageHeaderKey.TOPIC, EventTopic.UPDATE_ACTION_STATUS.name());


### PR DESCRIPTION
The `target-security-token` can only be retrieved with the correct permission. When re-sending DMF message based on the `DMF-Ping` aka `THING_CREATED` we do not have a correct security-context to retrieve the `target-security-token` we need to retrieve the token using the `SystemSecurityContext` to run it as system-code, otherwise the `target-security-token` will be null.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>