### PR TITLE
Correct colour of cancel/save button in DialogWindows

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
@@ -25,7 +25,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.ui.artifacts.smtable.SoftwareModuleAddUpdateWindow;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
-import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleBorderWithIcon;
+import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleNoBorderWithIcon;
 import org.eclipse.hawkbit.ui.layouts.AbstractCreateUpdateTagLayout;
 import org.eclipse.hawkbit.ui.management.targettable.TargetAddUpdateWindowLayout;
 import org.eclipse.hawkbit.ui.utils.I18N;
@@ -411,7 +411,7 @@ public class CommonDialogWindow extends Window implements Serializable {
 
     private void createCancelButton() {
         cancelButton = SPUIComponentProvider.getButton(SPUIComponentIdProvider.CANCEL_BUTTON, "Cancel", "", "", true,
-                FontAwesome.TIMES, SPUIButtonStyleBorderWithIcon.class);
+                FontAwesome.TIMES, SPUIButtonStyleNoBorderWithIcon.class);
         cancelButton.setSizeUndefined();
         if (cancelButtonClickListener != null) {
             cancelButton.addClickListener(cancelButtonClickListener);
@@ -424,7 +424,7 @@ public class CommonDialogWindow extends Window implements Serializable {
 
     private void createSaveButton() {
         saveButton = SPUIComponentProvider.getButton(SPUIComponentIdProvider.SAVE_BUTTON, "Save", "", "", true,
-                FontAwesome.SAVE, SPUIButtonStyleBorderWithIcon.class);
+                FontAwesome.SAVE, SPUIButtonStyleNoBorderWithIcon.class);
         saveButton.setSizeUndefined();
         saveButton.addClickListener(saveButtonClickListener);
         saveButton.setEnabled(false);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
@@ -378,11 +378,10 @@ public class CommonDialogWindow extends Window implements Serializable {
         buttonsLayout = new HorizontalLayout();
         buttonsLayout.setSizeFull();
         buttonsLayout.setSpacing(true);
+        buttonsLayout.addStyleName("actionButtonsMargin");
 
         createSaveButton();
-
         createCancelButton();
-        buttonsLayout.addStyleName("actionButtonsMargin");
 
         addHelpLink();
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
@@ -413,7 +413,6 @@ public class CommonDialogWindow extends Window implements Serializable {
         cancelButton = SPUIComponentProvider.getButton(SPUIComponentIdProvider.CANCEL_BUTTON, "Cancel", "", "", true,
                 FontAwesome.TIMES, SPUIButtonStyleBorderWithIcon.class);
         cancelButton.setSizeUndefined();
-        cancelButton.addStyleName("default-color");
         if (cancelButtonClickListener != null) {
             cancelButton.addClickListener(cancelButtonClickListener);
         }
@@ -427,7 +426,6 @@ public class CommonDialogWindow extends Window implements Serializable {
         saveButton = SPUIComponentProvider.getButton(SPUIComponentIdProvider.SAVE_BUTTON, "Save", "", "", true,
                 FontAwesome.SAVE, SPUIButtonStyleBorderWithIcon.class);
         saveButton.setSizeUndefined();
-        saveButton.addStyleName("default-color");
         saveButton.addClickListener(saveButtonClickListener);
         saveButton.setEnabled(false);
         buttonsLayout.addComponent(saveButton);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/decorators/SPUIButtonStyleBorderWithIcon.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/decorators/SPUIButtonStyleBorderWithIcon.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.hawkbit.ui.decorators;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.vaadin.server.Resource;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.themes.ValoTheme;
@@ -29,6 +31,7 @@ public class SPUIButtonStyleBorderWithIcon implements SPUIButtonDecorator {
         setButtonIcon(icon);
 
         button.addStyleName(ValoTheme.LABEL_SMALL);
+        button.addStyleName(ValoTheme.BUTTON_BORDERLESS_COLORED);
         button.setSizeFull();
 
         return button;
@@ -36,14 +39,12 @@ public class SPUIButtonStyleBorderWithIcon implements SPUIButtonDecorator {
 
     private void setButtonStyle(final String style, final boolean setStyle) {
 
-        if (style == null) {
+        if (StringUtils.isEmpty(style)) {
             return;
         }
 
         if (setStyle) {
             button.setStyleName(style);
-        } else {
-            button.addStyleName(style);
         }
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/decorators/SPUIButtonStyleNoBorderWithIcon.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/decorators/SPUIButtonStyleNoBorderWithIcon.java
@@ -15,7 +15,7 @@ import com.vaadin.ui.Button;
 import com.vaadin.ui.themes.ValoTheme;
 
 /**
- * Decorator class for a borderless Button with icon.
+ * Decorator class for a borderless Button with an icon.
  */
 public class SPUIButtonStyleNoBorderWithIcon implements SPUIButtonDecorator {
 
@@ -25,38 +25,25 @@ public class SPUIButtonStyleNoBorderWithIcon implements SPUIButtonDecorator {
     public Button decorate(final Button button, final String style, final boolean setStyle, final Resource icon) {
 
         this.button = button;
+        button.setSizeFull();
 
         button.addStyleName(ValoTheme.LABEL_SMALL);
         button.addStyleName(ValoTheme.BUTTON_BORDERLESS_COLORED);
+        setOrAddButtonStyle(style, setStyle);
 
-        setButtonStyle(style, setStyle);
         setButtonIcon(icon);
-
-        button.setSizeFull();
-
-        setButtonStyle(style, setStyle);
 
         return button;
     }
 
-    /**
-     * It is possible to add or set a new style to the button. If a new style is
-     * set the other styles (LABEL_SMALL and BUTTON_BORDERLESS_COLORED) will be
-     * overwritten
-     * 
-     * @param style
-     *            styleName
-     * @param setStyle
-     *            boolean: Trigger if the style should be added or replace the
-     *            other styles
-     */
-    private void setButtonStyle(final String style, final boolean setStyle) {
+    private void setOrAddButtonStyle(final String style, final boolean setStyle) {
 
         if (StringUtils.isEmpty(style)) {
             return;
         }
 
         if (setStyle) {
+            // overwrite all other styles
             button.setStyleName(style);
         } else {
             button.addStyleName(style);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/decorators/SPUIButtonStyleNoBorderWithIcon.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/decorators/SPUIButtonStyleNoBorderWithIcon.java
@@ -15,10 +15,9 @@ import com.vaadin.ui.Button;
 import com.vaadin.ui.themes.ValoTheme;
 
 /**
- * Button with icon decorator.
- *
+ * Decorator class for a borderless Button with icon.
  */
-public class SPUIButtonStyleBorderWithIcon implements SPUIButtonDecorator {
+public class SPUIButtonStyleNoBorderWithIcon implements SPUIButtonDecorator {
 
     private Button button;
 
@@ -27,16 +26,30 @@ public class SPUIButtonStyleBorderWithIcon implements SPUIButtonDecorator {
 
         this.button = button;
 
+        button.addStyleName(ValoTheme.LABEL_SMALL);
+        button.addStyleName(ValoTheme.BUTTON_BORDERLESS_COLORED);
+
         setButtonStyle(style, setStyle);
         setButtonIcon(icon);
 
-        button.addStyleName(ValoTheme.LABEL_SMALL);
-        button.addStyleName(ValoTheme.BUTTON_BORDERLESS_COLORED);
         button.setSizeFull();
+
+        setButtonStyle(style, setStyle);
 
         return button;
     }
 
+    /**
+     * It is possible to add or set a new style to the button. If a new style is
+     * set the other styles (LABEL_SMALL and BUTTON_BORDERLESS_COLORED) will be
+     * overwritten
+     * 
+     * @param style
+     *            styleName
+     * @param setStyle
+     *            boolean: Trigger if the style should be added or replace the
+     *            other styles
+     */
     private void setButtonStyle(final String style, final boolean setStyle) {
 
         if (StringUtils.isEmpty(style)) {
@@ -45,6 +58,8 @@ public class SPUIButtonStyleBorderWithIcon implements SPUIButtonDecorator {
 
         if (setStyle) {
             button.setStyleName(style);
+        } else {
+            button.addStyleName(style);
         }
     }
 

--- a/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/common.scss
+++ b/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/common.scss
@@ -293,8 +293,4 @@
 	padding-bottom: 12px !important;
   }
   
-  .v-button-default-color {
-  	color: #551f62;
-  }
-  
 }

--- a/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/popup-common.scss
+++ b/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/popup-common.scss
@@ -56,4 +56,5 @@
    .marginTop {
   	margin-top: 20px !important;
   }
+  
 }

--- a/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/popup-window.scss
+++ b/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/popup-window.scss
@@ -164,5 +164,6 @@
   
   .actionButtonsMargin {
   	margin-top: 30px;
+  	margin-bottom: 10px;
   }
 }


### PR DESCRIPTION
The colour of the cancel and save button was different as the other colours in the theme. Now it fits to the theme.

![borderless_button](https://cloud.githubusercontent.com/assets/18258708/16839717/e4454232-49d0-11e6-9b69-5778a79104c3.png)

Signed-off-by: Melanie Retter <melanie.retter@bosch-si.com>