### PR TITLE
Insert new constants for UI components

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/CreateUpdateDistSetTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/CreateUpdateDistSetTypeLayout.java
@@ -26,6 +26,7 @@ import org.eclipse.hawkbit.ui.distributions.event.DistributionSetTypeEvent;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionSetTypeEvent.DistributionSetTypeEnum;
 import org.eclipse.hawkbit.ui.layouts.CreateUpdateTypeLayout;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.SPUIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -130,8 +131,8 @@ public class CreateUpdateDistSetTypeLayout extends CreateUpdateTypeLayout<Distri
         buildSelectedTable();
 
         final VerticalLayout selectButtonLayout = new VerticalLayout();
-        final Button selectButton = SPUIComponentProvider.getButton("select-dist-type", "", "", "arrow-button", true,
-                FontAwesome.FORWARD, SPUIButtonStyleSmallNoBorder.class);
+        final Button selectButton = SPUIComponentProvider.getButton(SPUIComponentIdProvider.SELECT_DIST_TYPE, "", "",
+                "arrow-button", true, FontAwesome.FORWARD, SPUIButtonStyleSmallNoBorder.class);
         selectButton.addClickListener(event -> addSMType());
         final Button unSelectButton = SPUIComponentProvider.getButton("unselect-dist-type", "", "", "arrow-button",
                 true, FontAwesome.BACKWARD, SPUIButtonStyleSmallNoBorder.class);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
@@ -100,7 +100,7 @@ public class DistributionSetTableHeader extends AbstractTableHeader {
 
     @Override
     protected String getShowFilterButtonLayoutId() {
-        return "show.dist.tags.icon";
+        return SPUIComponentIdProvider.SHOW_DIST_TAG_ICON;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CreateOrUpdateFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CreateOrUpdateFilterHeader.java
@@ -444,8 +444,9 @@ public class CreateOrUpdateFilterHeader extends VerticalLayout implements Button
     }
 
     private SPUIButton createSearchResetIcon() {
-        final SPUIButton button = (SPUIButton) SPUIComponentProvider.getButton("create.custom.filter.close.Id", "", "",
-                null, false, FontAwesome.TIMES, SPUIButtonStyleSmallNoBorder.class);
+        final SPUIButton button = (SPUIButton) SPUIComponentProvider.getButton(
+                SPUIComponentIdProvider.CUSTOM_FILTER_CLOSE, "", "", null, false, FontAwesome.TIMES,
+                SPUIButtonStyleSmallNoBorder.class);
         button.addClickListener(event -> closeFilterLayout());
         return button;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterHeader.java
@@ -120,7 +120,7 @@ public class TargetFilterHeader extends VerticalLayout {
     }
 
     private TextField createSearchField() {
-        final TextField campSearchTextField = new TextFieldBuilder("target.filter.search.text.Id")
+        final TextField campSearchTextField = new TextFieldBuilder(SPUIComponentIdProvider.TARGET_FILTER_SEARCH_TEXT)
                 .createSearchField(event -> searchBy(event.getText()));
         campSearchTextField.setWidth(500.0F, Unit.PIXELS);
         return campSearchTextField;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterTable.java
@@ -94,7 +94,7 @@ public class TargetFilterTable extends Table {
         populateTableData();
         setColumnCollapsingAllowed(true);
         setColumnProperties();
-        setId(SPUIComponentIdProvider.TAEGET_FILTER_TABLE_ID);
+        setId(SPUIComponentIdProvider.TARGET_FILTER_TABLE_ID);
         eventBus.subscribe(this);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTableHeader.java
@@ -102,7 +102,7 @@ public class DistributionTableHeader extends AbstractTableHeader {
 
     @Override
     protected String getShowFilterButtonLayoutId() {
-        return "show.dist.tags.icon";
+        return SPUIComponentIdProvider.SHOW_DIST_TAG_ICON;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/ActionTypeOptionGroupLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/ActionTypeOptionGroupLayout.java
@@ -113,7 +113,7 @@ public class ActionTypeOptionGroupLayout extends HorizontalLayout {
                 .getItemComponent(ActionTypeOption.AUTO_FORCED);
         autoForceItem.setStyleName(STYLE_DIST_WINDOW_ACTIONTYPE);
         // setted Id for Time Forced radio button.
-        autoForceItem.setId("save.action.radio.timeforced");
+        autoForceItem.setId(SPUIComponentIdProvider.ACTION_TYPE_OPTION_GROUP_SAVE_TIMEFORCED);
         addComponent(autoForceItem);
         final Label autoForceLabel = new Label();
         autoForceLabel.setStyleName("statusIconPending");

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
@@ -398,7 +398,7 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
         pinBtn.setStyleName(pinBtnStyle.toString());
         pinBtn.setHeightUndefined();
         pinBtn.setData(itemId);
-        pinBtn.setId(SPUIComponentIdProvider.TARGET_PIN_ICON + "." + itemId);
+        pinBtn.setId(SPUIComponentIdProvider.TARGET_PIN_ICON + itemId);
         pinBtn.addClickListener(this::addPinClickListener);
         if (isPinned(((TargetIdName) itemId).getControllerId())) {
             pinBtn.addStyleName(TARGET_PINNED);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/AuthenticationConfigurationView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/AuthenticationConfigurationView.java
@@ -17,6 +17,7 @@ import org.eclipse.hawkbit.ui.tenantconfiguration.authentication.CertificateAuth
 import org.eclipse.hawkbit.ui.tenantconfiguration.authentication.GatewaySecurityTokenAuthenticationConfigurationItem;
 import org.eclipse.hawkbit.ui.tenantconfiguration.authentication.TargetSecurityTokenAuthenticationConfigurationItem;
 import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.SPUIComponentIdProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.vaadin.data.Property.ValueChangeEvent;
@@ -112,7 +113,7 @@ public class AuthenticationConfigurationView extends BaseConfigurationView
         gridLayout.addComponent(gatewaySecurityTokenAuthenticationConfigurationItem, 1, 2);
 
         downloadAnonymousCheckBox = SPUIComponentProvider.getCheckBox("", DIST_CHECKBOX_STYLE, null, false, "");
-        downloadAnonymousCheckBox.setId("downloadanonymouscheckbox");
+        downloadAnonymousCheckBox.setId(SPUIComponentIdProvider.DOWNLOAD_ANONYMOUS_CHECKBOX);
         downloadAnonymousCheckBox.setValue(anonymousDownloadAuthenticationConfigurationItem.isConfigEnabled());
         downloadAnonymousCheckBox.addValueChangeListener(this);
         anonymousDownloadAuthenticationConfigurationItem.addChangeListener(this);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIComponentIdProvider.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIComponentIdProvider.java
@@ -314,6 +314,11 @@ public final class SPUIComponentIdProvider {
     public static final String ACTION_HISTORY_TABLE_FORCE_QUIT_ID = "action.history.table.action.force.quit";
 
     /**
+     * ID for option group save timeforced
+     */
+    public static final String ACTION_TYPE_OPTION_GROUP_SAVE_TIMEFORCED = "save.action.radio.timeforced";
+
+    /**
      * Target filter wrapper id.
      */
     public static final String TARGET_FILTER_WRAPPER_ID = "target-drop-filter";
@@ -735,9 +740,19 @@ public final class SPUIComponentIdProvider {
     public static final String CUSTOM_TARGET_TAG_TABLE_ID = "custom.target.tag.tableId";
 
     /**
+     * ID for closing custom filter
+     */
+    public static final String CUSTOM_FILTER_CLOSE = "create.custom.filter.close.Id";
+
+    /**
+     * ID for custom filter query text
+     */
+    public static final String CUSTOM_FILTER_QUERY = "custom.query.text.Id";
+
+    /**
      * Target filter table id.
      */
-    public static final String TAEGET_FILTER_TABLE_ID = "target.query.filter.table.Id";
+    public static final String TARGET_FILTER_TABLE_ID = "target.query.filter.table.Id";
 
     /**
      * create or update target filter query - name label id.
@@ -962,17 +977,16 @@ public final class SPUIComponentIdProvider {
      */
     public static final String UPLOAD_STATUS_POPUP_ID = "artifact.upload.status.popup.id";
 
- /**
+    /**
      * Software module table - Manage metadata id.
      */
     public static final String SW_TABLE_MANAGE_METADATA_ID = "swtable.manage.metadata.id";
-    
-    
+
     /**
      * Metadata key id.
      */
     public static final String METADATA_KEY_FIELD_ID = "metadata.key.id";
-    
+
     /**
      * Metadata value id.
      */
@@ -981,12 +995,12 @@ public final class SPUIComponentIdProvider {
      * Metadata save id.
      */
     public static final String METADTA_SAVE_ICON_ID = "metadata.save.icon.id";
-    
+
     /**
      * Metadata discard id.
      */
     public static final String METADTA_DISCARD_ICON_ID = "metadata.discard.icon.id";
-    
+
     /**
      * Metadata add icon id.
      */
@@ -995,41 +1009,45 @@ public final class SPUIComponentIdProvider {
      * Metadata table id.
      */
     public static final String METDATA_TABLE_ID = "metadata.table.id";
-    
+
     /**
      * Distribution set table - Manage metadata id.
      */
     public static final String DS_TABLE_MANAGE_METADATA_ID = "dstable.manage.metadata.id";
-    
-   /**
+
+    /**
      * DistributionSet - Metadata button id.
      */
     public static final String DS_METADATA_DETAIL_LINK = "distributionset.metadata.detail.link";
-    
+
     /**
      * Metadata popup id.
      */
     public static final String METADATA_POPUP_ID = "metadata.popup.id";
-    
+
     /**
      * DistributionSet table details tab id in Distributions .
      */
     public static final String DISTRIBUTIONSET_DETAILS_TABSHEET_ID = "distributionset.details.tabsheet";
-    
+
     /**
      * Software module table details tab id in Distributions .
      */
     public static final String DIST_SW_MODULE_DETAILS_TABSHEET_ID = "dist.sw.module.details.tabsheet";
-    
+
     /**
      * Software Module - Metadata button id.
      */
     public static final String SW_METADATA_DETAIL_LINK = "softwaremodule.metadata.detail.link";
-    
+
     /**
      * Table multiselect for selecting DistType
      */
     public static final String SELECT_DIST_TYPE = "select-dist-type";
+    /**
+     * ID for download anonymous checkbox
+     */
+    public static final String DOWNLOAD_ANONYMOUS_CHECKBOX = "downloadanonymouscheckbox";
 
     /**
      * /* Private Constructor.

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIComponentIdProvider.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIComponentIdProvider.java
@@ -68,7 +68,7 @@ public final class SPUIComponentIdProvider {
     /**
      * ID-Targ.PIN.
      */
-    public static final String TARGET_PIN_ICON = "target.pin.icon";
+    public static final String TARGET_PIN_ICON = "target.pin.icon.";
 
     /**
      * Target search text id.

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIComponentIdProvider.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIComponentIdProvider.java
@@ -76,6 +76,11 @@ public final class SPUIComponentIdProvider {
     public static final String TARGET_TEXT_FIELD = "target.search.textfield";
 
     /**
+     * ID for target filter search
+     */
+    public static final String TARGET_FILTER_SEARCH_TEXT = "target.filter.search.text.Id";
+
+    /**
      * ID for add target filter icon
      */
     public static final String TARGET_FILTER_ADD_ICON_ID = "target.filter.add.id";
@@ -184,6 +189,11 @@ public final class SPUIComponentIdProvider {
      * ID-Dist.PIN.
      */
     public static final String DIST_PIN_BUTTON = "dist.pin.button";
+
+    /**
+     * ID for distribution set tag icon
+     */
+    public static final String SHOW_DIST_TAG_ICON = "show.dist.tags.icon";
     /**
      * ID - soft.module.name.
      */


### PR DESCRIPTION
The ID of the UI components should be stored in a constant for reusing purpose. Missing constants were added and remaining string values were substituted for constants.