### PR TITLE
Upgrade Spring AMQP to 1.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
       <jackson.version>2.5.5</jackson.version>
       <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
       <spring-cloud-connectors.version>1.2.0.RELEASE</spring-cloud-connectors.version>
-      <spring-amqp.version>1.6.0.RELEASE</spring-amqp.version>
+      <spring-amqp.version>1.6.1.RELEASE</spring-amqp.version>
       <rabbitmq.version>3.6.2</rabbitmq.version>
       <spring-hateoas.version>0.18.0.RELEASE</spring-hateoas.version>
       <!--  Support for MongoDB 3 -->


### PR DESCRIPTION
We have seen the problem that the spring team describes here https://jira.spring.io/browse/AMQP-621 several times.

So we should upgrade accordingly.

Signed-off-by: Kai Zimmermann <kai.zimmermann@bosch-si.com>