### PR TITLE
use ID property for sorting because its indexed on DB

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/ManageDistBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/ManageDistBeanQuery.java
@@ -40,7 +40,7 @@ import com.google.common.base.Strings;
 public class ManageDistBeanQuery extends AbstractBeanQuery<ProxyDistribution> {
 
     private static final long serialVersionUID = 5176481314404662215L;
-    private Sort sort = new Sort(Direction.ASC, "createdAt");
+    private Sort sort = new Sort(Direction.ASC, "id");
     private String searchText;
     private transient DistributionSetManagement distributionSetManagement;
     private transient Page<DistributionSet> firstPageDistributionSets;
@@ -68,8 +68,8 @@ public class ManageDistBeanQuery extends AbstractBeanQuery<ProxyDistribution> {
                 distributionSetType = (DistributionSetType) queryConfig
                         .get(SPUIDefinitions.FILTER_BY_DISTRIBUTION_SET_TYPE);
             }
-            if(queryConfig.get(SPUIDefinitions.FILTER_BY_DS_COMPLETE) != null) {
-                dsComplete = (Boolean)queryConfig.get(SPUIDefinitions.FILTER_BY_DS_COMPLETE);
+            if (queryConfig.get(SPUIDefinitions.FILTER_BY_DS_COMPLETE) != null) {
+                dsComplete = (Boolean) queryConfig.get(SPUIDefinitions.FILTER_BY_DS_COMPLETE);
             }
         }
 
@@ -101,8 +101,8 @@ public class ManageDistBeanQuery extends AbstractBeanQuery<ProxyDistribution> {
                     new OffsetBasedPageRequest(startIndex, count, sort), false, dsComplete);
         } else {
             final DistributionSetFilter distributionSetFilter = new DistributionSetFilterBuilder().setIsDeleted(false)
-                    .setIsComplete(dsComplete)
-                    .setSearchText(searchText).setSelectDSWithNoTag(Boolean.FALSE).setType(distributionSetType).build();
+                    .setIsComplete(dsComplete).setSearchText(searchText).setSelectDSWithNoTag(Boolean.FALSE)
+                    .setType(distributionSetType).build();
             distBeans = getDistributionSetManagement().findDistributionSetsByFilters(
                     new PageRequest(startIndex / count, count, sort), distributionSetFilter);
         }
@@ -127,8 +127,8 @@ public class ManageDistBeanQuery extends AbstractBeanQuery<ProxyDistribution> {
                     new PageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), false, dsComplete);
         } else {
             final DistributionSetFilter distributionSetFilter = new DistributionSetFilterBuilder().setIsDeleted(false)
-                    .setIsComplete(dsComplete)
-                    .setSearchText(searchText).setSelectDSWithNoTag(Boolean.FALSE).setType(distributionSetType).build();
+                    .setIsComplete(dsComplete).setSearchText(searchText).setSelectDSWithNoTag(Boolean.FALSE)
+                    .setType(distributionSetType).build();
             firstPageDistributionSets = getDistributionSetManagement().findDistributionSetsByFilters(
                     new PageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), distributionSetFilter);
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CustomTargetBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CustomTargetBeanQuery.java
@@ -45,7 +45,7 @@ import com.google.common.base.Strings;
 public class CustomTargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
 
     private static final long serialVersionUID = 6490445732785388071L;
-    private Sort sort = new Sort(Direction.DESC, "createdAt");
+    private Sort sort = new Sort(Direction.ASC, "id");
     private transient TargetManagement targetManagement;
     private FilterManagementUIState filterManagementUIState;
     private transient I18N i18N;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionBeanQuery.java
@@ -41,7 +41,7 @@ import com.google.common.base.Strings;
 public class DistributionBeanQuery extends AbstractBeanQuery<ProxyDistribution> {
 
     private static final long serialVersionUID = 5862679853949173536L;
-    private Sort sort = new Sort(Direction.ASC, "createdAt");
+    private Sort sort = new Sort(Direction.ASC, "id");
     private Collection<String> distributionTags;
     private String searchText;
     private String pinnedControllerId;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBeanQuery.java
@@ -20,8 +20,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.hawkbit.repository.FilterParams;
 import org.apache.commons.collections4.CollectionUtils;
+import org.eclipse.hawkbit.repository.FilterParams;
 import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
@@ -52,7 +52,7 @@ public class TargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
 
     private static final long serialVersionUID = -5645680058303167558L;
 
-    private Sort sort = new Sort(TARGET_TABLE_CREATE_AT_SORT_ORDER, "createdAt");
+    private Sort sort = new Sort(TARGET_TABLE_CREATE_AT_SORT_ORDER, "id");
     private transient Collection<TargetUpdateStatus> status;
     private transient Boolean overdueState;
     private String[] targetTags;
@@ -211,7 +211,8 @@ public class TargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
 
     private boolean isAnyFilterSelected() {
         final boolean isFilterSelected = isTagSelected() || isOverdueFilterEnabled();
-        return isFilterSelected || CollectionUtils.isNotEmpty(status) || distributionId != null || !isNullOrEmpty(searchText);
+        return isFilterSelected || CollectionUtils.isNotEmpty(status) || distributionId != null
+                || !isNullOrEmpty(searchText);
     }
 
     private TargetManagement getTargetManagement() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
@@ -47,7 +47,7 @@ public class RolloutBeanQuery extends AbstractBeanQuery<ProxyRollout> {
 
     private final String searchText;
 
-    private Sort sort = new Sort(Direction.ASC, "createdAt");
+    private Sort sort = new Sort(Direction.ASC, "id");
 
     private transient RolloutManagement rolloutManagement;
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupBeanQuery.java
@@ -42,7 +42,7 @@ public class RolloutGroupBeanQuery extends AbstractBeanQuery<ProxyRolloutGroup> 
 
     private static final long serialVersionUID = 5342450502894318589L;
 
-    private Sort sort = new Sort(Direction.ASC, "createdAt");
+    private Sort sort = new Sort(Direction.ASC, "id");
 
     private transient Page<RolloutGroup> firstPageRolloutGroupSets = null;
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsBeanQuery.java
@@ -39,7 +39,7 @@ public class RolloutGroupTargetsBeanQuery extends AbstractBeanQuery<ProxyTarget>
 
     private static final long serialVersionUID = -8841076207255485907L;
 
-    private final Sort sort = new Sort(Direction.ASC, "createdAt");
+    private final Sort sort = new Sort(Direction.ASC, "id");
 
     private transient Page<TargetWithActionStatus> firstPageTargetSets = null;
 


### PR DESCRIPTION
use the sort property `id` instead of `createdAt` because the `id` field is indexed.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>