### PR TITLE
Removed unnecessary target info startus persistence.

### DIFF
--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
@@ -243,12 +243,16 @@ public class AmqpConfiguration {
 
     /**
      * Create amqp handler service bean.
+     * 
+     * @param amqpMessageDispatcherService
+     *            to sending events to DMF client
      *
      * @return handler service bean
      */
     @Bean
-    public AmqpMessageHandlerService amqpMessageHandlerService() {
-        return new AmqpMessageHandlerService(rabbitTemplate());
+    public AmqpMessageHandlerService amqpMessageHandlerService(
+            final AmqpMessageDispatcherService amqpMessageDispatcherService) {
+        return new AmqpMessageHandlerService(rabbitTemplate(), amqpMessageDispatcherService);
     }
 
     /**

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -386,7 +386,7 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
         final Action action = checkActionExist(message, actionUpdateStatus);
 
         final ActionStatus actionStatus = createActionStatus(message, actionUpdateStatus, action);
-        updateLastPollTime(action);
+        updateLastPollTime(action.getTarget());
 
         switch (actionUpdateStatus.getActionStatus()) {
         case DOWNLOAD:
@@ -424,9 +424,8 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
         }
     }
 
-    private void updateLastPollTime(final Action action) {
-        controllerManagement.updateTargetStatus(action.getTarget().getTargetInfo(), null, System.currentTimeMillis(),
-                null);
+    private void updateLastPollTime(final Target target) {
+        controllerManagement.updateTargetStatus(target.getTargetInfo(), null, System.currentTimeMillis(), null);
     }
 
     private ActionStatus createActionStatus(final Message message, final ActionUpdateStatus actionUpdateStatus,

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpControllerAuthenticationTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpControllerAuthenticationTest.java
@@ -74,7 +74,8 @@ public class AmqpControllerAuthenticationTest {
         messageConverter = new Jackson2JsonMessageConverter();
         final RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
         when(rabbitTemplate.getMessageConverter()).thenReturn(messageConverter);
-        amqpMessageHandlerService = new AmqpMessageHandlerService(rabbitTemplate);
+        amqpMessageHandlerService = new AmqpMessageHandlerService(rabbitTemplate,
+                mock(AmqpMessageDispatcherService.class));
 
         authenticationManager = new AmqpControllerAuthentfication();
         authenticationManager.setControllerManagement(mock(ControllerManagement.class));

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -341,7 +341,7 @@ public class JpaControllerManagement implements ControllerManagement {
         targetInfo.setInstalledDistributionSet(ds);
         targetInfo.setInstallationDate(System.currentTimeMillis());
 
-        // check if the assigned set is equal no to the installed set (not
+        // check if the assigned set is equal to the installed set (not
         // necessarily the case as another update might be pending already).
         if (target.getAssignedDistributionSet() != null && target.getAssignedDistributionSet().getId()
                 .equals(targetInfo.getInstalledDistributionSet().getId())) {


### PR DESCRIPTION
Is actually not needed. Target is at that point of the state machine already in PENDING.


While at it I fixed two problems on the way:
* DMF is not updating last target poll in case of EVENT topic.
* DMF is sending internal DS assignment event duplicated. 

Signed-off-by: Kai Zimmermann <kai.zimmermann@bosch-si.com>