### PR TITLE
Upgrade vaadin from 7.6.8 -> 7.7.3:

### DIFF
--- a/examples/hawkbit-example-app/pom.xml
+++ b/examples/hawkbit-example-app/pom.xml
@@ -114,6 +114,18 @@
          <groupId>com.h2database</groupId>
          <artifactId>h2</artifactId>
       </dependency>
+      
+      <!-- exclude gwt-elemental as there are class conflicts -->
+      <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-client</artifactId>
+            <exclusions>
+               <exclusion>
+                  <groupId>com.vaadin.external.gwt</groupId>
+                  <artifactId>gwt-elemental</artifactId>
+               </exclusion>
+            </exclusions>
+         </dependency>  
    </dependencies>
 
 </project>

--- a/hawkbit-rest-core/pom.xml
+++ b/hawkbit-rest-core/pom.xml
@@ -48,7 +48,6 @@
       <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>javax.servlet-api</artifactId>
-         <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.tomcat.embed</groupId>

--- a/hawkbit-rest-core/pom.xml
+++ b/hawkbit-rest-core/pom.xml
@@ -48,6 +48,7 @@
       <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>javax.servlet-api</artifactId>
+         <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.tomcat.embed</groupId>

--- a/hawkbit-security-core/pom.xml
+++ b/hawkbit-security-core/pom.xml
@@ -29,6 +29,7 @@
       <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>javax.servlet-api</artifactId>
+         <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>org.springframework</groupId>

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/DistributionBarHelper.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/DistributionBarHelper.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ui.rollout;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -17,7 +18,7 @@ import org.vaadin.alump.distributionbar.gwt.client.GwtDistributionBar;
 
 /**
  * Distribution bar helper to render distribution bar in grid.
- * 
+ *
  */
 public final class DistributionBarHelper {
     private static final String HTML_DIV_END = "</div>";
@@ -33,10 +34,10 @@ public final class DistributionBarHelper {
 
     /**
      * Returns a string with details of status and count .
-     * 
+     *
      * @param statusTotalCountMap
      *            map with status and count
-     * 
+     *
      * @return string of format "status1:count,status2:count"
      */
     public static String getDistributionBarAsHTMLString(final Map<Status, Long> statusTotalCountMap) {
@@ -61,7 +62,7 @@ public final class DistributionBarHelper {
 
     /**
      * Returns the map with status having non zero values.
-     * 
+     *
      * @param statusTotalCountMap
      *            map with status and count
      * @return map with non zero values
@@ -73,7 +74,7 @@ public final class DistributionBarHelper {
 
     /**
      * Returns tool tip for progress bar.
-     * 
+     *
      * @param statusCountMap
      *            map with status and count details
      * @return tool tip
@@ -114,7 +115,9 @@ public final class DistributionBarHelper {
         final double minTotalSize = MINIMUM_PART_SIZE * noOfParts;
         final double availableSize = PARENT_SIZE_IN_PCT - minTotalSize;
         final double val = MINIMUM_PART_SIZE + (double) value / totalValue * availableSize;
-        return String.format("%.3f", val) + "%";
+        // necessary due the format must contain a dot and other locals might
+        // use a comma
+        return String.format(Locale.ENGLISH, "%.3f", val) + "%";
     }
 
     private static String getPart(final int partIndex, final Status status, final Long value, final Long totalValue,

--- a/pom.xml
+++ b/pom.xml
@@ -115,14 +115,14 @@
       <!-- Spring boot version overrides - END -->
 
       <!-- Vaadin versions - START -->
-      <vaadin.spring.version>1.0.0</vaadin.spring.version>
+      <vaadin.spring.version>1.0.2</vaadin.spring.version>
       <vaadin.spring.addon.version>0.0.6.RELEASE</vaadin.spring.addon.version>
-      <vaadin.version>7.6.8</vaadin.version>
+      <vaadin.version>7.7.3</vaadin.version>
       <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
       <vaadin.addon.vaadin-lazyquerycontainer.version>7.6.1.3</vaadin.addon.vaadin-lazyquerycontainer.version>
-      <vaadin.addon.flexibleoptiongroup.version>2.2.0</vaadin.addon.flexibleoptiongroup.version>
+      <vaadin.addon.flexibleoptiongroup.version>2.3.0</vaadin.addon.flexibleoptiongroup.version>
       <vaadin.addon.tokenfield.version>7.0.1</vaadin.addon.tokenfield.version>
-      <vaadin.addon.dbar-addon.version>1.2.0</vaadin.addon.dbar-addon.version>
+      <vaadin.addon.dbar-addon.version>2.0.0</vaadin.addon.dbar-addon.version>
       <vaadin.addon.contextmenu.version>4.5</vaadin.addon.contextmenu.version>
       <!-- Vaadin versions - END -->
 
@@ -472,7 +472,7 @@
             <version>${vaadin.version}</version>
             <type>pom</type>
             <scope>import</scope>
-         </dependency>         
+         </dependency>
          <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring-boot</artifactId>


### PR DESCRIPTION
upgrade vaadin.spring       from 1.0.0 -> 1.0.2
upgrade flexibleoptiongroup from 2.2.0 -> 2.3.0
upgrade dbar-addon          from 1.2.0 -> 2.0.0
exclude gwt-elemental for example app

Signed-off-by: Marcel Mager (INST-IOT/ESB) <Marcel.Mager@bosch-si.com>