### PR TITLE
Traffic data in DownloadProgress event

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/cache/DownloadIdCacheAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/cache/DownloadIdCacheAutoConfiguration.java
@@ -31,7 +31,7 @@ public class DownloadIdCacheAutoConfiguration {
     private CacheManager cacheManager;
 
     /**
-     * Bean for the downlod id cache.
+     * Bean for the download id cache.
      * 
      * @return the cache
      */

--- a/hawkbit-cache-redis/pom.xml
+++ b/hawkbit-cache-redis/pom.xml
@@ -46,6 +46,12 @@
 
       <!-- Test -->
       <dependency>
+         <groupId>org.eclipse.hawkbit</groupId>
+         <artifactId>hawkbit-repository-api</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.springframework.boot</groupId>
          <artifactId>spring-boot-starter-test</artifactId>
          <scope>test</scope>

--- a/hawkbit-cache-redis/src/test/java/org/eclipse/hawkbit/cache/eventbus/EventDistributorTest.java
+++ b/hawkbit-cache-redis/src/test/java/org/eclipse/hawkbit/cache/eventbus/EventDistributorTest.java
@@ -56,7 +56,7 @@ public class EventDistributorTest {
     @Test
     public void distributeDistributedEventSendsToRedis() {
 
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L);
         underTest.distribute(event);
 
         // origin node ID should be set by distributing the event
@@ -67,7 +67,7 @@ public class EventDistributorTest {
     @Test
     public void dontDistributeDistributedEventIfSameNode() {
         final String knownNodeId = EventDistributor.getNodeId();
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L);
         event.setNodeId(knownNodeId);
 
         // test
@@ -79,7 +79,7 @@ public class EventDistributorTest {
 
     @Test
     public void handleDistributedMessageFromRedis() {
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L);
         final String knownChannel = "someChannel";
 
         underTest.handleMessage(event, knownChannel);
@@ -90,7 +90,7 @@ public class EventDistributorTest {
 
     @Test
     public void handleDistributedMessageFilteredIfSameNodeId() {
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L);
         final String knownChannel = "someChannel";
         event.setOriginNodeId(EventDistributor.getNodeId());
 

--- a/hawkbit-cache-redis/src/test/java/org/eclipse/hawkbit/cache/eventbus/EventDistributorTest.java
+++ b/hawkbit-cache-redis/src/test/java/org/eclipse/hawkbit/cache/eventbus/EventDistributorTest.java
@@ -56,7 +56,7 @@ public class EventDistributorTest {
     @Test
     public void distributeDistributedEventSendsToRedis() {
 
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L, 200L);
         underTest.distribute(event);
 
         // origin node ID should be set by distributing the event
@@ -67,7 +67,7 @@ public class EventDistributorTest {
     @Test
     public void dontDistributeDistributedEventIfSameNode() {
         final String knownNodeId = EventDistributor.getNodeId();
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L, 200L);
         event.setNodeId(knownNodeId);
 
         // test
@@ -79,7 +79,7 @@ public class EventDistributorTest {
 
     @Test
     public void handleDistributedMessageFromRedis() {
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L, 200L);
         final String knownChannel = "someChannel";
 
         underTest.handleMessage(event, knownChannel);
@@ -90,7 +90,7 @@ public class EventDistributorTest {
 
     @Test
     public void handleDistributedMessageFilteredIfSameNodeId() {
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L, 200L);
         final String knownChannel = "someChannel";
         event.setOriginNodeId(EventDistributor.getNodeId());
 

--- a/hawkbit-cache-redis/src/test/java/org/eclipse/hawkbit/cache/eventbus/EventDistributorTest.java
+++ b/hawkbit-cache-redis/src/test/java/org/eclipse/hawkbit/cache/eventbus/EventDistributorTest.java
@@ -16,8 +16,8 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Collection;
 
-import org.eclipse.hawkbit.eventbus.event.DownloadProgressEvent;
 import org.eclipse.hawkbit.eventbus.event.EntityEvent;
+import org.eclipse.hawkbit.repository.eventbus.event.DownloadProgressEvent;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,7 +56,7 @@ public class EventDistributorTest {
     @Test
     public void distributeDistributedEventSendsToRedis() {
 
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L, 200L);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 500L, 100L, 200L);
         underTest.distribute(event);
 
         // origin node ID should be set by distributing the event
@@ -67,7 +67,7 @@ public class EventDistributorTest {
     @Test
     public void dontDistributeDistributedEventIfSameNode() {
         final String knownNodeId = EventDistributor.getNodeId();
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L, 200L);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 500L, 100L, 200L);
         event.setNodeId(knownNodeId);
 
         // test
@@ -79,7 +79,7 @@ public class EventDistributorTest {
 
     @Test
     public void handleDistributedMessageFromRedis() {
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L, 200L);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 500L, 100L, 200L);
         final String knownChannel = "someChannel";
 
         underTest.handleMessage(event, knownChannel);
@@ -90,7 +90,7 @@ public class EventDistributorTest {
 
     @Test
     public void handleDistributedMessageFilteredIfSameNodeId() {
-        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 10, 100L, 200L);
+        final DownloadProgressEvent event = new DownloadProgressEvent("tenant", 123L, 500L, 100L, 200L);
         final String knownChannel = "someChannel";
         event.setOriginNodeId(EventDistributor.getNodeId());
 

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/eventbus/event/DownloadProgressEvent.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/eventbus/event/DownloadProgressEvent.java
@@ -21,6 +21,7 @@ public class DownloadProgressEvent extends AbstractDistributedEvent {
 
     private final Long statusId;
     private final int progressPercent;
+    private final long shippedBytes;
 
     /**
      * Constructor.
@@ -32,13 +33,15 @@ public class DownloadProgressEvent extends AbstractDistributedEvent {
      * @param progressPercent
      *            number (1-100)
      */
-    public DownloadProgressEvent(final String tenant, final Long statusId, final int progressPercent) {
+    public DownloadProgressEvent(final String tenant, final Long statusId, final int progressPercent,
+            final long shippedBytes) {
         // the revision of the DownloadProgressEvent is just equal the
         // progressPercentage due the
         // percentage is going from 0 to 100.
         super(statusId, tenant);
         this.statusId = statusId;
         this.progressPercent = progressPercent;
+        this.shippedBytes = shippedBytes;
     }
 
     /**
@@ -54,4 +57,12 @@ public class DownloadProgressEvent extends AbstractDistributedEvent {
     public int getProgressPercent() {
         return progressPercent;
     }
+
+    /**
+     * @return the shippedBytes
+     */
+    public long getShippedBytes() {
+        return shippedBytes;
+    }
+
 }

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/eventbus/event/DownloadProgressEvent.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/eventbus/event/DownloadProgressEvent.java
@@ -29,7 +29,7 @@ public class DownloadProgressEvent extends AbstractDistributedEvent {
      * @param tenant
      *            the tenant for this event
      * @param statusId
-     *            of {@link UpdateActionStatus}
+     *            of {@link Action}
      * @param progressPercent
      *            number (1-100)
      */

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/eventbus/event/DownloadProgressEvent.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/eventbus/event/DownloadProgressEvent.java
@@ -21,7 +21,8 @@ public class DownloadProgressEvent extends AbstractDistributedEvent {
 
     private final Long statusId;
     private final int progressPercent;
-    private final long shippedBytes;
+    private final long shippedBytesSinceLast;
+    private final long shippedBytesOverall;
 
     /**
      * Constructor.
@@ -29,40 +30,39 @@ public class DownloadProgressEvent extends AbstractDistributedEvent {
      * @param tenant
      *            the tenant for this event
      * @param statusId
-     *            of {@link Action}
+     *            of {@link ActionStatus}
      * @param progressPercent
      *            number (1-100)
+     * @param shippedBytesSinceLast
+     *            bytes since last event
+     * @param shippedBytesOverall
+     *            on the download request
      */
     public DownloadProgressEvent(final String tenant, final Long statusId, final int progressPercent,
-            final long shippedBytes) {
+            final long shippedBytesSinceLast, final long shippedBytesOverall) {
         // the revision of the DownloadProgressEvent is just equal the
         // progressPercentage due the
         // percentage is going from 0 to 100.
         super(statusId, tenant);
         this.statusId = statusId;
         this.progressPercent = progressPercent;
-        this.shippedBytes = shippedBytes;
+        this.shippedBytesSinceLast = shippedBytesSinceLast;
+        this.shippedBytesOverall = shippedBytesOverall;
     }
 
-    /**
-     * @return the statusId
-     */
     public Long getStatusId() {
         return statusId;
     }
 
-    /**
-     * @return the progressPercent
-     */
     public int getProgressPercent() {
         return progressPercent;
     }
 
-    /**
-     * @return the shippedBytes
-     */
-    public long getShippedBytes() {
-        return shippedBytes;
+    public long getShippedBytesSinceLast() {
+        return shippedBytesSinceLast;
     }
 
+    public long getShippedBytesOverall() {
+        return shippedBytesOverall;
+    }
 }

--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactStoreController.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactStoreController.java
@@ -93,12 +93,12 @@ public class DdiArtifactStoreController implements DdiDlArtifactStoreControllerR
             // we set a download status only if we are aware of the
             // targetid, i.e. authenticated and not anonymous
             if (targetid != null && !"anonymous".equals(targetid)) {
-                final Action action = checkAndReportDownloadByTarget(
+                final ActionStatus actionStatus = checkAndReportDownloadByTarget(
                         requestResponseContextHolder.getHttpServletRequest(), targetid, artifact);
                 result = RestResourceConversionHelper.writeFileResponse(artifact,
                         requestResponseContextHolder.getHttpServletResponse(),
                         requestResponseContextHolder.getHttpServletRequest(), file, controllerManagement,
-                        action.getId());
+                        actionStatus.getId());
             } else {
                 result = RestResourceConversionHelper.writeFileResponse(artifact,
                         requestResponseContextHolder.getHttpServletResponse(),
@@ -131,7 +131,7 @@ public class DdiArtifactStoreController implements DdiDlArtifactStoreControllerR
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    private Action checkAndReportDownloadByTarget(final HttpServletRequest request, final String targetid,
+    private ActionStatus checkAndReportDownloadByTarget(final HttpServletRequest request, final String targetid,
             final LocalArtifact artifact) {
         final Target target = controllerManagement.updateLastTargetQuery(targetid,
                 IpUtil.getClientIpFromRequest(request, securityProperties));
@@ -152,8 +152,8 @@ public class DdiArtifactStoreController implements DdiDlArtifactStoreControllerR
             actionStatus.addMessage(
                     RepositoryConstants.SERVER_MESSAGE_PREFIX + "Target downloads: " + request.getRequestURI());
         }
-        controllerManagement.addInformationalActionStatus(actionStatus);
-        return action;
+
+        return controllerManagement.addInformationalActionStatus(actionStatus);
     }
 
 }

--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -156,8 +156,8 @@ public class DdiRootController implements DdiRootControllerRestApi {
             if (ifMatch != null && !RestResourceConversionHelper.matchesHttpHeader(ifMatch, artifact.getSha1Hash())) {
                 result = new ResponseEntity<>(HttpStatus.PRECONDITION_FAILED);
             } else {
-                final Action action = checkAndLogDownload(requestResponseContextHolder.getHttpServletRequest(), target,
-                        module);
+                final ActionStatus action = checkAndLogDownload(requestResponseContextHolder.getHttpServletRequest(),
+                        target, module);
                 result = RestResourceConversionHelper.writeFileResponse(artifact,
                         requestResponseContextHolder.getHttpServletResponse(),
                         requestResponseContextHolder.getHttpServletRequest(), file, controllerManagement,
@@ -167,7 +167,7 @@ public class DdiRootController implements DdiRootControllerRestApi {
         return result;
     }
 
-    private Action checkAndLogDownload(final HttpServletRequest request, final Target target,
+    private ActionStatus checkAndLogDownload(final HttpServletRequest request, final Target target,
             final SoftwareModule module) {
         final Action action = controllerManagement
                 .getActionForDownloadByTargetAndSoftwareModule(target.getControllerId(), module);
@@ -185,8 +185,8 @@ public class DdiRootController implements DdiRootControllerRestApi {
             statusMessage.addMessage(
                     RepositoryConstants.SERVER_MESSAGE_PREFIX + "Target downloads " + request.getRequestURI());
         }
-        controllerManagement.addInformationalActionStatus(statusMessage);
-        return action;
+
+        return controllerManagement.addInformationalActionStatus(statusMessage);
     }
 
     private static boolean checkModule(final String fileName, final SoftwareModule module) {

--- a/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactDownloadTest.java
+++ b/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactDownloadTest.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.RandomUtils;
-import org.eclipse.hawkbit.eventbus.event.DownloadProgressEvent;
+import org.eclipse.hawkbit.repository.eventbus.event.DownloadProgressEvent;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
 import org.eclipse.hawkbit.repository.model.Artifact;

--- a/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/systemmanagement/MgmtSystemTenantServiceUsage.java
+++ b/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/systemmanagement/MgmtSystemTenantServiceUsage.java
@@ -25,6 +25,7 @@ public class MgmtSystemTenantServiceUsage {
     private long artifacts;
     private long actions;
     private long overallArtifactVolumeInBytes;
+    private long overallArtifactTrafficInBytes;
 
     /**
      * Constructor.
@@ -32,8 +33,15 @@ public class MgmtSystemTenantServiceUsage {
      * @param tenantName
      */
     public MgmtSystemTenantServiceUsage(final String tenantName) {
-        super();
         this.tenantName = tenantName;
+    }
+
+    public long getOverallArtifactTrafficInBytes() {
+        return overallArtifactTrafficInBytes;
+    }
+
+    public void setOverallArtifactTrafficInBytes(final long overallArtifactTrafficInBytes) {
+        this.overallArtifactTrafficInBytes = overallArtifactTrafficInBytes;
     }
 
     public long getTargets() {

--- a/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/systemmanagement/MgmtSystemTenantServiceUsage.java
+++ b/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/systemmanagement/MgmtSystemTenantServiceUsage.java
@@ -25,7 +25,6 @@ public class MgmtSystemTenantServiceUsage {
     private long artifacts;
     private long actions;
     private long overallArtifactVolumeInBytes;
-    private long overallArtifactTrafficInBytes;
 
     /**
      * Constructor.
@@ -34,14 +33,6 @@ public class MgmtSystemTenantServiceUsage {
      */
     public MgmtSystemTenantServiceUsage(final String tenantName) {
         this.tenantName = tenantName;
-    }
-
-    public long getOverallArtifactTrafficInBytes() {
-        return overallArtifactTrafficInBytes;
-    }
-
-    public void setOverallArtifactTrafficInBytes(final long overallArtifactTrafficInBytes) {
-        this.overallArtifactTrafficInBytes = overallArtifactTrafficInBytes;
     }
 
     public long getTargets() {

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSystemManagementResource.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSystemManagementResource.java
@@ -87,7 +87,6 @@ public class MgmtSystemManagementResource implements MgmtSystemManagementRestApi
         result.setArtifacts(tenant.getArtifacts());
         result.setOverallArtifactVolumeInBytes(tenant.getOverallArtifactVolumeInBytes());
         result.setTargets(tenant.getTargets());
-        result.setOverallArtifactTrafficInBytes(tenant.getOverallArtifactTrafficInBytes());
 
         return result;
     }

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSystemManagementResource.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSystemManagementResource.java
@@ -87,6 +87,7 @@ public class MgmtSystemManagementResource implements MgmtSystemManagementRestApi
         result.setArtifacts(tenant.getArtifacts());
         result.setOverallArtifactVolumeInBytes(tenant.getOverallArtifactVolumeInBytes());
         result.setTargets(tenant.getTargets());
+        result.setOverallArtifactTrafficInBytes(tenant.getOverallArtifactTrafficInBytes());
 
         return result;
     }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -65,9 +65,11 @@ public interface ControllerManagement {
      *            the ID of the {@link ActionStatus}
      * @param progressPercent
      *            the progress in percentage which must be between 0-100
+     * @param shippedBytes
+     *            since last event
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    void downloadProgressPercent(long statusId, int progressPercent);
+    void downloadProgressPercent(long statusId, int progressPercent, long shippedBytes);
 
     /**
      * Simple addition of a new {@link ActionStatus} entry to the {@link Action}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -14,8 +14,8 @@ import java.util.Map;
 
 import javax.validation.constraints.NotNull;
 
-import org.eclipse.hawkbit.eventbus.event.DownloadProgressEvent;
 import org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions;
+import org.eclipse.hawkbit.repository.eventbus.event.DownloadProgressEvent;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.ToManyAttributeEntriesException;
@@ -58,21 +58,20 @@ public interface ControllerManagement {
     Action addCancelActionStatus(@NotNull ActionStatus actionStatus);
 
     /**
-     * Sends the download progress in percentage and notifies the
-     * {@link EventBus} with a {@link DownloadProgressEvent}.
+     * Sends the download progress and notifies the {@link EventBus} with a
+     * {@link DownloadProgressEvent}.
      * 
      * @param statusId
      *            the ID of the {@link ActionStatus}
-     * @param progressPercent
-     *            the progress in percentage which must be between 0-100
+     * @param requestedBytes
+     *            requested bytes of the request
      * @param shippedBytesSinceLast
      *            since the last report
      * @param shippedBytesOverall
      *            for the {@link ActionStatus}
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    void downloadProgressPercent(long statusId, int progressPercent, long shippedBytesSinceLast,
-            long shippedBytesOverall);
+    void downloadProgress(Long statusId, Long requestedBytes, Long shippedBytesSinceLast, Long shippedBytesOverall);
 
     /**
      * Simple addition of a new {@link ActionStatus} entry to the {@link Action}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -65,11 +65,14 @@ public interface ControllerManagement {
      *            the ID of the {@link ActionStatus}
      * @param progressPercent
      *            the progress in percentage which must be between 0-100
-     * @param shippedBytes
-     *            since last event
+     * @param shippedBytesSinceLast
+     *            since the last report
+     * @param shippedBytesOverall
+     *            for the {@link ActionStatus}
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    void downloadProgressPercent(long statusId, int progressPercent, long shippedBytes);
+    void downloadProgressPercent(long statusId, int progressPercent, long shippedBytesSinceLast,
+            long shippedBytesOverall);
 
     /**
      * Simple addition of a new {@link ActionStatus} entry to the {@link Action}
@@ -77,9 +80,11 @@ public interface ControllerManagement {
      * 
      * @param statusMessage
      *            to add to the action
+     * 
+     * @return create {@link ActionStatus} entity
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    void addInformationalActionStatus(@NotNull ActionStatus statusMessage);
+    ActionStatus addInformationalActionStatus(@NotNull ActionStatus statusMessage);
 
     /**
      * Adds an {@link ActionStatus} entry for an update {@link Action} including

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SystemManagement.java
@@ -63,11 +63,6 @@ public interface SystemManagement {
     /**
      * @return {@link TenantMetaData} of {@link TenantAware#getCurrentTenant()}
      */
-    // @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_REPOSITORY +
-    // SpringEvalExpressions.HAS_AUTH_OR
-    // + SpringEvalExpressions.HAS_AUTH_READ_TARGET +
-    // SpringEvalExpressions.HAS_AUTH_OR
-    // + SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
     TenantMetaData getTenantMetadata();
 
     /**
@@ -84,7 +79,6 @@ public interface SystemManagement {
      *            to retrieve data for
      * @return {@link TenantMetaData} of given tenant
      */
-    // @PreAuthorize(SpringEvalExpressions.IS_SYSTEM_CODE)
     TenantMetaData getTenantMetadata(@NotNull String tenant);
 
     /**
@@ -94,7 +88,6 @@ public interface SystemManagement {
      *            to update
      * @return updated {@link TenantMetaData} entity
      */
-    // @PreAuthorize(SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
     TenantMetaData updateTenantMetadata(@NotNull TenantMetaData metaData);
 
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SystemManagement.java
@@ -63,13 +63,18 @@ public interface SystemManagement {
     /**
      * @return {@link TenantMetaData} of {@link TenantAware#getCurrentTenant()}
      */
+    // @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_REPOSITORY +
+    // SpringEvalExpressions.HAS_AUTH_OR
+    // + SpringEvalExpressions.HAS_AUTH_READ_TARGET +
+    // SpringEvalExpressions.HAS_AUTH_OR
+    // + SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
     TenantMetaData getTenantMetadata();
 
     /**
      * Returns {@link TenantMetaData} of given and current tenant. Creates for
      * new tenants also two {@link SoftwareModuleType} (os and app) and
-     * {@link RepositoryConstants#DEFAULT_DS_TYPES_IN_TENANT} {@link DistributionSetType}s
-     * (os and os_app).
+     * {@link RepositoryConstants#DEFAULT_DS_TYPES_IN_TENANT}
+     * {@link DistributionSetType}s (os and os_app).
      *
      * DISCLAIMER: this variant is used during initial login (where the tenant
      * is not yet in the session). Please user {@link #getTenantMetadata()} for
@@ -79,6 +84,7 @@ public interface SystemManagement {
      *            to retrieve data for
      * @return {@link TenantMetaData} of given tenant
      */
+    // @PreAuthorize(SpringEvalExpressions.IS_SYSTEM_CODE)
     TenantMetaData getTenantMetadata(@NotNull String tenant);
 
     /**
@@ -88,6 +94,7 @@ public interface SystemManagement {
      *            to update
      * @return updated {@link TenantMetaData} entity
      */
+    // @PreAuthorize(SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
     TenantMetaData updateTenantMetadata(@NotNull TenantMetaData metaData);
 
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TenantStatsManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TenantStatsManagement.java
@@ -29,12 +29,4 @@ public interface TenantStatsManagement {
             + SpringEvalExpressions.IS_SYSTEM_CODE)
     TenantUsage getStatsOfTenant();
 
-    /**
-     * Resets {@link TenantUsage#getOverallArtifactTrafficInBytes()} to zero.
-     * 
-     */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
-    void resetTrafficStatsOfTenant();
-
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TenantStatsManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TenantStatsManagement.java
@@ -16,10 +16,11 @@ import org.springframework.security.access.prepost.PreAuthorize;
  * Management service for statistics of a single tenant.
  *
  */
+@FunctionalInterface
 public interface TenantStatsManagement {
 
     /**
-     * Service for stats of a single tenant.
+     * Service for stats of the current tenant.
      *
      * @return collected statistics
      */

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TenantStatsManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TenantStatsManagement.java
@@ -25,14 +25,16 @@ public interface TenantStatsManagement {
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_REPOSITORY + SpringEvalExpressions.HAS_AUTH_OR
             + SpringEvalExpressions.HAS_AUTH_READ_TARGET + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
+            + SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION + SpringEvalExpressions.HAS_AUTH_OR
+            + SpringEvalExpressions.IS_SYSTEM_CODE)
     TenantUsage getStatsOfTenant();
 
     /**
      * Resets {@link TenantUsage#getOverallArtifactTrafficInBytes()} to zero.
      * 
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION + SpringEvalExpressions.HAS_AUTH_OR
+            + SpringEvalExpressions.IS_SYSTEM_CODE)
     void resetTrafficStatsOfTenant();
 
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TenantStatsManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TenantStatsManagement.java
@@ -16,19 +16,23 @@ import org.springframework.security.access.prepost.PreAuthorize;
  * Management service for statistics of a single tenant.
  *
  */
-@FunctionalInterface
 public interface TenantStatsManagement {
 
     /**
-     * Service for stats of a single tenant. Opens a new transaction and as a
-     * result can an be used for multiple tenants, i.e. to allow in one session
-     * to collect data of all tenants in the system.
+     * Service for stats of a single tenant.
      *
-     * @param tenant
-     *            to collect for
      * @return collected statistics
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_SYSTEM_ADMIN)
-    TenantUsage getStatsOfTenant(String tenant);
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_REPOSITORY + SpringEvalExpressions.HAS_AUTH_OR
+            + SpringEvalExpressions.HAS_AUTH_READ_TARGET + SpringEvalExpressions.HAS_AUTH_OR
+            + SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
+    TenantUsage getStatsOfTenant();
+
+    /**
+     * Resets {@link TenantUsage#getOverallArtifactTrafficInBytes()} to zero.
+     * 
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
+    void resetTrafficStatsOfTenant();
 
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/eventbus/event/DownloadProgressEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/eventbus/event/DownloadProgressEvent.java
@@ -6,13 +6,13 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.hawkbit.eventbus.event;
+package org.eclipse.hawkbit.repository.eventbus.event;
+
+import org.eclipse.hawkbit.eventbus.event.AbstractDistributedEvent;
 
 /**
- * Event that contains an updated download progress for a given Action.
- *
- *
- *
+ * Event that contains an updated download progress for a given ActionStatus
+ * that was written for a download request.
  *
  */
 public class DownloadProgressEvent extends AbstractDistributedEvent {
@@ -20,7 +20,7 @@ public class DownloadProgressEvent extends AbstractDistributedEvent {
     private static final long serialVersionUID = 1L;
 
     private final Long statusId;
-    private final int progressPercent;
+    private final long requestedBytes;
     private final long shippedBytesSinceLast;
     private final long shippedBytesOverall;
 
@@ -30,22 +30,21 @@ public class DownloadProgressEvent extends AbstractDistributedEvent {
      * @param tenant
      *            the tenant for this event
      * @param statusId
-     *            of {@link ActionStatus}
-     * @param progressPercent
-     *            number (1-100)
+     *            of ActionStatus that was written for the download request
+     * @param requestedBytes
+     *            bytes requested
      * @param shippedBytesSinceLast
      *            bytes since last event
      * @param shippedBytesOverall
      *            on the download request
      */
-    public DownloadProgressEvent(final String tenant, final Long statusId, final int progressPercent,
-            final long shippedBytesSinceLast, final long shippedBytesOverall) {
+    public DownloadProgressEvent(final String tenant, final Long statusId, final Long requestedBytes,
+            final Long shippedBytesSinceLast, final Long shippedBytesOverall) {
         // the revision of the DownloadProgressEvent is just equal the
-        // progressPercentage due the
-        // percentage is going from 0 to 100.
-        super(statusId, tenant);
+        // shippedBytesOverall as this is a growing number.
+        super(shippedBytesOverall, tenant);
         this.statusId = statusId;
-        this.progressPercent = progressPercent;
+        this.requestedBytes = requestedBytes;
         this.shippedBytesSinceLast = shippedBytesSinceLast;
         this.shippedBytesOverall = shippedBytesOverall;
     }
@@ -54,8 +53,8 @@ public class DownloadProgressEvent extends AbstractDistributedEvent {
         return statusId;
     }
 
-    public int getProgressPercent() {
-        return progressPercent;
+    public long getRequestedBytes() {
+        return requestedBytes;
     }
 
     public long getShippedBytesSinceLast() {

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
@@ -40,12 +40,6 @@ public interface Action extends TenantAwareBaseEntity {
     }
 
     /**
-     * @return current {@link Status#DOWNLOAD} progress if known by the update
-     *         server.
-     */
-    int getDownloadProgressPercent();
-
-    /**
      * @return current {@link Status} of the {@link Action}.
      */
     Status getStatus();

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/ActionStatus.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/ActionStatus.java
@@ -44,6 +44,12 @@ public interface ActionStatus extends TenantAwareBaseEntity {
     void addMessage(String message);
 
     /**
+     * @return current {@link Status#DOWNLOAD} progress if known by the update
+     *         server.
+     */
+    int getDownloadProgressPercent();
+
+    /**
      * @return list of message entries that can be added to the
      *         {@link ActionStatus}.
      */

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/report/model/TenantUsage.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/report/model/TenantUsage.java
@@ -19,7 +19,6 @@ public class TenantUsage {
     private long artifacts;
     private long actions;
     private long overallArtifactVolumeInBytes;
-    private long overallArtifactTrafficInBytes;
 
     /**
      * Constructor.
@@ -106,28 +105,12 @@ public class TenantUsage {
         return this;
     }
 
-    /**
-     * @return the overallArtifactTrafficInBytes
-     */
-    public long getOverallArtifactTrafficInBytes() {
-        return overallArtifactTrafficInBytes;
-    }
-
-    /**
-     * @param overallArtifactTrafficInBytes
-     *            the overallArtifactTrafficInBytes to set
-     */
-    public void setOverallArtifactTrafficInBytes(final long overallArtifactTrafficInBytes) {
-        this.overallArtifactTrafficInBytes = overallArtifactTrafficInBytes;
-    }
-
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
         result = prime * result + (int) (actions ^ (actions >>> 32));
         result = prime * result + (int) (artifacts ^ (artifacts >>> 32));
-        result = prime * result + (int) (overallArtifactTrafficInBytes ^ (overallArtifactTrafficInBytes >>> 32));
         result = prime * result + (int) (overallArtifactVolumeInBytes ^ (overallArtifactVolumeInBytes >>> 32));
         result = prime * result + (int) (targets ^ (targets >>> 32));
         result = prime * result + ((tenantName == null) ? 0 : tenantName.hashCode());
@@ -142,7 +125,7 @@ public class TenantUsage {
         if (obj == null) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof TenantUsage)) {
             return false;
         }
         final TenantUsage other = (TenantUsage) obj;
@@ -150,9 +133,6 @@ public class TenantUsage {
             return false;
         }
         if (artifacts != other.artifacts) {
-            return false;
-        }
-        if (overallArtifactTrafficInBytes != other.overallArtifactTrafficInBytes) {
             return false;
         }
         if (overallArtifactVolumeInBytes != other.overallArtifactVolumeInBytes) {
@@ -174,8 +154,7 @@ public class TenantUsage {
     @Override
     public String toString() {
         return "TenantUsage [tenantName=" + tenantName + ", targets=" + targets + ", artifacts=" + artifacts
-                + ", actions=" + actions + ", overallArtifactVolumeInBytes=" + overallArtifactVolumeInBytes
-                + ", overallArtifactTrafficInBytes=" + overallArtifactTrafficInBytes + "]";
+                + ", actions=" + actions + ", overallArtifactVolumeInBytes=" + overallArtifactVolumeInBytes + "]";
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/report/model/TenantUsage.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/report/model/TenantUsage.java
@@ -19,6 +19,7 @@ public class TenantUsage {
     private long artifacts;
     private long actions;
     private long overallArtifactVolumeInBytes;
+    private long overallArtifactTrafficInBytes;
 
     /**
      * Constructor.
@@ -105,12 +106,28 @@ public class TenantUsage {
         return this;
     }
 
+    /**
+     * @return the overallArtifactTrafficInBytes
+     */
+    public long getOverallArtifactTrafficInBytes() {
+        return overallArtifactTrafficInBytes;
+    }
+
+    /**
+     * @param overallArtifactTrafficInBytes
+     *            the overallArtifactTrafficInBytes to set
+     */
+    public void setOverallArtifactTrafficInBytes(final long overallArtifactTrafficInBytes) {
+        this.overallArtifactTrafficInBytes = overallArtifactTrafficInBytes;
+    }
+
     @Override
-    public int hashCode() { // NOSONAR - as this is generated code
+    public int hashCode() {
         final int prime = 31;
         int result = 1;
         result = prime * result + (int) (actions ^ (actions >>> 32));
         result = prime * result + (int) (artifacts ^ (artifacts >>> 32));
+        result = prime * result + (int) (overallArtifactTrafficInBytes ^ (overallArtifactTrafficInBytes >>> 32));
         result = prime * result + (int) (overallArtifactVolumeInBytes ^ (overallArtifactVolumeInBytes >>> 32));
         result = prime * result + (int) (targets ^ (targets >>> 32));
         result = prime * result + ((tenantName == null) ? 0 : tenantName.hashCode());
@@ -118,8 +135,7 @@ public class TenantUsage {
     }
 
     @Override
-    public boolean equals(final Object obj) { // NOSONAR - as this is generated
-                                              // code
+    public boolean equals(final Object obj) {
         if (this == obj) {
             return true;
         }
@@ -134,6 +150,9 @@ public class TenantUsage {
             return false;
         }
         if (artifacts != other.artifacts) {
+            return false;
+        }
+        if (overallArtifactTrafficInBytes != other.overallArtifactTrafficInBytes) {
             return false;
         }
         if (overallArtifactVolumeInBytes != other.overallArtifactVolumeInBytes) {
@@ -154,8 +173,9 @@ public class TenantUsage {
 
     @Override
     public String toString() {
-        return "SystemUsage [tenantName=" + tenantName + ", targets=" + targets + ", artifacts=" + artifacts
-                + ", actions=" + actions + ", overallArtifactVolumeInBytes=" + overallArtifactVolumeInBytes + "]";
+        return "TenantUsage [tenantName=" + tenantName + ", targets=" + targets + ", artifacts=" + artifacts
+                + ", actions=" + actions + ", overallArtifactVolumeInBytes=" + overallArtifactVolumeInBytes
+                + ", overallArtifactTrafficInBytes=" + overallArtifactTrafficInBytes + "]";
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/RepositoryApplicationConfiguration.java
@@ -54,6 +54,7 @@ import org.eclipse.hawkbit.repository.jpa.model.helper.TenantConfigurationManage
 import org.eclipse.hawkbit.security.SecurityTokenGenerator;
 import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.tenancy.TenantAware;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration;
@@ -71,6 +72,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 
+import com.google.common.eventbus.EventBus;
+
 /**
  * General configuration for hawkBit's Repository.
  *
@@ -85,6 +88,9 @@ import org.springframework.validation.beanvalidation.MethodValidationPostProcess
 @EnableConfigurationProperties(RepositoryProperties.class)
 @EnableScheduling
 public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
+    @Autowired
+    private EventBus eventBus;
+
     /**
      * @return the {@link SystemSecurityContext} singleton bean which make it
      *         accessible in beans which cannot access the service directly,
@@ -249,7 +255,9 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public TenantStatsManagement tenantStatsManagement() {
-        return new JpaTenantStatsManagement();
+        final TenantStatsManagement mgmt = new JpaTenantStatsManagement();
+        eventBus.register(mgmt);
+        return mgmt;
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -451,8 +451,8 @@ public class JpaControllerManagement implements ControllerManagement {
     @Override
     @Modifying
     @Transactional(isolation = Isolation.READ_UNCOMMITTED)
-    public void addInformationalActionStatus(final ActionStatus statusMessage) {
-        actionStatusRepository.save((JpaActionStatus) statusMessage);
+    public ActionStatus addInformationalActionStatus(final ActionStatus statusMessage) {
+        return actionStatusRepository.save((JpaActionStatus) statusMessage);
     }
 
     @Override
@@ -469,8 +469,9 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    public void downloadProgressPercent(final long statusId, final int progressPercent, final long shippedBytes) {
-        cacheWriteNotify.downloadProgressPercent(statusId, progressPercent, shippedBytes);
+    public void downloadProgressPercent(final long statusId, final int progressPercent,
+            final long shippedBytesSinceLast, final long shippedBytesOverall) {
+        cacheWriteNotify.downloadProgressPercent(statusId, progressPercent, shippedBytesSinceLast, shippedBytesOverall);
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -469,8 +469,8 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    public void downloadProgressPercent(final long statusId, final int progressPercent) {
-        cacheWriteNotify.downloadProgressPercent(statusId, progressPercent);
+    public void downloadProgressPercent(final long statusId, final int progressPercent, final long shippedBytes) {
+        cacheWriteNotify.downloadProgressPercent(statusId, progressPercent, shippedBytes);
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -469,9 +469,9 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    public void downloadProgressPercent(final long statusId, final int progressPercent,
-            final long shippedBytesSinceLast, final long shippedBytesOverall) {
-        cacheWriteNotify.downloadProgressPercent(statusId, progressPercent, shippedBytesSinceLast, shippedBytesOverall);
+    public void downloadProgress(final Long statusId, final Long requestedBytes, final Long shippedBytesSinceLast,
+            final Long shippedBytesOverall) {
+        cacheWriteNotify.downloadProgress(statusId, requestedBytes, shippedBytesSinceLast, shippedBytesOverall);
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
@@ -147,7 +147,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
         final List<String> tenants = findTenants();
 
         tenants.forEach(tenant -> tenantAware.runAsTenant(tenant, () -> {
-            report.addTenantData(systemStatsManagement.getStatsOfTenant(tenant));
+            report.addTenantData(systemStatsManagement.getStatsOfTenant());
             return null;
         }));
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantStatsManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantStatsManagement.java
@@ -8,16 +8,22 @@
  */
 package org.eclipse.hawkbit.repository.jpa;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
+import org.eclipse.hawkbit.eventbus.event.DownloadProgressEvent;
 import org.eclipse.hawkbit.repository.TenantStatsManagement;
 import org.eclipse.hawkbit.repository.report.model.TenantUsage;
+import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
+
+import com.google.common.eventbus.Subscribe;
 
 /**
  * Management service for statistics of a single tenant.
@@ -35,9 +41,16 @@ public class JpaTenantStatsManagement implements TenantStatsManagement {
     @Autowired
     private ActionRepository actionRepository;
 
+    @Autowired
+    private TenantAware tenantAware;
+
+    private final Map<String, AtomicLong> traffic = new ConcurrentHashMap<>();
+
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.READ_UNCOMMITTED)
-    public TenantUsage getStatsOfTenant(final String tenant) {
+    public TenantUsage getStatsOfTenant() {
+        final String tenant = tenantAware.getCurrentTenant();
+
         final TenantUsage result = new TenantUsage(tenant);
 
         result.setTargets(targetRepository.count());
@@ -51,9 +64,26 @@ public class JpaTenantStatsManagement implements TenantStatsManagement {
         }
 
         result.setActions(actionRepository.count());
+        if (traffic.containsKey(tenant)) {
+            result.setOverallArtifactTrafficInBytes(traffic.get(tenant).get());
+        }
 
         return result;
 
+    }
+
+    @Override
+    public void resetTrafficStatsOfTenant() {
+        traffic.remove(tenantAware.getCurrentTenant());
+    }
+
+    @Subscribe
+    public void listen(final DownloadProgressEvent event) {
+        if (traffic.containsKey(event.getTenant())) {
+            traffic.get(event.getTenant()).addAndGet(event.getShippedBytes());
+        } else {
+            traffic.put(event.getTenant(), new AtomicLong(event.getShippedBytes()));
+        }
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/cache/CacheWriteNotify.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/cache/CacheWriteNotify.java
@@ -54,8 +54,10 @@ public class CacheWriteNotify {
      *            the ID of the {@link ActionStatus}
      * @param progressPercent
      *            the progress in percentage which must be between 0-100
+     * @param shippedBytes
+     *            since last event
      */
-    public void downloadProgressPercent(final long statusId, final int progressPercent) {
+    public void downloadProgressPercent(final long statusId, final int progressPercent, final long shippedBytes) {
 
         final Cache cache = cacheManager.getCache(Action.class.getName());
         final String cacheKey = CacheKeys.entitySpecificCacheKey(String.valueOf(statusId),
@@ -69,7 +71,8 @@ public class CacheWriteNotify {
             cache.evict(cacheKey);
         }
 
-        eventBus.post(new DownloadProgressEvent(tenantAware.getCurrentTenant(), statusId, progressPercent));
+        eventBus.post(
+                new DownloadProgressEvent(tenantAware.getCurrentTenant(), statusId, progressPercent, shippedBytes));
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/cache/CacheWriteNotify.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/cache/CacheWriteNotify.java
@@ -10,7 +10,6 @@ package org.eclipse.hawkbit.repository.jpa.cache;
 
 import org.eclipse.hawkbit.eventbus.event.DownloadProgressEvent;
 import org.eclipse.hawkbit.repository.eventbus.event.RolloutGroupCreatedEvent;
-import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.tenancy.TenantAware;
@@ -54,12 +53,15 @@ public class CacheWriteNotify {
      *            the ID of the {@link ActionStatus}
      * @param progressPercent
      *            the progress in percentage which must be between 0-100
-     * @param shippedBytes
+     * @param shippedBytesSinceLast
      *            since last event
+     * @param shippedBytesOverall
+     *            for the download request
      */
-    public void downloadProgressPercent(final long statusId, final int progressPercent, final long shippedBytes) {
+    public void downloadProgressPercent(final long statusId, final int progressPercent,
+            final long shippedBytesSinceLast, final long shippedBytesOverall) {
 
-        final Cache cache = cacheManager.getCache(Action.class.getName());
+        final Cache cache = cacheManager.getCache(ActionStatus.class.getName());
         final String cacheKey = CacheKeys.entitySpecificCacheKey(String.valueOf(statusId),
                 CacheKeys.DOWNLOAD_PROGRESS_PERCENT);
         if (progressPercent < DOWNLOAD_PROGRESS_MAX) {
@@ -71,8 +73,8 @@ public class CacheWriteNotify {
             cache.evict(cacheKey);
         }
 
-        eventBus.post(
-                new DownloadProgressEvent(tenantAware.getCurrentTenant(), statusId, progressPercent, shippedBytes));
+        eventBus.post(new DownloadProgressEvent(tenantAware.getCurrentTenant(), statusId, progressPercent,
+                shippedBytesSinceLast, shippedBytesOverall));
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaAction.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaAction.java
@@ -27,10 +27,7 @@ import javax.persistence.NamedEntityGraphs;
 import javax.persistence.NamedSubgraph;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import javax.persistence.Transient;
 
-import org.eclipse.hawkbit.repository.jpa.cache.CacheField;
-import org.eclipse.hawkbit.repository.jpa.cache.CacheKeys;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
@@ -89,13 +86,6 @@ public class JpaAction extends AbstractJpaTenantAwareBaseEntity implements Actio
     @JoinColumn(name = "rollout", foreignKey = @ForeignKey(value = ConstraintMode.CONSTRAINT, name = "fk_action_rollout"))
     private JpaRollout rollout;
 
-    /**
-     * Note: filled only in {@link Status#DOWNLOAD}.
-     */
-    @Transient
-    @CacheField(key = CacheKeys.DOWNLOAD_PROGRESS_PERCENT)
-    private int downloadProgressPercent;
-
     @Override
     public DistributionSet getDistributionSet() {
         return distributionSet;
@@ -118,15 +108,6 @@ public class JpaAction extends AbstractJpaTenantAwareBaseEntity implements Actio
     @Override
     public void setStatus(final Status status) {
         this.status = status;
-    }
-
-    @Override
-    public int getDownloadProgressPercent() {
-        return downloadProgressPercent;
-    }
-
-    public void setDownloadProgressPercent(final int downloadProgressPercent) {
-        this.downloadProgressPercent = downloadProgressPercent;
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaActionStatus.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaActionStatus.java
@@ -24,7 +24,10 @@ import javax.persistence.ManyToOne;
 import javax.persistence.NamedAttributeNode;
 import javax.persistence.NamedEntityGraph;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
+import org.eclipse.hawkbit.repository.jpa.cache.CacheField;
+import org.eclipse.hawkbit.repository.jpa.cache.CacheKeys;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
@@ -62,6 +65,13 @@ public class JpaActionStatus extends AbstractJpaTenantAwareBaseEntity implements
             @Index(name = "sp_idx_action_status_msgs_01", columnList = "action_status_id") })
     @Column(name = "detail_message", length = 512)
     private final List<String> messages = new ArrayList<>();
+
+    /**
+     * Note: filled only in {@link Status#DOWNLOAD}.
+     */
+    @Transient
+    @CacheField(key = CacheKeys.DOWNLOAD_PROGRESS_PERCENT)
+    private int downloadProgressPercent;
 
     /**
      * Creates a new {@link ActionStatus} object.
@@ -103,6 +113,11 @@ public class JpaActionStatus extends AbstractJpaTenantAwareBaseEntity implements
      */
     public JpaActionStatus() {
         // JPA default constructor.
+    }
+
+    @Override
+    public int getDownloadProgressPercent() {
+        return downloadProgressPercent;
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/cache/CacheWriteNotifyTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/cache/CacheWriteNotifyTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.hawkbit.eventbus.event.DownloadProgressEvent;
-import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,12 +61,12 @@ public class CacheWriteNotifyTest {
         final long knownStatusId = 1;
         final int knownPercentage = 23;
 
-        when(cacheManagerMock.getCache(Action.class.getName())).thenReturn(cacheMock);
+        when(cacheManagerMock.getCache(ActionStatus.class.getName())).thenReturn(cacheMock);
         when(tenantAwareMock.getCurrentTenant()).thenReturn("default");
 
-        underTest.downloadProgressPercent(knownStatusId, knownPercentage, 100L);
+        underTest.downloadProgressPercent(knownStatusId, knownPercentage, 100L, 500L);
 
-        verify(cacheManagerMock).getCache(eq(Action.class.getName()));
+        verify(cacheManagerMock).getCache(eq(ActionStatus.class.getName()));
         verify(cacheMock).put(knownStatusId + "." + CacheKeys.DOWNLOAD_PROGRESS_PERCENT, knownPercentage);
         verify(eventBusMock).post(any(DownloadProgressEvent.class));
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/cache/CacheWriteNotifyTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/cache/CacheWriteNotifyTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.eclipse.hawkbit.eventbus.event.DownloadProgressEvent;
+import org.eclipse.hawkbit.repository.eventbus.event.DownloadProgressEvent;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.junit.Before;
@@ -59,15 +59,14 @@ public class CacheWriteNotifyTest {
     @Test
     public void downloadgProgressIsCachedAndEventSent() {
         final long knownStatusId = 1;
-        final int knownPercentage = 23;
 
         when(cacheManagerMock.getCache(ActionStatus.class.getName())).thenReturn(cacheMock);
         when(tenantAwareMock.getCurrentTenant()).thenReturn("default");
 
-        underTest.downloadProgressPercent(knownStatusId, knownPercentage, 100L, 500L);
+        underTest.downloadProgress(knownStatusId, 500L, 100L, 100L);
 
         verify(cacheManagerMock).getCache(eq(ActionStatus.class.getName()));
-        verify(cacheMock).put(knownStatusId + "." + CacheKeys.DOWNLOAD_PROGRESS_PERCENT, knownPercentage);
+        verify(cacheMock).put(knownStatusId + "." + CacheKeys.DOWNLOAD_PROGRESS_PERCENT, 20);
         verify(eventBusMock).post(any(DownloadProgressEvent.class));
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/cache/CacheWriteNotifyTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/cache/CacheWriteNotifyTest.java
@@ -64,7 +64,7 @@ public class CacheWriteNotifyTest {
         when(cacheManagerMock.getCache(Action.class.getName())).thenReturn(cacheMock);
         when(tenantAwareMock.getCurrentTenant()).thenReturn("default");
 
-        underTest.downloadProgressPercent(knownStatusId, knownPercentage);
+        underTest.downloadProgressPercent(knownStatusId, knownPercentage, 100L);
 
         verify(cacheManagerMock).getCache(eq(Action.class.getName()));
         verify(cacheMock).put(knownStatusId + "." + CacheKeys.DOWNLOAD_PROGRESS_PERCENT, knownPercentage);

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
@@ -23,6 +23,7 @@ import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.repository.TenantStatsManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 import org.eclipse.hawkbit.security.DosFilter;
@@ -92,6 +93,9 @@ public abstract class AbstractIntegrationTest implements EnvironmentAware {
 
     @Autowired
     protected TargetManagement targetManagement;
+
+    @Autowired
+    protected TenantStatsManagement tenantStatsManagement;
 
     @Autowired
     protected TargetFilterQueryManagement targetFilterQueryManagement;

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
@@ -23,7 +23,6 @@ import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
-import org.eclipse.hawkbit.repository.TenantStatsManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 import org.eclipse.hawkbit.security.DosFilter;
@@ -93,9 +92,6 @@ public abstract class AbstractIntegrationTest implements EnvironmentAware {
 
     @Autowired
     protected TargetManagement targetManagement;
-
-    @Autowired
-    protected TenantStatsManagement tenantStatsManagement;
 
     @Autowired
     protected TargetFilterQueryManagement targetFilterQueryManagement;

--- a/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/RestResourceConversionHelper.java
+++ b/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/RestResourceConversionHelper.java
@@ -293,6 +293,7 @@ public final class RestResourceConversionHelper {
 
         long toRead = length;
         boolean toContinue = true;
+        long shippedSinceLastEvent = 0;
 
         while (toContinue) {
             final int r = from.read(buf);
@@ -304,9 +305,11 @@ public final class RestResourceConversionHelper {
             if (toRead > 0) {
                 to.write(buf, 0, r);
                 total += r;
+                shippedSinceLastEvent += r;
             } else {
                 to.write(buf, 0, (int) toRead + r);
                 total += toRead + r;
+                shippedSinceLastEvent += toRead + r;
                 toContinue = false;
             }
 
@@ -316,7 +319,8 @@ public final class RestResourceConversionHelper {
                 // every 10 percent an event
                 if (newPercent == 100 || newPercent > progressPercent + 10) {
                     progressPercent = newPercent;
-                    controllerManagement.downloadProgressPercent(statusId, progressPercent);
+                    controllerManagement.downloadProgressPercent(statusId, progressPercent, shippedSinceLastEvent);
+                    shippedSinceLastEvent = 0;
                 }
             }
         }

--- a/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/RestResourceConversionHelper.java
+++ b/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/RestResourceConversionHelper.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifact;
 import org.eclipse.hawkbit.repository.ControllerManagement;
+import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.repository.model.LocalArtifact;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,7 +88,7 @@ public final class RestResourceConversionHelper {
      * @param controllerManagement
      *            to write progress updates to
      * @param statusId
-     *            of the UpdateActionStatus
+     *            of the {@link ActionStatus}
      *
      * @return http code
      *
@@ -319,7 +320,8 @@ public final class RestResourceConversionHelper {
                 // every 10 percent an event
                 if (newPercent == 100 || newPercent > progressPercent + 10) {
                     progressPercent = newPercent;
-                    controllerManagement.downloadProgressPercent(statusId, progressPercent, shippedSinceLastEvent);
+                    controllerManagement.downloadProgressPercent(statusId, progressPercent, shippedSinceLastEvent,
+                            total);
                     shippedSinceLastEvent = 0;
                 }
             }

--- a/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/RestResourceConversionHelper.java
+++ b/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/RestResourceConversionHelper.java
@@ -320,8 +320,7 @@ public final class RestResourceConversionHelper {
                 // every 10 percent an event
                 if (newPercent == 100 || newPercent > progressPercent + 10) {
                     progressPercent = newPercent;
-                    controllerManagement.downloadProgressPercent(statusId, progressPercent, shippedSinceLastEvent,
-                            total);
+                    controllerManagement.downloadProgress(statusId, length, shippedSinceLastEvent, total);
                     shippedSinceLastEvent = 0;
                 }
             }


### PR DESCRIPTION
Added Traffic data to DownloadProgressEvent. That is in many use cases more helpful than the percentage which can be calculated by the receiver quite easily.

Fixed a bug that the DownloadProgressEvent is based on Action Id which is wrong. It should be ActionStatus as one of those is created per download. I guess this got messed up when we gave up the UpdateActionStatus concept.