### PR TITLE
add missing hash-code and equals for DownloadArtifactCache

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/cache/DownloadArtifactCache.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/cache/DownloadArtifactCache.java
@@ -25,7 +25,6 @@ public class DownloadArtifactCache {
      *            the searching id e.g. sha1, md5
      */
     public DownloadArtifactCache(final DownloadType downloadType, final String id) {
-        super();
         this.downloadType = downloadType;
         this.id = id;
     }
@@ -38,4 +37,31 @@ public class DownloadArtifactCache {
         return downloadType;
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((downloadType == null) ? 0 : downloadType.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        final DownloadArtifactCache other = (DownloadArtifactCache) obj;
+        if (downloadType != other.downloadType)
+            return false;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        return true;
+    }
 }


### PR DESCRIPTION
add missing `equals` and `hashCode` to the DownloadArtifactCache which is necessary for security checks.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>