### PR TITLE
Upgrade Apache Collections to 4.1 due to known vulnerability.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
       <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
       <spring-cloud-connectors.version>1.2.0.RELEASE</spring-cloud-connectors.version>
       <spring-amqp.version>1.6.1.RELEASE</spring-amqp.version>
-      <rabbitmq.version>3.6.2</rabbitmq.version>
       <spring-hateoas.version>0.18.0.RELEASE</spring-hateoas.version>
       <!--  Support for MongoDB 3 -->
       <spring-data-releasetrain.version>Fowler-SR1</spring-data-releasetrain.version>
@@ -111,7 +110,7 @@
       <jlorem.version>1.1</jlorem.version>
       <json-simple.version>1.1.1</json-simple.version>
       <commons-lang3.version>3.4</commons-lang3.version>
-      <commons-collections4.version>4.0</commons-collections4.version>
+      <commons-collections4.version>4.1</commons-collections4.version>
       <json.version>20141113</json.version>
       <rsql-parser.version>2.0.0</rsql-parser.version>
       <!-- Misc libraries versions - END -->
@@ -527,11 +526,6 @@
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa</artifactId>
             <version>${eclipselink.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>com.rabbitmq</groupId>
-            <artifactId>amqp-client</artifactId>
-            <version>${rabbitmq.version}</version>
          </dependency>
          <!-- RSQL / FIQL parser -->
          <dependency>


### PR DESCRIPTION
- Upgrade collections due to: https://issues.apache.org/jira/browse/COLLECTIONS-580
- Removed RabbitMQ custom client version setting as the new spring AMQP version already has a transitive dependency on the newest client.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>