### PR TITLE
Show error notification needs a lock when run in separate thread

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -56,9 +56,6 @@ import ru.yandex.qatools.allure.annotations.Stories;
 
 /**
  * Junit tests for RolloutManagment.
- * 
- * @author Michael Hirsch
- *
  */
 @Features("Component Tests - Repository")
 @Stories("Rollout Management")
@@ -923,7 +920,6 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     private void validateStatus(final TotalTargetCountStatus totalTargetCountStatus,
             final Map<TotalTargetCountStatus.Status, Long> expectedTotalCountStates) {
-
         for (final Map.Entry<TotalTargetCountStatus.Status, Long> entry : expectedTotalCountStates.entrySet()) {
             final Long countReady = totalTargetCountStatus.getTotalTargetCountByStatus(entry.getKey());
             assertThat(countReady).isEqualTo(entry.getValue());

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
@@ -83,6 +83,10 @@ public class HawkbitUIErrorHandler extends DefaultErrorHandler {
 
     protected HawkbitErrorNotificationMessage buildNotification(final Throwable exception) {
         LOG.error("Error in UI: ", exception);
+        return createHawkbitErrorNotificationMessage(exception);
+    }
+
+    protected HawkbitErrorNotificationMessage createHawkbitErrorNotificationMessage(final Throwable exception) {
         final I18N i18n = SpringContextHelper.getBean(I18N.class);
         return new HawkbitErrorNotificationMessage(STYLE, i18n.get("caption.error"),
                 i18n.get("message.error.temp", exception.getClass().getSimpleName()), false);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
@@ -46,16 +46,13 @@ public class HawkbitUIErrorHandler extends DefaultErrorHandler {
 
         if (originError.isPresent()) {
             final Connector connector = ((ConnectorErrorEvent) event).getConnector();
-            // in case of BulkUpload: BulkUpload needs a lock to show the
-            // notification
             if (connector instanceof UI) {
-                ((UI) (((ConnectorErrorEvent) event).getConnector())).access(() -> message.show(originError.get()));
+                ((UI) connector).access(() -> message.show(originError.get()));
                 return;
             }
             message.show(originError.get());
             return;
         }
-        // Default
         HawkbitErrorNotificationMessage.show(message.getCaption(), message.getDescription(), Type.HUMANIZED_MESSAGE);
     }
 
@@ -86,10 +83,6 @@ public class HawkbitUIErrorHandler extends DefaultErrorHandler {
 
     protected HawkbitErrorNotificationMessage buildNotification(final Throwable exception) {
         LOG.error("Error in UI: ", exception);
-        return createHawkbitErrorNotificationMessage(exception);
-    }
-
-    protected HawkbitErrorNotificationMessage createHawkbitErrorNotificationMessage(final Throwable exception) {
         final I18N i18n = SpringContextHelper.getBean(I18N.class);
         return new HawkbitErrorNotificationMessage(STYLE, i18n.get("caption.error"),
                 i18n.get("message.error.temp", exception.getClass().getSimpleName()), false);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
@@ -61,13 +61,13 @@ public class HawkbitUIErrorHandler extends DefaultErrorHandler {
         return getRootCauseOf(event.getThrowable());
     }
 
-    private static Throwable getRootCauseOf(final Throwable exception) {
+    private static Throwable getRootCauseOf(final Throwable ex) {
 
-        if (exception.getCause() != null) {
-            return getRootCauseOf(exception.getCause());
+        if (ex.getCause() != null) {
+            return getRootCauseOf(ex.getCause());
         }
 
-        return exception;
+        return ex;
     }
 
     private static Optional<Page> getPageOriginError(final ErrorEvent event) {
@@ -81,15 +81,16 @@ public class HawkbitUIErrorHandler extends DefaultErrorHandler {
         return Optional.absent();
     }
 
-    protected HawkbitErrorNotificationMessage buildNotification(final Throwable exception) {
-        LOG.error("Error in UI: ", exception);
-        return createHawkbitErrorNotificationMessage(exception);
-    }
+    protected HawkbitErrorNotificationMessage buildNotification(final Throwable ex) {
 
-    protected HawkbitErrorNotificationMessage createHawkbitErrorNotificationMessage(final Throwable exception) {
+        log(ex);
+
         final I18N i18n = SpringContextHelper.getBean(I18N.class);
         return new HawkbitErrorNotificationMessage(STYLE, i18n.get("caption.error"),
-                i18n.get("message.error.temp", exception.getClass().getSimpleName()), false);
+                i18n.get("message.error.temp", ex.getClass().getSimpleName()), false);
     }
 
+    protected void log(final Throwable exception) {
+        LOG.error("Error in UI: ", exception);
+    }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
@@ -41,19 +41,22 @@ public class HawkbitUIErrorHandler extends DefaultErrorHandler {
     public void error(final ErrorEvent event) {
 
         final Optional<Page> originError = getPageOriginError(event);
-
         final HawkbitErrorNotificationMessage message = buildNotification(getRootExceptionFrom(event));
 
-        if (originError.isPresent()) {
+        if (!originError.isPresent()) {
+            HawkbitErrorNotificationMessage.show(message.getCaption(), message.getDescription(),
+                    Type.HUMANIZED_MESSAGE);
+            return;
+        }
+
+        if (event instanceof ConnectorErrorEvent) {
             final Connector connector = ((ConnectorErrorEvent) event).getConnector();
             if (connector instanceof UI) {
                 ((UI) connector).access(() -> message.show(originError.get()));
                 return;
             }
-            message.show(originError.get());
-            return;
         }
-        HawkbitErrorNotificationMessage.show(message.getCaption(), message.getDescription(), Type.HUMANIZED_MESSAGE);
+        message.show(originError.get());
     }
 
     private static Throwable getRootExceptionFrom(final ErrorEvent event) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
@@ -46,7 +46,7 @@ public class HawkbitUIErrorHandler extends DefaultErrorHandler {
 
         if (originError.isPresent()) {
             final Connector connector = ((ConnectorErrorEvent) event).getConnector();
-            // in case of BulkUpload: BulkUpload needs a look to show the
+            // in case of BulkUpload: BulkUpload needs a lock to show the
             // notification
             if (connector instanceof UI) {
                 ((UI) (((ConnectorErrorEvent) event).getConnector())).access(() -> message.show(originError.get()));

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/HawkbitUIErrorHandler.java
@@ -23,7 +23,6 @@ import com.vaadin.server.DefaultErrorHandler;
 import com.vaadin.server.ErrorEvent;
 import com.vaadin.server.Page;
 import com.vaadin.shared.Connector;
-import com.vaadin.ui.AbstractComponent;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Notification.Type;
 import com.vaadin.ui.UI;
@@ -47,16 +46,14 @@ public class HawkbitUIErrorHandler extends DefaultErrorHandler {
 
         if (originError.isPresent()) {
             final Connector connector = ((ConnectorErrorEvent) event).getConnector();
-            // in case of BulkUpload
+            // in case of BulkUpload: BulkUpload needs a look to show the
+            // notification
             if (connector instanceof UI) {
                 ((UI) (((ConnectorErrorEvent) event).getConnector())).access(() -> message.show(originError.get()));
                 return;
             }
-            // Other UI components
-            if (connector instanceof AbstractComponent) {
-                ((AbstractComponent) connector).getUI().access(() -> message.show(originError.get()));
-                return;
-            }
+            message.show(originError.get());
+            return;
         }
         // Default
         HawkbitErrorNotificationMessage.show(message.getCaption(), message.getDescription(), Type.HUMANIZED_MESSAGE);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
@@ -100,6 +100,7 @@ public class BulkUploadHandler extends CustomComponent
     final TargetBulkUpdateWindowLayout targetBulkUpdateWindowLayout;
 
     private transient EntityFactory entityFactory;
+    private final UI uiInstance;
 
     /**
      *
@@ -111,8 +112,9 @@ public class BulkUploadHandler extends CustomComponent
      */
     public BulkUploadHandler(final TargetBulkUpdateWindowLayout targetBulkUpdateWindowLayout,
             final TargetManagement targetManagement, final ManagementUIState managementUIState,
-            final DeploymentManagement deploymentManagement, final I18N i18n) {
+            final DeploymentManagement deploymentManagement, final I18N i18n, final UI uiInstance) {
         this.targetBulkUpdateWindowLayout = targetBulkUpdateWindowLayout;
+        this.uiInstance = uiInstance;
         this.comboBox = targetBulkUpdateWindowLayout.getDsNamecomboBox();
         this.descTextArea = targetBulkUpdateWindowLayout.getDescTextArea();
         this.targetManagement = targetManagement;
@@ -213,7 +215,6 @@ public class BulkUploadHandler extends CustomComponent
                  * below event.
                  */
                 eventBus.publish(this, new TargetTableEvent(TargetComponentEvent.BULK_UPLOAD_PROCESS_STARTED));
-
                 while ((line = reader.readLine()) != null) {
                     innerCounter++;
                     readEachLine(line, innerCounter, totalFileSize);
@@ -222,9 +223,7 @@ public class BulkUploadHandler extends CustomComponent
             } catch (final IOException e) {
                 LOG.error("Error reading file {}", tempFile.getName(), e);
             } catch (final RuntimeException e) {
-                if (UI.getCurrent() != null) {
-                    UI.getCurrent().getErrorHandler().error(new com.vaadin.server.ErrorEvent(e));
-                }
+                uiInstance.getErrorHandler().error(new ConnectorErrorEvent(uiInstance, e));
             } finally {
                 deleteFile();
             }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
@@ -52,6 +52,7 @@ import com.vaadin.ui.Label;
 import com.vaadin.ui.Link;
 import com.vaadin.ui.ProgressBar;
 import com.vaadin.ui.TextArea;
+import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.Window;
 import com.vaadin.ui.themes.ValoTheme;
@@ -174,7 +175,7 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
 
     private BulkUploadHandler getBulkUploadHandler() {
         final BulkUploadHandler bulkUploadHandler = new BulkUploadHandler(this, targetManagement, managementUIState,
-                deploymentManagement, i18n);
+                deploymentManagement, i18n, UI.getCurrent());
         bulkUploadHandler.buildLayout();
         bulkUploadHandler.addStyleName(SPUIStyleDefinitions.BULK_UPLOAD_BUTTON);
         return bulkUploadHandler;


### PR DESCRIPTION
Extend the HawkbitUiErrorHandler, so it is possible to show an error notification if it runs in a separate thread. Furthermore the error notification is shown in the appropriate browser window (in case several browser windows are open)

Signed-off-by: Melanie Retter <melanie.retter@bosch-si.com>