### PR TITLE
Fix initial tenant creation

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/cache/CacheAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/cache/CacheAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.cache.interceptor.CacheOperationInvocationContext;
 import org.springframework.cache.interceptor.SimpleCacheResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 /**
  * A configuration for configuring the spring {@link CacheManager} for specific
@@ -33,9 +34,6 @@ import org.springframework.context.annotation.Configuration;
  *
  * This is done by providing a special {@link TenantCacheResolver} which
  * generates a cache name included the current tenant.
- *
- *
- *
  */
 @Configuration
 @EnableCaching
@@ -51,18 +49,27 @@ public class CacheAutoConfiguration extends CachingConfigurerSupport {
     @Override
     @Bean
     @ConditionalOnMissingBean
+    @Primary
     public TenancyCacheManager cacheManager() {
-        return new TenantAwareCacheManager(new GuavaCacheManager(), tenantAware);
+        return new TenantAwareCacheManager(directCacheManager(), tenantAware);
+    }
+
+    /**
+     * @return the direct cache manager to access without tenant aware check,
+     *         cause in sometimes it's necessary to access the cache directly
+     *         without having the current tenant, e.g. initial creation of
+     *         tenant
+     */
+    @Bean(name = "directCacheManager")
+    @ConditionalOnMissingBean(name = "directCacheManager")
+    public CacheManager directCacheManager() {
+        return new GuavaCacheManager();
     }
 
     /**
      * A {@link SimpleCacheResolver} implementation which includes the
      * {@link TenantAware#getCurrentTenant()} into the cache name before
      * resolving it.
-     *
-     *
-     *
-     *
      */
     public class TenantCacheResolver extends SimpleCacheResolver {
 

--- a/hawkbit-cache-redis/src/main/java/org/eclipse/hawkbit/cache/RedisConfiguration.java
+++ b/hawkbit-cache-redis/src/main/java/org/eclipse/hawkbit/cache/RedisConfiguration.java
@@ -15,6 +15,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -50,8 +51,14 @@ public class RedisConfiguration {
      * @return the spring redis cache manager.
      */
     @Bean
+    @Primary
     public CacheManager cacheManager() {
-        return new TenantAwareCacheManager(new RedisCacheManager(redisTemplate()), tenantAware);
+        return new TenantAwareCacheManager(directCacheManager(), tenantAware);
+    }
+
+    @Bean(name = "directCacheManager")
+    public CacheManager directCacheManager() {
+        return new RedisCacheManager(redisTemplate());
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
@@ -220,7 +220,6 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     @Modifying
     public void deleteTenant(final String tenant) {
         cacheManager.evictCaches(tenant);
-        cacheManager.getCache("currentTenant").evict(currentTenantKeyGenerator().generate(null, null));
         tenantAware.runAsTenant(tenant, () -> {
             entityManager.setProperty(PersistenceUnitProperties.MULTITENANT_PROPERTY_DEFAULT, tenant.toUpperCase());
             tenantMetaDataRepository.deleteByTenantIgnoreCase(tenant);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
@@ -19,6 +19,7 @@ import org.eclipse.hawkbit.repository.Constants;
 import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.repository.TenantStatsManagement;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
+import org.eclipse.hawkbit.repository.jpa.configuration.MultiTenantJpaTransactionManager;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSetType;
 import org.eclipse.hawkbit.repository.jpa.model.JpaSoftwareModuleType;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTenantMetaData;
@@ -26,6 +27,7 @@ import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 import org.eclipse.hawkbit.repository.model.TenantMetaData;
 import org.eclipse.hawkbit.repository.report.model.SystemUsageReport;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,11 +35,14 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.interceptor.KeyGenerator;
-import org.springframework.context.ApplicationContext;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.validation.annotation.Validated;
 
 /**
@@ -108,7 +113,10 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     private SystemManagementCacheKeyGenerator currentTenantCacheKeyGenerator;
 
     @Autowired
-    private ApplicationContext applicationContext;
+    private SystemSecurityContext systemSecurityContext;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
 
     @Override
     public SystemUsageReport getSystemUsageStatistics() {
@@ -159,25 +167,46 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     }
 
     @Override
-    @Cacheable(value = "tenantMetadata", key = "#tenant.toUpperCase()")
+    @Cacheable(value = "tenantMetadata", key = "#tenant.toUpperCase()", cacheManager = "directCacheManager")
     @Transactional(isolation = Isolation.READ_UNCOMMITTED)
     @Modifying
     public TenantMetaData getTenantMetadata(final String tenant) {
         final TenantMetaData result = tenantMetaDataRepository.findByTenantIgnoreCase(tenant);
-
         // Create if it does not exist
         if (result == null) {
             try {
                 currentTenantCacheKeyGenerator.getCreateInitialTenant().set(tenant);
-                cacheManager.getCache("currentTenant").evict(currentTenantKeyGenerator().generate(null, null));
-                applicationContext.getBean("currentTenantKeyGenerator");
-                return tenantMetaDataRepository.save(new JpaTenantMetaData(createStandardSoftwareDataSetup(), tenant));
+                return createInitialTenantMetaData(tenant);
+
             } finally {
                 currentTenantCacheKeyGenerator.getCreateInitialTenant().remove();
             }
         }
-
         return result;
+    }
+
+    /**
+     * Creating the initial tenant meta-data in a new transaction. Due the
+     * {@link MultiTenantJpaTransactionManager} is using the current tenant to
+     * set the necessary tenant discriminator to the query. This is not working
+     * if we don't have a current tenant set. Due the
+     * {@link #getTenantMetadata(String)} is maybe called without having a
+     * current tenant we need to re-open a new transaction so the
+     * {@link MultiTenantJpaTransactionManager} is called again and set the
+     * tenant for this transaction.
+     * 
+     * @param tenant
+     *            the tenant to be created
+     * @return the initial created {@link TenantMetaData}
+     */
+    private TenantMetaData createInitialTenantMetaData(final String tenant) {
+        final DefaultTransactionDefinition def = new DefaultTransactionDefinition();
+        def.setName("initial-tenant-creation");
+        def.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return systemSecurityContext.runAsSystemAsTenant(
+                () -> new TransactionTemplate(txManager, def).execute(status -> tenantMetaDataRepository
+                        .save(new JpaTenantMetaData(createStandardSoftwareDataSetup(), tenant))),
+                tenant);
     }
 
     @Override
@@ -226,7 +255,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     }
 
     @Override
-    @Cacheable(value = "currentTenant", keyGenerator = "currentTenantKeyGenerator")
+    @Cacheable(value = "currentTenant", keyGenerator = "currentTenantKeyGenerator", cacheManager = "directCacheManager")
     // set transaction to not supported, due we call this in
     // BaseEntity#prePersist methods
     // and it seems that JPA committing the transaction when executing this

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SystemManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SystemManagementTest.java
@@ -31,7 +31,7 @@ import ru.yandex.qatools.allure.annotations.Stories;
 public class SystemManagementTest extends AbstractJpaIntegrationTestWithMongoDB {
 
     @Test
-    @Description("Micha TODO!")
+    @Description("Ensures that you can create a tenant without setting the necessary security context which holds a current tenant")
     public void createInitialTenantWithoutSecurityContext() {
         securityRule.clear();
         final String tenantToBeCreated = "newTenantToCreate";

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SystemManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SystemManagementTest.java
@@ -17,6 +17,7 @@ import java.util.Random;
 import org.eclipse.hawkbit.repository.jpa.model.JpaSoftwareModule;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.model.TenantMetaData;
 import org.eclipse.hawkbit.repository.report.model.TenantUsage;
 import org.eclipse.hawkbit.repository.test.util.WithSpringAuthorityRule;
 import org.junit.Test;
@@ -28,6 +29,15 @@ import ru.yandex.qatools.allure.annotations.Stories;
 @Features("Component Tests - Repository")
 @Stories("System Management")
 public class SystemManagementTest extends AbstractJpaIntegrationTestWithMongoDB {
+
+    @Test
+    @Description("Micha TODO!")
+    public void createInitialTenantWithoutSecurityContext() {
+        securityRule.clear();
+        final String tenantToBeCreated = "newTenantToCreate";
+        final TenantMetaData tenantMetadata = systemManagement.getTenantMetadata(tenantToBeCreated);
+        assertThat(tenantMetadata).isNotNull();
+    }
 
     @Test
     @Description("Ensures that findTenants returns all tenants and not only restricted to the tenant which currently is logged in")

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/WithSpringAuthorityRule.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/WithSpringAuthorityRule.java
@@ -63,7 +63,7 @@ public class WithSpringAuthorityRule implements TestRule {
         }
         return oldContext;
     }
-
+    
     /**
      * @param annotation
      */
@@ -128,6 +128,14 @@ public class WithSpringAuthorityRule implements TestRule {
 
     private void after(final SecurityContext oldContext) {
         SecurityContextHolder.setContext(oldContext);
+    }
+    
+    /**
+     * Clears the current security context.
+     */
+    public void clear()
+    {
+        SecurityContextHolder.clearContext();
     }
 
     /**

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SecurityContextTenantAware.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SecurityContextTenantAware.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.security;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
 import org.eclipse.hawkbit.tenancy.TenantAware;
@@ -80,32 +81,37 @@ public class SecurityContextTenantAware implements TenantAware {
 
         @Override
         public boolean equals(final Object another) {
-            return delegate.equals(another);
+            if (delegate != null) {
+                return delegate.equals(another);
+            } else if (another == null) {
+                return true;
+            }
+            return false;
         }
 
         @Override
         public String toString() {
-            return delegate.toString();
+            return (delegate != null) ? delegate.toString() : null;
         }
 
         @Override
         public int hashCode() {
-            return delegate.hashCode();
+            return (delegate != null) ? delegate.hashCode() : null;
         }
 
         @Override
         public String getName() {
-            return delegate.getName();
+            return (delegate != null) ? delegate.getName() : null;
         }
 
         @Override
         public Collection<? extends GrantedAuthority> getAuthorities() {
-            return delegate.getAuthorities();
+            return (delegate != null) ? delegate.getAuthorities() : Collections.emptyList();
         }
 
         @Override
         public Object getCredentials() {
-            return delegate.getCredentials();
+            return (delegate != null) ? delegate.getCredentials() : null;
         }
 
         @Override
@@ -115,16 +121,19 @@ public class SecurityContextTenantAware implements TenantAware {
 
         @Override
         public Object getPrincipal() {
-            return delegate.getPrincipal();
+            return (delegate != null) ? delegate.getPrincipal() : null;
         }
 
         @Override
         public boolean isAuthenticated() {
-            return delegate.isAuthenticated();
+            return (delegate != null) ? delegate.isAuthenticated() : null;
         }
 
         @Override
-        public void setAuthenticated(final boolean isAuthenticated) throws IllegalArgumentException {
+        public void setAuthenticated(final boolean isAuthenticated) {
+            if (delegate == null) {
+                return;
+            }
             delegate.setAuthenticated(isAuthenticated);
         }
     }

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SystemSecurityContext.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SystemSecurityContext.java
@@ -67,12 +67,16 @@ public class SystemSecurityContext {
     // Exception squid:S2221 - Callable declares Exception
     @SuppressWarnings("squid:S2221")
     public <T> T runAsSystem(final Callable<T> callable) {
+        return runAsSystemAsTenant(callable, tenantAware.getCurrentTenant());
+    }
+
+    public <T> T runAsSystemAsTenant(final Callable<T> callable, final String tenant) {
         final SecurityContext oldContext = SecurityContextHolder.getContext();
         try {
             logger.debug("entering system code execution");
-            return tenantAware.runAsTenant(tenantAware.getCurrentTenant(), () -> {
+            return tenantAware.runAsTenant(tenant, () -> {
                 try {
-                    setSystemContext(oldContext);
+                    setSystemContext(SecurityContextHolder.getContext());
                     return callable.call();
                 } catch (final Exception e) {
                     throw Throwables.propagate(e);

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SystemSecurityContext.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SystemSecurityContext.java
@@ -60,6 +60,9 @@ public class SystemSecurityContext {
      * The security context will be switched to the system code and back after
      * the callable is called.
      * 
+     * The system code is executed for a current tenant by using the
+     * {@link TenantAware#getCurrentTenant()}.
+     * 
      * @param callable
      *            the callable to call within the system security context
      * @return the return value of the {@link Callable#call()} method.
@@ -70,6 +73,26 @@ public class SystemSecurityContext {
         return runAsSystemAsTenant(callable, tenantAware.getCurrentTenant());
     }
 
+    /**
+     * Runs a given {@link Callable} within a system security context, which is
+     * permitted to call secured system code. Often the system needs to call
+     * secured methods by it's own without relying on the current security
+     * context e.g. if the current security context does not contain the
+     * necessary permission it's necessary to execute code as system code to
+     * execute necessary methods and functionality.
+     * 
+     * The security context will be switched to the system code and back after
+     * the callable is called.
+     * 
+     * The system code is executed for a specific given tenant by using the
+     * {@link TenantAware}.
+     * 
+     * @param callable
+     *            the callable to call within the system security context
+     * @param tenant
+     *            the tenant to act as system code
+     * @return the return value of the {@link Callable#call()} method.
+     */
     public <T> T runAsSystemAsTenant(final Callable<T> callable, final String tenant) {
         final SecurityContext oldContext = SecurityContextHolder.getContext();
         try {
@@ -104,6 +127,13 @@ public class SystemSecurityContext {
         SecurityContextHolder.setContext(securityContextImpl);
     }
 
+    /**
+     * An implementation of the Spring's {@link Authentication} object which is
+     * used within a system security code block and wraps the original
+     * authentication object. The wrapped object contains the necessary
+     * {@link SpringEvalExpressions#SYSTEM_ROLE} which is allowed to execute all
+     * secured methods.
+     */
     public static class SystemCodeAuthentication implements Authentication {
 
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
The initial tenant creation via `org.eclipse.hawkbit.repository.SystemManagement.getTenantMetadata(String)` did not work in case no security context is set which holding the current tenant. 

This has multiple reasons:
* The wrapped `TenantAwareCacheManager` returns a `null` cache if the current tenant is not set, which is causing a problem in the `org.springframework.cache.interceptor.AbstractCacheResolver.resolveCaches(CacheOperationInvocationContext<?>)`.
 * So introducing a `directCacheManager` which is not relying on the current tenant in the security context due there is none and the tenant is given via parameter. Don't use the `TenantAwareCacheManager` when creating new tenant.

* When calling the `org.eclipse.hawkbit.repository.SystemManagement.getTenantMetadata(String)` a new transaction is created and the `org.eclipse.hawkbit.repository.jpa.configuration.MultiTenantJpaTransactionManager` is setting the current tenant to the transaction for EclipseLink. This can be null during tenant creation due no current tenant is set. When now then create the necessary entities in database the tenant discremenator is already set to `null` and the `MultiTenantJpaTransactionManager` is not called again because no new transaction is created. 
 * We need to create a own transaction and running in the `TenantAware#runAsTenant()` context to set the correct tenant discremenator for EclipseLink.