### PR TITLE
Encode filenames.

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/api/PropertyBasedArtifactUrlHandler.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/api/PropertyBasedArtifactUrlHandler.java
@@ -14,11 +14,14 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.eclipse.hawkbit.tenancy.TenantAware;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
+import com.google.common.net.UrlEscapers;
 
 /**
  * Implementation for ArtifactUrlHandler for creating urls to download resource
@@ -27,6 +30,8 @@ import com.google.common.base.Strings;
 @Component
 @EnableConfigurationProperties(ArtifactUrlHandlerProperties.class)
 public class PropertyBasedArtifactUrlHandler implements ArtifactUrlHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PropertyBasedArtifactUrlHandler.class);
 
     private static final String PROTOCOL_PLACEHOLDER = "protocol";
     private static final String TARGET_ID_PLACEHOLDER = "targetId";
@@ -55,8 +60,8 @@ public class PropertyBasedArtifactUrlHandler implements ArtifactUrlHandler {
         }
 
         String urlPattern = properties.getPattern();
-        final Set<Entry<String, String>> entrySet = getReplaceMap(targetId, softwareModuleId, filename, sha1Hash,
-                protocolString, properties).entrySet();
+        final Set<Entry<String, String>> entrySet = getReplaceMap(targetId, softwareModuleId,
+                UrlEscapers.urlFragmentEscaper().escape(filename), sha1Hash, protocolString, properties).entrySet();
         for (final Entry<String, String> entry : entrySet) {
             if (entry.getKey().equals(PORT_PLACEHOLDER)) {
                 urlPattern = urlPattern.replace(":{" + entry.getKey() + "}",
@@ -65,7 +70,9 @@ public class PropertyBasedArtifactUrlHandler implements ArtifactUrlHandler {
                 urlPattern = urlPattern.replace("{" + entry.getKey() + "}", entry.getValue());
             }
         }
+
         return urlPattern;
+
     }
 
     private Map<String, String> getReplaceMap(final String targetId, final Long softwareModuleId, final String filename,


### PR DESCRIPTION
Artefact URLs may contain illegal characters as the filename can be configured by the user and might contain illegal characters (e.g. white spaces).
Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>