### PR TITLE
correct ordinal of RolloutGroupStatus

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRolloutGroup.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRolloutGroup.java
@@ -32,6 +32,9 @@ import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus;
 import org.eclipse.hawkbit.repository.model.helper.EventPublisherHolder;
+import org.eclipse.persistence.annotations.ConversionValue;
+import org.eclipse.persistence.annotations.Convert;
+import org.eclipse.persistence.annotations.ObjectTypeConverter;
 import org.eclipse.persistence.descriptors.DescriptorEvent;
 
 /**
@@ -45,6 +48,13 @@ import org.eclipse.persistence.descriptors.DescriptorEvent;
 // exception squid:S2160 - BaseEntity equals/hashcode is handling correctly for
 // sub entities
 @SuppressWarnings("squid:S2160")
+@ObjectTypeConverter(name = "rolloutgroupstatus", objectType = RolloutGroup.RolloutGroupStatus.class, dataType = Integer.class, conversionValues = {
+        @ConversionValue(objectValue = "READY", dataValue = "0"),
+        @ConversionValue(objectValue = "SCHEDULED", dataValue = "1"),
+        @ConversionValue(objectValue = "FINISHED", dataValue = "2"),
+        @ConversionValue(objectValue = "ERROR", dataValue = "3"),
+        @ConversionValue(objectValue = "RUNNING", dataValue = "4"),
+        @ConversionValue(objectValue = "CREATING", dataValue = "5") })
 public class JpaRolloutGroup extends AbstractJpaNamedEntity implements RolloutGroup, EventAwareEntity {
 
     private static final long serialVersionUID = 1L;
@@ -54,6 +64,7 @@ public class JpaRolloutGroup extends AbstractJpaNamedEntity implements RolloutGr
     private JpaRollout rollout;
 
     @Column(name = "status")
+    @Convert("rolloutgroupstatus")
     private RolloutGroupStatus status = RolloutGroupStatus.CREATING;
 
     @OneToMany(fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST }, targetEntity = RolloutTargetGroup.class)


### PR DESCRIPTION
In the pull-request: https://github.com/eclipse/hawkbit/pull/337/files#diff-12b5a398f430daeb3331d7c37bbbbbc7#L218-L223 the ordinal of the `RolloutGroupStatus` has been changed and so existing rolloutgroups states has been shifted by one because the ordinal is stored in the database table.

This behavior should be corrected, so further deployments of hawkBit are not breaking existing, running rollouts. So the order of the enum `RolloutGroupStatus` should be corrected again.

Anyway there might be already mixed up database entries by the `RolloutScheduler` of existing rollout-groups and shifted the state by one, in case an update with the wrong ordinal entry of the `RolloutGroupStatus` has been done.
To correct persisted mixing up `Rollouts` with this pull-request the necessary database SQL scripts have to be executed:

Where as `UPDATE_HAWKBIT_TS` is the update of the broken rollouts in case there have been a broken hawkbit-update-server with the master including the wrong ordinal order of the `RolloutGroupStatus`
```
UPDATE sp_rolloutgroup SET status = status -1 WHERE created_at > [UPDATE_HAWKBIT_TS];
UPDATE sp_rolloutgroup SET status = 5 WHERE created_at > [UPDATE_HAWKBIT_TS] AND status = -1;
```

Modified groups in that time need to be manually recovered.
```
SELECT * FROM sp_rolloutgroup WHERE created_at < [DEPLOYMENT_TS] and last_modified_at > [DEPLOYMENT_TS]
```

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>