### PR TITLE
fix typo in HashNotMatchException

### DIFF
--- a/hawkbit-artifact-repository-filesystem/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemRepository.java
+++ b/hawkbit-artifact-repository-filesystem/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemRepository.java
@@ -146,7 +146,7 @@ public class ArtifactFilesystemRepository implements ArtifactRepository {
             return artifact;
         }
         if (hash.getSha1() != null && !artifact.getHashes().getSha1().equals(hash.getSha1())) {
-            throw new HashNotMatchException("The given sh1 hash " + hash.getSha1()
+            throw new HashNotMatchException("The given sha1 hash " + hash.getSha1()
                     + " does not match with the calcualted sha1 hash " + artifact.getHashes().getSha1(),
                     HashNotMatchException.SHA1);
         }


### PR DESCRIPTION
Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>