### PR TITLE
Fixed broken rollout management API concerning target status map.

### DIFF
--- a/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutResponseBody.java
+++ b/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutResponseBody.java
@@ -37,8 +37,8 @@ public class MgmtRolloutResponseBody extends MgmtNamedEntity {
     @JsonProperty(required = true)
     private Long totalTargets;
 
-    @JsonProperty(required = true)
-    private final Map<String, Long> totalTargetsPerStatus = new HashMap<>();
+    @JsonProperty
+    private Map<String, Long> totalTargetsPerStatus;
 
     /**
      * @return the status
@@ -120,5 +120,13 @@ public class MgmtRolloutResponseBody extends MgmtNamedEntity {
      */
     public Map<String, Long> getTotalTargetsPerStatus() {
         return totalTargetsPerStatus;
+    }
+
+    public void addTotalTargetsPerStatus(final String status, final Long totalTargetCountByStatus) {
+        if (totalTargetsPerStatus == null) {
+            totalTargetsPerStatus = new HashMap<>();
+        }
+
+        totalTargetsPerStatus.put(status, totalTargetCountByStatus);
     }
 }

--- a/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rolloutgroup/MgmtRolloutGroupResponseBody.java
+++ b/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rolloutgroup/MgmtRolloutGroupResponseBody.java
@@ -8,13 +8,13 @@
  */
 package org.eclipse.hawkbit.mgmt.json.model.rolloutgroup;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Model for the rollout group annotated with json-annotations for easier
@@ -32,34 +32,20 @@ public class MgmtRolloutGroupResponseBody extends MgmtRolloutGroup {
 
     private int totalTargets;
 
-    private final Map<String, Long> totalTargetsPerStatus = new HashMap<>();
+    private Map<String, Long> totalTargetsPerStatus;
 
-    /**
-     * @return the rolloutGroupId
-     */
     public Long getRolloutGroupId() {
         return rolloutGroupId;
     }
 
-    /**
-     * @param rolloutGroupId
-     *            the rolloutGroupId to set
-     */
     public void setRolloutGroupId(final Long rolloutGroupId) {
         this.rolloutGroupId = rolloutGroupId;
     }
 
-    /**
-     * @return the status
-     */
     public String getStatus() {
         return status;
     }
 
-    /**
-     * @param status
-     *            the status to set
-     */
     public void setStatus(final String status) {
         this.status = status;
     }
@@ -68,12 +54,20 @@ public class MgmtRolloutGroupResponseBody extends MgmtRolloutGroup {
         return totalTargets;
     }
 
-    public void setTotalTargets(int totalTargets) {
+    public void setTotalTargets(final int totalTargets) {
         this.totalTargets = totalTargets;
     }
 
     public Map<String, Long> getTotalTargetsPerStatus() {
         return totalTargetsPerStatus;
+    }
+
+    public void addTotalTargetsPerStatus(final String status, final Long totalTargetCountByStatus) {
+        if (totalTargetsPerStatus == null) {
+            totalTargetsPerStatus = new HashMap<>();
+        }
+
+        totalTargetsPerStatus.put(status, totalTargetCountByStatus);
     }
 
 }

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
@@ -61,10 +61,10 @@ final class MgmtRolloutMapper {
             return Collections.emptyList();
         }
 
-        return rollouts.stream().map(MgmtRolloutMapper::toResponseRollout).collect(Collectors.toList());
+        return rollouts.stream().map(rollout -> toResponseRollout(rollout, false)).collect(Collectors.toList());
     }
 
-    static MgmtRolloutResponseBody toResponseRollout(final Rollout rollout) {
+    static MgmtRolloutResponseBody toResponseRollout(final Rollout rollout, final boolean withDetails) {
         final MgmtRolloutResponseBody body = new MgmtRolloutResponseBody();
         body.setCreatedAt(rollout.getCreatedAt());
         body.setCreatedBy(rollout.getCreatedBy());
@@ -78,9 +78,11 @@ final class MgmtRolloutMapper {
         body.setStatus(rollout.getStatus().toString().toLowerCase());
         body.setTotalTargets(rollout.getTotalTargets());
 
-        for (final TotalTargetCountStatus.Status status : TotalTargetCountStatus.Status.values()) {
-            body.getTotalTargetsPerStatus().put(status.name().toLowerCase(),
-                    rollout.getTotalTargetCountStatus().getTotalTargetCountByStatus(status));
+        if (withDetails) {
+            for (final TotalTargetCountStatus.Status status : TotalTargetCountStatus.Status.values()) {
+                body.addTotalTargetsPerStatus(status.name().toLowerCase(),
+                        rollout.getTotalTargetCountStatus().getTotalTargetCountByStatus(status));
+            }
         }
 
         body.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRollout(rollout.getId())).withRel("self"));
@@ -144,10 +146,11 @@ final class MgmtRolloutMapper {
             return Collections.emptyList();
         }
 
-        return rollouts.stream().map(MgmtRolloutMapper::toResponseRolloutGroup).collect(Collectors.toList());
+        return rollouts.stream().map(group -> toResponseRolloutGroup(group, false)).collect(Collectors.toList());
     }
 
-    static MgmtRolloutGroupResponseBody toResponseRolloutGroup(final RolloutGroup rolloutGroup) {
+    static MgmtRolloutGroupResponseBody toResponseRolloutGroup(final RolloutGroup rolloutGroup,
+            final boolean withDetailedStatus) {
         final MgmtRolloutGroupResponseBody body = new MgmtRolloutGroupResponseBody();
         body.setCreatedAt(rolloutGroup.getCreatedAt());
         body.setCreatedBy(rolloutGroup.getCreatedBy());
@@ -171,9 +174,11 @@ final class MgmtRolloutMapper {
         body.setErrorAction(
                 new MgmtRolloutErrorAction(map(rolloutGroup.getErrorAction()), rolloutGroup.getErrorActionExp()));
 
-        for (final TotalTargetCountStatus.Status status : TotalTargetCountStatus.Status.values()) {
-            body.getTotalTargetsPerStatus().put(status.name().toLowerCase(),
-                    rolloutGroup.getTotalTargetCountStatus().getTotalTargetCountByStatus(status));
+        if (withDetailedStatus) {
+            for (final TotalTargetCountStatus.Status status : TotalTargetCountStatus.Status.values()) {
+                body.addTotalTargetsPerStatus(status.name().toLowerCase(),
+                        rolloutGroup.getTotalTargetCountStatus().getTotalTargetCountByStatus(status));
+            }
         }
 
         body.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRolloutGroup(rolloutGroup.getRollout().getId(),

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -108,9 +108,6 @@ public interface ControllerManagement {
      * @throws TooManyStatusEntriesException
      *             if more than the allowed number of status entries are
      *             inserted
-     * @throws TooManyStatusEntriesException
-     *             if more than the allowed number of status entries are
-     *             inserted
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
     Action addUpdateActionStatus(@NotNull ActionStatusCreate create);

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
@@ -90,7 +90,7 @@ public interface RolloutGroupManagement {
      *             if the RSQL syntax is wrong
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
-    Page<RolloutGroup> findRolloutGroupsAll(@NotNull Rollout rollout, @NotNull String rsqlParam,
+    Page<RolloutGroup> findRolloutGroupsAll(@NotNull Long rollout, @NotNull String rsqlParam,
             @NotNull Pageable pageable);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
@@ -236,7 +236,7 @@ public interface RolloutManagement {
      *             if the RSQL syntax is wrong
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
-    Page<Rollout> findAllWithDetailedStatusByPredicate(@NotNull String rsqlParam, @NotNull Pageable pageable);
+    Page<Rollout> findAllByPredicate(@NotNull String rsqlParam, @NotNull Pageable pageable);
 
     /**
      * Finds rollouts by given text in name or description.
@@ -249,7 +249,7 @@ public interface RolloutManagement {
      *         not exists
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
-    Slice<Rollout> findRolloutByFilters(@NotNull Pageable pageable, @NotEmpty String searchText);
+    Slice<Rollout> findRolloutWithDetailedStatusByFilters(@NotNull Pageable pageable, @NotEmpty String searchText);
 
     /**
      * Retrieves a specific rollout by its ID.
@@ -312,12 +312,14 @@ public interface RolloutManagement {
      * @param rollout
      *            the rollout to be paused.
      *
+     * @throws EntityNotFoundException
+     *             if rollout with given ID does not exist
      * @throws RolloutIllegalStateException
      *             if given rollout is not in {@link RolloutStatus#RUNNING}.
      *             Only running rollouts can be paused.
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE)
-    void pauseRollout(@NotNull Rollout rollout);
+    void pauseRollout(@NotNull Long rollout);
 
     /**
      * Resumes a paused rollout. The rollout switches back to
@@ -326,12 +328,15 @@ public interface RolloutManagement {
      *
      * @param rollout
      *            the rollout to be resumed
+     * 
+     * @throws EntityNotFoundException
+     *             if rollout with given ID does not exist
      * @throws RolloutIllegalStateException
      *             if given rollout is not in {@link RolloutStatus#PAUSED}. Only
      *             paused rollouts can be resumed.
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE)
-    void resumeRollout(@NotNull Rollout rollout);
+    void resumeRollout(@NotNull Long rollout);
 
     /**
      * Starts a rollout which has been created. The rollout must be in
@@ -344,13 +349,15 @@ public interface RolloutManagement {
      *            the rollout to be started
      *
      * @return started rollout
-     *
+     * 
+     * @throws EntityNotFoundException
+     *             if rollout with given ID does not exist
      * @throws RolloutIllegalStateException
      *             if given rollout is not in {@link RolloutStatus#READY}. Only
      *             ready rollouts can be started.
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_WRITE)
-    Rollout startRollout(@NotNull Rollout rollout);
+    Rollout startRollout(@NotNull Long rollout);
 
     /**
      * Update rollout details.

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
@@ -29,13 +29,13 @@ import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
 import org.eclipse.hawkbit.repository.jpa.model.JpaAction_;
 import org.eclipse.hawkbit.repository.jpa.model.JpaRolloutGroup;
 import org.eclipse.hawkbit.repository.jpa.model.JpaRolloutGroup_;
+import org.eclipse.hawkbit.repository.jpa.model.JpaRollout_;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTarget;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTarget_;
 import org.eclipse.hawkbit.repository.jpa.model.RolloutTargetGroup;
 import org.eclipse.hawkbit.repository.jpa.model.RolloutTargetGroup_;
 import org.eclipse.hawkbit.repository.jpa.rsql.RSQLUtility;
 import org.eclipse.hawkbit.repository.model.Action;
-import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.Rollout.RolloutStatus;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.repository.model.Target;
@@ -94,7 +94,7 @@ public class JpaRolloutGroupManagement implements RolloutGroupManagement {
     }
 
     @Override
-    public Page<RolloutGroup> findRolloutGroupsAll(final Rollout rollout, final String rsqlParam,
+    public Page<RolloutGroup> findRolloutGroupsAll(final Long rolloutId, final String rsqlParam,
             final Pageable pageable) {
 
         final Specification<JpaRolloutGroup> specification = RSQLUtility.parse(rsqlParam, RolloutGroupFields.class,
@@ -103,9 +103,10 @@ public class JpaRolloutGroupManagement implements RolloutGroupManagement {
         return convertPage(
                 rolloutGroupRepository
                         .findAll(
-                                (root, query, criteriaBuilder) -> criteriaBuilder.and(
-                                        criteriaBuilder.equal(root.get(JpaRolloutGroup_.rollout), rollout),
-                                        specification.toPredicate(root, query, criteriaBuilder)),
+                                (root, query,
+                                        criteriaBuilder) -> criteriaBuilder.and(criteriaBuilder.equal(
+                                                root.get(JpaRolloutGroup_.rollout).get(JpaRollout_.id), rolloutId),
+                                                specification.toPredicate(root, query, criteriaBuilder)),
                                 pageable),
                 pageable);
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/PauseRolloutGroupAction.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/PauseRolloutGroupAction.java
@@ -46,7 +46,7 @@ public class PauseRolloutGroupAction implements RolloutGroupActionEvaluator {
         systemSecurityContext.runAsSystem(() -> {
             rolloutGroup.setStatus(RolloutGroupStatus.ERROR);
             rolloutGroupRepository.save(rolloutGroup);
-            rolloutManagement.pauseRollout(rollout);
+            rolloutManagement.pauseRollout(rollout.getId());
             return null;
         });
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -191,7 +191,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
         final Rollout createdRollout = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,
                 amountOtherTargets, amountGroups, successCondition, errorCondition);
-        rolloutManagement.startRollout(createdRollout);
+        rolloutManagement.startRollout(createdRollout.getId());
 
         // Run here, because scheduler is disabled during tests
         rolloutManagement.checkStartingRollouts(0);
@@ -334,7 +334,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         scheduleGroups.forEach(group -> assertThat(group.getStatus()).isEqualTo(RolloutGroupStatus.SCHEDULED));
 
         // resume the rollout again after it gets paused by error action
-        rolloutManagement.resumeRollout(rolloutManagement.findRolloutById(createdRollout.getId()));
+        rolloutManagement.resumeRollout(createdRollout.getId());
 
         // the rollout should be running again
         assertThat(rolloutManagement.findRolloutById(createdRollout.getId()).getStatus())
@@ -406,7 +406,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         validationMap.put(TotalTargetCountStatus.Status.NOTSTARTED, 8L);
         validateRolloutActionStatus(createdRollout.getId(), validationMap);
 
-        rolloutManagement.startRollout(createdRollout);
+        rolloutManagement.startRollout(createdRollout.getId());
 
         // Run here, because scheduler is disabled during tests
         rolloutManagement.checkStartingRollouts(0);
@@ -469,7 +469,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         validationMap.put(TotalTargetCountStatus.Status.NOTSTARTED, 8L);
         validateRolloutActionStatus(createdRollout.getId(), validationMap);
 
-        rolloutManagement.startRollout(createdRollout);
+        rolloutManagement.startRollout(createdRollout.getId());
 
         // Run here, because scheduler is disabled during tests
         rolloutManagement.checkStartingRollouts(0);
@@ -599,7 +599,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         expectedTargetCountStatus.put(TotalTargetCountStatus.Status.SCHEDULED, 5L);
         validateRolloutActionStatus(rolloutOne.getId(), expectedTargetCountStatus);
 
-        rolloutManagement.startRollout(rolloutTwo);
+        rolloutManagement.startRollout(rolloutTwo.getId());
 
         // Run here, because scheduler is disabled during tests
         rolloutManagement.checkStartingRollouts(0);
@@ -650,7 +650,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         Rollout rolloutTwo = createRolloutByVariables("rolloutTwo", "This is the description for rollout two",
                 amountGroupsForRolloutTwo, "controllerId==rollout-*", distributionSet, "50", "80");
 
-        rolloutManagement.startRollout(rolloutTwo);
+        rolloutManagement.startRollout(rolloutTwo.getId());
 
         // Run here, because scheduler is disabled during tests
         rolloutManagement.checkStartingRollouts(0);
@@ -752,14 +752,14 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final String errorCondition = "20";
         final Rollout rolloutA = createTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout, amountGroups,
                 successCondition, errorCondition, "RolloutA", "RolloutA");
-        rolloutManagement.startRollout(rolloutA);
+        rolloutManagement.startRollout(rolloutA.getId());
         rolloutManagement.checkStartingRollouts(0);
 
         final int amountTargetsForRollout2 = 10;
         final int amountGroups2 = 2;
         final Rollout rolloutB = createTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout2, amountGroups2,
                 successCondition, errorCondition, "RolloutB", "RolloutB");
-        rolloutManagement.startRollout(rolloutB);
+        rolloutManagement.startRollout(rolloutB.getId());
         rolloutManagement.checkStartingRollouts(0);
 
         changeStatusForAllRunningActions(rolloutB, Status.FINISHED);
@@ -769,7 +769,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups3 = 2;
         final Rollout rolloutC = createTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout3, amountGroups3,
                 successCondition, errorCondition, "RolloutC", "RolloutC");
-        rolloutManagement.startRollout(rolloutC);
+        rolloutManagement.startRollout(rolloutC.getId());
         rolloutManagement.checkStartingRollouts(0);
 
         changeStatusForAllRunningActions(rolloutC, Status.ERROR);
@@ -779,7 +779,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final int amountGroups4 = 3;
         final Rollout rolloutD = createTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout4, amountGroups4,
                 successCondition, errorCondition, "RolloutD", "RolloutD");
-        rolloutManagement.startRollout(rolloutD);
+        rolloutManagement.startRollout(rolloutD.getId());
         rolloutManagement.checkStartingRollouts(0);
 
         changeStatusForRunningActions(rolloutD, Status.ERROR, 1);
@@ -873,8 +873,8 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
                     errorCondition, "SomethingElse" + i, "SomethingElse" + i);
         }
 
-        final Slice<Rollout> rollout = rolloutManagement
-                .findRolloutByFilters(new OffsetBasedPageRequest(0, 100, new Sort(Direction.ASC, "name")), "Rollout%");
+        final Slice<Rollout> rollout = rolloutManagement.findRolloutWithDetailedStatusByFilters(
+                new OffsetBasedPageRequest(0, 100, new Sort(Direction.ASC, "name")), "Rollout%");
         final List<Rollout> rolloutList = rollout.getContent();
         assertThat(rolloutList.size()).isEqualTo(5);
         int i = 1;
@@ -912,7 +912,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final String rolloutName = "MyRollout";
         Rollout myRollout = createTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout, amountGroups,
                 successCondition, errorCondition, rolloutName, rolloutName);
-        rolloutManagement.startRollout(myRollout);
+        rolloutManagement.startRollout(myRollout.getId());
 
         // Run here, because scheduler is disabled during tests
         rolloutManagement.checkStartingRollouts(0);
@@ -958,7 +958,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
         final String rsqlParam = "controllerId==*MyRoll*";
 
-        rolloutManagement.startRollout(myRollout);
+        rolloutManagement.startRollout(myRollout.getId());
 
         // Run here, because scheduler is disabled during tests
         rolloutManagement.checkStartingRollouts(0);
@@ -1060,7 +1060,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         assertThat(groups.get(4).getStatus()).isEqualTo(RolloutGroupStatus.READY);
         assertThat(groups.get(4).getTotalTargets()).isEqualTo(0);
 
-        rolloutManagement.startRollout(myRollout);
+        rolloutManagement.startRollout(myRollout.getId());
 
         // Run here, because scheduler is disabled during tests
         rolloutManagement.checkStartingRollouts(0);
@@ -1096,7 +1096,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
                 "controllerId==" + targetPrefixName + "-*", distributionSet, successCondition, errorCondition);
 
         assertThat(myRollout.getStatus()).isEqualTo(RolloutStatus.READY);
-        rolloutManagement.startRollout(myRollout);
+        rolloutManagement.startRollout(myRollout.getId());
 
         // Run here, because scheduler is disabled during tests
         rolloutManagement.checkStartingRollouts(0);
@@ -1266,7 +1266,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         assertThat(myRollout.getStatus()).isEqualTo(RolloutStatus.CREATING);
 
         try {
-            rolloutManagement.startRollout(myRollout);
+            rolloutManagement.startRollout(myRollout.getId());
             fail("Was able to start a Rollout in CREATING status");
         } catch (final RolloutIllegalStateException e) {
             // OK

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLRolloutGroupFields.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLRolloutGroupFields.java
@@ -73,8 +73,8 @@ public class RSQLRolloutGroupFields extends AbstractJpaIntegrationTest {
     }
 
     private void assertRSQLQuery(final String rsqlParam, final long expcetedTargets) {
-        final Page<RolloutGroup> findTargetPage = rolloutGroupManagement.findRolloutGroupsAll(rollout, rsqlParam,
-                new PageRequest(0, 100));
+        final Page<RolloutGroup> findTargetPage = rolloutGroupManagement.findRolloutGroupsAll(rollout.getId(),
+                rsqlParam, new PageRequest(0, 100));
         final long countTargetsAll = findTargetPage.getTotalElements();
         assertThat(findTargetPage).isNotNull();
         assertThat(countTargetsAll).isEqualTo(expcetedTargets);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
@@ -109,7 +109,7 @@ public class RolloutBeanQuery extends AbstractBeanQuery<ProxyRollout> {
             rolloutBeans = getRolloutManagement().findAllRolloutsWithDetailedStatus(
                     new PageRequest(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort));
         } else {
-            rolloutBeans = getRolloutManagement().findRolloutByFilters(
+            rolloutBeans = getRolloutManagement().findRolloutWithDetailedStatusByFilters(
                     new PageRequest(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort),
                     searchText);
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
@@ -397,7 +397,7 @@ public class RolloutListGrid extends AbstractGrid {
 
         final String rolloutName = (String) row.getItemProperty(VAR_NAME).getValue();
 
-        rolloutManagement.pauseRollout(rolloutManagement.findRolloutById(rolloutId));
+        rolloutManagement.pauseRollout(rolloutId);
         uiNotification.displaySuccess(i18n.get("message.rollout.paused", rolloutName));
     }
 
@@ -408,13 +408,13 @@ public class RolloutListGrid extends AbstractGrid {
         final String rolloutName = (String) row.getItemProperty(VAR_NAME).getValue();
 
         if (RolloutStatus.READY.equals(rolloutStatus)) {
-            rolloutManagement.startRollout(rolloutManagement.findRolloutByName(rolloutName));
+            rolloutManagement.startRollout(rolloutId);
             uiNotification.displaySuccess(i18n.get("message.rollout.started", rolloutName));
             return;
         }
 
         if (RolloutStatus.PAUSED.equals(rolloutStatus)) {
-            rolloutManagement.resumeRollout(rolloutManagement.findRolloutById(rolloutId));
+            rolloutManagement.resumeRollout(rolloutId);
             uiNotification.displaySuccess(i18n.get("message.rollout.resumed", rolloutName));
             return;
         }


### PR DESCRIPTION
The target status is presented in management Apia s MAP with numbers for every status.

* Fixed problem where the data is not correctly filled for deployment groups.
* Fixed performance impact as the value are also calculated for the GET that returns all rollouts/deployment groups, i.e. I removed it from the overview and return it only for single rollout/group access.
* While at it I removed the last RolloutManagement API calls based open Rollout entity and not ID.
* Added missing tests on the matter.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>