### PR TITLE
Fixed bug where DDI deplyomentBase URL does not reflect TIMEFORCED

### DIFF
--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DataConversionHelper.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DataConversionHelper.java
@@ -79,12 +79,12 @@ public final class DataConversionHelper {
             final org.eclipse.hawkbit.repository.model.SoftwareModule module,
             final ArtifactUrlHandler artifactUrlHandler) {
         final List<DdiArtifact> files = new ArrayList<>();
-        
+
         module.getLocalArtifacts()
-        .forEach(artifact -> files.add(createArtifact(targetid, artifactUrlHandler, artifact)));
+                .forEach(artifact -> files.add(createArtifact(targetid, artifactUrlHandler, artifact)));
         return files;
     }
-    
+
     private static DdiArtifact createArtifact(final String targetid, final ArtifactUrlHandler artifactUrlHandler,
             final LocalArtifact artifact) {
         final DdiArtifact file = new DdiArtifact();
@@ -125,7 +125,7 @@ public final class DataConversionHelper {
                 // response because of eTags.
                 result.add(linkTo(methodOn(DdiRootController.class, tenantAware.getCurrentTenant())
                         .getControllerBasedeploymentAction(target.getControllerId(), action.getId(),
-                                actions.hashCode())).withRel(DdiRestConstants.DEPLOYMENT_BASE_ACTION));
+                                calculateEtag(action))).withRel(DdiRestConstants.DEPLOYMENT_BASE_ACTION));
                 addedUpdate = true;
             } else if (action.isCancelingOrCanceled() && !addedCancel) {
                 result.add(linkTo(methodOn(DdiRootController.class, tenantAware.getCurrentTenant())
@@ -139,6 +139,22 @@ public final class DataConversionHelper {
             result.add(linkTo(methodOn(DdiRootController.class, tenantAware.getCurrentTenant()).putConfigData(null,
                     target.getControllerId())).withRel(DdiRestConstants.CONFIG_DATA_ACTION));
         }
+        return result;
+    }
+
+    /**
+     * Calculates an etag for the given {@link Action} based on the entities
+     * hashcode and the {@link Action#isHitAutoForceTime(long)} to reflect a
+     * force switch.
+     * 
+     * @param action
+     *            to calculate the etag for
+     * @return the etag
+     */
+    private static int calculateEtag(final Action action) {
+        final int prime = 31;
+        int result = action.hashCode();
+        result = prime * result + (action.isHitAutoForceTime(System.currentTimeMillis()) ? 1231 : 1237);
         return result;
     }
 

--- a/hawkbit-ddi-resource/src/test/resources/logback.xml
+++ b/hawkbit-ddi-resource/src/test/resources/logback.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<configuration>
+   <include resource="org/springframework/boot/logging/logback/base.xml" />
+      
+<!--    <Logger name="org.eclipse.hawkbit.rest.util.MockMvcResultPrinter" level="DEBUG" /> -->
+
+   <Root level="INFO">
+      <AppenderRef ref="Console" />
+   </Root>
+
+</configuration>


### PR DESCRIPTION
We have a feature that we add to deploymentBase URLs an etag get param to reflect SOFT to FORCED changes on the same action in case of TIMEFORCED.

We broke that with a repo change a couple of months ago. I fixed it an created a test,


Signed-off-by: Kai Zimmermann <kai.zimmermann@bosch-si.com>