### PR TITLE
remove unnecessary methods for getting artifact by id

### DIFF
--- a/hawkbit-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactStore.java
+++ b/hawkbit-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactStore.java
@@ -96,18 +96,6 @@ public class ArtifactStore implements ArtifactRepository {
         return map(gridFs.findOne(new Query().addCriteria(Criteria.where(MD5).is(md5Hash))));
     }
 
-    /**
-     * Retrieves a {@link GridFSDBFile} from the store by it's object id.
-     * 
-     * @param id
-     *            the id of the file to lookup.
-     * @return The gridfs file object or {@code null} if no file exists.
-     */
-    @Override
-    public DbArtifact getArtifactById(final String id) {
-        return map(gridFs.findOne(new Query().addCriteria(Criteria.where(ID).is(id))));
-    }
-
     @Override
     public DbArtifact store(final InputStream content, final String filename, final String contentType) {
         return store(content, filename, contentType, null);
@@ -131,15 +119,6 @@ public class ArtifactStore implements ArtifactRepository {
             if (tempFile != null && !tempFile.delete()) {
                 LOGGER.error("Could not delete temporary file: {}", tempFile);
             }
-        }
-    }
-
-    @Override
-    public void deleteById(final String artifactId) {
-        try {
-            deleteArtifact(gridFs.findOne(new Query().addCriteria(Criteria.where(ID).is(artifactId))));
-        } catch (final MongoException e) {
-            throw new ArtifactStoreException(e.getMessage(), e);
         }
     }
 
@@ -228,19 +207,6 @@ public class ArtifactStore implements ArtifactRepository {
      */
     private List<DbArtifact> map(final List<GridFSDBFile> dbFiles) {
         return dbFiles.stream().map(ArtifactStore::map).collect(Collectors.toList());
-    }
-
-    /**
-     * Retrieves a list of {@link GridFSDBFile} from the store by all SHA1
-     * hashes.
-     * 
-     * @param sha1Hashes
-     *            the sha1-hashes of the files to lookup.
-     * @return list of artifacts
-     */
-    @Override
-    public List<DbArtifact> getArtifactsBySha1(final List<String> sha1Hashes) {
-        return map(gridFs.find(new Query().addCriteria(Criteria.where(SHA1).in(sha1Hashes))));
     }
 
     /**

--- a/hawkbit-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/ArtifactStoreTest.java
+++ b/hawkbit-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/ArtifactStoreTest.java
@@ -11,27 +11,21 @@ package org.eclipse.hawkbit.artifact.repository;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Random;
 
-import org.apache.commons.io.IOUtils;
 import org.eclipse.hawkbit.artifact.TestConfiguration;
-import org.eclipse.hawkbit.artifact.repository.model.DbArtifact;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.gridfs.GridFsOperations;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.google.common.io.BaseEncoding;
-import com.mongodb.gridfs.GridFSDBFile;
 
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
@@ -49,19 +43,6 @@ public class ArtifactStoreTest {
 
     @Autowired
     private GridFsOperations gridFs;
-
-    @Test
-    @Description("Ensures that storage in MongoDB is correctly executed.s")
-    public void storeArtifactInMongoDB() {
-        final int filelengthBytes = 128;
-        final String filename = "testfile.json";
-        final String contentType = "application/json";
-        final DbArtifact storedFile = artifactStoreUnderTest.store(generateInputStream(filelengthBytes), filename,
-                contentType);
-
-        assertThat(storedFile).isNotNull();
-        assertThat(artifactStoreUnderTest.getArtifactById(storedFile.getArtifactId())).isNotNull();
-    }
 
     @Test
     @Description("Ensures that search by SHA1 hash (which is used by hawkBit as artifact ID) finds the expected results.")
@@ -87,43 +68,6 @@ public class ArtifactStoreTest {
         artifactStoreUnderTest.store(digestInputStream, filename, contentType);
         assertThat(artifactStoreUnderTest.getArtifactByMd5(
                 BaseEncoding.base16().lowerCase().encode(digestInputStream.getMessageDigest().digest()))).isNotNull();
-    }
-
-    @Test
-    @Description("Ensures that artifact content can be read through InputStream.")
-    public void getInputStreamFromArtifact() throws IOException {
-        final int filelengthBytes = 128;
-        final String filename = "testfile.json";
-        final String contentType = "application/json";
-
-        final ByteArrayInputStream inputStream = generateInputStream(filelengthBytes);
-        final DbArtifact artifact = artifactStoreUnderTest
-                .getArtifactById(artifactStoreUnderTest.store(inputStream, filename, contentType).getArtifactId());
-        inputStream.reset();
-
-        final byte[] artifactBytes = new byte[filelengthBytes];
-        final byte[] artifactStoredBytes = new byte[filelengthBytes];
-        IOUtils.readFully(inputStream, artifactBytes);
-        IOUtils.readFully(artifact.getFileInputStream(), artifactStoredBytes);
-
-        assertThat(artifactBytes).isEqualTo(artifactStoredBytes);
-    }
-
-    @Test
-    @Description("Ensures that artifact delete actually results in deletion from database.")
-    public void deleteArtifact() throws NoSuchAlgorithmException {
-        final int filelengthBytes = 128;
-        final String filename = "testfile.json";
-        final String contentType = "application/json";
-
-        final DigestInputStream digestInputStream = digestInputStream(generateInputStream(filelengthBytes), "SHA-1");
-        final DbArtifact store = artifactStoreUnderTest.store(digestInputStream, filename, contentType);
-
-        artifactStoreUnderTest.deleteById(store.getArtifactId());
-
-        final GridFSDBFile findOne = gridFs
-                .findOne(new Query().addCriteria(Criteria.where("_id").is(store.getArtifactId())));
-        assertThat(findOne).isNull();
     }
 
     private static ByteArrayInputStream generateInputStream(final int length) {

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactRepository.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactRepository.java
@@ -9,7 +9,6 @@
 package org.eclipse.hawkbit.artifact.repository;
 
 import java.io.InputStream;
-import java.util.List;
 
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
@@ -61,14 +60,6 @@ public interface ArtifactRepository {
     DbArtifact store(final InputStream content, final String filename, final String contentType, DbArtifactHash hash);
 
     /**
-     * Deletes an artifact by its ID.
-     * 
-     * @param artifactId
-     *            the ID of the artifact to delete
-     */
-    void deleteById(final String artifactId);
-
-    /**
      * Deletes an artifact by its SHA1 hash.
      * 
      * @param sha1Hash
@@ -84,26 +75,4 @@ public interface ArtifactRepository {
      * @return The artifact file object or {@code null} if no file exists.
      */
     DbArtifact getArtifactBySha1(String sha1);
-
-    /**
-     * Retrieves a {@link DbArtifact} from the store by it's ID.
-     * 
-     * @param id
-     *            the ID of the artifact to retrieve
-     * @return The artifact file object or {@code null} if no file exists.
-     */
-    DbArtifact getArtifactById(final String id);
-
-    /**
-     * Retrieves a list of {@link GridFSDBFile} from the store by all SHA1
-     * hashes.
-     * 
-     * @param tenant
-     *            the tenant to retrieve the artifacts from, ignore case.
-     * @param sha1Hashes
-     *            the sha1-hashes of the files to lookup.
-     * @return list of artfiacts
-     */
-    List<DbArtifact> getArtifactsBySha1(final List<String> sha1Hashes);
-
 }


### PR DESCRIPTION
* There were methods declared in the 'org.eclipse.hawkbit.artifact.repository.ArtifactRepository' interface which only used by tests and actually would not work e.g. with `ArtifactRepository` implementation for file-system and aws-s3.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>