### PR TITLE
Changed if statement of how we distinguish if a softwareModule type i…

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/CreateUpdateSoftwareTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/CreateUpdateSoftwareTypeLayout.java
@@ -164,10 +164,10 @@ public class CreateUpdateSoftwareTypeLayout extends CreateUpdateTypeLayout {
         if (null != selectedTypeTag) {
             tagDesc.setValue(selectedTypeTag.getDescription());
             typeKey.setValue(selectedTypeTag.getKey());
-            if (selectedTypeTag.getMaxAssignments() == Integer.MAX_VALUE) {
-                assignOptiongroup.setValue(multiAssignStr);
-            } else {
+            if (selectedTypeTag.getMaxAssignments() == 1) {
                 assignOptiongroup.setValue(singleAssignStr);
+            } else {
+                assignOptiongroup.setValue(multiAssignStr);
             }
             setColorPickerComponentsColor(selectedTypeTag.getColour());
         }


### PR DESCRIPTION
…s a firmware or a software
We had an issue that if the max assignments of a software module type was not Integer.MAX_VALUE it was handled as firmware. With this fix we only handle a software module type as firmware if the max assignment is exactly 1. In all other cases the software module type is a software.

Signed-off-by: Jonathan Philip Knoblauch <JonathanPhilip.Knoblauch@bosch-si.com>