### PR TITLE
Bug rollout management threshold calculation not target delete aware

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
@@ -154,10 +154,10 @@ public interface RolloutGroupManagement {
     /**
      * Count targets of rollout group.
      * 
-     * @param rolloutGroup
-     *            the rollout group for the count
+     * @param rolloutGroupId
+     *            the rollout group id for the count
      * @return the target rollout group count
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
-    Long countTargetsOfRolloutsGroup(@NotNull RolloutGroup rolloutGroup);
+    Long countTargetsOfRolloutsGroup(@NotNull Long rolloutGroupId);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
@@ -150,4 +150,14 @@ public interface RolloutGroupManagement {
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
     RolloutGroup findRolloutGroupWithDetailedStatus(@NotNull Long rolloutGroupId);
+
+    /**
+     * Count targets of rollout group.
+     * 
+     * @param rolloutGroup
+     *            the rollout group for the count
+     * @return the target rollout group count
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
+    Long countTargetsOfRolloutsGroup(@NotNull RolloutGroup rolloutGroup);
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
@@ -206,14 +206,13 @@ public class JpaRolloutGroupManagement implements RolloutGroupManagement {
     }
 
     @Override
-    public Long countTargetsOfRolloutsGroup(@NotNull final RolloutGroup rolloutGroup) {
+    public Long countTargetsOfRolloutsGroup(@NotNull final Long rolloutGroupId) {
         final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         final CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
         final Root<RolloutTargetGroup> countQueryFrom = countQuery.from(RolloutTargetGroup.class);
-        countQuery.select(cb.count(countQueryFrom))
-                .where(cb.equal(countQueryFrom.get(RolloutTargetGroup_.rolloutGroup), rolloutGroup));
+        countQuery.select(cb.count(countQueryFrom)).where(cb
+                .equal(countQueryFrom.get(RolloutTargetGroup_.rolloutGroup).get(JpaRolloutGroup_.id), rolloutGroupId));
         return entityManager.createQuery(countQuery).getSingleResult();
-
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
@@ -20,6 +20,7 @@ import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.ListJoin;
 import javax.persistence.criteria.Root;
+import javax.validation.constraints.NotNull;
 
 import org.eclipse.hawkbit.repository.RolloutGroupFields;
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
@@ -33,7 +34,6 @@ import org.eclipse.hawkbit.repository.jpa.model.JpaTarget_;
 import org.eclipse.hawkbit.repository.jpa.model.RolloutTargetGroup;
 import org.eclipse.hawkbit.repository.jpa.model.RolloutTargetGroup_;
 import org.eclipse.hawkbit.repository.jpa.rsql.RSQLUtility;
-import org.eclipse.hawkbit.repository.rsql.VirtualPropertyReplacer;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.Rollout.RolloutStatus;
@@ -42,6 +42,7 @@ import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetWithActionStatus;
 import org.eclipse.hawkbit.repository.model.TotalTargetCountActionStatus;
 import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus;
+import org.eclipse.hawkbit.repository.rsql.VirtualPropertyReplacer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -202,6 +203,17 @@ public class JpaRolloutGroupManagement implements RolloutGroupManagement {
                 .stream().map(o -> new TargetWithActionStatus((Target) o[0], (Action.Status) o[1]))
                 .collect(Collectors.toList());
         return new PageImpl<>(targetWithActionStatus, pageRequest, totalCount);
+    }
+
+    @Override
+    public Long countTargetsOfRolloutsGroup(@NotNull final RolloutGroup rolloutGroup) {
+        final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        final CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        final Root<RolloutTargetGroup> countQueryFrom = countQuery.from(RolloutTargetGroup.class);
+        countQuery.select(cb.count(countQueryFrom))
+                .where(cb.equal(countQueryFrom.get(RolloutTargetGroup_.rolloutGroup), rolloutGroup));
+        return entityManager.createQuery(countQuery).getSingleResult();
+
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -488,9 +488,7 @@ public class JpaRolloutManagement implements RolloutManagement {
 
     private void checkIfTargetsOfRolloutGroupDeleted(final JpaRolloutGroup rolloutGroup) {
 
-        final long countTargetsOfRolloutGroup = rolloutGroupManagement
-                .findRolloutGroupTargets(rolloutGroup, new OffsetBasedPageRequest(0, 1, null)).getTotalElements();
-
+        final long countTargetsOfRolloutGroup = rolloutGroupManagement.countTargetsOfRolloutsGroup(rolloutGroup);
         if (rolloutGroup.getTotalTargets() != countTargetsOfRolloutGroup) {
             // targets have been deleted and we have to update the
             // total target count in the rollout and the rollout group

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupSuccessCondition.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupSuccessCondition.java
@@ -8,45 +8,61 @@
  */
 package org.eclipse.hawkbit.repository.jpa.rollout.condition;
 
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
+import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.jpa.ActionRepository;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
+import org.eclipse.hawkbit.repository.model.Target;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 /**
- *
+ * Threshold to calculate if rollout group success condition is reached and the
+ * next rollout group can get started.
  */
 @Component("thresholdRolloutGroupSuccessCondition")
 public class ThresholdRolloutGroupSuccessCondition implements RolloutGroupConditionEvaluator {
     private static final Logger LOGGER = LoggerFactory.getLogger(ThresholdRolloutGroupSuccessCondition.class);
 
     @Autowired
+    private RolloutGroupManagement rolloutGroupManagement;
+
+    @Autowired
     private ActionRepository actionRepository;
 
     @Override
     public boolean eval(final Rollout rollout, final RolloutGroup rolloutGroup, final String expression) {
+
         final long totalGroup = rolloutGroup.getTotalTargets();
-        final long finished = this.actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(rollout.getId(),
+        if (totalGroup == 0) {
+            // in case e.g. targets has been deleted we don't have any
+            // actions left for this group, so the group is finished
+            return true;
+        }
+
+        final long finishedByStatus = this.actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(rollout.getId(),
                 rolloutGroup.getId(), Action.Status.FINISHED);
+        final long finished = finishedByStatus + countDeletedTargets(rolloutGroup);
+
         try {
             final Integer threshold = Integer.valueOf(expression);
-
-            if (totalGroup == 0) {
-                // in case e.g. targets has been deleted we don't have any
-                // actions
-                // left for this group, so the group is finished
-                return true;
-            }
             // calculate threshold
-            return ((float) finished / (float) totalGroup) >= ((float) threshold / 100F);
+            return ((float) finished / totalGroup) >= ((float) threshold / 100F);
         } catch (final NumberFormatException e) {
             LOGGER.error("Cannot evaluate condition expression " + expression, e);
             return false;
         }
+    }
+
+    private long countDeletedTargets(final RolloutGroup rolloutGroup) {
+        final Page<Target> targetsOfRolloutGroup = rolloutGroupManagement.findRolloutGroupTargets(rolloutGroup,
+                new OffsetBasedPageRequest(0, 1, null));
+        return rolloutGroup.getTotalTargets() - targetsOfRolloutGroup.getTotalElements();
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -170,7 +170,6 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final String errorCondition = "80";
         final Rollout createdRollout = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
                 amountOtherTargets, amountGroups, successCondition, errorCondition);
-
         rolloutManagement.startRollout(createdRollout);
 
         // finish group one by finishing targets and deleting targets
@@ -183,7 +182,6 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
                 runningActions.get(4).getTarget().getId());
 
         rolloutManagement.checkRunningRollouts(0);
-
         // validate that the second group is in running state
         List<RolloutGroup> runningRolloutGroups = rolloutGroupManagement.findRolloutGroupsByRolloutId(
                 createdRollout.getId(), new OffsetBasedPageRequest(0, 10, new Sort(Direction.ASC, "id"))).getContent();

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -96,11 +96,8 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 5;
         final String successCondition = "50";
         final String errorCondition = "80";
-        final Rollout createdRollout = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
-
-        // start the rollout
-        rolloutManagement.startRollout(createdRollout);
+        final Rollout createdRollout = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
 
         // verify first group is running
         final RolloutGroup firstGroup = rolloutGroupManagement.findRolloutGroupsByRolloutId(createdRollout.getId(),
@@ -130,10 +127,9 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 5;
         final String successCondition = "50";
         final String errorCondition = "80";
-        final Rollout createdRollout = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
+        final Rollout createdRollout = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
 
-        rolloutManagement.startRollout(createdRollout);
         final List<Action> runningActions = deploymentManagement.findActionsByRolloutAndStatus(createdRollout,
                 Status.RUNNING);
         // finish one action should be sufficient due the finish condition is at
@@ -177,18 +173,18 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
         finishActionAndDeleteTargetsOfFirstRunningGroup(createdRollout);
 
-        checkStatusOfRolloutGroupsAfterDeletingTargets(createdRollout);
+        checkSecondGroupStatusIsRunning(createdRollout);
 
         finishActionAndDeleteTargetsOfSecondRunningGroup(createdRollout);
 
-        deleteThrirdGroup(createdRollout);
+        deleteAllTargetsFromThirdGroup(createdRollout);
 
         checkStatusOfRolloutAndRolloutGroupsAfterDeletingTargets(createdRollout);
 
     }
 
     @Step("Create a rollout by the given parameter and start it.")
-    public Rollout createAndStartRollout(final int amountTargetsForRollout, final int amountOtherTargets,
+    private Rollout createAndStartRollout(final int amountTargetsForRollout, final int amountOtherTargets,
             final int amountGroups, final String successCondition, final String errorCondition) {
 
         final Rollout createdRollout = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
@@ -198,7 +194,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Step("Finish three actions of the rollout group and delete two targets")
-    public void finishActionAndDeleteTargetsOfFirstRunningGroup(final Rollout createdRollout) {
+    private void finishActionAndDeleteTargetsOfFirstRunningGroup(final Rollout createdRollout) {
         // finish group one by finishing targets and deleting targets
         final List<Action> runningActions = deploymentManagement.findActionsByRolloutAndStatus(createdRollout,
                 Status.RUNNING);
@@ -209,8 +205,8 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
                 runningActions.get(4).getTarget().getId());
     }
 
-    @Step("Check the status of the rollout groups")
-    public void checkStatusOfRolloutGroupsAfterDeletingTargets(final Rollout createdRollout) {
+    @Step("Check the status of the rollout groups, second group should be in running status")
+    private void checkSecondGroupStatusIsRunning(final Rollout createdRollout) {
         rolloutManagement.checkRunningRollouts(0);
         // validate that the second group is in running state
         final List<RolloutGroup> runningRolloutGroups = rolloutGroupManagement.findRolloutGroupsByRolloutId(
@@ -221,7 +217,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Step("Finish one action of the rollout group and delete four targets")
-    public void finishActionAndDeleteTargetsOfSecondRunningGroup(final Rollout createdRollout) {
+    private void finishActionAndDeleteTargetsOfSecondRunningGroup(final Rollout createdRollout) {
         final List<Action> runningActions = deploymentManagement.findActionsByRolloutAndStatus(createdRollout,
                 Status.RUNNING);
         finishAction(runningActions.get(0));
@@ -232,7 +228,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Step("Delete all targets of the rollout group")
-    public void deleteThrirdGroup(final Rollout createdRollout) {
+    private void deleteAllTargetsFromThirdGroup(final Rollout createdRollout) {
         // delete all targets of the third group
         final List<Action> runningActions = deploymentManagement.findActionsByRolloutAndStatus(createdRollout,
                 Status.SCHEDULED);
@@ -242,7 +238,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Step("Check the status of the rollout groups and the rollout")
-    public void checkStatusOfRolloutAndRolloutGroupsAfterDeletingTargets(final Rollout createdRollout) {
+    private void checkStatusOfRolloutAndRolloutGroupsAfterDeletingTargets(final Rollout createdRollout) {
         rolloutManagement.checkRunningRollouts(0);
         final List<RolloutGroup> runningRolloutGroups = rolloutGroupManagement.findRolloutGroupsByRolloutId(
                 createdRollout.getId(), new OffsetBasedPageRequest(0, 10, new Sort(Direction.ASC, "id"))).getContent();
@@ -269,10 +265,9 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 5;
         final String successCondition = "50";
         final String errorCondition = "80";
-        final Rollout createdRollout = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
+        final Rollout createdRollout = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
 
-        rolloutManagement.startRollout(createdRollout);
         // set both actions in error state so error condition is hit and error
         // action is executed
         final List<Action> runningActions = deploymentManagement.findActionsByRolloutAndStatus(createdRollout,
@@ -313,9 +308,9 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 5;
         final String successCondition = "50";
         final String errorCondition = "80";
-        final Rollout createdRollout = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
-        rolloutManagement.startRollout(createdRollout);
+        final Rollout createdRollout = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
+
         // set both actions in error state so error condition is hit and error
         // action is executed
         final List<Action> runningActions = deploymentManagement.findActionsByRolloutAndStatus(createdRollout,
@@ -365,9 +360,9 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 5;
         final String successCondition = "50";
         final String errorCondition = "80";
-        final Rollout createdRollout = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
-        rolloutManagement.startRollout(createdRollout);
+        final Rollout createdRollout = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
+
         // finish running actions, 2 actions should be finished
         assertThat(changeStatusForAllRunningActions(createdRollout, Status.FINISHED)).isEqualTo(2);
 
@@ -497,10 +492,9 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 4;
         final String successCondition = "50";
         final String errorCondition = "80";
-        Rollout createdRollout = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
+        Rollout createdRollout = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
 
-        rolloutManagement.startRollout(createdRollout);
         changeStatusForAllRunningActions(createdRollout, Status.FINISHED);
         rolloutManagement.checkRunningRollouts(0);
 
@@ -529,11 +523,10 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 2;
         final String successCondition = "50";
         final String errorCondition = "80";
-        Rollout createdRollout = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
+        Rollout createdRollout = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
         final DistributionSet ds = createdRollout.getDistributionSet();
 
-        rolloutManagement.startRollout(createdRollout);
         createdRollout = rolloutManagement.findRolloutById(createdRollout.getId());
         // 5 targets are running
         final List<Action> runningActions = deploymentManagement.findActionsByRolloutAndStatus(createdRollout,
@@ -574,9 +567,9 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 3;
         final String successCondition = "50";
         final String errorCondition = "80";
-        Rollout rolloutOne = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
-        rolloutManagement.startRollout(rolloutOne);
+        Rollout rolloutOne = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
+
         rolloutOne = rolloutManagement.findRolloutById(rolloutOne.getId());
 
         final DistributionSet dsForRolloutTwo = testdataFactory.createDistributionSet("dsForRolloutTwo");
@@ -611,10 +604,10 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 3;
         final String successCondition = "50";
         final String errorCondition = "80";
-        Rollout rolloutOne = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
+        Rollout rolloutOne = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
         final DistributionSet distributionSet = rolloutOne.getDistributionSet();
-        rolloutManagement.startRollout(rolloutOne);
+
         rolloutOne = rolloutManagement.findRolloutById(rolloutOne.getId());
         changeStatusForRunningActions(rolloutOne, Status.ERROR, 2);
         changeStatusForRunningActions(rolloutOne, Status.FINISHED, 3);
@@ -666,10 +659,9 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 2;
         final String successCondition = "50";
         final String errorCondition = "80";
-        Rollout rolloutOne = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
+        Rollout rolloutOne = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
 
-        rolloutManagement.startRollout(rolloutOne);
         rolloutOne = rolloutManagement.findRolloutById(rolloutOne.getId());
         changeStatusForRunningActions(rolloutOne, Status.ERROR, 2);
         changeStatusForRunningActions(rolloutOne, Status.FINISHED, 3);
@@ -691,10 +683,9 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 2;
         final String successCondition = "80";
         final String errorCondition = "90";
-        Rollout rolloutOne = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
+        Rollout rolloutOne = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
 
-        rolloutManagement.startRollout(rolloutOne);
         rolloutOne = rolloutManagement.findRolloutById(rolloutOne.getId());
         changeStatusForRunningActions(rolloutOne, Status.ERROR, 2);
         changeStatusForRunningActions(rolloutOne, Status.FINISHED, 3);
@@ -717,10 +708,9 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups = 2;
         final String successCondition = "50";
         final String errorCondition = "20";
-        Rollout rolloutOne = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
-                amountOtherTargets, amountGroups, successCondition, errorCondition);
+        Rollout rolloutOne = createAndStartRollout(amountTargetsForRollout, amountOtherTargets, amountGroups,
+                successCondition, errorCondition);
 
-        rolloutManagement.startRollout(rolloutOne);
         rolloutOne = rolloutManagement.findRolloutById(rolloutOne.getId());
         changeStatusForRunningActions(rolloutOne, Status.ERROR, 2);
         changeStatusForRunningActions(rolloutOne, Status.FINISHED, 3);
@@ -804,7 +794,6 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     public void rightCountForAllRollouts() {
 
         final int amountTargetsForRollout = 6;
-        ;
         final int amountGroups = 2;
         final String successCondition = "50";
         final String errorCondition = "80";

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -179,7 +179,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
         deleteAllTargetsFromThirdGroup(createdRollout);
 
-        checkStatusOfRolloutAndRolloutGroupsAfterDeletingTargets(createdRollout);
+        verifyRolloutAndAllGroupsAreFinished(createdRollout);
 
     }
 
@@ -208,7 +208,6 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     @Step("Check the status of the rollout groups, second group should be in running status")
     private void checkSecondGroupStatusIsRunning(final Rollout createdRollout) {
         rolloutManagement.checkRunningRollouts(0);
-        // validate that the second group is in running state
         final List<RolloutGroup> runningRolloutGroups = rolloutGroupManagement.findRolloutGroupsByRolloutId(
                 createdRollout.getId(), new OffsetBasedPageRequest(0, 10, new Sort(Direction.ASC, "id"))).getContent();
         assertThat(runningRolloutGroups.get(0).getStatus()).isEqualTo(RolloutGroupStatus.FINISHED);
@@ -229,7 +228,6 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Step("Delete all targets of the rollout group")
     private void deleteAllTargetsFromThirdGroup(final Rollout createdRollout) {
-        // delete all targets of the third group
         final List<Action> runningActions = deploymentManagement.findActionsByRolloutAndStatus(createdRollout,
                 Status.SCHEDULED);
         targetManagement.deleteTargets(runningActions.get(0).getTarget().getId(),
@@ -238,7 +236,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Step("Check the status of the rollout groups and the rollout")
-    private void checkStatusOfRolloutAndRolloutGroupsAfterDeletingTargets(final Rollout createdRollout) {
+    private void verifyRolloutAndAllGroupsAreFinished(final Rollout createdRollout) {
         rolloutManagement.checkRunningRollouts(0);
         final List<RolloutGroup> runningRolloutGroups = rolloutGroupManagement.findRolloutGroupsByRolloutId(
                 createdRollout.getId(), new OffsetBasedPageRequest(0, 10, new Sort(Direction.ASC, "id"))).getContent();

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -70,7 +70,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     private RolloutGroupManagement rolloutGroupManagement;
 
     @Test
-    @Description("Verfiying that the rollout is created correctly, executing the filter and split up the targets in the correct group size.")
+    @Description("Verifying that the rollout is created correctly, executing the filter and split up the targets in the correct group size.")
     public void creatingRolloutIsCorrectPersisted() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
@@ -89,7 +89,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description("Verfiying that when the rollout is started the actions for all targets in the rollout is created and the state of the first group is running as well as the corresponding actions")
+    @Description("Verifying that when the rollout is started the actions for all targets in the rollout is created and the state of the first group is running as well as the corresponding actions")
     public void startRolloutSetFirstGroupAndActionsInRunningStateAndOthersInScheduleState() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
@@ -120,7 +120,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description("Verfiying that a finish condition of a group is hit the next group of the rollout is also started")
+    @Description("Verifying that a finish condition of a group is hit the next group of the rollout is also started")
     public void checkRunningRolloutsDoesNotStartNextGroupIfFinishConditionIsNotHit() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;


### PR DESCRIPTION
Fix for the Bug
- The target count of running rollout groups now gets updated if targets have been deleted and the group will finish since success condition threshold is reached. The update of the target counts is done by the rollout scheduler.
-  The target count of the rollout also will get updated if deleted targets were in running rollout group. 
- Added junit test to verify bug.

Signed-off-by: Jonathan Philip Knoblauch JonathanPhilip.Knoblauch@bosch-si.com
