### PR TITLE
Feature multi known hashes for issuer hash based auth

### DIFF
--- a/hawkbit-http-security/src/test/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProviderTest.java
+++ b/hawkbit-http-security/src/test/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProviderTest.java
@@ -21,6 +21,8 @@ import org.springframework.security.authentication.InsufficientAuthenticationExc
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
+import com.google.common.collect.Lists;
+
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Stories;
@@ -45,8 +47,8 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
     public void principalAndCredentialsNotTheSameThrowsAuthenticationException() {
         final String principal = "controllerIdURL";
         final String credentials = "controllerIdHeader";
-        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                credentials);
+        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(
+                principal, Lists.newArrayList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
         // test, should throw authentication exception
@@ -64,11 +66,12 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
     public void principalAndCredentialsAreTheSameWithNoSourceIpCheckIsSuccessful() {
         final String principal = "controllerId";
         final String credentials = "controllerId";
-        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                credentials);
+        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(
+                principal, Lists.newArrayList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
-        final Authentication authenticate = underTestWithoutSourceIpCheck.authenticate(token);
+        final Authentication authenticate = underTestWithoutSourceIpCheck
+                .authenticate(token);
         assertThat(authenticate.isAuthenticated()).isTrue();
     }
 
@@ -78,8 +81,8 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
         final String remoteAddress = "192.168.1.1";
         final String principal = "controllerId";
         final String credentials = "controllerId";
-        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                credentials);
+        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(
+                principal, Lists.newArrayList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
         when(webAuthenticationDetailsMock.getRemoteAddress()).thenReturn(remoteAddress);
@@ -99,14 +102,15 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
     public void priniciapAndCredentialsAreTheSameAndSourceIpIsTrusted() {
         final String principal = "controllerId";
         final String credentials = "controllerId";
-        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                credentials);
+        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(
+                principal, Lists.newArrayList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
         when(webAuthenticationDetailsMock.getRemoteAddress()).thenReturn(REQUEST_SOURCE_IP);
 
         // test, should throw authentication exception
-        final Authentication authenticate = underTestWithSourceIpCheck.authenticate(token);
+        final Authentication authenticate = underTestWithSourceIpCheck
+                .authenticate(token);
         assertThat(authenticate.isAuthenticated()).isTrue();
     }
 
@@ -116,8 +120,8 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
                 "192.168.1.3" };
         final String principal = "controllerId";
         final String credentials = "controllerId";
-        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                credentials);
+        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(
+                principal, Lists.newArrayList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
         when(webAuthenticationDetailsMock.getRemoteAddress()).thenReturn(REQUEST_SOURCE_IP);
@@ -135,8 +139,8 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
         final String[] trustedIPAddresses = new String[] { "192.168.1.1", "192.168.1.2", "192.168.1.3" };
         final String principal = "controllerId";
         final String credentials = "controllerId";
-        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                credentials);
+        final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(
+                principal, Lists.newArrayList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
         when(webAuthenticationDetailsMock.getRemoteAddress()).thenReturn(REQUEST_SOURCE_IP);

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/AbstractControllerAuthenticationFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/AbstractControllerAuthenticationFilter.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 /**
  * An abstraction for all controller based security. Check if the tenant
  * configuration is enabled.
- * 
+ *
  *
  *
  */
@@ -50,7 +50,7 @@ public abstract class AbstractControllerAuthenticationFilter implements PreAuthe
     public abstract HeaderAuthentication getPreAuthenticatedPrincipal(TenantSecurityToken secruityToken);
 
     @Override
-    public abstract HeaderAuthentication getPreAuthenticatedCredentials(TenantSecurityToken secruityToken);
+    public abstract Object getPreAuthenticatedCredentials(TenantSecurityToken secruityToken);
 
     private final class SecurityConfigurationKeyTenantRunner implements TenantAware.TenantRunner<Boolean> {
         @Override

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/AbstractControllerAuthenticationFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/AbstractControllerAuthenticationFilter.java
@@ -46,12 +46,6 @@ public abstract class AbstractControllerAuthenticationFilter implements PreAuthe
         return tenantAware.runAsTenant(secruityToken.getTenant(), configurationKeyTenantRunner);
     }
 
-    @Override
-    public abstract Object getPreAuthenticatedPrincipal(TenantSecurityToken secruityToken);
-
-    @Override
-    public abstract Object getPreAuthenticatedCredentials(TenantSecurityToken secruityToken);
-
     private final class SecurityConfigurationKeyTenantRunner implements TenantAware.TenantRunner<Boolean> {
         @Override
         public Boolean run() {

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/AbstractControllerAuthenticationFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/AbstractControllerAuthenticationFilter.java
@@ -47,7 +47,7 @@ public abstract class AbstractControllerAuthenticationFilter implements PreAuthe
     }
 
     @Override
-    public abstract HeaderAuthentication getPreAuthenticatedPrincipal(TenantSecurityToken secruityToken);
+    public abstract Object getPreAuthenticatedPrincipal(TenantSecurityToken secruityToken);
 
     @Override
     public abstract Object getPreAuthenticatedCredentials(TenantSecurityToken secruityToken);

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilter.java
@@ -20,6 +20,8 @@ import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Sets;
+
 /**
  * An pre-authenticated processing filter which extracts the principal from a
  * request URI and the credential from a request header in a the
@@ -113,7 +115,7 @@ public class ControllerPreAuthenticatedSecurityHeaderFilter extends AbstractCont
 
         List<String> knownHashes = splitMultiHash(authorityNameConfigurationValue);
 
-        Set<HeaderAuthentication> multiHashes = new HashSet<>();
+        Set<HeaderAuthentication> multiHashes = Sets.newHashSetWithExpectedSize(knownHashes.size());
         final String cntlId = controllerId;
         knownHashes.forEach(hashItem -> multiHashes.add(new HeaderAuthentication(cntlId, hashItem)));
         return multiHashes;

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilter.java
@@ -9,7 +9,6 @@
 package org.eclipse.hawkbit.security;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilter.java
@@ -77,7 +77,7 @@ public class ControllerPreAuthenticatedSecurityHeaderFilter extends AbstractCont
     }
 
     @Override
-    public Object getPreAuthenticatedPrincipal(final TenantSecurityToken secruityToken) {
+    public HeaderAuthentication getPreAuthenticatedPrincipal(final TenantSecurityToken secruityToken) {
         // retrieve the common name header and the authority name header from
         // the http request and combine them together
         final String commonNameValue = secruityToken.getHeader(caCommonNameHeader);

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProvider.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProvider.java
@@ -123,14 +123,18 @@ public class PreAuthTokenSourceTrustAuthenticationProvider implements Authentica
      * certificate.
      *
      * @param principal
+     *            the {@link HeaderAuthentication} from the header
      * @param credentials
+     *            a single {@link HeaderAuthentication} or a Collection of
+     *            HeaderAuthentication
      * @param tokenDetails
+     *            authentication details
      * @return <code>true</code> if authentication succeeded, otherwise
      *         <code>false</code>
      */
     private boolean calculateAuthenticationSuccess(Object principal, Object credentials, Object tokenDetails) {
         boolean successAuthentication = false;
-        if (Collection.class.isAssignableFrom(credentials.getClass())) {
+        if (credentials instanceof Collection) {
             final Collection<?> multiValueCredentials = (Collection<?>) credentials;
             if (multiValueCredentials.contains(principal)) {
                 successAuthentication = checkSourceIPAddressIfNeccessary(tokenDetails);

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProvider.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProvider.java
@@ -110,34 +110,35 @@ public class PreAuthTokenSourceTrustAuthenticationProvider implements Authentica
 
         throw new BadCredentialsException("The provided principal and credentials are not match");
     }
-    
+
 	/**
-	 * 
-	 * The credentials may either be of type HeaderAuthentication or of type
-	 * Collection<HeaderAuthentication> depending on the authentication mode in
-	 * use (the latter is used in case of trusted reverse-proxy). It is checked
-	 * whether principal equals credentials (respectively if credentials
-	 * contains principal in case of collection) because we want to check if
-	 * e.g. controllerId containing in the URL equals the controllerId in the
-	 * special header set by the reverse-proxy which extracted the CN from the
-	 * certificate.
-	 * 
-	 * @param principal
-	 * @param credentials
-	 * @param tokenDetails
-	 * @return
-	 */
+     *
+     * The credentials may either be of type HeaderAuthentication or of type
+     * Collection<HeaderAuthentication> depending on the authentication mode in
+     * use (the latter is used in case of trusted reverse-proxy). It is checked
+     * whether principal equals credentials (respectively if credentials
+     * contains principal in case of collection) because we want to check if
+     * e.g. controllerId containing in the URL equals the controllerId in the
+     * special header set by the reverse-proxy which extracted the CN from the
+     * certificate.
+     *
+     * @param principal
+     * @param credentials
+     * @param tokenDetails
+     * @return <code>true</code> if authentication succeeded, otherwise
+     *         <code>false</code>
+     */
     private boolean calculateAuthenticationSuccess(Object principal, Object credentials, Object tokenDetails) {
     	boolean successAuthentication = false;
-    	if (principal.equals(credentials)) {
-            successAuthentication = checkSourceIPAddressIfNeccessary(tokenDetails);
-        } else if (Collection.class.isAssignableFrom(credentials.getClass())) {
+        if (Collection.class.isAssignableFrom(credentials.getClass())) {
             final Collection<?> multiValueCredentials = (Collection<?>) credentials;
             if (multiValueCredentials.contains(principal)) {
                 successAuthentication = checkSourceIPAddressIfNeccessary(tokenDetails);
             }
+        } else if (principal.equals(credentials)) {
+            successAuthentication = checkSourceIPAddressIfNeccessary(tokenDetails);
         }
-    	
+
     	return successAuthentication;
     }
 

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProvider.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProvider.java
@@ -27,17 +27,17 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
  * An spring authentication provider which supports authentication tokens of
  * type {@link PreAuthenticatedAuthenticationToken} created by the
  * {@link ControllerPreAuthenticatedSecurityHeaderFilter}.
- * 
+ *
  * Additionally to the authentication token providing the principal and the
  * credentials which must be match, this authentication provider can also check
  * the remote IP address of the request.
- * 
+ *
  * E.g. The request path is /controller/v1/{controllerId} then the controllerId
  * in the path is the principal. The credentials are the extracted information
  * from e.g. a certificate provided by an reverse proxy. Due this request is
  * only allowed from a specific source address this authentication manager can
  * also check the remote IP address of the request.
- * 
+ *
  *
  *
  */
@@ -58,7 +58,7 @@ public class PreAuthTokenSourceTrustAuthenticationProvider implements Authentica
      * Creates a new PreAuthTokenSourceTrustAuthenticationProvider with given
      * source IP addresses which are trusted and should be checked against the
      * request remote IP address.
-     * 
+     *
      * @param authorizedSourceIps
      *            a list of IP addresses.
      */
@@ -70,7 +70,7 @@ public class PreAuthTokenSourceTrustAuthenticationProvider implements Authentica
      * Creates a new PreAuthTokenSourceTrustAuthenticationProvider with given
      * source IP addresses which are trusted and should be checked against the
      * request remote IP address.
-     * 
+     *
      * @param authorizedSourceIps
      *            a list of IP addresses.
      */
@@ -104,6 +104,12 @@ public class PreAuthTokenSourceTrustAuthenticationProvider implements Authentica
         // proxy which extracted the CN from the certificate
         if (principal.equals(credentials)) {
             successAuthentication = checkSourceIPAddressIfNeccessary(tokenDetails);
+
+        } else if (Collection.class.isAssignableFrom(credentials.getClass())) {
+            final Collection<?> multiValueCredentials = (Collection<?>) credentials;
+            if (multiValueCredentials.contains(principal)) {
+                successAuthentication = checkSourceIPAddressIfNeccessary(tokenDetails);
+            }
         }
 
         if (successAuthentication) {

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProvider.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProvider.java
@@ -111,7 +111,7 @@ public class PreAuthTokenSourceTrustAuthenticationProvider implements Authentica
         throw new BadCredentialsException("The provided principal and credentials are not match");
     }
 
-	/**
+    /**
      *
      * The credentials may either be of type HeaderAuthentication or of type
      * Collection<HeaderAuthentication> depending on the authentication mode in
@@ -129,7 +129,7 @@ public class PreAuthTokenSourceTrustAuthenticationProvider implements Authentica
      *         <code>false</code>
      */
     private boolean calculateAuthenticationSuccess(Object principal, Object credentials, Object tokenDetails) {
-    	boolean successAuthentication = false;
+        boolean successAuthentication = false;
         if (Collection.class.isAssignableFrom(credentials.getClass())) {
             final Collection<?> multiValueCredentials = (Collection<?>) credentials;
             if (multiValueCredentials.contains(principal)) {
@@ -139,7 +139,7 @@ public class PreAuthTokenSourceTrustAuthenticationProvider implements Authentica
             successAuthentication = checkSourceIPAddressIfNeccessary(tokenDetails);
         }
 
-    	return successAuthentication;
+        return successAuthentication;
     }
 
     private boolean checkSourceIPAddressIfNeccessary(final Object tokenDetails) {

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProvider.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProvider.java
@@ -97,14 +97,16 @@ public class PreAuthTokenSourceTrustAuthenticationProvider implements Authentica
             throw new BadCredentialsException("The provided principal and credentials are not match");
         }
 
-        // check if principal equals credentials because we want to check if
-        // e.g. controllerId
-        // containing in the URL equals the controllerId in the special header
-        // set by the reverse
-        // proxy which extracted the CN from the certificate
+        // The credentials may either be of type HeaderAuthentication or of type
+        // Collection<HeaderAuthentication> depending on the authentication mode
+        // in use (the latter is used in case of trusted reverse-proxy).
+        // It is checked whether principal equals credentials (respectively if
+        // credentials contains principal in case of collection) because we want
+        // to check if e.g. controllerId containing in the URL equals the
+        // controllerId in the special header set by the reverse-proxy which
+        // extracted the CN from the certificate.
         if (principal.equals(credentials)) {
             successAuthentication = checkSourceIPAddressIfNeccessary(tokenDetails);
-
         } else if (Collection.class.isAssignableFrom(credentials.getClass())) {
             final Collection<?> multiValueCredentials = (Collection<?>) credentials;
             if (multiValueCredentials.contains(principal)) {

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthentificationFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthentificationFilter.java
@@ -22,7 +22,7 @@ public interface PreAuthentificationFilter {
 
     /**
      * Check if the filter is enabled.
-     * 
+     *
      * @param secruityToken
      *            the secruity info
      * @return <true> is enabled <false> diabled
@@ -31,7 +31,7 @@ public interface PreAuthentificationFilter {
 
     /**
      * Extract the principal information from the current secruityToken.
-     * 
+     *
      * @param secruityToken
      *            the secruityToken
      * @return the extracted tenant and controller id
@@ -40,17 +40,17 @@ public interface PreAuthentificationFilter {
 
     /**
      * Extract the principal credentials from the current secruityToken.
-     * 
+     *
      * @param secruityToken
      *            the secruityToken
      * @return the extracted tenant and controller id
      */
-    HeaderAuthentication getPreAuthenticatedCredentials(TenantSecurityToken secruityToken);
+    Object getPreAuthenticatedCredentials(TenantSecurityToken secruityToken);
 
     /**
      * Allows to add additional authorities to the successful authenticated
      * token.
-     * 
+     *
      * @return the authorities granted to the principal, or an empty collection
      *         if the token has not been authenticated. Never null.
      * @see Authentication#getAuthorities()

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthentificationFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthentificationFilter.java
@@ -36,7 +36,7 @@ public interface PreAuthentificationFilter {
      *            the secruityToken
      * @return the extracted tenant and controller id
      */
-    Object getPreAuthenticatedPrincipal(TenantSecurityToken secruityToken);
+    HeaderAuthentication getPreAuthenticatedPrincipal(TenantSecurityToken secruityToken);
 
     /**
      * Extract the principal credentials from the current secruityToken.

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthentificationFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthentificationFilter.java
@@ -36,7 +36,7 @@ public interface PreAuthentificationFilter {
      *            the secruityToken
      * @return the extracted tenant and controller id
      */
-    HeaderAuthentication getPreAuthenticatedPrincipal(TenantSecurityToken secruityToken);
+    Object getPreAuthenticatedPrincipal(TenantSecurityToken secruityToken);
 
     /**
      * Extract the principal credentials from the current secruityToken.

--- a/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
+++ b/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.security;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.hawkbit.dmf.json.model.TenantSecurityToken;
+import org.eclipse.hawkbit.dmf.json.model.TenantSecurityToken.FileResource;
+import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.repository.model.TenantConfigurationValue;
+import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import ru.yandex.qatools.allure.annotations.Description;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Stories;
+
+@Features("Unit Tests - Security")
+@Stories("Issuer hash based authentication")
+@RunWith(MockitoJUnitRunner.class)
+public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
+
+    private ControllerPreAuthenticatedSecurityHeaderFilter underTest;
+
+    @Mock
+    private TenantConfigurationManagement tenantConfigurationManagementMock;
+
+    @Mock
+    private TenantSecurityToken tenantSecurityTokenMock;
+
+    private SecurityContextTenantAware tenantAware = new SecurityContextTenantAware();
+
+    private static final String CA_COMMON_NAME = "ca-cn";
+
+    private static final String X_SSL_ISSUER_HASH_1 = "X-Ssl-Issuer-Hash-1";
+
+    private static final String SINGLE_HASH = "hash1";
+
+    private static final String MULTI_HASH = "hash1;hash2;hash3";
+
+    private static final TenantConfigurationValue<String> CONFIG_VALUE_SINGLE_HASH = TenantConfigurationValue
+            .<String>builder().value(SINGLE_HASH).build();
+
+    private static final TenantConfigurationValue<String> CONFIG_VALUE_MULTI_HASH = TenantConfigurationValue
+            .<String>builder().value(MULTI_HASH).build();
+
+    @Before
+    public void before() {
+        underTest = new ControllerPreAuthenticatedSecurityHeaderFilter(CA_COMMON_NAME, "X-Ssl-Issuer-Hash-%d",
+                tenantConfigurationManagementMock,
+                tenantAware, new SystemSecurityContext(tenantAware));
+    }
+
+    @Test
+    @Description("Tests the filter for issuer hash based authentication with a single known hash")
+    public void testIssuerHashBasedAuthenticationWithSingleKnownHash() {
+        // prepare security token
+        final TenantSecurityToken securityToken = prepareSecurityToken();
+        securityToken.getHeaders().put(X_SSL_ISSUER_HASH_1, SINGLE_HASH);
+        // use single known hash
+        when(tenantConfigurationManagementMock.getConfigurationValue(
+                eq(TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_AUTHORITY_NAME), eq(String.class)))
+                        .thenReturn(CONFIG_VALUE_SINGLE_HASH);
+        assertNotNull(underTest.getPreAuthenticatedPrincipal(securityToken));
+    }
+
+    @Test
+    @Description("Tests the filter for issuer hash based authentication with multiple known hashes")
+    public void testIssuerHashBasedAuthenticationWithMultipleKnownHashes() {
+        // prepare security token
+        final TenantSecurityToken securityToken = prepareSecurityToken();
+        securityToken.getHeaders().put(X_SSL_ISSUER_HASH_1, SINGLE_HASH);
+        // use multiple known hashes
+        when(tenantConfigurationManagementMock.getConfigurationValue(
+                eq(TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_AUTHORITY_NAME), eq(String.class)))
+                        .thenReturn(CONFIG_VALUE_MULTI_HASH);
+        assertNotNull(underTest.getPreAuthenticatedPrincipal(securityToken));
+    }
+
+    @Test
+    @Description("Tests the filter for issuer hash based authentication with unknown hash")
+    public void testIssuerHashBasedAuthenticationWithUnknownHash() {
+        // prepare security token
+        final TenantSecurityToken securityToken = prepareSecurityToken();
+        securityToken.getHeaders().put(X_SSL_ISSUER_HASH_1, "unknown");
+        // use single known hash
+        when(tenantConfigurationManagementMock.getConfigurationValue(
+                eq(TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_AUTHORITY_NAME), eq(String.class)))
+                        .thenReturn(CONFIG_VALUE_MULTI_HASH);
+        assertNull(underTest.getPreAuthenticatedPrincipal(securityToken));
+    }
+
+    private static TenantSecurityToken prepareSecurityToken() {
+        final TenantSecurityToken securityToken = new TenantSecurityToken("default", "1234",
+                FileResource.createFileResourceBySha1("12345"));
+        securityToken.getHeaders().put(CA_COMMON_NAME, "any");
+
+        return securityToken;
+    }
+
+}

--- a/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
+++ b/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
@@ -8,7 +8,10 @@
  */
 package org.eclipse.hawkbit.security;
 
-import static org.junit.Assert.*;
+
+//import static org.junit.Assert.*;
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -75,7 +78,7 @@ public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
         when(tenantConfigurationManagementMock.getConfigurationValue(
                 eq(TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_AUTHORITY_NAME), eq(String.class)))
                         .thenReturn(CONFIG_VALUE_SINGLE_HASH);
-        assertNotNull(underTest.getPreAuthenticatedPrincipal(securityToken));
+        assertThat(underTest.getPreAuthenticatedPrincipal(securityToken)).isNotNull();
     }
 
     @Test
@@ -88,7 +91,7 @@ public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
         when(tenantConfigurationManagementMock.getConfigurationValue(
                 eq(TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_AUTHORITY_NAME), eq(String.class)))
                         .thenReturn(CONFIG_VALUE_MULTI_HASH);
-        assertNotNull(underTest.getPreAuthenticatedPrincipal(securityToken));
+        assertThat(underTest.getPreAuthenticatedPrincipal(securityToken)).isNotNull();
     }
 
     @Test
@@ -101,7 +104,8 @@ public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
         when(tenantConfigurationManagementMock.getConfigurationValue(
                 eq(TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_AUTHORITY_NAME), eq(String.class)))
                         .thenReturn(CONFIG_VALUE_MULTI_HASH);
-        assertNull(underTest.getPreAuthenticatedPrincipal(securityToken));
+        assertThat(underTest.getPreAuthenticatedPrincipal(securityToken)).isNull();
+        ;
     }
 
     @Test
@@ -119,7 +123,7 @@ public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
         HeaderAuthentication expected = new HeaderAuthentication("box1", "hash1");
         Collection<HeaderAuthentication> credentials = (Collection<HeaderAuthentication>) underTest
                 .getPreAuthenticatedCredentials(securityToken);
-        assertTrue(credentials.contains(expected));
+        assertThat(credentials.contains(expected)).isTrue();
 
         Object principal = underTest.getPreAuthenticatedPrincipal(securityToken);
         assertEquals(expected, principal);
@@ -128,7 +132,7 @@ public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
         securityToken.getHeaders().put(X_SSL_ISSUER_HASH_1, "hash2");
         expected = new HeaderAuthentication("box1", "hash2");
         credentials = (Collection<HeaderAuthentication>) underTest.getPreAuthenticatedCredentials(securityToken);
-        assertTrue(credentials.contains(expected));
+        assertThat(credentials.contains(expected)).isTrue();
 
         principal = underTest.getPreAuthenticatedPrincipal(securityToken);
         assertEquals(expected, principal);

--- a/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
+++ b/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
@@ -126,7 +126,7 @@ public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
         assertThat(credentials.contains(expected)).isTrue();
 
         Object principal = underTest.getPreAuthenticatedPrincipal(securityToken);
-        assertEquals(expected, principal);
+        assertEquals("hash1 expected in principal!", expected, principal);
 
         securityToken = prepareSecurityToken();
         securityToken.getHeaders().put(X_SSL_ISSUER_HASH_1, "hash2");
@@ -135,7 +135,7 @@ public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
         assertThat(credentials.contains(expected)).isTrue();
 
         principal = underTest.getPreAuthenticatedPrincipal(securityToken);
-        assertEquals(expected, principal);
+        assertEquals("hash2 expected in principal!", expected, principal);
 
     }
 

--- a/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
+++ b/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
@@ -8,8 +8,6 @@
  */
 package org.eclipse.hawkbit.security;
 
-
-//import static org.junit.Assert.*;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
@@ -105,7 +103,6 @@ public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
                 eq(TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_AUTHORITY_NAME), eq(String.class)))
                         .thenReturn(CONFIG_VALUE_MULTI_HASH);
         assertThat(underTest.getPreAuthenticatedPrincipal(securityToken)).isNull();
-        ;
     }
 
     @Test

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/CertificateAuthenticationConfigurationItem.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/CertificateAuthenticationConfigurationItem.java
@@ -63,13 +63,17 @@ public class CertificateAuthenticationConfigurationItem extends AbstractAuthenti
         final Label caRootAuthorityLabel = new LabelBuilder().name("SSL Issuer Hash:").buildLabel();
         caRootAuthorityLabel.setDescription(
                 "The SSL Issuer iRules.X509 hash, to validate against the controller request certifcate.");
+        caRootAuthorityLabel.setWidthUndefined();
 
-        caRootAuthorityTextField = new TextFieldBuilder().immediate(true).maxLengthAllowed(128).buildTextComponent();
-        caRootAuthorityTextField.setWidth("500px");
+        caRootAuthorityTextField = new TextFieldBuilder().immediate(true).maxLengthAllowed(160).buildTextComponent();
+        caRootAuthorityTextField.setWidth("100%");
         caRootAuthorityTextField.addTextChangeListener(event -> caRootAuthorityChanged());
 
         caRootAuthorityLayout.addComponent(caRootAuthorityLabel);
+        caRootAuthorityLayout.setExpandRatio(caRootAuthorityLabel, 0);
         caRootAuthorityLayout.addComponent(caRootAuthorityTextField);
+        caRootAuthorityLayout.setExpandRatio(caRootAuthorityTextField, 1);
+        caRootAuthorityLayout.setWidth("100%");
 
         detailLayout.addComponent(caRootAuthorityLayout);
 


### PR DESCRIPTION
Extends the reverse-proxy authentication feature with the possibility to have multiple issuer hashes configured for a tenant. 
For authentication one of these configured issuers hashes has to match with the requestors one.
Values are separated by semicolon.