### PR TITLE
Fix enable showing errors during bulk upload

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
@@ -68,7 +68,7 @@ public class HawkbitUIErrorHandler extends DefaultErrorHandler {
             return Optional.fromNullable(errorOrigin.getUI().getPage());
         }
 
-        return Optional.absent();
+        return Optional.of(Page.getCurrent());
     }
 
     protected HawkbitErrorNotificationMessage buildNotification(final Throwable exception) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
@@ -36,8 +36,6 @@ public class HawkbitUIErrorHandler extends DefaultErrorHandler {
     @Override
     public void error(final ErrorEvent event) {
 
-        LOG.error("Error in UI: ", event.getThrowable());
-
         final Optional<Page> originError = getPageOriginError(event);
 
         if (originError.isPresent()) {
@@ -72,7 +70,11 @@ public class HawkbitUIErrorHandler extends DefaultErrorHandler {
     }
 
     protected HawkbitErrorNotificationMessage buildNotification(final Throwable exception) {
+        LOG.error("Error in UI: ", exception);
+        return createHawkbitErrorNotificationMessage(exception);
+    }
 
+    protected HawkbitErrorNotificationMessage createHawkbitErrorNotificationMessage(final Throwable exception) {
         final I18N i18n = SpringContextHelper.getBean(I18N.class);
         return new HawkbitErrorNotificationMessage(STYLE, i18n.get("caption.error"),
                 i18n.get("message.error.temp", exception.getClass().getSimpleName()), false);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.Executor;
 
 import org.eclipse.hawkbit.repository.DeploymentManagement;
@@ -99,8 +98,6 @@ public class BulkUploadHandler extends CustomComponent
     private transient EventBus.SessionEventBus eventBus;
 
     final TargetBulkUpdateWindowLayout targetBulkUpdateWindowLayout;
-
-    private TargetTableHeader targetTableHeader;
 
     private transient EntityFactory entityFactory;
 
@@ -225,9 +222,9 @@ public class BulkUploadHandler extends CustomComponent
             } catch (final IOException e) {
                 LOG.error("Error reading file {}", tempFile.getName(), e);
             } catch (final RuntimeException e) {
-                Optional.ofNullable(UI.getCurrent()).ifPresent(error -> UI.getCurrent().getErrorHandler()
-                        .error(new ConnectorErrorEvent(targetTableHeader, e)));
-
+                if (UI.getCurrent() != null) {
+                    UI.getCurrent().getErrorHandler().error(new com.vaadin.server.ErrorEvent(e));
+                }
             } finally {
                 updateBulkUpload();
                 doAssignments();
@@ -465,7 +462,4 @@ public class BulkUploadHandler extends CustomComponent
         }
     }
 
-    public void setTargetBulkUpdateWindowLayout(final TargetTableHeader targetTableHeader) {
-        this.targetTableHeader = targetTableHeader;
-    }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
@@ -138,7 +138,7 @@ public class BulkUploadHandler extends CustomComponent
     public void buildLayout() {
         final HorizontalLayout horizontalLayout = new HorizontalLayout();
         upload = new Upload();
-        upload.setEnabled(true);
+        upload.setEnabled(false);
         upload.setButtonCaption("Bulk Upload");
         upload.setReceiver(this);
         upload.setImmediate(true);
@@ -227,6 +227,7 @@ public class BulkUploadHandler extends CustomComponent
             } catch (final RuntimeException e) {
                 Optional.ofNullable(UI.getCurrent()).ifPresent(error -> UI.getCurrent().getErrorHandler()
                         .error(new ConnectorErrorEvent(targetTableHeader, e)));
+
             } finally {
                 updateBulkUpload();
                 doAssignments();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
@@ -226,13 +226,25 @@ public class BulkUploadHandler extends CustomComponent
                     UI.getCurrent().getErrorHandler().error(new com.vaadin.server.ErrorEvent(e));
                 }
             } finally {
-                updateBulkUpload();
-                doAssignments();
-                eventBus.publish(this, new TargetTableEvent(TargetComponentEvent.BULK_UPLOAD_COMPLETED));
-                // Clearing after assignments are done
-                managementUIState.getTargetTableFilters().getBulkUpload().getTargetsCreated().clear();
-                resetCounts();
                 deleteFile();
+            }
+            syncCountAfterUpload();
+            doAssignments();
+            eventBus.publish(this, new TargetTableEvent(TargetComponentEvent.BULK_UPLOAD_COMPLETED));
+            // Clearing after assignments are done
+            managementUIState.getTargetTableFilters().getBulkUpload().getTargetsCreated().clear();
+            resetCounts();
+        }
+
+        private void syncCountAfterUpload() {
+            if (managementUIState.getTargetTableFilters().getBulkUpload()
+                    .getSucessfulUploadCount() != successfullTargetCount) {
+                managementUIState.getTargetTableFilters().getBulkUpload()
+                        .setSucessfulUploadCount(successfullTargetCount);
+                eventBus.publish(this, new TargetTableEvent(TargetComponentEvent.BULK_TARGET_CREATED));
+            }
+            if (managementUIState.getTargetTableFilters().getBulkUpload().getFailedUploadCount() != failedTargetCount) {
+                managementUIState.getTargetTableFilters().getBulkUpload().setSucessfulUploadCount(failedTargetCount);
             }
         }
 
@@ -284,14 +296,11 @@ public class BulkUploadHandler extends CustomComponent
             if (Math.abs(next - 0.1) < 0.00001 || current - next >= 0 || next - current >= 0.05
                     || Math.abs(next - 1) < 0.00001) {
                 managementUIState.getTargetTableFilters().getBulkUpload().setProgressBarCurrentValue(next);
-                updateBulkUpload();
+                managementUIState.getTargetTableFilters().getBulkUpload()
+                        .setSucessfulUploadCount(successfullTargetCount);
+                managementUIState.getTargetTableFilters().getBulkUpload().setFailedUploadCount(failedTargetCount);
+                eventBus.publish(this, new TargetTableEvent(TargetComponentEvent.BULK_TARGET_CREATED));
             }
-        }
-
-        private void updateBulkUpload() {
-            managementUIState.getTargetTableFilters().getBulkUpload().setSucessfulUploadCount(successfullTargetCount);
-            managementUIState.getTargetTableFilters().getBulkUpload().setFailedUploadCount(failedTargetCount);
-            eventBus.publish(this, new TargetTableEvent(TargetComponentEvent.BULK_TARGET_CREATED));
         }
 
         private void doAssignments() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
@@ -44,7 +44,6 @@ import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
-import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.vaadin.spring.events.EventBus;
@@ -85,8 +84,6 @@ public class BulkUploadHandler extends CustomComponent
     private final transient DeploymentManagement deploymentManagement;
     private final transient DistributionSetManagement distributionSetManagement;
 
-    private final UINotification uINotification;
-
     protected File tempFile = null;
     private Upload upload;
 
@@ -101,7 +98,7 @@ public class BulkUploadHandler extends CustomComponent
     private final transient Executor executor;
     private transient EventBus.SessionEventBus eventBus;
 
-    TargetBulkUpdateWindowLayout targetBulkUpdateWindowLayout;
+    private final TargetBulkUpdateWindowLayout targetBulkUpdateWindowLayout;
 
     private transient EntityFactory entityFactory;
 
@@ -111,12 +108,11 @@ public class BulkUploadHandler extends CustomComponent
      * @param targetManagement
      * @param managementUIState
      * @param deploymentManagement
-     * @param uINotification
      * @param i18n
      */
     public BulkUploadHandler(final TargetBulkUpdateWindowLayout targetBulkUpdateWindowLayout,
             final TargetManagement targetManagement, final ManagementUIState managementUIState,
-            final DeploymentManagement deploymentManagement, final UINotification uINotification, final I18N i18n) {
+            final DeploymentManagement deploymentManagement, final I18N i18n) {
         this.targetBulkUpdateWindowLayout = targetBulkUpdateWindowLayout;
         this.comboBox = targetBulkUpdateWindowLayout.getDsNamecomboBox();
         this.descTextArea = targetBulkUpdateWindowLayout.getDescTextArea();
@@ -124,7 +120,6 @@ public class BulkUploadHandler extends CustomComponent
         this.progressBar = targetBulkUpdateWindowLayout.getProgressBar();
         this.managementUIState = managementUIState;
         this.deploymentManagement = deploymentManagement;
-        this.uINotification = uINotification;
         this.targetsCountLabel = targetBulkUpdateWindowLayout.getTargetsCountLabel();
         this.targetBulkTokenTags = targetBulkUpdateWindowLayout.getTargetBulkTokenTags();
         this.i18n = i18n;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
@@ -100,7 +100,7 @@ public class BulkUploadHandler extends CustomComponent
 
     final TargetBulkUpdateWindowLayout targetBulkUpdateWindowLayout;
 
-    TargetTableHeader targetTableHeader;
+    private TargetTableHeader targetTableHeader;
 
     private transient EntityFactory entityFactory;
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
@@ -214,22 +214,22 @@ public class BulkUploadHandler extends CustomComponent
                  * below event.
                  */
                 eventBus.publish(this, new TargetTableEvent(TargetComponentEvent.BULK_UPLOAD_PROCESS_STARTED));
+
                 while ((line = reader.readLine()) != null) {
                     innerCounter++;
                     readEachLine(line, innerCounter, totalFileSize);
                 }
-                doAssignments();
-                eventBus.publish(this, new TargetTableEvent(TargetComponentEvent.BULK_UPLOAD_COMPLETED));
 
-                // Clearing after assignments are done
-                managementUIState.getTargetTableFilters().getBulkUpload().getTargetsCreated().clear();
             } catch (final IOException e) {
                 LOG.error("Error reading file {}", tempFile.getName(), e);
             } catch (final RuntimeException e) {
                 Optional.ofNullable(UI.getCurrent()).ifPresent(
                         error -> UI.getCurrent().getErrorHandler().error(new ConnectorErrorEvent(upload, e)));
-                targetBulkUpdateWindowLayout.closePopupAfterFailureAndRefresh();
             } finally {
+                doAssignments();
+                eventBus.publish(this, new TargetTableEvent(TargetComponentEvent.BULK_UPLOAD_COMPLETED));
+                // Clearing after assignments are done
+                managementUIState.getTargetTableFilters().getBulkUpload().getTargetsCreated().clear();
                 resetCounts();
                 deleteFile();
             }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
@@ -178,7 +178,7 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
 
     private BulkUploadHandler getBulkUploadHandler() {
         final BulkUploadHandler bulkUploadHandler = new BulkUploadHandler(this, targetManagement, managementUIState,
-                deploymentManagement, uINotification, i18n);
+                deploymentManagement, i18n);
         bulkUploadHandler.buildLayout();
         bulkUploadHandler.addStyleName(SPUIStyleDefinitions.BULK_UPLOAD_BUTTON);
         return bulkUploadHandler;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
@@ -240,6 +240,15 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
     }
 
     /**
+     * Close and refresh this component.
+     */
+    public void closePopupAfterFailureAndRefresh() {
+        closePopup();
+        destroy();
+        init();
+    }
+
+    /**
      * @return
      */
     private Container createContainer() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
@@ -31,7 +31,6 @@ import org.eclipse.hawkbit.ui.utils.SPUIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
@@ -72,9 +71,6 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
 
     @Autowired
     private transient TargetManagement targetManagement;
-
-    @Autowired
-    private transient UINotification uINotification;
 
     @Autowired
     private transient EventBus.SessionEventBus eventBus;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
@@ -296,8 +296,9 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
         descTextArea.clear();
         targetBulkTokenTags.getTokenField().clear();
         targetBulkTokenTags.populateContainer();
-        progressBar.setValue(0f);
+        progressBar.setValue(0F);
         progressBar.setVisible(false);
+        managementUIState.getTargetTableFilters().getBulkUpload().setProgressBarCurrentValue(0F);
         targetsCountLabel.setVisible(false);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
@@ -240,15 +240,6 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
     }
 
     /**
-     * Close and refresh this component.
-     */
-    public void closePopupAfterFailureAndRefresh() {
-        closePopup();
-        destroy();
-        init();
-    }
-
-    /**
      * @return
      */
     private Container createContainer() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
@@ -82,6 +82,7 @@ public class TargetTableHeader extends AbstractTableHeader {
         // creating add window for adding new target
         targetAddUpdateWindow.init();
         targetBulkUpdateWindow.init();
+        targetBulkUpdateWindow.getBulkUploader().setTargetBulkUpdateWindowLayout(this);
         onLoadRestoreState();
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
@@ -82,7 +82,6 @@ public class TargetTableHeader extends AbstractTableHeader {
         // creating add window for adding new target
         targetAddUpdateWindow.init();
         targetBulkUpdateWindow.init();
-        targetBulkUpdateWindow.getBulkUploader().setTargetBulkUpdateWindowLayout(this);
         onLoadRestoreState();
     }
 


### PR DESCRIPTION
With this fix errors triggered by RuntimeExceptions will be shown on UI during bulk upload. If such an error is thrown the bulk upload dialog will return to a valid state: