### PR TITLE
Fixed DMF sending out wrong message if action on CANCELING

### DIFF
--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DataConversionHelper.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DataConversionHelper.java
@@ -14,6 +14,7 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
@@ -29,7 +30,6 @@ import org.eclipse.hawkbit.ddi.json.model.DdiControllerBase;
 import org.eclipse.hawkbit.ddi.json.model.DdiPolling;
 import org.eclipse.hawkbit.ddi.rest.api.DdiRestConstants;
 import org.eclipse.hawkbit.repository.model.Action;
-import org.eclipse.hawkbit.repository.model.Action.Status;
 import org.eclipse.hawkbit.repository.model.LocalArtifact;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.tenancy.TenantAware;
@@ -108,30 +108,25 @@ public final class DataConversionHelper {
         return file;
     }
 
-    static DdiControllerBase fromTarget(final Target target, final List<Action> actions,
+    static DdiControllerBase fromTarget(final Target target, final Optional<Action> action,
             final String defaultControllerPollTime, final TenantAware tenantAware) {
         final DdiControllerBase result = new DdiControllerBase(
                 new DdiConfig(new DdiPolling(defaultControllerPollTime)));
 
-        boolean addedUpdate = false;
-        boolean addedCancel = false;
-        final long countCancelingActions = actions.stream().filter(a -> a.getStatus() == Status.CANCELING).count();
-        for (final Action action : actions) {
-            if (countCancelingActions <= 0 && !action.isCancelingOrCanceled() && !addedUpdate) {
+        if (action.isPresent()) {
+            if (action.get().isCancelingOrCanceled()) {
+                result.add(linkTo(methodOn(DdiRootController.class, tenantAware.getCurrentTenant())
+                        .getControllerCancelAction(target.getControllerId(), action.get().getId()))
+                                .withRel(DdiRestConstants.CANCEL_ACTION));
+            } else {
                 // we need to add the hashcode here of the actionWithStatus
                 // because the action might
                 // have changed from 'soft' to 'forced' type and we need to
                 // change the payload of the
                 // response because of eTags.
                 result.add(linkTo(methodOn(DdiRootController.class, tenantAware.getCurrentTenant())
-                        .getControllerBasedeploymentAction(target.getControllerId(), action.getId(),
-                                calculateEtag(action))).withRel(DdiRestConstants.DEPLOYMENT_BASE_ACTION));
-                addedUpdate = true;
-            } else if (action.isCancelingOrCanceled() && !addedCancel) {
-                result.add(linkTo(methodOn(DdiRootController.class, tenantAware.getCurrentTenant())
-                        .getControllerCancelAction(target.getControllerId(), action.getId()))
-                                .withRel(DdiRestConstants.CANCEL_ACTION));
-                addedCancel = true;
+                        .getControllerBasedeploymentAction(target.getControllerId(), action.get().getId(),
+                                calculateEtag(action.get()))).withRel(DdiRestConstants.DEPLOYMENT_BASE_ACTION));
             }
         }
 

--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -130,7 +130,7 @@ public class DdiRootController implements DdiRootControllerRestApi {
         }
 
         return new ResponseEntity<>(
-                DataConversionHelper.fromTarget(target, controllerManagement.findActionByTargetAndActive(target),
+                DataConversionHelper.fromTarget(target, controllerManagement.findOldestActionByTargetAndActive(target),
                         controllerManagement.getPollingTime(), tenantAware),
                 HttpStatus.OK);
     }

--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -130,7 +130,7 @@ public class DdiRootController implements DdiRootControllerRestApi {
         }
 
         return new ResponseEntity<>(
-                DataConversionHelper.fromTarget(target, controllerManagement.findOldestActionByTargetAndActive(target),
+                DataConversionHelper.fromTarget(target, controllerManagement.findOldestActiveActionByTarget(target),
                         controllerManagement.getPollingTime(), tenantAware),
                 HttpStatus.OK);
     }

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -346,7 +346,7 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
     }
 
     private void lookIfUpdateAvailable(final Target target) {
-        final Optional<Action> action = controllerManagement.findOldestActionByTargetAndActive(target);
+        final Optional<Action> action = controllerManagement.findOldestActiveActionByTarget(target);
         if (!action.isPresent()) {
             return;
         }

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.hawkbit.api.HostnameResolver;
 import org.eclipse.hawkbit.artifact.repository.ArtifactRepository;
@@ -155,6 +156,7 @@ public class AmqpMessageHandlerServiceTest {
         final ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
         when(controllerManagementMock.findOrRegisterTargetIfItDoesNotexist(targetIdCaptor.capture(),
                 uriCaptor.capture())).thenReturn(null);
+        when(controllerManagementMock.findOldestActionByTargetAndActive(Matchers.any())).thenReturn(Optional.empty());
 
         amqpMessageHandlerService.onMessage(message, MessageType.THING_CREATED.name(), TENANT, "vHost");
 
@@ -362,9 +364,8 @@ public class AmqpMessageHandlerServiceTest {
         when(controllerManagementMock.addUpdateActionStatus(Matchers.any())).thenReturn(action);
         when(entityFactoryMock.generateActionStatus()).thenReturn(new JpaActionStatus());
         // for the test the same action can be used
-        final List<Action> actionList = new ArrayList<>();
-        actionList.add(action);
-        when(controllerManagementMock.findActionByTargetAndActive(Matchers.any())).thenReturn(actionList);
+        when(controllerManagementMock.findOldestActionByTargetAndActive(Matchers.any()))
+                .thenReturn(Optional.of(action));
 
         final List<SoftwareModule> softwareModuleList = createSoftwareModuleList();
         when(controllerManagementMock.findSoftwareModulesByDistributionSet(Matchers.any()))

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -156,7 +156,7 @@ public class AmqpMessageHandlerServiceTest {
         final ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
         when(controllerManagementMock.findOrRegisterTargetIfItDoesNotexist(targetIdCaptor.capture(),
                 uriCaptor.capture())).thenReturn(null);
-        when(controllerManagementMock.findOldestActionByTargetAndActive(Matchers.any())).thenReturn(Optional.empty());
+        when(controllerManagementMock.findOldestActiveActionByTarget(Matchers.any())).thenReturn(Optional.empty());
 
         amqpMessageHandlerService.onMessage(message, MessageType.THING_CREATED.name(), TENANT, "vHost");
 
@@ -364,7 +364,7 @@ public class AmqpMessageHandlerServiceTest {
         when(controllerManagementMock.addUpdateActionStatus(Matchers.any())).thenReturn(action);
         when(entityFactoryMock.generateActionStatus()).thenReturn(new JpaActionStatus());
         // for the test the same action can be used
-        when(controllerManagementMock.findOldestActionByTargetAndActive(Matchers.any()))
+        when(controllerManagementMock.findOldestActiveActionByTarget(Matchers.any()))
                 .thenReturn(Optional.of(action));
 
         final List<SoftwareModule> softwareModuleList = createSoftwareModuleList();

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.repository;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.validation.constraints.NotNull;
 
@@ -112,6 +113,17 @@ public interface ControllerManagement {
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
     List<Action> findActionByTargetAndActive(@NotNull Target target);
+
+    /**
+     * Retrieves oldest {@link Action} that is active and assigned to a
+     * {@link Target}.
+     *
+     * @param target
+     *            the target to retrieve the actions from
+     * @return a list of actions assigned to given target which are active
+     */
+    @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
+    Optional<Action> findOldestActionByTargetAndActive(@NotNull Target target);
 
     /**
      * Get the {@link Action} entity for given actionId with all lazy

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -112,7 +112,7 @@ public interface ControllerManagement {
      * @return a list of actions assigned to given target which are active
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    List<Action> findActionByTargetAndActive(@NotNull Target target);
+    List<Action> findActiveActionByTarget(@NotNull Target target);
 
     /**
      * Retrieves oldest {@link Action} that is active and assigned to a
@@ -123,7 +123,7 @@ public interface ControllerManagement {
      * @return a list of actions assigned to given target which are active
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    Optional<Action> findOldestActionByTargetAndActive(@NotNull Target target);
+    Optional<Action> findOldestActiveActionByTarget(@NotNull Target target);
 
     /**
      * Get the {@link Action} entity for given actionId with all lazy

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.jpa;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet;
@@ -79,20 +80,30 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
     Slice<Action> findByTarget(Pageable pageable, JpaTarget target);
 
     /**
-     * Retrieves all {@link Action}s which are active and referring the given
-     * {@link Target} in a specified order. Loads also the lazy
-     * {@link Action#getDistributionSet()} field.
+     * Retrieves all {@link Action}s which are active and referring to the given
+     * {@link Target} order by ID ascending.
      *
-     * @param pageable
-     *            page parameters
      * @param target
      *            the target to find assigned actions
      * @param active
      *            the action active flag
      * @return the found {@link Action}s
      */
-    @EntityGraph(value = "Action.ds", type = EntityGraphType.LOAD)
     List<Action> findByTargetAndActiveOrderByIdAsc(final JpaTarget target, boolean active);
+
+    /**
+     * Retrieves the oldest {@link Action} that is active and referring to the
+     * given {@link Target}.
+     *
+     * @param target
+     *            the target to find assigned actions
+     * @param active
+     *            the action active flag
+     * 
+     * @return the found {@link Action}
+     */
+    @EntityGraph(value = "Action.ds", type = EntityGraphType.LOAD)
+    Optional<Action> findFirstByTargetAndActiveOrderByIdAsc(final JpaTarget target, boolean active);
 
     /**
      * Retrieves latest {@link UpdateAction} for given target and

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -157,12 +157,12 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    public List<Action> findActionByTargetAndActive(final Target target) {
+    public List<Action> findActiveActionByTarget(final Target target) {
         return actionRepository.findByTargetAndActiveOrderByIdAsc((JpaTarget) target, true);
     }
 
     @Override
-    public Optional<Action> findOldestActionByTargetAndActive(final Target target) {
+    public Optional<Action> findOldestActiveActionByTarget(final Target target) {
         return actionRepository.findFirstByTargetAndActiveOrderByIdAsc((JpaTarget) target, true);
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -12,6 +12,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -158,6 +159,11 @@ public class JpaControllerManagement implements ControllerManagement {
     @Override
     public List<Action> findActionByTargetAndActive(final Target target) {
         return actionRepository.findByTargetAndActiveOrderByIdAsc((JpaTarget) target, true);
+    }
+
+    @Override
+    public Optional<Action> findOldestActionByTargetAndActive(final Target target) {
+        return actionRepository.findFirstByTargetAndActiveOrderByIdAsc((JpaTarget) target, true);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
       <org.powermock.version>1.5.4</org.powermock.version>
       <pl.pragmatists.version>1.0.2</pl.pragmatists.version>
       <guava.version>19.0</guava.version>
-      <mariadb-java-client.version>1.4.3</mariadb-java-client.version>
+      <mariadb-java-client.version>1.5.2</mariadb-java-client.version>
       <embedded-mongo.version>1.50.5</embedded-mongo.version>
       <javax.el-api.version>2.2.4</javax.el-api.version>
       <corn-cps.version>1.1.7</corn-cps.version>


### PR DESCRIPTION
DMF is sending out an UPDATE message even when the action is on CANCELING. Fixes this.

While at it I also optimised the same functionality in DDI by means of letting the database filtering out the oldest action instead of getting all active actions and let the JVM filter them. Upgrade to newest MariaDB driver was done as well.

Signed-off-by: Kai Zimmermann <kai.zimmermann@bosch-si.com>