### PR TITLE
Made queue declaration retry count configurable.

### DIFF
--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
@@ -22,11 +22,11 @@ import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.FanoutExchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.QueueBuilder;
-import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -268,15 +268,8 @@ public class AmqpConfiguration {
      *         AMQP messages
      */
     @Bean(name = { "listenerContainerFactory" })
-    public SimpleRabbitListenerContainerFactory listenerContainerFactory() {
-        final SimpleRabbitListenerContainerFactory containerFactory = new SimpleRabbitListenerContainerFactory();
-        containerFactory.setDefaultRequeueRejected(true);
-        containerFactory.setConnectionFactory(rabbitConnectionFactory);
-        containerFactory.setMissingQueuesFatal(amqpProperties.isMissingQueuesFatal());
-        containerFactory.setConcurrentConsumers(amqpProperties.getInitialConcurrentConsumers());
-        containerFactory.setMaxConcurrentConsumers(amqpProperties.getMaxConcurrentConsumers());
-        containerFactory.setPrefetchCount(amqpProperties.getPrefetchCount());
-        return containerFactory;
+    public RabbitListenerContainerFactory<SimpleMessageListenerContainer> listenerContainerFactory() {
+        return new ConfigurableRabbitListenerContainerFactory(amqpProperties, rabbitConnectionFactory);
     }
 
     private static Map<String, Object> getTTLMaxArgsAuthenticationQueue() {

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -408,12 +408,16 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
 
         if (ArrayUtils.isNotEmpty(message.getMessageProperties().getCorrelationId())) {
             actionStatus.addMessage(RepositoryConstants.SERVER_MESSAGE_PREFIX + "DMF message correlation-id "
-                    + new String(message.getMessageProperties().getCorrelationId()));
+                    + convertCorrelationId(message));
         }
 
         actionStatus.setAction(action);
         actionStatus.setOccurredAt(System.currentTimeMillis());
         return actionStatus;
+    }
+
+    private static String convertCorrelationId(final Message message) {
+        return new String(message.getMessageProperties().getCorrelationId());
     }
 
     private Action getUpdateActionStatus(final ActionStatus actionStatus) {

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
@@ -68,6 +68,29 @@ public class AmqpProperties {
      */
     private int initialConcurrentConsumers = 3;
 
+    /**
+     * The number of retry attempts when passive queue declaration fails.
+     * Passive queue declaration occurs when the consumer starts or, when
+     * consuming from multiple queues, when not all queues were available during
+     * initialization.
+     */
+    private int declarationRetries = 50;
+
+    /**
+     * @return the declarationRetries
+     */
+    public int getDeclarationRetries() {
+        return declarationRetries;
+    }
+
+    /**
+     * @param declarationRetries
+     *            the declarationRetries to set
+     */
+    public void setDeclarationRetries(final int declarationRetries) {
+        this.declarationRetries = declarationRetries;
+    }
+
     public String getAuthenticationReceiverQueue() {
         return authenticationReceiverQueue;
     }

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.amqp;
+
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+
+/**
+ * {@link RabbitListenerContainerFactory} that can be configured through
+ * hawkBit's {@link AmqpProperties}.
+ *
+ */
+public class ConfigurableRabbitListenerContainerFactory extends SimpleRabbitListenerContainerFactory {
+    private final AmqpProperties amqpProperties;
+
+    /**
+     * Constructor.
+     * 
+     * @param rabbitConnectionFactory
+     *            for the container factory
+     * @param amqpProperties
+     *            to configure the container factory
+     */
+    public ConfigurableRabbitListenerContainerFactory(final AmqpProperties amqpProperties,
+            final ConnectionFactory rabbitConnectionFactory) {
+        this.amqpProperties = amqpProperties;
+        setDefaultRequeueRejected(true);
+        setConnectionFactory(rabbitConnectionFactory);
+        setMissingQueuesFatal(amqpProperties.isMissingQueuesFatal());
+        setConcurrentConsumers(amqpProperties.getInitialConcurrentConsumers());
+        setMaxConcurrentConsumers(amqpProperties.getMaxConcurrentConsumers());
+        setPrefetchCount(amqpProperties.getPrefetchCount());
+
+    }
+
+    @Override
+    protected void initializeContainer(final SimpleMessageListenerContainer instance) {
+        super.initializeContainer(instance);
+        instance.setDeclarationRetries(amqpProperties.getDeclarationRetries());
+    }
+}

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
@@ -42,6 +42,9 @@ public class ConfigurableRabbitListenerContainerFactory extends SimpleRabbitList
     }
 
     @Override
+    // Exception squid:UnusedProtectedMethod - called by
+    // AbstractRabbitListenerContainerFactory
+    @SuppressWarnings("squid:UnusedProtectedMethod")
     protected void initializeContainer(final SimpleMessageListenerContainer instance) {
         super.initializeContainer(instance);
         instance.setDeclarationRetries(amqpProperties.getDeclarationRetries());

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -141,7 +141,7 @@ public class AmqpMessageHandlerServiceTest {
         try {
             amqpMessageHandlerService.onMessage(message, MessageType.THING_CREATED.name(), TENANT, "vHost");
             fail("IllegalArgumentException was excepeted due to worng content type");
-        } catch (final IllegalArgumentException e) {
+        } catch (final AmqpRejectAndDontRequeueException e) {
         }
     }
 

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -140,7 +140,7 @@ public class AmqpMessageHandlerServiceTest {
         final Message message = new Message(new byte[0], messageProperties);
         try {
             amqpMessageHandlerService.onMessage(message, MessageType.THING_CREATED.name(), TENANT, "vHost");
-            fail("IllegalArgumentException was excepeted due to worng content type");
+            fail("AmqpRejectAndDontRequeueException was excepeted due to worng content type");
         } catch (final AmqpRejectAndDontRequeueException e) {
         }
     }
@@ -175,7 +175,7 @@ public class AmqpMessageHandlerServiceTest {
 
         try {
             amqpMessageHandlerService.onMessage(message, MessageType.THING_CREATED.name(), TENANT, "vHost");
-            fail("IllegalArgumentException was excepeted since no replyTo header was set");
+            fail("AmqpRejectAndDontRequeueException was excepeted since no replyTo header was set");
         } catch (final AmqpRejectAndDontRequeueException exception) {
             // test ok - exception was excepted
         }
@@ -189,7 +189,7 @@ public class AmqpMessageHandlerServiceTest {
         final Message message = messageConverter.toMessage(new byte[0], messageProperties);
         try {
             amqpMessageHandlerService.onMessage(message, MessageType.THING_CREATED.name(), TENANT, "vHost");
-            fail("IllegalArgumentException was excepeted since no thingID was set");
+            fail("AmqpRejectAndDontRequeueException was excepeted since no thingID was set");
         } catch (final AmqpRejectAndDontRequeueException exception) {
             // test ok - exception was excepted
         }
@@ -205,7 +205,7 @@ public class AmqpMessageHandlerServiceTest {
 
         try {
             amqpMessageHandlerService.onMessage(message, type, TENANT, "vHost");
-            fail("IllegalArgumentException was excepeted due to unknown message type");
+            fail("AmqpRejectAndDontRequeueException was excepeted due to unknown message type");
         } catch (final AmqpRejectAndDontRequeueException exception) {
             // test ok - exception was excepted
         }
@@ -218,21 +218,21 @@ public class AmqpMessageHandlerServiceTest {
         final Message message = new Message(new byte[0], messageProperties);
         try {
             amqpMessageHandlerService.onMessage(message, MessageType.EVENT.name(), TENANT, "vHost");
-            fail("IllegalArgumentException was excepeted due to unknown message type");
+            fail("AmqpRejectAndDontRequeueException was excepeted due to unknown message type");
         } catch (final AmqpRejectAndDontRequeueException e) {
         }
 
         try {
             messageProperties.setHeader(MessageHeaderKey.TOPIC, "wrongTopic");
             amqpMessageHandlerService.onMessage(message, MessageType.EVENT.name(), TENANT, "vHost");
-            fail("IllegalArgumentException was excepeted due to unknown topic");
+            fail("AmqpRejectAndDontRequeueException was excepeted due to unknown topic");
         } catch (final AmqpRejectAndDontRequeueException e) {
         }
 
         messageProperties.setHeader(MessageHeaderKey.TOPIC, EventTopic.CANCEL_DOWNLOAD.name());
         try {
             amqpMessageHandlerService.onMessage(message, MessageType.EVENT.name(), TENANT, "vHost");
-            fail("IllegalArgumentException was excepeted because there was no event topic");
+            fail("AmqpRejectAndDontRequeueException was excepeted because there was no event topic");
         } catch (final AmqpRejectAndDontRequeueException exception) {
             // test ok - exception was excepted
         }
@@ -251,7 +251,7 @@ public class AmqpMessageHandlerServiceTest {
 
         try {
             amqpMessageHandlerService.onMessage(message, MessageType.EVENT.name(), TENANT, "vHost");
-            fail("IllegalArgumentException was excepeted since no action id was set");
+            fail("AmqpRejectAndDontRequeueException was excepeted since no action id was set");
         } catch (final AmqpRejectAndDontRequeueException exception) {
             // test ok - exception was excepted
         }
@@ -268,7 +268,7 @@ public class AmqpMessageHandlerServiceTest {
 
         try {
             amqpMessageHandlerService.onMessage(message, MessageType.EVENT.name(), TENANT, "vHost");
-            fail("IllegalArgumentException was excepeted since no action id was set");
+            fail("AmqpRejectAndDontRequeueException was excepeted since no action id was set");
         } catch (final AmqpRejectAndDontRequeueException exception) {
             // test ok - exception was excepted
         }


### PR DESCRIPTION
We had the need to configure queue declaration retry count. I added an new RabbitListenerContainerFactory implementation to make this configurable.

While at it I fixed also a wrong exception, byte to string conversion and fixed a sonar issue.

Signed-off-by: Kai Zimmermann <kai.zimmermann@bosch-si.com>