### PR TITLE
Allow to set error handler or take default one

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/amqp/AmqpAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/amqp/AmqpAutoConfiguration.java
@@ -10,8 +10,12 @@ package org.eclipse.hawkbit.autoconfigure.amqp;
 
 import org.eclipse.hawkbit.amqp.AmqpConfiguration;
 import org.eclipse.hawkbit.amqp.annotation.EnableAmqp;
+import org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ErrorHandler;
 
 /**
  * The amqp autoconfiguration.
@@ -23,5 +27,16 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(value = AmqpConfiguration.class)
 @EnableAmqp
 public class AmqpAutoConfiguration {
+
+    /**
+     * Create default error handler bean.
+     * 
+     * @return the default error handler bean
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public ErrorHandler errorHandler() {
+        return new ConditionalRejectingErrorHandler();
+    }
 
 }

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
@@ -267,7 +267,9 @@ public class AmqpConfiguration {
 
     /**
      * Returns the Listener factory.
-     *
+     * 
+     * @param errorHandler
+     *            the error hander
      * @return the {@link SimpleMessageListenerContainer} that gets used receive
      *         AMQP messages
      */

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
@@ -60,8 +60,8 @@ public class AmqpConfiguration {
     @Autowired
     private ConnectionFactory rabbitConnectionFactory;
 
-    @Autowired
-    private ErrorHandler errorHandler;
+    // @Autowired
+    // private ErrorHandler errorHandler;
 
     @Configuration
     @ConditionalOnMissingBean(ConnectionFactory.class)
@@ -273,7 +273,8 @@ public class AmqpConfiguration {
      *         AMQP messages
      */
     @Bean(name = { "listenerContainerFactory" })
-    public RabbitListenerContainerFactory<SimpleMessageListenerContainer> listenerContainerFactory() {
+    public RabbitListenerContainerFactory<SimpleMessageListenerContainer> listenerContainerFactory(
+            final ErrorHandler errorHandler) {
         return new ConfigurableRabbitListenerContainerFactory(amqpProperties, rabbitConnectionFactory, errorHandler);
     }
 

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
@@ -283,17 +282,6 @@ public class AmqpConfiguration {
         args.put("x-message-ttl", Duration.ofSeconds(30).toMillis());
         args.put("x-max-length", 1_000);
         return args;
-    }
-
-    /**
-     * Create default error handler bean.
-     * 
-     * @return the default error handler bean
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    public ErrorHandler errorHandler() {
-        return new ConditionalRejectingErrorHandler();
     }
 
 }

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.util.ErrorHandler;;
+import org.springframework.util.ErrorHandler;
 
 /**
  * The spring AMQP configuration which is enabled by using the profile
@@ -58,9 +58,6 @@ public class AmqpConfiguration {
 
     @Autowired
     private ConnectionFactory rabbitConnectionFactory;
-
-    // @Autowired
-    // private ErrorHandler errorHandler;
 
     @Configuration
     @ConditionalOnMissingBean(ConnectionFactory.class)

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
@@ -12,6 +12,7 @@ import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFacto
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.util.ErrorHandler;
 
 /**
  * {@link RabbitListenerContainerFactory} that can be configured through
@@ -30,8 +31,9 @@ public class ConfigurableRabbitListenerContainerFactory extends SimpleRabbitList
      *            to configure the container factory
      */
     public ConfigurableRabbitListenerContainerFactory(final AmqpProperties amqpProperties,
-            final ConnectionFactory rabbitConnectionFactory) {
+            final ConnectionFactory rabbitConnectionFactory, final ErrorHandler errorHandler) {
         this.amqpProperties = amqpProperties;
+        setErrorHandler(errorHandler);
         setDefaultRequeueRejected(true);
         setConnectionFactory(rabbitConnectionFactory);
         setMissingQueuesFatal(amqpProperties.isMissingQueuesFatal());

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
@@ -29,6 +29,8 @@ public class ConfigurableRabbitListenerContainerFactory extends SimpleRabbitList
      *            for the container factory
      * @param amqpProperties
      *            to configure the container factory
+     * @param errorHandler
+     *            the error handler which should be use
      */
     public ConfigurableRabbitListenerContainerFactory(final AmqpProperties amqpProperties,
             final ConnectionFactory rabbitConnectionFactory, final ErrorHandler errorHandler) {


### PR DESCRIPTION
With this feature it is now possible to set a custom error handler. If no error hander is set the default one will be used. 

Signed-off-by: Jonathan Philip Knoblauch <JonathanPhilip.Knoblauch@bosch-si.com>