### PR TITLE
delete file quietly

### DIFF
--- a/hawkbit-ui/pom.xml
+++ b/hawkbit-ui/pom.xml
@@ -171,6 +171,10 @@
          <artifactId>hawkbit-repository-api</artifactId>
          <version>${project.version}</version>
       </dependency>
+      <dependency>
+         <groupId>commons-io</groupId>
+         <artifactId>commons-io</artifactId>
+      </dependency>
       <!-- Vaadin -->
       <dependency>
          <groupId>com.vaadin</groupId>

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadLayout.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.apache.commons.io.FileUtils;
 import org.eclipse.hawkbit.repository.exception.ArtifactUploadFailedException;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent;
@@ -593,10 +594,7 @@ public class UploadLayout extends VerticalLayout {
     void clearFileList() {
         // delete file system zombies
         artifactUploadState.getFileSelected().forEach(customFile -> {
-            final File file = new File(customFile.getFilePath());
-            if (!file.delete()) {
-                LOG.warn("Failed to delete file {} in upload dialog", customFile.getFilePath());
-            }
+            FileUtils.deleteQuietly(new File(customFile.getFilePath()));
         });
 
         artifactUploadState.getFileSelected().clear();


### PR DESCRIPTION
* The files were already deleted before and the method just tried to delete again of a file which doesn't exists anymore, so just try to delete quietly.
The file has been already deleted in a finally block of `org.eclipse.hawkbit.ui.artifacts.upload.UploadConfirmationWindow.createArtifact(String, String, ArtifactManagement, SoftwareModule)`
```
finally {
            if (newFile.exists() && !newFile.delete()) {
                LOG.error("Could not delete temporary file: {}", newFile);
            }
        }
```

But in case of file discarding the file need to be deleted, but I should be sufficient to do it silently. 

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>