### PR TITLE
use security-props for retrieving spring user configuration

### DIFF
--- a/examples/hawkbit-example-app/src/main/resources/application.properties
+++ b/examples/hawkbit-example-app/src/main/resources/application.properties
@@ -7,6 +7,10 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #
 
+# User Security
+security.user.name=admin
+security.user.password=admin
+
 # DDI authentication configuration
 hawkbit.server.ddi.security.authentication.anonymous.enabled=true
 hawkbit.server.ddi.security.authentication.targettoken.enabled=true

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/InMemoryUserManagementConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/InMemoryUserManagementConfiguration.java
@@ -13,7 +13,9 @@ import java.util.ArrayList;
 import org.eclipse.hawkbit.im.authentication.MultitenancyIndicator;
 import org.eclipse.hawkbit.im.authentication.PermissionUtils;
 import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -34,6 +36,9 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 @ConditionalOnMissingBean(UserDetailsService.class)
 public class InMemoryUserManagementConfiguration extends GlobalAuthenticationConfigurerAdapter {
 
+    @Autowired
+    private SecurityProperties securityProperties;
+
     @Override
     public void configure(final AuthenticationManagerBuilder auth) throws Exception {
         final DaoAuthenticationProvider userDaoAuthenticationProvider = new TenantDaoAuthenticationProvider();
@@ -49,7 +54,8 @@ public class InMemoryUserManagementConfiguration extends GlobalAuthenticationCon
     public UserDetailsService userDetailsService() {
         final InMemoryUserDetailsManager inMemoryUserDetailsManager = new InMemoryUserDetailsManager(new ArrayList<>());
         inMemoryUserDetailsManager.setAuthenticationManager(null);
-        inMemoryUserDetailsManager.createUser(new User("admin", "admin", PermissionUtils.createAllAuthorityList()));
+        inMemoryUserDetailsManager.createUser(new User(securityProperties.getUser().getName(),
+                securityProperties.getUser().getPassword(), PermissionUtils.createAllAuthorityList()));
         return inMemoryUserDetailsManager;
     }
 


### PR DESCRIPTION
* make use of the spring-security-configuration to remove the hard-coded username and password `admin` and allow to configure the user and password by using spring.
`security.user.name` and `security.user.password`

* Configuration added to example app to use `admin` user again


Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>