### PR TITLE
don't requeue too many status entries ex, fix typo of ex

### DIFF
--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -41,7 +41,7 @@ import org.eclipse.hawkbit.repository.RepositoryConstants;
 import org.eclipse.hawkbit.repository.eventbus.event.TargetAssignDistributionSetEvent;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.TenantNotExistException;
-import org.eclipse.hawkbit.repository.exception.ToManyStatusEntriesException;
+import org.eclipse.hawkbit.repository.exception.TooManyStatusEntriesException;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
@@ -155,7 +155,7 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
             return handleAuthentifiactionMessage(message);
         } catch (final IllegalArgumentException ex) {
             throw new AmqpRejectAndDontRequeueException("Invalid message!", ex);
-        } catch (final TenantNotExistException | ToManyStatusEntriesException e) {
+        } catch (final TenantNotExistException | TooManyStatusEntriesException e) {
             throw new AmqpRejectAndDontRequeueException(e);
         } finally {
             SecurityContextHolder.setContext(oldContext);
@@ -196,8 +196,8 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
             }
         } catch (final IllegalArgumentException ex) {
             throw new AmqpRejectAndDontRequeueException("Invalid message!", ex);
-        } catch (final TenantNotExistException teex) {
-            throw new AmqpRejectAndDontRequeueException(teex);
+        } catch (final TenantNotExistException | TooManyStatusEntriesException e) {
+            throw new AmqpRejectAndDontRequeueException(e);
         } finally {
             SecurityContextHolder.setContext(oldContext);
         }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -19,7 +19,7 @@ import org.eclipse.hawkbit.repository.eventbus.event.DownloadProgressEvent;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.ToManyAttributeEntriesException;
-import org.eclipse.hawkbit.repository.exception.ToManyStatusEntriesException;
+import org.eclipse.hawkbit.repository.exception.TooManyStatusEntriesException;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
@@ -95,7 +95,7 @@ public interface ControllerManagement {
      *
      * @throws EntityAlreadyExistsException
      *             if a given entity already exists
-     * @throws ToManyStatusEntriesException
+     * @throws TooManyStatusEntriesException
      *             if more than the allowed number of status entries are
      *             inserted
      */

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/TooManyStatusEntriesException.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/TooManyStatusEntriesException.java
@@ -18,7 +18,7 @@ import org.eclipse.hawkbit.exception.AbstractServerRtException;
  *
  *
  */
-public final class ToManyStatusEntriesException extends AbstractServerRtException {
+public final class TooManyStatusEntriesException extends AbstractServerRtException {
     /**
     *
     */
@@ -28,7 +28,7 @@ public final class ToManyStatusEntriesException extends AbstractServerRtExceptio
      * Creates a new FileUploadFailedException with
      * {@link SpServerError#SP_REST_BODY_NOT_READABLE} error.
      */
-    public ToManyStatusEntriesException() {
+    public TooManyStatusEntriesException() {
         super(SpServerError.SP_ACTION_STATUS_TO_MANY_ENTRIES);
     }
 
@@ -36,7 +36,7 @@ public final class ToManyStatusEntriesException extends AbstractServerRtExceptio
      * @param cause
      *            for the exception
      */
-    public ToManyStatusEntriesException(final Throwable cause) {
+    public TooManyStatusEntriesException(final Throwable cause) {
         super(SpServerError.SP_ACTION_STATUS_TO_MANY_ENTRIES, cause);
     }
 
@@ -44,7 +44,7 @@ public final class ToManyStatusEntriesException extends AbstractServerRtExceptio
      * @param message
      *            of the error
      */
-    public ToManyStatusEntriesException(final String message) {
+    public TooManyStatusEntriesException(final String message) {
         super(message, SpServerError.SP_ACTION_STATUS_TO_MANY_ENTRIES);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -26,7 +26,7 @@ import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.ToManyAttributeEntriesException;
-import org.eclipse.hawkbit.repository.exception.ToManyStatusEntriesException;
+import org.eclipse.hawkbit.repository.exception.TooManyStatusEntriesException;
 import org.eclipse.hawkbit.repository.jpa.cache.CacheWriteNotify;
 import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
 import org.eclipse.hawkbit.repository.jpa.model.JpaActionStatus;
@@ -326,7 +326,7 @@ public class JpaControllerManagement implements ControllerManagement {
                 LOG_DOS.error(
                         "Potential denial of service (DOS) attack identfied. More status entries in the system than permitted ({})!",
                         securityProperties.getDos().getMaxStatusEntriesPerAction());
-                throw new ToManyStatusEntriesException(
+                throw new TooManyStatusEntriesException(
                         String.valueOf(securityProperties.getDos().getMaxStatusEntriesPerAction()));
             }
         }


### PR DESCRIPTION
* Fix typo of `TooManyStatusEntriesException`
* don't requeue `TooManyStatusEntriesException` back to RabbitMQ due a circle.


Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>