### PR TITLE
Add IS_SYSTEM_CODE to all springEvalExpr and remove explicit usage

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
@@ -269,8 +269,7 @@ public interface DeploymentManagement {
      * @return the actions referring a specific rollout and a specific parent
      *         rollout group in a specific status
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
     List<Action> findActionsByRolloutGroupParentAndStatus(@NotNull Rollout rollout,
             @NotNull RolloutGroup rolloutGroupParent, @NotNull Action.Status actionStatus);
 
@@ -496,8 +495,7 @@ public interface DeploymentManagement {
      *            the action to start now.
      * @return the action which has been started
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
     Action startScheduledAction(@NotNull Action action);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
@@ -61,8 +61,7 @@ public interface RolloutManagement {
      *            this check. This check is only applied if the last check is
      *            less than (lastcheck-delay).
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE)
     void checkRunningRollouts(long delayBetweenChecks);
 
     /**
@@ -266,8 +265,7 @@ public interface RolloutManagement {
      *             if given rollout is not in {@link RolloutStatus#RUNNING}.
      *             Only running rollouts can be paused.
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE)
     void pauseRollout(@NotNull Rollout rollout);
 
     /**
@@ -281,8 +279,7 @@ public interface RolloutManagement {
      *             if given rollout is not in {@link RolloutStatus#PAUSED}. Only
      *             paused rollouts can be resumed.
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE)
     void resumeRollout(@NotNull Rollout rollout);
 
     /**
@@ -303,8 +300,7 @@ public interface RolloutManagement {
      *             if given rollout is not in {@link RolloutStatus#READY}. Only
      *             ready rollouts can be started.
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE)
     Rollout startRollout(@NotNull Rollout rollout);
 
     /**
@@ -326,8 +322,7 @@ public interface RolloutManagement {
      *             if given rollout is not in {@link RolloutStatus#READY}. Only
      *             ready rollouts can be started.
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE)
     Rollout startRolloutAsync(@NotNull Rollout rollout);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SystemManagement.java
@@ -39,16 +39,14 @@ public interface SystemManagement {
      * @param tenant
      *            to delete
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_SYSTEM_ADMIN + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_SYSTEM_ADMIN)
     void deleteTenant(@NotNull String tenant);
 
     /**
      *
      * @return list of all tenant names in the system.
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_SYSTEM_ADMIN + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_SYSTEM_ADMIN)
     List<String> findTenants();
 
     /**
@@ -68,8 +66,8 @@ public interface SystemManagement {
     /**
      * Returns {@link TenantMetaData} of given and current tenant. Creates for
      * new tenants also two {@link SoftwareModuleType} (os and app) and
-     * {@link RepositoryConstants#DEFAULT_DS_TYPES_IN_TENANT} {@link DistributionSetType}s
-     * (os and os_app).
+     * {@link RepositoryConstants#DEFAULT_DS_TYPES_IN_TENANT}
+     * {@link DistributionSetType}s (os and os_app).
      *
      * DISCLAIMER: this variant is used during initial login (where the tenant
      * is not yet in the session). Please user {@link #getTenantMetadata()} for

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TenantConfigurationManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TenantConfigurationManagement.java
@@ -54,8 +54,7 @@ public interface TenantConfigurationManagement {
      * @return <null> if no default value is set and no database value available
      *         or returns the tenant configuration value
      */
-    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
     <T> TenantConfigurationValue<T> buildTenantConfigurationValueByKey(TenantConfigurationKey configurationKey,
             Class<T> propertyType, TenantConfiguration tenantConfiguration);
 
@@ -87,8 +86,7 @@ public interface TenantConfigurationManagement {
      *             if the property cannot be converted to the given
      *             {@code propertyType}
      */
-    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
     <T> TenantConfigurationValue<T> getConfigurationValue(TenantConfigurationKey configurationKey);
 
     /**
@@ -114,8 +112,7 @@ public interface TenantConfigurationManagement {
      *             if the property cannot be converted to the given
      *             {@code propertyType}
      */
-    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
     <T> TenantConfigurationValue<T> getConfigurationValue(TenantConfigurationKey configurationKey,
             Class<T> propertyType);
 
@@ -139,7 +136,6 @@ public interface TenantConfigurationManagement {
      *             if the property cannot be converted to the given
      *             {@code propertyType}
      */
-    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION + SpringEvalExpressions.HAS_AUTH_OR
-            + SpringEvalExpressions.IS_SYSTEM_CODE)
+    @PreAuthorize(value = SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION)
     <T> T getGlobalConfigurationValue(TenantConfigurationKey configurationKey, Class<T> propertyType);
 }

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
@@ -367,7 +367,7 @@ public final class SpPermission {
         /**
          * Spring security eval hasAnyRole expression to check if the spring
          * context contains the anoynmous role or the controller specific role
-         * {@link SpPermission#CONTROLLER_ROLE}.
+         * {@link SpringEvalExpressions#CONTROLLER_ROLE}.
          */
         public static final String IS_CONTROLLER = "hasAnyRole('" + CONTROLLER_ROLE_ANONYMOUS + "', '" + CONTROLLER_ROLE
                 + "')";
@@ -375,7 +375,7 @@ public final class SpPermission {
         /**
          * Spring security eval hasAuthority expression to check if the spring
          * context contains the role to allow controllers to download specific
-         * role {@link SpPermission#CONTROLLER_DOWNLOAD_ROLE}.
+         * role {@link SpringEvalExpressions#CONTROLLER_DOWNLOAD_ROLE}
          */
         public static final String HAS_CONTROLLER_DOWNLOAD = HAS_AUTH_PREFIX + CONTROLLER_DOWNLOAD_ROLE
                 + HAS_AUTH_SUFFIX;

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
@@ -224,8 +224,10 @@ public final class SpPermission {
         /*
          * Spring security eval expressions.
          */
-        private static final String HAS_AUTH_PREFIX = "hasAuthority('";
-        private static final String HAS_AUTH_SUFFIX = "')";
+        private static final String BRACKET_OPEN = "(";
+        private static final String BRACKET_CLOSE = ")";
+        private static final String HAS_AUTH_PREFIX = "hasAuthority" + BRACKET_OPEN + "'";
+        private static final String HAS_AUTH_SUFFIX = "'" + BRACKET_CLOSE;
         private static final String HAS_AUTH_AND = " and ";
 
         /**
@@ -258,81 +260,109 @@ public final class SpPermission {
         public static final String HAS_AUTH_OR = " or ";
 
         /**
-         * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#UPDATE_TARGET}.
+         * Spring security eval hasAnyRole expression to check if the spring
+         * context contains system code role
+         * {@link SpringEvalExpressions#SYSTEM_ROLE}.
          */
-        public static final String HAS_AUTH_UPDATE_TARGET = HAS_AUTH_PREFIX + UPDATE_TARGET + HAS_AUTH_SUFFIX;
+        public static final String IS_SYSTEM_CODE = HAS_AUTH_PREFIX + SYSTEM_ROLE + HAS_AUTH_SUFFIX;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#SYSTEM_ADMIN}.
+         * context contains {@link SpPermission#UPDATE_TARGET} or
+         * {@link #IS_SYSTEM_CODE}.
          */
-        public static final String HAS_AUTH_SYSTEM_ADMIN = HAS_AUTH_PREFIX + SYSTEM_ADMIN + HAS_AUTH_SUFFIX;
+        public static final String HAS_AUTH_UPDATE_TARGET = HAS_AUTH_PREFIX + UPDATE_TARGET + HAS_AUTH_SUFFIX
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#READ_TARGET}.
+         * context contains {@link SpPermission#SYSTEM_ADMIN} or
+         * {@link #IS_SYSTEM_CODE}.
          */
-        public static final String HAS_AUTH_READ_TARGET = HAS_AUTH_PREFIX + READ_TARGET + HAS_AUTH_SUFFIX;
+        public static final String HAS_AUTH_SYSTEM_ADMIN = HAS_AUTH_PREFIX + SYSTEM_ADMIN + HAS_AUTH_SUFFIX
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#CREATE_TARGET}.
+         * context contains {@link SpPermission#READ_TARGET} or
+         * {@link #IS_SYSTEM_CODE}.
          */
-        public static final String HAS_AUTH_CREATE_TARGET = HAS_AUTH_PREFIX + CREATE_TARGET + HAS_AUTH_SUFFIX;
+        public static final String HAS_AUTH_READ_TARGET = HAS_AUTH_PREFIX + READ_TARGET + HAS_AUTH_SUFFIX + HAS_AUTH_OR
+                + IS_SYSTEM_CODE;;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#DELETE_TARGET}.
+         * context contains {@link SpPermission#CREATE_TARGET} or
+         * {@link #IS_SYSTEM_CODE}.
          */
-        public static final String HAS_AUTH_DELETE_TARGET = HAS_AUTH_PREFIX + DELETE_TARGET + HAS_AUTH_SUFFIX;
+        public static final String HAS_AUTH_CREATE_TARGET = HAS_AUTH_PREFIX + CREATE_TARGET + HAS_AUTH_SUFFIX
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#READ_REPOSITORY} and
-         * {@link SpPermission#UPDATE_TARGET}.
+         * context contains {@link SpPermission#DELETE_TARGET} or
+         * {@link #IS_SYSTEM_CODE}.
          */
-        public static final String HAS_AUTH_READ_REPOSITORY_AND_UPDATE_TARGET = HAS_AUTH_PREFIX + READ_REPOSITORY
-                + HAS_AUTH_SUFFIX + HAS_AUTH_AND + HAS_AUTH_PREFIX + UPDATE_TARGET + HAS_AUTH_SUFFIX;
-
-        /**
-         * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#CREATE_REPOSITORY}.
-         */
-        public static final String HAS_AUTH_CREATE_REPOSITORY = HAS_AUTH_PREFIX + CREATE_REPOSITORY + HAS_AUTH_SUFFIX;
-
-        /**
-         * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#DELETE_REPOSITORY}.
-         */
-        public static final String HAS_AUTH_DELETE_REPOSITORY = HAS_AUTH_PREFIX + DELETE_REPOSITORY + HAS_AUTH_SUFFIX;
-
-        /**
-         * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#READ_REPOSITORY}.
-         */
-        public static final String HAS_AUTH_READ_REPOSITORY = HAS_AUTH_PREFIX + READ_REPOSITORY + HAS_AUTH_SUFFIX;
-
-        /**
-         * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#UPDATE_REPOSITORY}.
-         */
-        public static final String HAS_AUTH_UPDATE_REPOSITORY = HAS_AUTH_PREFIX + UPDATE_REPOSITORY + HAS_AUTH_SUFFIX;
+        public static final String HAS_AUTH_DELETE_TARGET = HAS_AUTH_PREFIX + DELETE_TARGET + HAS_AUTH_SUFFIX
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
          * context contains {@link SpPermission#READ_REPOSITORY} and
-         * {@link SpPermission#READ_TARGET}.
+         * {@link SpPermission#UPDATE_TARGET} or {@link #IS_SYSTEM_CODE}.
          */
-        public static final String HAS_AUTH_READ_REPOSITORY_AND_READ_TARGET = HAS_AUTH_PREFIX + READ_REPOSITORY
-                + HAS_AUTH_SUFFIX + HAS_AUTH_AND + HAS_AUTH_PREFIX + READ_TARGET + HAS_AUTH_SUFFIX;
+        public static final String HAS_AUTH_READ_REPOSITORY_AND_UPDATE_TARGET = BRACKET_OPEN + HAS_AUTH_PREFIX
+                + READ_REPOSITORY + HAS_AUTH_SUFFIX + HAS_AUTH_AND + HAS_AUTH_PREFIX + UPDATE_TARGET + HAS_AUTH_SUFFIX
+                + BRACKET_CLOSE + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#DOWNLOAD_REPOSITORY_ARTIFACT}.
+         * context contains {@link SpPermission#CREATE_REPOSITORY} or
+         * {@link #IS_SYSTEM_CODE}.
+         */
+        public static final String HAS_AUTH_CREATE_REPOSITORY = HAS_AUTH_PREFIX + CREATE_REPOSITORY + HAS_AUTH_SUFFIX
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;
+
+        /**
+         * Spring security eval hasAuthority expression to check if spring
+         * context contains {@link SpPermission#DELETE_REPOSITORY} or
+         * {@link #IS_SYSTEM_CODE}.
+         */
+        public static final String HAS_AUTH_DELETE_REPOSITORY = HAS_AUTH_PREFIX + DELETE_REPOSITORY + HAS_AUTH_SUFFIX
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;
+
+        /**
+         * Spring security eval hasAuthority expression to check if spring
+         * context contains {@link SpPermission#READ_REPOSITORY} or
+         * {@link #IS_SYSTEM_CODE}.
+         */
+        public static final String HAS_AUTH_READ_REPOSITORY = HAS_AUTH_PREFIX + READ_REPOSITORY + HAS_AUTH_SUFFIX
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;
+
+        /**
+         * Spring security eval hasAuthority expression to check if spring
+         * context contains {@link SpPermission#UPDATE_REPOSITORY} or
+         * {@link #IS_SYSTEM_CODE}.
+         */
+        public static final String HAS_AUTH_UPDATE_REPOSITORY = HAS_AUTH_PREFIX + UPDATE_REPOSITORY + HAS_AUTH_SUFFIX
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;
+
+        /**
+         * Spring security eval hasAuthority expression to check if spring
+         * context contains {@link SpPermission#READ_REPOSITORY} and
+         * {@link SpPermission#READ_TARGET} or {@link #IS_SYSTEM_CODE}.
+         */
+        public static final String HAS_AUTH_READ_REPOSITORY_AND_READ_TARGET = BRACKET_OPEN + HAS_AUTH_PREFIX
+                + READ_REPOSITORY + HAS_AUTH_SUFFIX + HAS_AUTH_AND + HAS_AUTH_PREFIX + READ_TARGET + HAS_AUTH_SUFFIX
+                + BRACKET_CLOSE + HAS_AUTH_OR + IS_SYSTEM_CODE;
+
+        /**
+         * Spring security eval hasAuthority expression to check if spring
+         * context contains {@link SpPermission#DOWNLOAD_REPOSITORY_ARTIFACT} or
+         * {@link #IS_SYSTEM_CODE}.
          */
         public static final String HAS_AUTH_DOWNLOAD_ARTIFACT = HAS_AUTH_PREFIX + DOWNLOAD_REPOSITORY_ARTIFACT
-                + HAS_AUTH_SUFFIX;
+                + HAS_AUTH_SUFFIX + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAnyRole expression to check if the spring
@@ -351,56 +381,55 @@ public final class SpPermission {
                 + HAS_AUTH_SUFFIX;
 
         /**
-         * Spring security eval hasAnyRole expression to check if the spring
-         * context contains system code role
-         * {@link SpringEvalExpressions#SYSTEM_ROLE}.
-         */
-        public static final String IS_SYSTEM_CODE = HAS_AUTH_PREFIX + SYSTEM_ROLE + HAS_AUTH_SUFFIX;
-
-        /**
          * Spring security eval hasAuthority expression to check if spring
          * context contains {@link SpPermission#CREATE_REPOSITORY} and
-         * {@link SpPermission#CREATE_TARGET}.
+         * {@link SpPermission#CREATE_TARGET} or {@link #IS_SYSTEM_CODE}.
          */
-        public static final String HAS_AUTH_CREATE_REPOSITORY_AND_CREATE_TARGET = HAS_AUTH_PREFIX + CREATE_REPOSITORY
-                + HAS_AUTH_SUFFIX + HAS_AUTH_AND + HAS_AUTH_PREFIX + CREATE_TARGET + HAS_AUTH_SUFFIX;
+        public static final String HAS_AUTH_CREATE_REPOSITORY_AND_CREATE_TARGET = BRACKET_OPEN + HAS_AUTH_PREFIX
+                + CREATE_REPOSITORY + HAS_AUTH_SUFFIX + HAS_AUTH_AND + HAS_AUTH_PREFIX + CREATE_TARGET + HAS_AUTH_SUFFIX
+                + BRACKET_CLOSE + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#ROLLOUT_MANAGEMENT}
+         * context contains {@link SpPermission#ROLLOUT_MANAGEMENT} or
+         * {@link #IS_SYSTEM_CODE}.
          */
         public static final String HAS_AUTH_ROLLOUT_MANAGEMENT_READ = HAS_AUTH_PREFIX + ROLLOUT_MANAGEMENT
-                + HAS_AUTH_SUFFIX;
+                + HAS_AUTH_SUFFIX + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
          * context contains {@link SpPermission#ROLLOUT_MANAGEMENT} and
-         * {@link SpPermission#READ_TARGET}
+         * {@link SpPermission#READ_TARGET} or {@link #IS_SYSTEM_CODE}.
          */
-        public static final String HAS_AUTH_ROLLOUT_MANAGEMENT_READ_AND_TARGET_READ = HAS_AUTH_PREFIX
-                + ROLLOUT_MANAGEMENT + HAS_AUTH_SUFFIX + HAS_AUTH_AND + HAS_AUTH_PREFIX + READ_TARGET
-                + HAS_AUTH_SUFFIX;;
+        public static final String HAS_AUTH_ROLLOUT_MANAGEMENT_READ_AND_TARGET_READ = BRACKET_OPEN + HAS_AUTH_PREFIX
+                + ROLLOUT_MANAGEMENT + HAS_AUTH_SUFFIX + HAS_AUTH_AND + HAS_AUTH_PREFIX + READ_TARGET + HAS_AUTH_SUFFIX
+                + BRACKET_CLOSE + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
          * context contains {@link SpPermission#ROLLOUT_MANAGEMENT} and
-         * {@link SpPermission#UPDATE_TARGET}.
+         * {@link SpPermission#UPDATE_TARGET} or {@link #IS_SYSTEM_CODE}.
          */
-        public static final String HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE = HAS_AUTH_PREFIX + ROLLOUT_MANAGEMENT
-                + HAS_AUTH_SUFFIX + HAS_AUTH_AND + HAS_AUTH_PREFIX + UPDATE_TARGET + HAS_AUTH_SUFFIX;
+        public static final String HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE = BRACKET_OPEN + HAS_AUTH_PREFIX
+                + ROLLOUT_MANAGEMENT + HAS_AUTH_SUFFIX + HAS_AUTH_AND + HAS_AUTH_PREFIX + UPDATE_TARGET
+                + HAS_AUTH_SUFFIX + BRACKET_CLOSE + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#TENANT_CONFIGURATION}
+         * context contains {@link SpPermission#TENANT_CONFIGURATION} or
+         * {@link #IS_SYSTEM_CODE}.
          */
         public static final String HAS_AUTH_TENANT_CONFIGURATION = HAS_AUTH_PREFIX + TENANT_CONFIGURATION
-                + HAS_AUTH_SUFFIX;
+                + HAS_AUTH_SUFFIX + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
-         * context contains {@link SpPermission#SYSTEM_MONITOR}
+         * context contains {@link SpPermission#SYSTEM_MONITOR} or
+         * {@link #IS_SYSTEM_CODE}.
          */
-        public static final String HAS_AUTH_SYSTEM_MONITOR = HAS_AUTH_PREFIX + SYSTEM_MONITOR + HAS_AUTH_SUFFIX;
+        public static final String HAS_AUTH_SYSTEM_MONITOR = HAS_AUTH_PREFIX + SYSTEM_MONITOR + HAS_AUTH_SUFFIX
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         private SpringEvalExpressions() {
             // utility class

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
@@ -280,7 +280,7 @@ public final class SpPermission {
          * {@link #IS_SYSTEM_CODE}.
          */
         public static final String HAS_AUTH_SYSTEM_ADMIN = HAS_AUTH_PREFIX + SYSTEM_ADMIN + HAS_AUTH_SUFFIX
-                + HAS_AUTH_OR + IS_SYSTEM_CODE;;
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
@@ -288,7 +288,7 @@ public final class SpPermission {
          * {@link #IS_SYSTEM_CODE}.
          */
         public static final String HAS_AUTH_READ_TARGET = HAS_AUTH_PREFIX + READ_TARGET + HAS_AUTH_SUFFIX + HAS_AUTH_OR
-                + IS_SYSTEM_CODE;;
+                + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
@@ -296,7 +296,7 @@ public final class SpPermission {
          * {@link #IS_SYSTEM_CODE}.
          */
         public static final String HAS_AUTH_CREATE_TARGET = HAS_AUTH_PREFIX + CREATE_TARGET + HAS_AUTH_SUFFIX
-                + HAS_AUTH_OR + IS_SYSTEM_CODE;;
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAuthority expression to check if spring
@@ -304,7 +304,7 @@ public final class SpPermission {
          * {@link #IS_SYSTEM_CODE}.
          */
         public static final String HAS_AUTH_DELETE_TARGET = HAS_AUTH_PREFIX + DELETE_TARGET + HAS_AUTH_SUFFIX
-                + HAS_AUTH_OR + IS_SYSTEM_CODE;;
+                + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         /**
          * Spring security eval hasAuthority expression to check if spring


### PR DESCRIPTION
Add `or hasAuthority('ROLE_SYSTEM_CODE')` to every `SpringEvalExpressions` and allow system-code to invoke all management APIs. Removing the explicit usage of the `IS_SYSTEM_CODE` in the `@PreAuthorize` because otherwise it's split up all the code that some methods are allow to invoked by system and some not. 

This does not make sense we want to have a general bypass for system invocation to execute code and not only some selected methods which were necessary for a special use-case.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>