### PR TITLE
Semi automatic Rollouts with fine groups definition

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/exception/SpServerError.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/exception/SpServerError.java
@@ -164,7 +164,12 @@ public enum SpServerError {
     /**
      * 
      */
-    SP_ROLLOUT_ILLEGAL_STATE("hawkbit.server.error.rollout.illegalstate", "The rollout is currently in the wrong state for the current operation");
+    SP_ROLLOUT_ILLEGAL_STATE("hawkbit.server.error.rollout.illegalstate", "The rollout is currently in the wrong state for the current operation"),
+
+    /**
+     *
+     */
+    SP_ROLLOUT_VERIFICATION_FAILED("hawkbit.server.error.rollout.verificationFailed", "The rollout configuration could not be verified successfully");
 
     private final String key;
     private final String message;

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/TargetFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/TargetFields.java
@@ -33,6 +33,14 @@ public enum TargetFields implements FieldNameProvider {
      */
     DESCRIPTION("description"),
     /**
+     * The createdAt field.
+     */
+    CREATEDAT("createdAt"),
+    /**
+     * The createdAt field.
+     */
+    LASTMODIFIEDAT("lastModifiedAt"),
+    /**
      * The controllerId field.
      */
     CONTROLLERID("controllerId"),
@@ -75,19 +83,19 @@ public enum TargetFields implements FieldNameProvider {
     private List<String> subEntityAttribues;
     private boolean mapField;
 
-    private TargetFields(final String fieldName) {
+    TargetFields(final String fieldName) {
         this(fieldName, false, Collections.emptyList());
     }
 
-    private TargetFields(final String fieldName, final boolean isMapField) {
+    TargetFields(final String fieldName, final boolean isMapField) {
         this(fieldName, isMapField, Collections.emptyList());
     }
 
-    private TargetFields(final String fieldName, final String... subEntityAttribues) {
+    TargetFields(final String fieldName, final String... subEntityAttribues) {
         this(fieldName, false, Arrays.asList(subEntityAttribues));
     }
 
-    private TargetFields(final String fieldName, final boolean mapField, final List<String> subEntityAttribues) {
+    TargetFields(final String fieldName, final boolean mapField, final List<String> subEntityAttribues) {
         this.fieldName = fieldName;
         this.mapField = mapField;
         this.subEntityAttribues = subEntityAttribues;

--- a/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/AbstractMgmtRolloutConditionsEntity.java
+++ b/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/AbstractMgmtRolloutConditionsEntity.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.json.model.rollout;
+
+import org.eclipse.hawkbit.mgmt.json.model.MgmtNamedEntity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Model for defining Conditions and Actions
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class AbstractMgmtRolloutConditionsEntity extends MgmtNamedEntity {
+
+    private MgmtRolloutCondition successCondition = new MgmtRolloutCondition();
+    private MgmtRolloutSuccessAction successAction = new MgmtRolloutSuccessAction();
+    private MgmtRolloutCondition errorCondition;
+    private MgmtRolloutErrorAction errorAction;
+
+    public MgmtRolloutCondition getSuccessCondition() {
+        return successCondition;
+    }
+
+    public void setSuccessCondition(final MgmtRolloutCondition successCondition) {
+        this.successCondition = successCondition;
+    }
+
+    public MgmtRolloutSuccessAction getSuccessAction() {
+        return successAction;
+    }
+
+    public void setSuccessAction(final MgmtRolloutSuccessAction successAction) {
+        this.successAction = successAction;
+    }
+
+    public MgmtRolloutCondition getErrorCondition() {
+        return errorCondition;
+    }
+
+    public void setErrorCondition(final MgmtRolloutCondition errorCondition) {
+        this.errorCondition = errorCondition;
+    }
+
+    public MgmtRolloutErrorAction getErrorAction() {
+        return errorAction;
+    }
+
+    public void setErrorAction(final MgmtRolloutErrorAction errorAction) {
+        this.errorAction = errorAction;
+    }
+
+}

--- a/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutErrorAction.java
+++ b/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutErrorAction.java
@@ -13,14 +13,34 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
- * 
+ * An action that runs when the error condition is met
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MgmtRolloutErrorAction {
 
     private ErrorAction action = ErrorAction.PAUSE;
-    private String expression = null;
+    private String expression;
+
+    /**
+     * Creates a rollout error action
+     * 
+     * @param action
+     *            the action to run when th error condition is met
+     * @param expression
+     *            the expression for the action
+     */
+    public MgmtRolloutErrorAction(ErrorAction action, String expression) {
+        this.action = action;
+        this.expression = expression;
+    }
+
+    /**
+     * Default constructor
+     */
+    public MgmtRolloutErrorAction() {
+        // Instantiate default error action
+    }
 
     /**
      * @return the action
@@ -52,6 +72,9 @@ public class MgmtRolloutErrorAction {
         this.expression = expression;
     }
 
+    /**
+     * Possible actions
+     */
     public enum ErrorAction {
         PAUSE;
     }

--- a/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutRestRequestBody.java
+++ b/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutRestRequestBody.java
@@ -8,12 +8,14 @@
  */
 package org.eclipse.hawkbit.mgmt.json.model.rollout;
 
-import org.eclipse.hawkbit.mgmt.json.model.MgmtNamedEntity;
 import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtActionType;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.eclipse.hawkbit.mgmt.json.model.rolloutgroup.MgmtRolloutGroup;
+
+import java.util.List;
 
 /**
  * Model for request containing a rollout body e.g. in a POST request of
@@ -21,66 +23,18 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class MgmtRolloutRestRequestBody extends MgmtNamedEntity {
+public class MgmtRolloutRestRequestBody extends AbstractMgmtRolloutConditionsEntity {
 
     private String targetFilterQuery;
     private long distributionSetId;
 
-    private int amountGroups = 1;
-
-    private MgmtRolloutCondition successCondition = new MgmtRolloutCondition();
-    private MgmtRolloutSuccessAction successAction = new MgmtRolloutSuccessAction();
-    private MgmtRolloutCondition errorCondition = null;
-    private MgmtRolloutErrorAction errorAction = null;
+    private Integer amountGroups;
 
     private Long forcetime;
 
     private MgmtActionType type;
 
-    /**
-     * @return the finishCondition
-     */
-    public MgmtRolloutCondition getSuccessCondition() {
-        return successCondition;
-    }
-
-    /**
-     * @param successCondition
-     *            the finishCondition to set
-     */
-    public void setSuccessCondition(final MgmtRolloutCondition successCondition) {
-        this.successCondition = successCondition;
-    }
-
-    /**
-     * @return the successAction
-     */
-    public MgmtRolloutSuccessAction getSuccessAction() {
-        return successAction;
-    }
-
-    /**
-     * @param successAction
-     *            the successAction to set
-     */
-    public void setSuccessAction(final MgmtRolloutSuccessAction successAction) {
-        this.successAction = successAction;
-    }
-
-    /**
-     * @return the errorCondition
-     */
-    public MgmtRolloutCondition getErrorCondition() {
-        return errorCondition;
-    }
-
-    /**
-     * @param errorCondition
-     *            the errorCondition to set
-     */
-    public void setErrorCondition(final MgmtRolloutCondition errorCondition) {
-        this.errorCondition = errorCondition;
-    }
+    private List<MgmtRolloutGroup> groups;
 
     /**
      * @return the targetFilterQuery
@@ -115,7 +69,7 @@ public class MgmtRolloutRestRequestBody extends MgmtNamedEntity {
     /**
      * @return the groupSize
      */
-    public int getAmountGroups() {
+    public Integer getAmountGroups() {
         return amountGroups;
     }
 
@@ -123,7 +77,7 @@ public class MgmtRolloutRestRequestBody extends MgmtNamedEntity {
      * @param groupSize
      *            the groupSize to set
      */
-    public void setAmountGroups(final int groupSize) {
+    public void setAmountGroups(final Integer groupSize) {
         this.amountGroups = groupSize;
     }
 
@@ -158,18 +112,16 @@ public class MgmtRolloutRestRequestBody extends MgmtNamedEntity {
     }
 
     /**
-     * @return the errorAction
+     * @return the List of defined Groups
      */
-    public MgmtRolloutErrorAction getErrorAction() {
-        return errorAction;
+    public List<MgmtRolloutGroup> getGroups() {
+        return groups;
     }
 
     /**
-     * @param errorAction
-     *            the errorAction to set
+     * @param groups List of {@link MgmtRolloutGroup}
      */
-    public void setErrorAction(final MgmtRolloutErrorAction errorAction) {
-        this.errorAction = errorAction;
+    public void setGroups(List<MgmtRolloutGroup> groups) {
+        this.groups = groups;
     }
-
 }

--- a/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rolloutgroup/MgmtRolloutGroup.java
+++ b/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rolloutgroup/MgmtRolloutGroup.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.json.model.rolloutgroup;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.eclipse.hawkbit.mgmt.json.model.rollout.AbstractMgmtRolloutConditionsEntity;
+
+/**
+ * Model for defining the Attributes of a Rollout Group
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MgmtRolloutGroup extends AbstractMgmtRolloutConditionsEntity {
+
+    private String targetFilterQuery;
+    private Float targetPercentage;
+
+    public String getTargetFilterQuery() {
+        return targetFilterQuery;
+    }
+
+    public void setTargetFilterQuery(final String targetFilterQuery) {
+        this.targetFilterQuery = targetFilterQuery;
+    }
+
+    public Float getTargetPercentage() {
+        return targetPercentage;
+    }
+
+    public void setTargetPercentage(Float targetPercentage) {
+        this.targetPercentage = targetPercentage;
+    }
+}

--- a/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rolloutgroup/MgmtRolloutGroupResponseBody.java
+++ b/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rolloutgroup/MgmtRolloutGroupResponseBody.java
@@ -8,12 +8,13 @@
  */
 package org.eclipse.hawkbit.mgmt.json.model.rolloutgroup;
 
-import org.eclipse.hawkbit.mgmt.json.model.MgmtNamedEntity;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Model for the rollout group annotated with json-annotations for easier
@@ -21,13 +22,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class MgmtRolloutGroupResponseBody extends MgmtNamedEntity {
+public class MgmtRolloutGroupResponseBody extends MgmtRolloutGroup {
 
     @JsonProperty(value = "id", required = true)
     private Long rolloutGroupId;
 
     @JsonProperty(required = true)
     private String status;
+
+    private int totalTargets;
+
+    @JsonProperty(required = true)
+    private final Map<String, Long> totalTargetsPerStatus = new HashMap<>();
 
     /**
      * @return the rolloutGroupId
@@ -58,4 +64,17 @@ public class MgmtRolloutGroupResponseBody extends MgmtNamedEntity {
     public void setStatus(final String status) {
         this.status = status;
     }
+
+    public int getTotalTargets() {
+        return totalTargets;
+    }
+
+    public void setTotalTargets(int totalTargets) {
+        this.totalTargets = totalTargets;
+    }
+
+    public Map<String, Long> getTotalTargetsPerStatus() {
+        return totalTargetsPerStatus;
+    }
+
 }

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
@@ -15,15 +15,20 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutCondition;
 import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutCondition.Condition;
+import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutErrorAction;
 import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutErrorAction.ErrorAction;
 import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutResponseBody;
 import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutRestRequestBody;
+import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutSuccessAction;
 import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutSuccessAction.SuccessAction;
+import org.eclipse.hawkbit.mgmt.json.model.rolloutgroup.MgmtRolloutGroup;
 import org.eclipse.hawkbit.mgmt.json.model.rolloutgroup.MgmtRolloutGroupResponseBody;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRolloutRestApi;
 import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.exception.ConstraintViolationException;
 import org.eclipse.hawkbit.repository.model.Action.ActionType;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.Rollout;
@@ -88,12 +93,12 @@ final class MgmtRolloutMapper {
     }
 
     static Rollout fromRequest(final EntityFactory entityFactory, final MgmtRolloutRestRequestBody restRequest,
-            final DistributionSet distributionSet, final String filterQuery) {
+            final DistributionSet distributionSet) {
         final Rollout rollout = entityFactory.generateRollout();
         rollout.setName(restRequest.getName());
         rollout.setDescription(restRequest.getDescription());
         rollout.setDistributionSet(distributionSet);
-        rollout.setTargetFilterQuery(filterQuery);
+        rollout.setTargetFilterQuery(restRequest.getTargetFilterQuery());
         final ActionType convertActionType = MgmtRestModelMapper.convertActionType(restRequest.getType());
         if (convertActionType != null) {
             rollout.setActionType(convertActionType);
@@ -103,6 +108,44 @@ final class MgmtRolloutMapper {
 
         }
         return rollout;
+    }
+
+    static RolloutGroup fromRequest(final EntityFactory entityFactory, final MgmtRolloutGroup restRequest) {
+        final RolloutGroup group = entityFactory.generateRolloutGroup();
+        group.setName(restRequest.getName());
+        group.setDescription(restRequest.getDescription());
+
+        if(restRequest.getTargetFilterQuery() != null) {
+            group.setTargetFilterQuery(restRequest.getTargetFilterQuery());
+        }
+
+        final Float targetPercentage = restRequest.getTargetPercentage();
+        if(targetPercentage == null) {
+            group.setTargetPercentage(100);
+        } else if(targetPercentage < 0 || targetPercentage >100) {
+            throw new ConstraintViolationException("Target percentage out of Range 0 - 100.");
+        } else {
+            group.setTargetPercentage(restRequest.getTargetPercentage());
+        }
+
+        if(restRequest.getSuccessCondition() != null) {
+            group.setSuccessCondition(mapFinishCondition(restRequest.getSuccessCondition().getCondition()));
+            group.setSuccessConditionExp(restRequest.getSuccessCondition().getExpression());
+        }
+        if(restRequest.getSuccessAction() != null) {
+            group.setSuccessAction(map(restRequest.getSuccessAction().getAction()));
+            group.setSuccessActionExp(restRequest.getSuccessAction().getExpression());
+        }
+        if(restRequest.getErrorCondition() != null) {
+            group.setErrorCondition(mapErrorCondition(restRequest.getErrorCondition().getCondition()));
+            group.setErrorConditionExp(restRequest.getErrorCondition().getExpression());
+        }
+        if(restRequest.getErrorAction() != null) {
+            group.setErrorAction(map(restRequest.getErrorAction().getAction()));
+            group.setErrorActionExp(restRequest.getErrorAction().getExpression());
+        }
+
+        return group;
     }
 
     static List<MgmtRolloutGroupResponseBody> toResponseRolloutGroup(final List<RolloutGroup> rollouts) {
@@ -123,6 +166,25 @@ final class MgmtRolloutMapper {
         body.setName(rolloutGroup.getName());
         body.setRolloutGroupId(rolloutGroup.getId());
         body.setStatus(rolloutGroup.getStatus().toString().toLowerCase());
+        body.setTargetPercentage(rolloutGroup.getTargetPercentage());
+        body.setTargetFilterQuery(rolloutGroup.getTargetFilterQuery());
+        body.setTotalTargets(rolloutGroup.getTotalTargets());
+
+        body.setSuccessCondition(new MgmtRolloutCondition(map(rolloutGroup.getSuccessCondition()),
+                rolloutGroup.getSuccessConditionExp()));
+        body.setSuccessAction(
+                new MgmtRolloutSuccessAction(map(rolloutGroup.getSuccessAction()), rolloutGroup.getSuccessActionExp()));
+
+        body.setErrorCondition(
+                new MgmtRolloutCondition(map(rolloutGroup.getErrorCondition()), rolloutGroup.getErrorConditionExp()));
+        body.setErrorAction(
+                new MgmtRolloutErrorAction(map(rolloutGroup.getErrorAction()), rolloutGroup.getErrorActionExp()));
+
+        for (final TotalTargetCountStatus.Status status : TotalTargetCountStatus.Status.values()) {
+            body.getTotalTargetsPerStatus().put(status.name().toLowerCase(),
+                    rolloutGroup.getTotalTargetCountStatus().getTotalTargetCountByStatus(status));
+        }
+
         body.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRolloutGroup(rolloutGroup.getRollout().getId(),
                 rolloutGroup.getId())).withRel("self"));
         return body;
@@ -149,6 +211,13 @@ final class MgmtRolloutMapper {
         throw new IllegalArgumentException("Rollout group condition " + rolloutCondition + NOT_SUPPORTED);
     }
 
+    static Condition map(final RolloutGroupErrorCondition rolloutCondition) {
+        if (RolloutGroupErrorCondition.THRESHOLD.equals(rolloutCondition)) {
+            return Condition.THRESHOLD;
+        }
+        throw new IllegalArgumentException("Rollout group condition " + rolloutCondition + NOT_SUPPORTED);
+    }
+
     static RolloutGroupErrorAction map(final ErrorAction action) {
         if (ErrorAction.PAUSE.equals(action)) {
             return RolloutGroupErrorAction.PAUSE;
@@ -161,6 +230,20 @@ final class MgmtRolloutMapper {
             return RolloutGroupSuccessAction.NEXTGROUP;
         }
         throw new IllegalArgumentException("Success Action " + action + NOT_SUPPORTED);
+    }
+
+    static SuccessAction map(final RolloutGroupSuccessAction successAction) {
+        if (RolloutGroupSuccessAction.NEXTGROUP.equals(successAction)) {
+            return SuccessAction.NEXTGROUP;
+        }
+        throw new IllegalArgumentException("Rollout group success action " + successAction + NOT_SUPPORTED);
+    }
+
+    static ErrorAction map(final RolloutGroupErrorAction errorAction) {
+        if (RolloutGroupErrorAction.PAUSE.equals(errorAction)) {
+            return ErrorAction.PAUSE;
+        }
+        throw new IllegalArgumentException("Rollout group error action " + errorAction + NOT_SUPPORTED);
     }
 
     private static String createIllegalArgumentLiteral(final Condition condition) {

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
@@ -19,6 +19,8 @@ import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterSyntaxException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterUnsupportedFieldException;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.Rollout;
+import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.repository.model.Tag;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
@@ -287,6 +289,36 @@ public interface TargetManagement {
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
     Long countTargetsByTargetFilterQueryAndNonDS(Long distributionSetId, @NotNull TargetFilterQuery targetFilterQuery);
+
+    /**
+     * Finds all targets for all the given parameter {@link TargetFilterQuery}
+     * and that are not assigned to one of the {@link RolloutGroup}s
+     *
+     * @param pageRequest
+     *            the pageRequest to enhance the query for paging and sorting
+     * @param groups
+     *            the list of {@link RolloutGroup}s
+     * @param targetFilterQuery
+     *            RSQL filter
+     * @return the found {@link TargetIdName}s
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    Page<Target> findAllTargetsByTargetFilterQueryAndNotInRolloutGroups(@NotNull Pageable pageRequest,
+            List<RolloutGroup> groups, @NotNull String targetFilterQuery);
+
+    /**
+     * Counts all targets for all the given parameter {@link TargetFilterQuery}
+     * and that are not assigned to one of the {@link RolloutGroup}s
+     *
+     * @param groups
+     *            the list of {@link RolloutGroup}s
+     * @param targetFilterQuery
+     *            RSQL filter
+     * @return the found {@link TargetIdName}s
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    Long countAllTargetsByTargetFilterQueryAndNotInRolloutGroups(List<RolloutGroup> groups,
+            @NotNull String targetFilterQuery);
 
     /**
      * retrieves {@link Target}s by the assigned {@link DistributionSet} without

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/RolloutVerificationException.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/RolloutVerificationException.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.exception;
+
+import org.eclipse.hawkbit.exception.AbstractServerRtException;
+import org.eclipse.hawkbit.exception.SpServerError;
+
+/**
+ * the {@link RolloutVerificationException} is thrown when a rollout or
+ * its groups get created or modified with a configuration that is
+ * not valid or can't be verified
+ * 
+ */
+public class RolloutVerificationException extends AbstractServerRtException {
+
+    private static final long serialVersionUID = 1L;
+    private static final SpServerError THIS_ERROR = SpServerError.SP_ROLLOUT_VERIFICATION_FAILED;
+
+    /**
+     * Default constructor.
+     */
+    public RolloutVerificationException() {
+        super(THIS_ERROR);
+    }
+
+    /**
+     * Parameterized constructor.
+     *
+     * @param cause
+     *            of the exception
+     */
+    public RolloutVerificationException(final Throwable cause) {
+        super(THIS_ERROR, cause);
+    }
+
+    /**
+     * Parameterized constructor.
+     *
+     * @param message
+     *            of the exception
+     * @param cause
+     *            of the exception
+     */
+    public RolloutVerificationException(final String message, final Throwable cause) {
+        super(message, THIS_ERROR, cause);
+    }
+
+    /**
+     * Parameterized constructor.
+     *
+     * @param message
+     *            of the exception
+     */
+    public RolloutVerificationException(final String message) {
+        super(message, THIS_ERROR);
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/RolloutGroup.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/RolloutGroup.java
@@ -153,6 +153,23 @@ public interface RolloutGroup extends NamedEntity {
     String getSuccessActionExp();
 
     /**
+     * @param successAction
+     *            which is executed if the {@link RolloutGroupSuccessCondition}
+     *            is met
+     */
+    void setSuccessAction(RolloutGroupSuccessAction successAction);
+
+    /**
+     *
+     * @param successActionExp
+     *            a String representation of the expression to be evaluated by
+     *            the {@link RolloutGroupSuccessAction} might be {@code null} if
+     *            no expression must be set for the
+     *            {@link RolloutGroupSuccessAction}
+     */
+    void setSuccessActionExp(String successActionExp);
+
+    /**
      * @return the total amount of targets containing in this group
      */
     int getTotalTargets();
@@ -169,10 +186,41 @@ public interface RolloutGroup extends NamedEntity {
     void setTotalTargetCountStatus(TotalTargetCountStatus totalTargetCountStatus);
 
     /**
-     * Rollout goup state machine.
+     * @return the target filter query, that is used to assign Targets to this
+     *         Group
+     */
+    String getTargetFilterQuery();
+
+    /**
+     * @param targetFilterQuery
+     *            the target filter query, that is used to assign Targets to
+     *            this Group. Can be null, if no restrictions should apply.
+     */
+    void setTargetFilterQuery(String targetFilterQuery);
+
+    /**
+     * @return the percentage of matching Targets that should be assigned to
+     *         this Group
+     */
+    float getTargetPercentage();
+
+    /**
+     * @param targetPercentage
+     *            the percentage of matching Targets that should be assigned to
+     *            this Group
+     */
+    void setTargetPercentage(float targetPercentage);
+
+    /**
+     * Rollout group state machine.
      *
      */
-    public enum RolloutGroupStatus {
+    enum RolloutGroupStatus {
+
+        /**
+         * Group has been defined, but not all targets have been assigned yet.
+         */
+        CREATING,
 
         /**
          * Ready to start the group.
@@ -198,18 +246,18 @@ public interface RolloutGroup extends NamedEntity {
         /**
          * Group is running.
          */
-        RUNNING;
+        RUNNING
     }
 
     /**
      * The condition to evaluate if an group is success state.
      */
-    public enum RolloutGroupSuccessCondition {
+    enum RolloutGroupSuccessCondition {
         THRESHOLD("thresholdRolloutGroupSuccessCondition");
 
         private final String beanName;
 
-        private RolloutGroupSuccessCondition(final String beanName) {
+        RolloutGroupSuccessCondition(final String beanName) {
             this.beanName = beanName;
         }
 
@@ -224,12 +272,12 @@ public interface RolloutGroup extends NamedEntity {
     /**
      * The condition to evaluate if an group is in error state.
      */
-    public enum RolloutGroupErrorCondition {
+    enum RolloutGroupErrorCondition {
         THRESHOLD("thresholdRolloutGroupErrorCondition");
 
         private final String beanName;
 
-        private RolloutGroupErrorCondition(final String beanName) {
+        RolloutGroupErrorCondition(final String beanName) {
             this.beanName = beanName;
         }
 
@@ -242,14 +290,14 @@ public interface RolloutGroup extends NamedEntity {
     }
 
     /**
-     * The actions executed when the {@link RolloutGroup#errorCondition} is hit.
+     * The actions executed when the {@link RolloutGroup#getErrorCondition()} is hit.
      */
-    public enum RolloutGroupErrorAction {
+    enum RolloutGroupErrorAction {
         PAUSE("pauseRolloutGroupAction");
 
         private final String beanName;
 
-        private RolloutGroupErrorAction(final String beanName) {
+        RolloutGroupErrorAction(final String beanName) {
             this.beanName = beanName;
         }
 
@@ -262,15 +310,15 @@ public interface RolloutGroup extends NamedEntity {
     }
 
     /**
-     * The actions executed when the {@link RolloutGroup#successCondition} is
+     * The actions executed when the {@link RolloutGroup#getSuccessCondition()} is
      * hit.
      */
-    public enum RolloutGroupSuccessAction {
+    enum RolloutGroupSuccessAction {
         NEXTGROUP("startNextRolloutGroupAction");
 
         private final String beanName;
 
-        private RolloutGroupSuccessAction(final String beanName) {
+        RolloutGroupSuccessAction(final String beanName) {
             this.beanName = beanName;
         }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/RolloutGroupConditions.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/RolloutGroupConditions.java
@@ -18,14 +18,14 @@ import org.eclipse.hawkbit.repository.model.RolloutGroup.RolloutGroupSuccessCond
  * easily built.
  */
 public class RolloutGroupConditions {
-    private RolloutGroupSuccessCondition successCondition;
-    private String successConditionExp;
-    private RolloutGroupSuccessAction successAction;
-    private String successActionExp;
-    private RolloutGroupErrorCondition errorCondition;
-    private String errorConditionExp;
-    private RolloutGroupErrorAction errorAction;
-    private String errorActionExp;
+    private RolloutGroupSuccessCondition successCondition = RolloutGroupSuccessCondition.THRESHOLD;
+    private String successConditionExp = "50";
+    private RolloutGroupSuccessAction successAction = RolloutGroupSuccessAction.NEXTGROUP;
+    private String successActionExp = "";
+    private RolloutGroupErrorCondition errorCondition = RolloutGroupErrorCondition.THRESHOLD;
+    private String errorConditionExp = "50";
+    private RolloutGroupErrorAction errorAction = RolloutGroupErrorAction.PAUSE;
+    private String errorActionExp = "";
 
     public RolloutGroupSuccessCondition getSuccessCondition() {
         return successCondition;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -17,14 +17,18 @@ import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.DeploymentManagement;
-import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.RolloutFields;
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.RolloutIllegalStateException;
+import org.eclipse.hawkbit.repository.exception.RolloutVerificationException;
 import org.eclipse.hawkbit.repository.jpa.cache.CacheWriteNotify;
 import org.eclipse.hawkbit.repository.jpa.model.JpaRollout;
 import org.eclipse.hawkbit.repository.jpa.model.JpaRolloutGroup;
@@ -56,14 +60,14 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -79,6 +83,11 @@ import org.springframework.validation.annotation.Validated;
 @Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
 public class JpaRolloutManagement implements RolloutManagement {
     private static final Logger LOGGER = LoggerFactory.getLogger(RolloutManagement.class);
+
+    /**
+     * Maximum amount of targets that are assigned to a Rollout Group in one transaction.
+     */
+    private static final long TRANSACTION_TARGETS = 1000;
 
     @Autowired
     private EntityManager entityManager;
@@ -176,119 +185,292 @@ public class JpaRolloutManagement implements RolloutManagement {
     @Modifying
     public Rollout createRollout(final Rollout rollout, final int amountGroup,
             final RolloutGroupConditions conditions) {
-        final JpaRollout savedRollout = createRollout((JpaRollout) rollout, amountGroup);
+        RolloutHelper.verifyRolloutGroupParameter(amountGroup);
+        final JpaRollout savedRollout = createRollout((JpaRollout) rollout);
         return createRolloutGroups(amountGroup, conditions, savedRollout);
     }
 
     @Override
     @Transactional(isolation = Isolation.READ_UNCOMMITTED)
     @Modifying
-    public Rollout createRolloutAsync(final Rollout rollout, final int amountGroup,
-            final RolloutGroupConditions conditions) {
-        final JpaRollout savedRollout = createRollout((JpaRollout) rollout, amountGroup);
-        creatingRollouts.add(savedRollout.getName());
-        // need to flush the entity manager here to get the ID of the rollout,
-        // because entity manager is set to FlushMode#Auto, entitymanager will
-        // flush the Target entity, due the indirect relationship to the Rollout
-        // entity without set an ID JPA is throwing a Invalid
-        // 'org.springframework.dao.InvalidDataAccessApiUsageException: During
-        // synchronization aect was found through a relationship that was not
-        // marked cascade PERSIST'
-        entityManager.flush();
-        executor.execute(() -> {
-            try {
-                createRolloutGroupsInNewTransaction(amountGroup, conditions, savedRollout);
-            } finally {
-                creatingRollouts.remove(savedRollout.getName());
-            }
-        });
-        return savedRollout;
+    public Rollout createRollout(final Rollout rollout,
+                                 final List<RolloutGroup> groups,
+                                 final RolloutGroupConditions conditions) {
+        final JpaRollout savedRollout = createRollout((JpaRollout) rollout);
+        if(groups != null) {
+            return createRolloutGroups(groups, conditions, rollout);
+        } else {
+            return savedRollout;
+        }
     }
 
-    private JpaRollout createRollout(final JpaRollout rollout, final int amountGroup) {
-        verifyRolloutGroupParameter(amountGroup);
+    private JpaRollout createRollout(final JpaRollout rollout) {
+        JpaRollout existingRollout = rolloutRepository.findByName(rollout.getName());
+        if(existingRollout != null) {
+            throw new EntityAlreadyExistsException(existingRollout.getName());
+        }
+
         final Long totalTargets = targetManagement.countTargetByTargetFilterQuery(rollout.getTargetFilterQuery());
-        rollout.setTotalTargets(totalTargets.longValue());
+        if(totalTargets == 0) {
+            throw new RolloutVerificationException("Rollout does not match any existing targets");
+        }
+        rollout.setTotalTargets(totalTargets);
         return rolloutRepository.save(rollout);
     }
 
-    private static void verifyRolloutGroupParameter(final int amountGroup) {
-        if (amountGroup <= 0) {
-            throw new IllegalArgumentException("the amountGroup must be greater than zero");
-        } else if (amountGroup > 500) {
-            throw new IllegalArgumentException("the amountGroup must not be greater than 500");
-        }
-    }
-
-    private Rollout createRolloutGroupsInNewTransaction(final int amountOfGroups,
-            final RolloutGroupConditions conditions, final JpaRollout savedRollout) {
-        final DefaultTransactionDefinition def = new DefaultTransactionDefinition();
-        def.setName("creatingRollout");
-        def.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-        return new TransactionTemplate(txManager, def)
-                .execute(status -> createRolloutGroups(amountOfGroups, conditions, savedRollout));
-    }
-
-    /**
-     * Method for creating rollout groups and calculating group sizes. Group
-     * sizes are calculated by dividing the total count of targets through the
-     * amount of given groups. In same cases this will lead to less rollout
-     * groups than given by client.
-     *
-     * @param amountOfGroups
-     *            the amount of groups
-     * @param conditions
-     *            the rollout group conditions
-     * @param savedRollout
-     *            the rollout
-     * @return the rollout with created groups
-     */
     private Rollout createRolloutGroups(final int amountOfGroups, final RolloutGroupConditions conditions,
-            final JpaRollout savedRollout) {
-        int pageIndex = 0;
-        int groupIndex = 0;
-        final Long totalCount = savedRollout.getTotalTargets();
-        final int groupSize = (int) Math.ceil((double) totalCount / (double) amountOfGroups);
-        // validate if the amount of groups that will be created are the amount
-        // of groups that the client what's to have created.
-        int amountGroupValidated = amountOfGroups;
-        final int amountGroupCreation = (int) (Math.ceil((double) totalCount / (double) groupSize));
-        if (amountGroupCreation == (amountOfGroups - 1)) {
-            amountGroupValidated--;
-        }
+            final Rollout rollout) {
+        RolloutHelper.verifyRolloutInStatus(rollout, RolloutStatus.CREATING);
+        RolloutHelper.verifyRolloutGroupConditions(conditions);
+
+        final JpaRollout savedRollout = (JpaRollout) rollout;
+
         RolloutGroup lastSavedGroup = null;
-        while (pageIndex < totalCount) {
-            groupIndex++;
-            final String nameAndDesc = "group-" + groupIndex;
+        for (int i = 0; i < amountOfGroups; i++) {
+            final String nameAndDesc = "group-" + (i + 1);
             final JpaRolloutGroup group = new JpaRolloutGroup();
             group.setName(nameAndDesc);
             group.setDescription(nameAndDesc);
             group.setRollout(savedRollout);
             group.setParent(lastSavedGroup);
+            group.setStatus(RolloutGroupStatus.CREATING);
+
             group.setSuccessCondition(conditions.getSuccessCondition());
             group.setSuccessConditionExp(conditions.getSuccessConditionExp());
+
+            group.setSuccessAction(conditions.getSuccessAction());
+            group.setSuccessActionExp(conditions.getSuccessActionExp());
+
             group.setErrorCondition(conditions.getErrorCondition());
             group.setErrorConditionExp(conditions.getErrorConditionExp());
+
             group.setErrorAction(conditions.getErrorAction());
             group.setErrorActionExp(conditions.getErrorActionExp());
 
-            final JpaRolloutGroup savedGroup = rolloutGroupRepository.save(group);
+            group.setTargetPercentage(1.0F / (amountOfGroups - i) * 100);
 
-            final Slice<Target> targetGroup = targetManagement.findTargetsAll(savedRollout.getTargetFilterQuery(),
-                    new OffsetBasedPageRequest(pageIndex, groupSize, new Sort(Direction.ASC, "id")));
-            savedGroup.setTotalTargets(targetGroup.getContent().size());
+            lastSavedGroup = rolloutGroupRepository.save(group);
 
-            lastSavedGroup = savedGroup;
-
-            targetGroup
-                    .forEach(target -> rolloutTargetGroupRepository.save(new RolloutTargetGroup(savedGroup, target)));
-            cacheWriteNotify.rolloutGroupCreated(groupIndex, savedRollout.getId(), savedGroup.getId(),
-                    amountGroupValidated, groupIndex);
-            pageIndex += groupSize;
         }
 
-        savedRollout.setStatus(RolloutStatus.READY);
+        savedRollout.setRolloutGroupsCreated(amountOfGroups);
         return rolloutRepository.save(savedRollout);
+    }
+
+    private Rollout createRolloutGroups(final List<RolloutGroup> groupList, final RolloutGroupConditions conditions,
+            final Rollout rollout) {
+        RolloutHelper.verifyRolloutInStatus(rollout, RolloutStatus.CREATING);
+        final JpaRollout savedRollout = (JpaRollout) rollout;
+
+        // Preparing the groups
+        final List<RolloutGroup> groups = groupList.stream().map(
+                group -> RolloutHelper.prepareRolloutGroupWithDefaultConditions(group, conditions))
+                .collect(Collectors.toList());
+        groups.forEach(RolloutHelper::verifyRolloutGroupHasConditions);
+
+        verifyRolloutGroupTargetCounts(groups, savedRollout);
+
+        // Persisting the groups
+        RolloutGroup lastSavedGroup = null;
+        for (final RolloutGroup srcGroup : groups) {
+            final JpaRolloutGroup group = new JpaRolloutGroup();
+            group.setName(srcGroup.getName());
+            group.setDescription(srcGroup.getDescription());
+            group.setRollout(savedRollout);
+            group.setParent(lastSavedGroup);
+            group.setStatus(RolloutGroupStatus.CREATING);
+
+            group.setTargetPercentage(srcGroup.getTargetPercentage());
+            if (srcGroup.getTargetFilterQuery() != null) {
+                group.setTargetFilterQuery(srcGroup.getTargetFilterQuery());
+            } else {
+                group.setTargetFilterQuery("");
+            }
+
+            group.setSuccessCondition(srcGroup.getSuccessCondition());
+            group.setSuccessConditionExp(srcGroup.getSuccessConditionExp());
+
+            group.setSuccessAction(srcGroup.getSuccessAction());
+            group.setSuccessActionExp(srcGroup.getSuccessActionExp());
+
+            group.setErrorCondition(srcGroup.getErrorCondition());
+            group.setErrorConditionExp(srcGroup.getErrorConditionExp());
+
+            group.setErrorAction(srcGroup.getErrorAction());
+            group.setErrorActionExp(srcGroup.getErrorActionExp());
+
+            try {
+                lastSavedGroup = rolloutGroupRepository.save(group);
+            } catch (ConstraintViolationException e) {
+                for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
+                    LOGGER.error("Violation: " + violation.getPropertyPath() + " " + violation.getMessage());
+                }
+                throw e;
+            }
+        }
+
+        savedRollout.setRolloutGroupsCreated(groups.size());
+        return rolloutRepository.save(savedRollout);
+    }
+
+    @Override
+    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Modifying
+    public void fillRolloutGroupsWithTargets(final Rollout rollout) {
+        RolloutHelper.verifyRolloutInStatus(rollout, RolloutStatus.CREATING);
+
+        List<RolloutGroup> rolloutGroups = rollout.getRolloutGroups();
+        int readyGroups = 0;
+        int totalTargets = 0;
+        for (RolloutGroup group : rolloutGroups) {
+            if (group.getStatus() != RolloutGroupStatus.CREATING) {
+                readyGroups++;
+                totalTargets += group.getTotalTargets();
+                continue;
+            }
+
+            group = fillRolloutGroupWithTargets(rollout, group);
+            if(group.getStatus() == RolloutGroupStatus.READY) {
+                readyGroups++;
+                totalTargets += group.getTotalTargets();
+            }
+        }
+
+        // When all groups are ready the rollout status can be changed to be ready, too.
+        if(readyGroups == rolloutGroups.size()) {
+            final JpaRollout jpaRollout = (JpaRollout) rollout;
+            jpaRollout.setStatus(RolloutStatus.READY);
+            jpaRollout.setTotalTargets(totalTargets);
+            rolloutRepository.save(jpaRollout);
+        }
+    }
+
+    private RolloutGroup fillRolloutGroupWithTargets(final Rollout rollout, final RolloutGroup group1) {
+        RolloutHelper.verifyRolloutInStatus(rollout, RolloutStatus.CREATING);
+
+        JpaRolloutGroup group = (JpaRolloutGroup) group1;
+
+        final String baseFilter = RolloutHelper.getTargetFilterQuery(rollout);
+        final String groupTargetFilter;
+        if (StringUtils.isNotEmpty(group.getTargetFilterQuery())) {
+            groupTargetFilter = baseFilter + ";" + group.getTargetFilterQuery();
+        } else {
+            groupTargetFilter = baseFilter;
+        }
+
+        final List<RolloutGroup> readyGroups = RolloutHelper.getGroupsByStatus(rollout, RolloutGroupStatus.READY);
+
+        final long targetsInGroupFilter = targetManagement
+                .countAllTargetsByTargetFilterQueryAndNotInRolloutGroups(readyGroups, groupTargetFilter);
+        final long expectedInGroup = Math.round(group.getTargetPercentage() / 100 * (double) targetsInGroupFilter);
+        final long currentlyInGroup = rolloutTargetGroupRepository.countByRolloutGroup(group);
+
+        // Switch the Group status to READY, when there are enough Targets in
+        // the Group
+        if (currentlyInGroup >= expectedInGroup) {
+            group.setStatus(RolloutGroupStatus.READY);
+            return rolloutGroupRepository.save(group);
+        }
+
+        long targetsLeftToAdd = expectedInGroup - currentlyInGroup;
+
+        try {
+            do {
+                // Add up to TRANSACTION_TARGETS of the left targets
+                // In case a TransactionException is thrown this loop aborts
+                targetsLeftToAdd -= assignTargetsToGroupInNewTransaction(rollout, group, groupTargetFilter,
+                        Math.min(TRANSACTION_TARGETS, targetsLeftToAdd));
+            } while (targetsLeftToAdd > 0);
+
+            group.setStatus(RolloutGroupStatus.READY);
+            group.setTotalTargets(rolloutTargetGroupRepository.countByRolloutGroup(group).intValue());
+            return rolloutGroupRepository.save(group);
+
+        } catch (TransactionException e) {
+            LOGGER.warn("Transaction assigning Targets to RolloutGroup failed", e);
+            return group;
+        }
+    }
+
+    private long assignTargetsToGroupInNewTransaction(final Rollout rollout, final RolloutGroup group,
+            final String targetFilter, final long limit) {
+        final PageRequest pageRequest = new PageRequest(0, Math.toIntExact(limit));
+        final DefaultTransactionDefinition def = new DefaultTransactionDefinition();
+        def.setName("assignTargetsToRolloutGroup");
+        def.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return new TransactionTemplate(txManager, def).execute(status -> {
+
+            final List<RolloutGroup> readyGroups = RolloutHelper.getGroupsByStatus(rollout, RolloutGroupStatus.READY);
+
+            Page<Target> targets = targetManagement.findAllTargetsByTargetFilterQueryAndNotInRolloutGroups(pageRequest,
+                    readyGroups, targetFilter);
+
+            targets.forEach(target -> rolloutTargetGroupRepository.save(new RolloutTargetGroup(group, target)));
+
+            return targets.getTotalElements();
+        });
+    }
+
+    private void verifyRolloutGroupTargetCounts(final List<RolloutGroup> groups, final JpaRollout rollout) {
+        final String baseFilter = RolloutHelper.getTargetFilterQuery(rollout);
+        final long totalTargets = targetManagement.countTargetByTargetFilterQuery(baseFilter);
+        if (totalTargets == 0) {
+            throw new RolloutVerificationException("Rollout target filter does not match any targets");
+        }
+
+        long targetCount = totalTargets;
+        long unusedTargetsCount = 0;
+
+        for (int i = 0; i < groups.size(); i++) {
+            final RolloutGroup group = groups.get(i);
+            RolloutHelper.verifyRolloutGroupTargetPercentage(group.getTargetPercentage());
+
+            final long targetsInGroupFilter = countTargetsOfGroup(baseFilter, totalTargets, group);
+            final long overlappingTargets = countOverlappingTargetsWithPreviousGroups(baseFilter, groups, group, i);
+
+            final long realTargetsInGroup;
+            // Assume that targets which were not used in the previous groups are used in this group
+            if (overlappingTargets > 0 && unusedTargetsCount > 0) {
+                realTargetsInGroup = targetsInGroupFilter - overlappingTargets + unusedTargetsCount;
+                unusedTargetsCount = 0;
+            } else {
+                realTargetsInGroup = targetsInGroupFilter - overlappingTargets;
+            }
+
+            final long reducedTargetsInGroup = Math
+                    .round(group.getTargetPercentage() / 100 * (double) realTargetsInGroup);
+            targetCount -= reducedTargetsInGroup;
+            unusedTargetsCount += realTargetsInGroup - reducedTargetsInGroup;
+
+        }
+
+        RolloutHelper.verifyRemainingTargets(targetCount);
+
+    }
+
+    private long countTargetsOfGroup(final String baseFilter, final long baseFilterCount, final RolloutGroup group) {
+        if (StringUtils.isNotEmpty(group.getTargetFilterQuery())) {
+            return targetManagement
+                    .countTargetByTargetFilterQuery(baseFilter + ";" + group.getTargetFilterQuery());
+        } else {
+            return baseFilterCount;
+        }
+    }
+
+    private long countOverlappingTargetsWithPreviousGroups(final String baseFilter, final List<RolloutGroup> groups,
+            final RolloutGroup group, final int groupIndex) {
+        // there can't be overlapping targets in the first group
+        if(groupIndex == 0) {
+            return 0;
+        }
+        final List<RolloutGroup> previousGroups = groups.subList(0, groupIndex);
+        String overlappingTargetsFilter = RolloutHelper.getOverlappingWithGroupsTargetFilter(previousGroups, group);
+        if (StringUtils.isNotEmpty(overlappingTargetsFilter)) {
+            overlappingTargetsFilter = baseFilter + ";" + overlappingTargetsFilter;
+        } else {
+            overlappingTargetsFilter = baseFilter;
+        }
+        return targetManagement.countTargetByTargetFilterQuery(overlappingTargetsFilter);
     }
 
     @Override
@@ -334,14 +516,18 @@ public class JpaRolloutManagement implements RolloutManagement {
         for (int iGroup = 0; iGroup < rolloutGroups.size(); iGroup++) {
             final JpaRolloutGroup rolloutGroup = rolloutGroups.get(iGroup);
             final List<Target> targetGroup = targetRepository.findByRolloutTargetGroupRolloutGroup(rolloutGroup);
-            // firstgroup can already be started
-            if (iGroup == 0) {
+            if(targetGroup.isEmpty()) {
+                rolloutGroup.setStatus(RolloutGroupStatus.FINISHED);
+
+            } else if (iGroup == 0) {
+                // first group can already be started
                 final List<TargetWithActionType> targetsWithActionType = targetGroup.stream()
                         .map(t -> new TargetWithActionType(t.getControllerId(), actionType, forceTime))
                         .collect(Collectors.toList());
                 deploymentManagement.assignDistributionSet(distributionSet.getId(), targetsWithActionType, rollout,
                         rolloutGroup);
                 rolloutGroup.setStatus(RolloutGroupStatus.RUNNING);
+
             } else {
                 // create only not active actions with status scheduled so they
                 // can be activated later
@@ -577,6 +763,30 @@ public class JpaRolloutManagement implements RolloutManagement {
     private void executeRolloutGroupSuccessAction(final Rollout rollout, final RolloutGroup rolloutGroup) {
         context.getBean(rolloutGroup.getSuccessAction().getBeanName(), RolloutGroupActionEvaluator.class).eval(rollout,
                 rolloutGroup, rolloutGroup.getSuccessActionExp());
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.READ_UNCOMMITTED)
+    @Modifying
+    public void checkCreatingRollouts(long delayBetweenChecks) {
+        final long lastCheck = System.currentTimeMillis();
+        final int updated = rolloutRepository.updateLastCheck(lastCheck, delayBetweenChecks, RolloutStatus.CREATING);
+        if (updated == 0) {
+            // nothing to check, maybe another instance already checked in
+            // between
+            LOGGER.debug("No rollouts creating check necessary for current scheduled check {}, next check at {}", lastCheck,
+                    lastCheck + delayBetweenChecks);
+            return;
+        }
+
+        final List<JpaRollout> rolloutsToCheck = rolloutRepository.findByLastCheckAndStatus(lastCheck,
+                RolloutStatus.CREATING);
+        LOGGER.info("Found {} creating rollouts to check", rolloutsToCheck.size());
+
+        for (JpaRollout rollout : rolloutsToCheck) {
+            fillRolloutGroupsWithTargets(rollout);
+        }
+
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -44,6 +44,7 @@ import org.eclipse.hawkbit.repository.jpa.model.JpaTargetInfo_;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTargetTag;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTarget_;
 import org.eclipse.hawkbit.repository.jpa.rsql.RSQLUtility;
+import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.repository.rsql.VirtualPropertyReplacer;
 import org.eclipse.hawkbit.repository.jpa.specifications.SpecificationsBuilder;
 import org.eclipse.hawkbit.repository.jpa.specifications.TargetSpecifications;
@@ -598,6 +599,30 @@ public class JpaTargetManagement implements TargetManagement {
                                 .hasNotDistributionSetInActions(distributionSetId).toPredicate(root, cq, cb)),
                 pageRequest);
 
+    }
+
+    @Override
+    public Page<Target> findAllTargetsByTargetFilterQueryAndNotInRolloutGroups(@NotNull final Pageable pageRequest,
+                                                                               final List<RolloutGroup> groups, @NotNull final String targetFilterQuery) {
+
+        final Specification<JpaTarget> spec = RSQLUtility.parse(targetFilterQuery, TargetFields.class,
+                virtualPropertyReplacer);
+
+        return findTargetsBySpec((root, cq, cb) -> cb.and(spec.toPredicate(root, cq, cb),
+                TargetSpecifications.isNotInRolloutGroups(groups).toPredicate(root, cq, cb)), pageRequest);
+
+    }
+
+    @Override
+    public Long countAllTargetsByTargetFilterQueryAndNotInRolloutGroups(final List<RolloutGroup> groups,
+                                                                        @NotNull final String targetFilterQuery) {
+        final Specification<JpaTarget> spec = RSQLUtility.parse(targetFilterQuery, TargetFields.class,
+                virtualPropertyReplacer);
+        final List<Specification<JpaTarget>> specList = new ArrayList<>(2);
+        specList.add(spec);
+        specList.add(TargetSpecifications.isNotInRolloutGroups(groups));
+
+        return countByCriteriaAPI(specList);
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutHelper.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutHelper.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.hawkbit.repository.exception.RolloutIllegalStateException;
+import org.eclipse.hawkbit.repository.exception.RolloutVerificationException;
+import org.eclipse.hawkbit.repository.model.Rollout;
+import org.eclipse.hawkbit.repository.model.RolloutGroup;
+import org.eclipse.hawkbit.repository.model.RolloutGroupConditions;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+final class RolloutHelper {
+    private RolloutHelper() {
+    }
+
+    static void verifyRolloutGroupConditions(final RolloutGroupConditions conditions) {
+        if (conditions.getSuccessCondition() == null) {
+            throw new RolloutVerificationException("Rollout group is missing success condition");
+        }
+        if (conditions.getSuccessAction() == null) {
+            throw new RolloutVerificationException("Rollout group is missing success action");
+        }
+        if (conditions.getErrorCondition() == null) {
+            throw new RolloutVerificationException("Rollout group is missing error condition");
+        }
+        if (conditions.getErrorAction() == null) {
+            throw new RolloutVerificationException("Rollout group is missing error action");
+        }
+    }
+
+    static RolloutGroup verifyRolloutGroupHasConditions(final RolloutGroup group) {
+        if (group.getSuccessCondition() == null) {
+            throw new RolloutVerificationException("Rollout group is missing success condition");
+        }
+        if (group.getSuccessAction() == null) {
+            throw new RolloutVerificationException("Rollout group is missing success action");
+        }
+        if (group.getErrorCondition() == null) {
+            throw new RolloutVerificationException("Rollout group is missing error condition");
+        }
+        if (group.getErrorAction() == null) {
+            throw new RolloutVerificationException("Rollout group is missing error action");
+        }
+        return group;
+    }
+
+    static RolloutGroup prepareRolloutGroupWithDefaultConditions(final RolloutGroup group,
+                                                                 final RolloutGroupConditions conditions) {
+        if (group.getSuccessCondition() == null) {
+            group.setSuccessCondition(conditions.getSuccessCondition());
+        }
+        if (group.getSuccessConditionExp() == null) {
+            group.setSuccessConditionExp(conditions.getSuccessConditionExp());
+        }
+        if (group.getSuccessAction() == null) {
+            group.setSuccessAction(conditions.getSuccessAction());
+        }
+        if (group.getSuccessActionExp() == null) {
+            group.setSuccessActionExp(conditions.getSuccessActionExp());
+        }
+
+        if (group.getErrorCondition() == null) {
+            group.setErrorCondition(conditions.getErrorCondition());
+        }
+        if (group.getErrorConditionExp() == null) {
+            group.setErrorConditionExp(conditions.getErrorConditionExp());
+        }
+        if (group.getErrorAction() == null) {
+            group.setErrorAction(conditions.getErrorAction());
+        }
+        if (group.getErrorActionExp() == null) {
+            group.setErrorActionExp(conditions.getErrorActionExp());
+        }
+        return group;
+    }
+
+    static void verifyRolloutGroupParameter(final int amountGroup) {
+        if (amountGroup <= 0) {
+            throw new RolloutVerificationException("the amountGroup must be greater than zero");
+        } else if (amountGroup > 500) {
+            throw new RolloutVerificationException("the amountGroup must not be greater than 500");
+        }
+    }
+
+    static void verifyRolloutGroupTargetPercentage(final float percentage) {
+        if (percentage <= 0) {
+            throw new RolloutVerificationException("the percentage must be greater than zero");
+        } else if (percentage > 100) {
+            throw new RolloutVerificationException("the percentage must not be greater than 100");
+        }
+    }
+
+    static String getTargetFilterQuery(final Rollout rollout) {
+        if (rollout.getCreatedAt() != null) {
+            return rollout.getTargetFilterQuery() + ";createdat=le=" + rollout.getCreatedAt().toString();
+        }
+        return rollout.getTargetFilterQuery();
+    }
+
+    static void verifyRolloutInStatus(final Rollout rollout, final Rollout.RolloutStatus status) {
+        if (!rollout.getStatus().equals(status)) {
+            throw new RolloutIllegalStateException("Rollout is not in status " + status.toString());
+        }
+    }
+
+    static List<RolloutGroup> getGroupsByStatus(final Rollout rollout, final RolloutGroup.RolloutGroupStatus status) {
+        return rollout.getRolloutGroups().stream().filter(g -> g.getStatus().equals(status))
+                .collect(Collectors.toList());
+    }
+
+
+    /**
+     * Creates an RSQL expression that matches all targets in the provided groups.
+     * Links all target filter queries with OR.
+     *
+     * @param groups the rollout groups
+     * @return RSQL string without base filter of the Rollout. Can be an empty string.
+     */
+    static String getAllGroupsTargetFilter(final List<RolloutGroup> groups) {
+        if (groups.stream().anyMatch(g -> StringUtils.isEmpty(g.getTargetFilterQuery()))) {
+            return "";
+        }
+        return groups.stream().map(RolloutGroup::getTargetFilterQuery).collect(Collectors.joining(","));
+    }
+
+    /**
+     * Creates an RSQL Filter that matches all targets that are in the provided group and
+     * in the provided groups.
+     *
+     * @param groups the rollout groups
+     * @param group   the group
+     * @return RSQL string without base filter of the Rollout. Can be an empty string.
+     */
+    static String getOverlappingWithGroupsTargetFilter(final List<RolloutGroup> groups, final RolloutGroup group) {
+        final String previousGroupFilters = getAllGroupsTargetFilter(groups);
+        if (StringUtils.isNotEmpty(previousGroupFilters) && StringUtils.isNotEmpty(group.getTargetFilterQuery())) {
+            return group.getTargetFilterQuery() + ";(" + previousGroupFilters + ")";
+        } else if (StringUtils.isNotEmpty(previousGroupFilters)) {
+            return "(" + previousGroupFilters + ")";
+        } else if (StringUtils.isNotEmpty(group.getTargetFilterQuery())) {
+            return group.getTargetFilterQuery();
+        } else {
+            return "";
+        }
+    }
+
+    static void verifyRemainingTargets(final long targetCount) {
+        if (targetCount > 0) {
+            throw new RolloutVerificationException(
+                    "Rollout groups don't match all targets that are targeted by the rollout");
+        }
+        if (targetCount != 0) {
+            throw new RolloutVerificationException("Rollout groups target count verification failed");
+        }
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutTargetGroupRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutTargetGroupRepository.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.repository.jpa;
 
+import org.eclipse.hawkbit.repository.jpa.model.JpaRolloutGroup;
 import org.eclipse.hawkbit.repository.jpa.model.RolloutTargetGroup;
 import org.eclipse.hawkbit.repository.jpa.model.RolloutTargetGroupId;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -22,4 +23,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
 public interface RolloutTargetGroupRepository
         extends CrudRepository<RolloutTargetGroup, RolloutTargetGroupId>, JpaSpecificationExecutor<RolloutTargetGroup> {
+
+    /**
+     * Counts all entries that have the specified rolloutGroup
+     * 
+     * @param rolloutGroup
+     *            the group to filter for
+     * @return count of targets in the group
+     */
+    Long countByRolloutGroup(final JpaRolloutGroup rolloutGroup);
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRolloutGroup.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRolloutGroup.java
@@ -54,7 +54,7 @@ public class JpaRolloutGroup extends AbstractJpaNamedEntity implements RolloutGr
     private JpaRollout rollout;
 
     @Column(name = "status")
-    private RolloutGroupStatus status = RolloutGroupStatus.READY;
+    private RolloutGroupStatus status = RolloutGroupStatus.CREATING;
 
     @OneToMany(fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST }, targetEntity = RolloutTargetGroup.class)
     @JoinColumn(name = "rolloutGroup_Id", insertable = false, updatable = false)
@@ -93,6 +93,13 @@ public class JpaRolloutGroup extends AbstractJpaNamedEntity implements RolloutGr
 
     @Column(name = "total_targets")
     private int totalTargets;
+
+    @Column(name = "target_filter", length = 1024)
+    @Size(max = 1024)
+    private String targetFilterQuery = "";
+
+    @Column(name = "target_percentage")
+    private float targetPercentage = 100;
 
     @Transient
     private transient TotalTargetCountStatus totalTargetCountStatus;
@@ -213,12 +220,34 @@ public class JpaRolloutGroup extends AbstractJpaNamedEntity implements RolloutGr
         this.totalTargets = totalTargets;
     }
 
+    @Override
     public void setSuccessAction(final RolloutGroupSuccessAction successAction) {
         this.successAction = successAction;
     }
 
+    @Override
     public void setSuccessActionExp(final String successActionExp) {
         this.successActionExp = successActionExp;
+    }
+
+    @Override
+    public String getTargetFilterQuery() {
+        return targetFilterQuery;
+    }
+
+    @Override
+    public void setTargetFilterQuery(String targetFilterQuery) {
+        this.targetFilterQuery = targetFilterQuery;
+    }
+
+    @Override
+    public float getTargetPercentage() {
+        return targetPercentage;
+    }
+
+    @Override
+    public void setTargetPercentage(float targetPercentage) {
+        this.targetPercentage = targetPercentage;
     }
 
     /**
@@ -243,10 +272,10 @@ public class JpaRolloutGroup extends AbstractJpaNamedEntity implements RolloutGr
 
     @Override
     public String toString() {
-        return "RolloutGroup [rollout=" + rollout + ", status=" + status + ", rolloutTargetGroup=" + rolloutTargetGroup
-                + ", parent=" + parent + ", finishCondition=" + successCondition + ", finishExp=" + successConditionExp
-                + ", errorCondition=" + errorCondition + ", errorExp=" + errorConditionExp + ", getName()=" + getName()
-                + ", getId()=" + getId() + "]";
+        return "RolloutGroup [rollout=" + (rollout != null ? rollout.getId() : "") + ", status=" + status
+                + ", rolloutTargetGroup=" + rolloutTargetGroup + ", parent=" + parent + ", finishCondition="
+                + successCondition + ", finishExp=" + successConditionExp + ", errorCondition=" + errorCondition
+                + ", errorExp=" + errorConditionExp + ", getName()=" + getName() + ", getId()=" + getId() + "]";
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/RolloutScheduler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/RolloutScheduler.java
@@ -73,7 +73,9 @@ public class RolloutScheduler {
             LOGGER.info("Checking rollouts for {} tenants", tenants.size());
             for (final String tenant : tenants) {
                 tenantAware.runAsTenant(tenant, () -> {
-                    rolloutManagement.checkRunningRollouts(rolloutProperties.getScheduler().getFixedDelay());
+                    final long fixedDelay = rolloutProperties.getScheduler().getFixedDelay();
+                    rolloutManagement.checkCreatingRollouts(fixedDelay);
+                    rolloutManagement.checkRunningRollouts(fixedDelay);
                     return null;
                 });
             }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_9_0__advanced_rollout__H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_9_0__advanced_rollout__H2.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sp_rolloutgroup
+  ADD COLUMN target_percentage FLOAT;
+ALTER TABLE sp_rolloutgroup
+  ADD COLUMN target_filter VARCHAR (1024);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_9_0__advanced_rollout__MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_9_0__advanced_rollout__MYSQL.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sp_rolloutgroup
+  ADD COLUMN target_percentage FLOAT;
+ALTER TABLE sp_rolloutgroup
+  ADD COLUMN target_filter VARCHAR (1024);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLActionFieldsTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLActionFieldsTest.java
@@ -18,6 +18,7 @@ import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTarget;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.ActionType;
+import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.data.domain.PageRequest;
@@ -36,17 +37,20 @@ public class RSQLActionFieldsTest extends AbstractJpaIntegrationTest {
 
     @Before
     public void setupBeforeTest() {
+        final DistributionSet dsA = testdataFactory.createDistributionSet("daA");
         target = new JpaTarget("targetId123");
         target.setDescription("targetId123");
         targetManagement.createTarget(target);
         action = new JpaAction();
         action.setActionType(ActionType.SOFT);
+        action.setDistributionSet(dsA);
         target.addAction(action);
         action.setTarget(target);
         actionRepository.save(action);
         for (int i = 0; i < 10; i++) {
             final JpaAction newAction = new JpaAction();
             newAction.setActionType(ActionType.SOFT);
+            newAction.setDistributionSet(dsA);
             newAction.setActive(i % 2 == 0);
             newAction.setTarget(target);
             actionRepository.save(newAction);

--- a/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/util/JsonBuilder.java
+++ b/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/util/JsonBuilder.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
+import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.repository.model.RolloutGroupConditions;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
@@ -398,7 +399,13 @@ public abstract class JsonBuilder {
     }
 
     public static String rollout(final String name, final String description, final int groupSize,
-            final long distributionSetId, final String targetFilterQuery, final RolloutGroupConditions conditions) {
+                                 final long distributionSetId, final String targetFilterQuery, final RolloutGroupConditions conditions) {
+        return rollout(name, description, groupSize, distributionSetId, targetFilterQuery, conditions, null);
+    }
+
+    public static String rollout(final String name, final String description, final Integer groupSize,
+            final long distributionSetId, final String targetFilterQuery, final RolloutGroupConditions conditions,
+                                 final List<RolloutGroup> groups) {
         final JSONObject json = new JSONObject();
         json.put("name", name);
         json.put("description", description);
@@ -410,22 +417,64 @@ public abstract class JsonBuilder {
             final JSONObject successCondition = new JSONObject();
             json.put("successCondition", successCondition);
             successCondition.put("condition", conditions.getSuccessCondition().toString());
-            successCondition.put("expression", conditions.getSuccessConditionExp().toString());
+            successCondition.put("expression", conditions.getSuccessConditionExp());
 
             final JSONObject successAction = new JSONObject();
             json.put("successAction", successAction);
             successAction.put("action", conditions.getSuccessAction().toString());
-            successAction.put("expression", conditions.getSuccessActionExp().toString());
+            successAction.put("expression", conditions.getSuccessActionExp());
 
             final JSONObject errorCondition = new JSONObject();
             json.put("errorCondition", errorCondition);
             errorCondition.put("condition", conditions.getErrorCondition().toString());
-            errorCondition.put("expression", conditions.getErrorConditionExp().toString());
+            errorCondition.put("expression", conditions.getErrorConditionExp());
 
             final JSONObject errorAction = new JSONObject();
             json.put("errorAction", errorAction);
             errorAction.put("action", conditions.getErrorAction().toString());
-            errorAction.put("expression", conditions.getErrorActionExp().toString());
+            errorAction.put("expression", conditions.getErrorActionExp());
+        }
+
+        if(groups != null) {
+            final JSONArray jsonGroups = new JSONArray();
+
+            for (RolloutGroup group : groups) {
+                final JSONObject jsonGroup = new JSONObject();
+                jsonGroup.put("name", group.getName());
+                jsonGroup.put("description", group.getDescription());
+                jsonGroup.put("targetFilterQuery", group.getTargetFilterQuery());
+                jsonGroup.put("targetPercentage", group.getTargetPercentage());
+
+                if(group.getSuccessCondition() != null) {
+                    final JSONObject successCondition = new JSONObject();
+                    jsonGroup.put("successCondition", successCondition);
+                    successCondition.put("condition", group.getSuccessCondition().toString());
+                    successCondition.put("expression", group.getSuccessConditionExp());
+                }
+                if(group.getSuccessAction() != null) {
+                    final JSONObject successAction = new JSONObject();
+                    jsonGroup.put("successAction", successAction);
+                    successAction.put("action", group.getSuccessAction().toString());
+                    successAction.put("expression", group.getSuccessActionExp());
+                }
+                if(group.getErrorCondition() != null) {
+                    final JSONObject errorCondition = new JSONObject();
+                    jsonGroup.put("errorCondition", errorCondition);
+                    errorCondition.put("condition", group.getErrorCondition().toString());
+                    errorCondition.put("expression", group.getErrorConditionExp());
+                }
+                if(group.getErrorAction() != null) {
+                    final JSONObject errorAction = new JSONObject();
+                    jsonGroup.put("errorAction", errorAction);
+                    errorAction.put("action", group.getErrorAction().toString());
+                    errorAction.put("expression", group.getErrorActionExp());
+                }
+
+                jsonGroups.put(jsonGroup);
+            }
+
+            json.put("groups", jsonGroups);
+
         }
 
         return json.toString();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
@@ -491,7 +491,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
         rolloutToCreate.setActionType(getActionType());
         rolloutToCreate.setForcedTime(getForcedTimeStamp());
 
-        rolloutToCreate = rolloutManagement.createRolloutAsync(rolloutToCreate, amountGroup, conditions);
+        rolloutToCreate = rolloutManagement.createRollout(rolloutToCreate, amountGroup, conditions);
         return rolloutToCreate;
     }
 


### PR DESCRIPTION
The target of this Rollouts feature extension is to enable the creation of Rollouts with a custom groups definition.

**MgmtAPI**
The MgmtAPI is held backward compatible to the full automatic Group creation by just providing the wished amount of Groups.
The createRollout request has been extended to accept a defined list of groups.

**Changed Rollout creation process** 
When a Rollout creation is requested, just the Rollout and RolloutGroup entities are created in the _CREATING_ status, but no Targets are assigned to the Groups immediately. The Groups can have a _target filter_ and _target percentage_, which are used by the fill process to assign Targets to a Group.

**Fill process**
The fill process is started by the Rollout Scheduler. All Rollouts that are in the CREATING status are checked for Groups in the CREATING status. Once a Group is found in the CREATING status, the remaining Targets, which are not in a previous Group and match the optional _target filter_ of the Group, are selected and the _target percentage_ of those is assigned to the Group.
Once a Group has reached the desired amount of Targets, its status is switched to READY. When all Groups are READY, the Rollout is switched to READY.

**Defining groups example**
To put 1000 Targets into two Groups in a 30/70 relation, the first Group defines _target percentage_ 30 (300 Targets) and the second Group defines _target percentage_ 100, because the second Group needs to address 100% of the remaining 700 Targets.