### PR TITLE
Fixed security header filter test, to comply with new TenantSecurityToken API

### DIFF
--- a/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
+++ b/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
@@ -134,8 +134,8 @@ public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
     private static TenantSecurityToken prepareSecurityToken(String issuerHashHeaderValue) {
         final TenantSecurityToken securityToken = new TenantSecurityToken("DEFAULT", CA_COMMON_NAME_VALUE,
                 FileResource.createFileResourceBySha1("12345"));
-        securityToken.getHeaders().put(CA_COMMON_NAME, CA_COMMON_NAME_VALUE);
-        securityToken.getHeaders().put(X_SSL_ISSUER_HASH_1, issuerHashHeaderValue);
+        securityToken.putHeader(CA_COMMON_NAME, CA_COMMON_NAME_VALUE);
+        securityToken.putHeader(X_SSL_ISSUER_HASH_1, issuerHashHeaderValue);
         return securityToken;
     }
 


### PR DESCRIPTION
After merging the feature_multi_known_hashes_for_issuer_hash_based_auth to master, the ControllerPreAuthenticatedSecurityHeaderFilterTest failed, because it expected from TenantSecurityToken#getHeaders a mutable map. But this changed in the meantime to return an immutable Map. 
This fix uses now the new TenantSecurityToken#putHeader method to modify the headers.