### PR TITLE
Fix UI login and view change performance

### DIFF
--- a/examples/hawkbit-custom-theme-example/src/main/java/org/eclipse/hawkbit/app/MyLoginUI.java
+++ b/examples/hawkbit-custom-theme-example/src/main/java/org/eclipse/hawkbit/app/MyLoginUI.java
@@ -10,10 +10,13 @@ package org.eclipse.hawkbit.app;
 
 import org.eclipse.hawkbit.ui.login.HawkbitLoginUI;
 import org.eclipse.hawkbit.ui.themes.HawkbitTheme;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 
 import com.vaadin.annotations.Theme;
 import com.vaadin.annotations.Title;
 import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.navigator.SpringViewProvider;
 
 /**
  * Example hawkBit login UI implementation.
@@ -30,5 +33,10 @@ import com.vaadin.spring.annotation.SpringUI;
 public class MyLoginUI extends HawkbitLoginUI {
 
     private static final long serialVersionUID = 1L;
+
+    @Autowired
+    protected MyLoginUI(final SpringViewProvider viewProvider, final ApplicationContext context) {
+        super(viewProvider, context);
+    }
 
 }

--- a/examples/hawkbit-custom-theme-example/src/main/java/org/eclipse/hawkbit/app/MyUI.java
+++ b/examples/hawkbit-custom-theme-example/src/main/java/org/eclipse/hawkbit/app/MyUI.java
@@ -10,7 +10,6 @@ package org.eclipse.hawkbit.app;
 
 import org.eclipse.hawkbit.ui.HawkbitUI;
 import org.eclipse.hawkbit.ui.push.EventPushStrategy;
-import org.vaadin.spring.events.EventBus.SessionEventBus;
 
 import com.vaadin.annotations.Push;
 import com.vaadin.annotations.Theme;
@@ -43,7 +42,7 @@ public class MyUI extends HawkbitUI {
      * @param eventBus
      *            the event bus
      */
-    public MyUI(final EventPushStrategy pushStrategy, final SessionEventBus eventBus) {
-        super(pushStrategy, eventBus);
+    public MyUI(final EventPushStrategy pushStrategy) {
+        super(pushStrategy);
     }
 }

--- a/examples/hawkbit-example-app/src/main/java/org/eclipse/hawkbit/app/MyLoginUI.java
+++ b/examples/hawkbit-example-app/src/main/java/org/eclipse/hawkbit/app/MyLoginUI.java
@@ -10,8 +10,11 @@ package org.eclipse.hawkbit.app;
 
 import org.eclipse.hawkbit.ui.login.HawkbitLoginUI;
 import org.eclipse.hawkbit.ui.themes.HawkbitTheme;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 
 import com.vaadin.spring.annotation.SpringUI;
+import com.vaadin.spring.navigator.SpringViewProvider;
 
 /**
  * Example hawkBit login UI implementation.
@@ -26,6 +29,11 @@ import com.vaadin.spring.annotation.SpringUI;
 // Vaadin.
 @SuppressWarnings({ "squid:MaximumInheritanceDepth" })
 public class MyLoginUI extends HawkbitLoginUI {
+
+    @Autowired
+    protected MyLoginUI(final SpringViewProvider viewProvider, final ApplicationContext context) {
+        super(viewProvider, context);
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/examples/hawkbit-example-app/src/main/java/org/eclipse/hawkbit/app/MyUI.java
+++ b/examples/hawkbit-example-app/src/main/java/org/eclipse/hawkbit/app/MyUI.java
@@ -10,7 +10,6 @@ package org.eclipse.hawkbit.app;
 
 import org.eclipse.hawkbit.ui.HawkbitUI;
 import org.eclipse.hawkbit.ui.push.EventPushStrategy;
-import org.vaadin.spring.events.EventBus.SessionEventBus;
 
 import com.vaadin.annotations.Push;
 import com.vaadin.shared.communication.PushMode;
@@ -41,8 +40,8 @@ public class MyUI extends HawkbitUI {
      * @param eventBus
      *            the event bus
      */
-    public MyUI(final EventPushStrategy pushStrategy, final SessionEventBus eventBus) {
-        super(pushStrategy, eventBus);
+    public MyUI(final EventPushStrategy pushStrategy) {
+        super(pushStrategy);
     }
 
 }

--- a/examples/hawkbit-example-mgmt-simulator/src/main/java/org/eclipse/hawkbit/mgmt/client/scenarios/ConfigurableScenario.java
+++ b/examples/hawkbit-example-mgmt-simulator/src/main/java/org/eclipse/hawkbit/mgmt/client/scenarios/ConfigurableScenario.java
@@ -69,9 +69,6 @@ public class ConfigurableScenario {
 
     private final MgmtSoftwareModuleClientResource uploadSoftwareModule;
 
-    // Exception - squid:S00107 - this is a simulator that leverages multiple
-    // resouces/feign beans.
-    @SuppressWarnings("squid:S00107")
     public ConfigurableScenario(final MgmtDistributionSetClientResource distributionSetResource,
             final MgmtSoftwareModuleClientResource softwareModuleResource,
             final MgmtSoftwareModuleClientResource uploadSoftwareModule, final MgmtTargetClientResource targetResource,

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/ui/UIAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/ui/UIAutoConfiguration.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.hawkbit.autoconfigure.ui;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import org.eclipse.hawkbit.DistributedResourceBundleMessageSource;
 import org.eclipse.hawkbit.ui.push.DelayedEventBusPushStrategy;
 import org.eclipse.hawkbit.ui.push.EventPushStrategy;
@@ -18,6 +20,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.vaadin.spring.annotation.EnableVaadinExtensions;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.annotation.EnableEventBus;
 import org.vaadin.spring.security.annotation.EnableVaadinSecurity;
 
@@ -65,8 +68,11 @@ public class UIAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @UIScope
-    public EventPushStrategy eventPushStrategy(final ConfigurableApplicationContext applicationContext) {
-        final DelayedEventBusPushStrategy delayedEventBusPushStrategy = new DelayedEventBusPushStrategy();
+    public EventPushStrategy eventPushStrategy(final ConfigurableApplicationContext applicationContext,
+            final ScheduledExecutorService executorService, final UIEventBus eventBus,
+            final UIEventProvider eventProvider) {
+        final DelayedEventBusPushStrategy delayedEventBusPushStrategy = new DelayedEventBusPushStrategy(executorService,
+                eventBus, eventProvider);
         applicationContext.addApplicationListener(delayedEventBusPushStrategy);
         return delayedEventBusPushStrategy;
     }

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/ControllerPollProperties.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/ControllerPollProperties.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.hawkbit;
 
+import java.io.Serializable;
+
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.EnvironmentAware;
@@ -25,7 +27,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @ConfigurationProperties(prefix = "hawkbit.controller")
-public class ControllerPollProperties {
+public class ControllerPollProperties implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     /**
      * Maximum polling time that can be configured by a tenant in HH:MM:SS

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
@@ -63,7 +63,8 @@ public interface TargetManagement {
      *
      * @return number of found {@link Target}s.
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET + SpringEvalExpressions.HAS_AUTH_OR
+            + SpringEvalExpressions.HAS_AUTH_READ_REPOSITORY)
     Long countTargetByAssignedDistributionSet(@NotNull Long distId);
 
     /**
@@ -104,7 +105,8 @@ public interface TargetManagement {
      *            to search for
      * @return number of found {@link Target}s.
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET + SpringEvalExpressions.HAS_AUTH_OR
+            + SpringEvalExpressions.HAS_AUTH_READ_REPOSITORY)
     Long countTargetByInstalledDistributionSet(@NotNull Long distId);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSet.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSet.java
@@ -11,8 +11,6 @@ package org.eclipse.hawkbit.repository.model;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.hawkbit.repository.DistributionSetManagement;
-
 /**
  * A {@link DistributionSet} defines a meta package that combines a set of
  * {@link SoftwareModule}s which have to be or are provisioned to a
@@ -37,12 +35,6 @@ public interface DistributionSet extends NamedVersionedEntity {
     boolean isDeleted();
 
     /**
-     * @return immutable {@link List} of {@link DistributionSetMetadata}
-     *         elements. See {@link DistributionSetManagement} to alter.
-     */
-    List<DistributionSetMetadata> getMetadata();
-
-    /**
      * @return <code>true</code> if {@link DistributionSet} contains a mandatory
      *         migration step, i.e. unfinished {@link Action}s will kept active
      *         and not automatically canceled if overridden by a newer update.
@@ -50,19 +42,9 @@ public interface DistributionSet extends NamedVersionedEntity {
     boolean isRequiredMigrationStep();
 
     /**
-     * @return the assignedTargets
-     */
-    List<Target> getAssignedTargets();
-
-    /**
      * @return the auto assign target filters
      */
     List<TargetFilterQuery> getAutoAssignFilters();
-
-    /**
-     * @return the installedTargets
-     */
-    List<TargetInfo> getInstalledTargets();
 
     /**
      *

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
@@ -231,7 +231,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     private JpaDistributionSet findDistributionSetAndThrowExceptionIfNotFound(final Long setId) {
-        final JpaDistributionSet set = (JpaDistributionSet) findDistributionSetByIdWithDetails(setId);
+        final JpaDistributionSet set = (JpaDistributionSet) findDistributionSetById(setId);
 
         if (set == null) {
             throw new EntityNotFoundException("Distribution set cannot be updated as it does not exixt" + setId);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetTagRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetTagRepository.java
@@ -34,7 +34,7 @@ public interface TargetTagRepository
      */
     @Modifying
     @Transactional(isolation = Isolation.READ_UNCOMMITTED)
-    Long deleteByName(final String tagName);
+    Long deleteByName(String tagName);
 
     /**
      * find {@link TargetTag} by its name.
@@ -43,7 +43,7 @@ public interface TargetTagRepository
      *            to filter on
      * @return the {@link TargetTag} if found, otherwise null
      */
-    JpaTargetTag findByNameEquals(final String tagName);
+    JpaTargetTag findByNameEquals(String tagName);
 
     /**
      * Returns all instances of the type.

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSet.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSet.java
@@ -209,7 +209,6 @@ public class JpaDistributionSet extends AbstractJpaNamedVersionedEntity implemen
         return deleted;
     }
 
-    @Override
     public List<DistributionSetMetadata> getMetadata() {
         if (metadata == null) {
             return Collections.emptyList();
@@ -242,26 +241,8 @@ public class JpaDistributionSet extends AbstractJpaNamedVersionedEntity implemen
     }
 
     @Override
-    public List<Target> getAssignedTargets() {
-        if (assignedToTargets == null) {
-            return Collections.emptyList();
-        }
-
-        return Collections.unmodifiableList(assignedToTargets);
-    }
-
-    @Override
     public List<TargetFilterQuery> getAutoAssignFilters() {
         return autoAssignFilters;
-    }
-
-    @Override
-    public List<TargetInfo> getInstalledTargets() {
-        if (installedAtTargets == null) {
-            return Collections.emptyList();
-        }
-
-        return Collections.unmodifiableList(installedAtTargets);
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModule.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModule.java
@@ -176,14 +176,6 @@ public class JpaSoftwareModule extends AbstractJpaNamedVersionedEntity implement
         this.type = type;
     }
 
-    public List<SoftwareModuleMetadata> getMetadata() {
-        if (metadata == null) {
-            return Collections.emptyList();
-        }
-
-        return Collections.unmodifiableList(metadata);
-    }
-
     @Override
     public String toString() {
         return "SoftwareModule [deleted=" + deleted + ", name=" + getName() + ", version=" + getVersion()

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/DistributionSetSpecification.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/DistributionSetSpecification.java
@@ -83,7 +83,6 @@ public final class DistributionSetSpecification {
             targetRoot.fetch(JpaDistributionSet_.modules, JoinType.LEFT);
             targetRoot.fetch(JpaDistributionSet_.tags, JoinType.LEFT);
             targetRoot.fetch(JpaDistributionSet_.type, JoinType.LEFT);
-            targetRoot.fetch(JpaDistributionSet_.metadata, JoinType.LEFT);
             query.distinct(true);
 
             return predicate;
@@ -110,8 +109,8 @@ public final class DistributionSetSpecification {
     }
 
     /**
-     * {@link Specification} for retrieving {@link DistributionSet}s by
-     * "like name or like description or like version".
+     * {@link Specification} for retrieving {@link DistributionSet}s by "like
+     * name or like description or like version".
      * 
      * @param subString
      *            to be filtered on
@@ -125,8 +124,8 @@ public final class DistributionSetSpecification {
     }
 
     /**
-     * {@link Specification} for retrieving {@link DistributionSet}s by
-     * "has at least one of the given tag names".
+     * {@link Specification} for retrieving {@link DistributionSet}s by "has at
+     * least one of the given tag names".
      * 
      * @param tagNames
      *            to be filtered on

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/repository/SpPermissionChecker.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/repository/SpPermissionChecker.java
@@ -14,22 +14,21 @@ import org.eclipse.hawkbit.im.authentication.PermissionService;
 import org.eclipse.hawkbit.im.authentication.SpPermission;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.validation.annotation.Validated;
 
 /**
  * Bean which contains all SP permissions.
  *
- *
- *
- *
  */
-@Validated
 @Service
 public class SpPermissionChecker implements Serializable {
     private static final long serialVersionUID = 2757865286212875704L;
 
-    @Autowired
     private transient PermissionService permissionService;
+
+    @Autowired
+    SpPermissionChecker(final PermissionService permissionService) {
+        this.permissionService = permissionService;
+    }
 
     /**
      * Gets the SP monitor View Permission.

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/ErrorView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/ErrorView.java
@@ -32,23 +32,22 @@ import com.vaadin.ui.VerticalLayout;
  *
  * @see Navigator#setErrorView(Class)
  */
-@SuppressWarnings("serial")
 @SpringComponent
 @UIScope
 class ErrorView extends VerticalLayout implements View {
 
+    private static final long serialVersionUID = 1L;
+
     private final Label message;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
+
+    private final DashboardMenu dashboardMenu;
 
     @Autowired
-    private DashboardMenu dashboardMenu;
-
-    /**
-     * Constructor.
-     */
-    public ErrorView() {
+    ErrorView(final I18N i18n, final DashboardMenu dashboardMenu) {
+        this.i18n = i18n;
+        this.dashboardMenu = dashboardMenu;
         setMargin(true);
         message = new Label();
         addComponent(message);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/HawkbitUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/HawkbitUI.java
@@ -61,7 +61,8 @@ public class HawkbitUI extends DefaultHawkbitUI implements DetachListener {
 
     private transient EventPushStrategy pushStrategy;
 
-    protected transient EventBus.SessionEventBus eventBus;
+    @Autowired
+    protected transient EventBus.UIEventBus eventBus;
 
     @Autowired
     private SpringViewProvider viewProvider;
@@ -81,22 +82,12 @@ public class HawkbitUI extends DefaultHawkbitUI implements DetachListener {
     private ErrorView errorview;
 
     /**
-     * Default constructor.
-     */
-    @Autowired
-    public HawkbitUI(final EventBus.SessionEventBus eventBus) {
-        this.eventBus = eventBus;
-    }
-
-    /**
      * Constructor taking the push strategy.
      *
      * @param pushStrategy
      *            the strategy to push events from the backend to the UI
      */
-    @Autowired
-    public HawkbitUI(final EventPushStrategy pushStrategy, final EventBus.SessionEventBus eventBus) {
-        this(eventBus);
+    public HawkbitUI(final EventPushStrategy pushStrategy) {
         this.pushStrategy = pushStrategy;
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.hawkbit.ui;
 
+import java.io.Serializable;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -17,13 +19,15 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @ConfigurationProperties("hawkbit.server.ui")
-public class UiProperties {
+public class UiProperties implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     /**
      * Demo account login information.
      *
      */
-    public static class Demo {
+    public static class Demo implements Serializable {
+        private static final long serialVersionUID = 1L;
 
         /**
          * Demo tenant.
@@ -72,12 +76,15 @@ public class UiProperties {
      * documentation etc.).
      *
      */
-    public static class Links {
+    public static class Links implements Serializable {
+        private static final long serialVersionUID = 1L;
+
         /**
          * Configuration of UI documentation links.
          *
          */
-        public static class Documentation {
+        public static class Documentation implements Serializable {
+            private static final long serialVersionUID = 1L;
             /**
              * Link to root of documentation and user guides.
              */
@@ -235,13 +242,15 @@ public class UiProperties {
      * Configuration of login view.
      *
      */
-    public static class Login {
+    public static class Login implements Serializable {
+        private static final long serialVersionUID = 1L;
 
         /**
          * Cookie configuration for login credential cookie.
          *
          */
-        public static class Cookie {
+        public static class Cookie implements Serializable {
+            private static final long serialVersionUID = 1L;
             /**
              * Secure cookie enabled.
              */

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/UploadArtifactView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/UploadArtifactView.java
@@ -8,13 +8,19 @@
  */
 package org.eclipse.hawkbit.ui.artifacts;
 
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.eclipse.hawkbit.repository.ArtifactManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SoftwareManagement;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.ui.HawkbitUI;
 import org.eclipse.hawkbit.ui.artifacts.details.ArtifactDetailsLayout;
 import org.eclipse.hawkbit.ui.artifacts.event.ArtifactDetailsEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent;
+import org.eclipse.hawkbit.ui.artifacts.event.UploadViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.artifacts.footer.SMDeleteActionsLayout;
 import org.eclipse.hawkbit.ui.artifacts.smtable.SoftwareModuleTableLayout;
 import org.eclipse.hawkbit.ui.artifacts.smtype.SMTypeFilterLayout;
@@ -25,8 +31,10 @@ import org.eclipse.hawkbit.ui.management.event.DragEvent;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.eclipse.hawkbit.util.SPInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -37,7 +45,7 @@ import com.vaadin.server.Page;
 import com.vaadin.server.Page.BrowserWindowResizeEvent;
 import com.vaadin.server.Page.BrowserWindowResizeListener;
 import com.vaadin.spring.annotation.SpringView;
-import com.vaadin.spring.annotation.ViewScope;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.DragAndDropWrapper;
 import com.vaadin.ui.GridLayout;
@@ -47,45 +55,33 @@ import com.vaadin.ui.VerticalLayout;
 
 /**
  * Display artifacts upload view.
- *
- *
  */
+@UIScope
 @SpringView(name = UploadArtifactView.VIEW_NAME, ui = HawkbitUI.class)
-@ViewScope
 public class UploadArtifactView extends VerticalLayout implements View, BrowserWindowResizeListener {
 
     public static final String VIEW_NAME = "spUpload";
     private static final long serialVersionUID = 8754632011301553682L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private SpPermissionChecker permChecker;
+    private final SpPermissionChecker permChecker;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient UINotification uiNotification;
+    private final UINotification uiNotification;
 
-    @Autowired
-    private ArtifactUploadState artifactUploadState;
+    private final ArtifactUploadState artifactUploadState;
 
-    @Autowired
-    private SMTypeFilterLayout filterByTypeLayout;
+    private final SMTypeFilterLayout filterByTypeLayout;
 
-    @Autowired
-    private SoftwareModuleTableLayout smTableLayout;
+    private final SoftwareModuleTableLayout smTableLayout;
 
-    @Autowired
-    private ArtifactDetailsLayout artifactDetailsLayout;
+    private final ArtifactDetailsLayout artifactDetailsLayout;
 
-    @Autowired
-    private UploadLayout uploadLayout;
+    private final UploadLayout uploadLayout;
 
-    @Autowired
-    private SMDeleteActionsLayout deleteActionsLayout;
+    private final SMDeleteActionsLayout deleteActionsLayout;
 
     private VerticalLayout detailAndUploadLayout;
 
@@ -94,8 +90,31 @@ public class UploadArtifactView extends VerticalLayout implements View, BrowserW
     private GridLayout mainLayout;
     private DragAndDropWrapper dadw;
 
-    @Override
-    public void enter(final ViewChangeEvent event) {
+    @Autowired
+    UploadArtifactView(final UIEventBus eventBus, final SpPermissionChecker permChecker, final I18N i18n,
+            final UINotification uiNotification, final ArtifactUploadState artifactUploadState,
+            final TagManagement tagManagement, final EntityFactory entityFactory,
+            final SoftwareManagement softwareManagement, final UploadViewAcceptCriteria uploadViewAcceptCriteria,
+            final SPInfo spInfo, final ArtifactManagement artifactManagement) {
+        this.eventBus = eventBus;
+        this.permChecker = permChecker;
+        this.i18n = i18n;
+        this.uiNotification = uiNotification;
+        this.artifactUploadState = artifactUploadState;
+        this.filterByTypeLayout = new SMTypeFilterLayout(artifactUploadState, i18n, permChecker, eventBus,
+                tagManagement, entityFactory, uiNotification, softwareManagement, uploadViewAcceptCriteria);
+        this.smTableLayout = new SoftwareModuleTableLayout(i18n, permChecker, artifactUploadState, uiNotification,
+                eventBus, softwareManagement, entityFactory, uploadViewAcceptCriteria);
+        this.artifactDetailsLayout = new ArtifactDetailsLayout(i18n, eventBus, artifactUploadState, uiNotification,
+                artifactManagement);
+        this.uploadLayout = new UploadLayout(i18n, uiNotification, eventBus, artifactUploadState, spInfo,
+                artifactManagement);
+        this.deleteActionsLayout = new SMDeleteActionsLayout(i18n, permChecker, eventBus, uiNotification,
+                artifactUploadState, softwareManagement, uploadViewAcceptCriteria);
+    }
+
+    @PostConstruct
+    void init() {
         buildLayout();
         restoreState();
         checkNoDataAvaialble();
@@ -109,7 +128,7 @@ public class UploadArtifactView extends VerticalLayout implements View, BrowserW
         eventBus.unsubscribe(this);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SoftwareModuleEvent event) {
         if (BaseEntityEventType.MINIMIZED == event.getEventType()) {
             minimizeSwTable();
@@ -118,7 +137,7 @@ public class UploadArtifactView extends VerticalLayout implements View, BrowserW
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final ArtifactDetailsEvent event) {
         if (event == ArtifactDetailsEvent.MINIMIZED) {
             minimizeArtifactoryDetails();
@@ -270,6 +289,11 @@ public class UploadArtifactView extends VerticalLayout implements View, BrowserW
             filterByTypeLayout.setVisible(true);
             smTableLayout.setShowFilterButtonVisible(false);
         }
+    }
+
+    @Override
+    public void enter(final ViewChangeEvent event) {
+        // This view is constructed in the init() method()
     }
 
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/event/UploadViewAcceptCriteria.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/event/UploadViewAcceptCriteria.java
@@ -14,10 +14,13 @@ import java.util.Map;
 
 import org.eclipse.hawkbit.ui.common.AbstractAcceptCriteria;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.google.common.collect.Maps;
 import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.Component;
 
 /**
@@ -25,7 +28,7 @@ import com.vaadin.ui.Component;
  * 
  */
 @SpringComponent
-@ViewScope
+@UIScope
 public class UploadViewAcceptCriteria extends AbstractAcceptCriteria {
 
     private static final long serialVersionUID = 5158811326115667378L;
@@ -33,6 +36,11 @@ public class UploadViewAcceptCriteria extends AbstractAcceptCriteria {
     private static final Map<String, List<String>> DROP_CONFIGS = createDropConfigurations();
 
     private static final Map<String, Object> DROP_HINTS_CONFIGS = createDropHintConfigurations();
+
+    @Autowired
+    UploadViewAcceptCriteria(final UINotification uiNotification, final UIEventBus eventBus) {
+        super(uiNotification, eventBus);
+    }
 
     @Override
     protected String getComponentId(final Component component) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/footer/SMDeleteActionsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/footer/SMDeleteActionsLayout.java
@@ -10,22 +10,24 @@ package org.eclipse.hawkbit.ui.artifacts.footer;
 
 import java.util.Set;
 
+import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.artifacts.event.UploadArtifactUIEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.UploadViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.artifacts.state.ArtifactUploadState;
 import org.eclipse.hawkbit.ui.common.footer.AbstractDeleteActionsLayout;
 import org.eclipse.hawkbit.ui.common.table.AbstractTable;
 import org.eclipse.hawkbit.ui.management.event.DragEvent;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Table;
 import com.vaadin.ui.Table.TableTransferable;
@@ -33,24 +35,30 @@ import com.vaadin.ui.UI;
 
 /**
  * Upload view footer layout implementation.
- *
  */
-@SpringComponent
-@ViewScope
 public class SMDeleteActionsLayout extends AbstractDeleteActionsLayout {
 
     private static final long serialVersionUID = -3273982053389866299L;
 
-    @Autowired
-    private ArtifactUploadState artifactUploadState;
+    private final ArtifactUploadState artifactUploadState;
 
-    @Autowired
-    private UploadViewConfirmationWindowLayout uploadViewConfirmationWindowLayout;
+    private final UploadViewConfirmationWindowLayout uploadViewConfirmationWindowLayout;
 
-    @Autowired
-    private UploadViewAcceptCriteria uploadViewAcceptCriteria;
+    private final UploadViewAcceptCriteria uploadViewAcceptCriteria;
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    public SMDeleteActionsLayout(final I18N i18n, final SpPermissionChecker permChecker, final UIEventBus eventBus,
+            final UINotification notification, final ArtifactUploadState artifactUploadState,
+            final SoftwareManagement softwareManagement, final UploadViewAcceptCriteria uploadViewAcceptCriteria) {
+        super(i18n, permChecker, eventBus, notification);
+        this.artifactUploadState = artifactUploadState;
+        this.uploadViewConfirmationWindowLayout = new UploadViewConfirmationWindowLayout(i18n, eventBus,
+                softwareManagement, artifactUploadState);
+        this.uploadViewAcceptCriteria = uploadViewAcceptCriteria;
+
+        init();
+    }
+
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final UploadArtifactUIEvent event) {
 
         if (isSoftwareEvent(event) || isSoftwareTypeEvent(event)) {
@@ -84,7 +92,7 @@ public class SMDeleteActionsLayout extends AbstractDeleteActionsLayout {
                 || event == UploadArtifactUIEvent.DISCARD_DELETE_SOFTWARE_TYPE;
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DragEvent event) {
         if (event == DragEvent.HIDE_DROP_HINT) {
             UI.getCurrent().access(() -> hideDropHints());
@@ -134,9 +142,8 @@ public class SMDeleteActionsLayout extends AbstractDeleteActionsLayout {
 
             final String swModuleTypeName = sourceComponent.getId()
                     .replace(UIComponentIdProvider.UPLOAD_TYPE_BUTTON_PREFIX, "");
-            if (artifactUploadState.getSoftwareModuleFilters().getSoftwareModuleType().isPresent()
-                    && artifactUploadState.getSoftwareModuleFilters().getSoftwareModuleType().get().getName()
-                            .equalsIgnoreCase(swModuleTypeName)) {
+            if (artifactUploadState.getSoftwareModuleFilters().getSoftwareModuleType()
+                    .map(type -> type.getName().equalsIgnoreCase(swModuleTypeName)).orElse(false)) {
                 notification.displayValidationError(
                         i18n.get("message.swmodule.type.check.delete", new Object[] { swModuleTypeName }));
             } else {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/footer/UploadViewConfirmationWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/footer/UploadViewConfirmationWindowLayout.java
@@ -20,30 +20,24 @@ import org.eclipse.hawkbit.ui.artifacts.state.CustomFile;
 import org.eclipse.hawkbit.ui.common.confirmwindow.layout.AbstractConfirmationWindowLayout;
 import org.eclipse.hawkbit.ui.common.confirmwindow.layout.ConfirmationTab;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.google.common.collect.Maps;
 import com.vaadin.data.Container;
 import com.vaadin.data.Item;
 import com.vaadin.data.util.IndexedContainer;
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickListener;
 import com.vaadin.ui.Table.Align;
 
 /**
  * Abstract layout of confirm actions window.
- *
- *
- *
  */
-@SpringComponent
-@ViewScope
 public class UploadViewConfirmationWindowLayout extends AbstractConfirmationWindowLayout {
 
     private static final long serialVersionUID = 1804036019105286988L;
@@ -56,11 +50,16 @@ public class UploadViewConfirmationWindowLayout extends AbstractConfirmationWind
 
     private static final String DISCARD = "Discard";
 
-    @Autowired
-    private transient SoftwareManagement softwareManagement;
+    private final transient SoftwareManagement softwareManagement;
 
-    @Autowired
-    private ArtifactUploadState artifactUploadState;
+    private final ArtifactUploadState artifactUploadState;
+
+    UploadViewConfirmationWindowLayout(final I18N i18n, final UIEventBus eventBus,
+            final SoftwareManagement softwareManagement, final ArtifactUploadState artifactUploadState) {
+        super(i18n, eventBus);
+        this.softwareManagement = softwareManagement;
+        this.artifactUploadState = artifactUploadState;
+    }
 
     @Override
     protected Map<String, ConfirmationTab> getConfimrationTabs() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleAddUpdateWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleAddUpdateWindow.java
@@ -8,8 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.artifacts.smtable;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
@@ -29,12 +27,10 @@ import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.ComboBox;
 import com.vaadin.ui.CustomComponent;
 import com.vaadin.ui.FormLayout;
@@ -46,26 +42,19 @@ import com.vaadin.ui.themes.ValoTheme;
 /**
  * Generates window for Software module add or update.
  */
-@SpringComponent
-@ViewScope
 public class SoftwareModuleAddUpdateWindow extends CustomComponent {
 
     private static final long serialVersionUID = -5217675246477211483L;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient UINotification uiNotifcation;
+    private final UINotification uiNotifcation;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private transient SoftwareManagement softwareManagement;
+    private final transient SoftwareManagement softwareManagement;
 
-    @Autowired
-    private transient EntityFactory entityFactory;
+    private final transient EntityFactory entityFactory;
 
     private TextField nameTextField;
 
@@ -77,13 +66,22 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
 
     private TextArea descTextArea;
 
-    private CommonDialogWindow window;
-
     private Boolean editSwModule = Boolean.FALSE;
 
     private Long baseSwModuleId;
 
     private FormLayout formLayout;
+
+    public SoftwareModuleAddUpdateWindow(final I18N i18n, final UINotification uiNotifcation, final UIEventBus eventBus,
+            final SoftwareManagement softwareManagement, final EntityFactory entityFactory) {
+        this.i18n = i18n;
+        this.uiNotifcation = uiNotifcation;
+        this.eventBus = eventBus;
+        this.softwareManagement = softwareManagement;
+        this.entityFactory = entityFactory;
+
+        createRequiredComponents();
+    }
 
     /**
      * Save or update the sw module.
@@ -102,14 +100,6 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
         public boolean canWindowSaveOrUpdate() {
             return editSwModule || !isDuplicate();
         }
-    }
-
-    /**
-     * Initialize Distribution Add and Edit Window.
-     */
-    @PostConstruct
-    void init() {
-        createRequiredComponents();
     }
 
     /**
@@ -133,9 +123,9 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
     public CommonDialogWindow createUpdateSoftwareModuleWindow(final Long baseSwModuleId) {
         this.baseSwModuleId = baseSwModuleId;
         resetComponents();
+        populateTypeNameCombo();
         populateValuesOfSwModule();
-        createWindow();
-        return window;
+        return createWindow();
     }
 
     private void createRequiredComponents() {
@@ -157,7 +147,6 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
         typeComboBox.setStyleName(SPUIDefinitions.COMBO_BOX_SPECIFIC_STYLE + " " + ValoTheme.COMBOBOX_TINY);
         typeComboBox.setNewItemsAllowed(Boolean.FALSE);
         typeComboBox.setImmediate(Boolean.TRUE);
-        populateTypeNameCombo();
     }
 
     private TextField createTextField(final String in18Key, final String id) {
@@ -181,7 +170,7 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
         editSwModule = Boolean.FALSE;
     }
 
-    private void createWindow() {
+    private CommonDialogWindow createWindow() {
         final Label madatoryStarLabel = new Label("*");
         madatoryStarLabel.setStyleName("v-caption v-required-field-indicator");
         madatoryStarLabel.setWidth(null);
@@ -198,7 +187,7 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
 
         setCompositionRoot(formLayout);
 
-        window = new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW)
+        final CommonDialogWindow window = new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW)
                 .caption(i18n.get("upload.caption.add.new.swmodule")).content(this).layout(formLayout).i18n(i18n)
                 .saveDialogCloseListener(new SaveOnDialogCloseListener()).buildCommonDialogWindow();
         nameTextField.setEnabled(!editSwModule);
@@ -206,6 +195,8 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
         typeComboBox.setEnabled(!editSwModule);
 
         typeComboBox.focus();
+
+        return window;
     }
 
     private void addNewBaseSoftware() {
@@ -271,6 +262,7 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
                 : HawkbitCommonUtil.trimAndNullIfEmpty(swModle.getVendor()));
         descTextArea.setValue(swModle.getDescription() == null ? HawkbitCommonUtil.SP_STRING_EMPTY
                 : HawkbitCommonUtil.trimAndNullIfEmpty(swModle.getDescription()));
+
         if (swModle.getType().isDeleted()) {
             typeComboBox.addItem(swModle.getType().getName());
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleTableHeader.java
@@ -8,43 +8,41 @@
  */
 package org.eclipse.hawkbit.ui.artifacts.smtable;
 
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.artifacts.event.SMFilterEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.UploadArtifactUIEvent;
 import org.eclipse.hawkbit.ui.artifacts.state.ArtifactUploadState;
 import org.eclipse.hawkbit.ui.common.table.AbstractTableHeader;
 import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.event.dd.DropHandler;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.Window;
 
 /**
  * Header of Software module table.
- * 
- *
- * 
  */
-@SpringComponent
-@ViewScope
 public class SoftwareModuleTableHeader extends AbstractTableHeader {
 
     private static final long serialVersionUID = 242961845006626297L;
 
-    @Autowired
-    private ArtifactUploadState artifactUploadState;
+    private final SoftwareModuleAddUpdateWindow softwareModuleAddUpdateWindow;
 
-    @Autowired
-    private SoftwareModuleAddUpdateWindow softwareModuleAddUpdateWindow;
+    SoftwareModuleTableHeader(final I18N i18n, final SpPermissionChecker permChecker, final UIEventBus eventbus,
+            final ArtifactUploadState artifactUploadState,
+            final SoftwareModuleAddUpdateWindow softwareModuleAddUpdateWindow) {
+        super(i18n, permChecker, eventbus, null, null, artifactUploadState);
+        this.softwareModuleAddUpdateWindow = softwareModuleAddUpdateWindow;
+    }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final UploadArtifactUIEvent event) {
         if (event == UploadArtifactUIEvent.HIDE_FILTER_BY_TYPE) {
             setFilterButtonsIconVisible(true);
@@ -73,10 +71,7 @@ public class SoftwareModuleTableHeader extends AbstractTableHeader {
 
     @Override
     protected String onLoadSearchBoxValue() {
-        if (artifactUploadState.getSoftwareModuleFilters().getSearchText().isPresent()) {
-            return artifactUploadState.getSoftwareModuleFilters().getSearchText().get();
-        }
-        return null;
+        return artifactUploadState.getSoftwareModuleFilters().getSearchText().orElse(null);
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleTableLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleTableLayout.java
@@ -8,38 +8,42 @@
  */
 package org.eclipse.hawkbit.ui.artifacts.smtable;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.ui.artifacts.event.UploadViewAcceptCriteria;
+import org.eclipse.hawkbit.ui.artifacts.state.ArtifactUploadState;
 import org.eclipse.hawkbit.ui.common.table.AbstractTableLayout;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import org.eclipse.hawkbit.ui.distributions.smtable.SwMetadataPopupLayout;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 /**
  * Software module table layout. (Upload Management)
  */
-@SpringComponent
-@ViewScope
 public class SoftwareModuleTableLayout extends AbstractTableLayout {
 
     private static final long serialVersionUID = 6464291374980641235L;
 
-    @Autowired
-    private SoftwareModuleDetails softwareModuleDetails;
+    public SoftwareModuleTableLayout(final I18N i18n, final SpPermissionChecker permChecker,
+            final ArtifactUploadState artifactUploadState, final UINotification uiNotification,
+            final UIEventBus eventBus, final SoftwareManagement softwareManagement, final EntityFactory entityFactory,
+            final UploadViewAcceptCriteria uploadViewAcceptCriteria) {
 
-    @Autowired
-    private SoftwareModuleTableHeader smTableHeader;
+        final SoftwareModuleAddUpdateWindow softwareModuleAddUpdateWindow = new SoftwareModuleAddUpdateWindow(i18n,
+                uiNotification, eventBus, softwareManagement, entityFactory);
 
-    @Autowired
-    private SoftwareModuleTable smTable;
+        final SwMetadataPopupLayout swMetadataPopupLayout = new SwMetadataPopupLayout(i18n, uiNotification, eventBus,
+                softwareManagement, entityFactory, permChecker);
 
-    /**
-     * Initialize the filter layout.
-     */
-    @PostConstruct
-    void init() {
-        super.init(smTableHeader, smTable, softwareModuleDetails);
+        super.init(
+                new SoftwareModuleTableHeader(i18n, permChecker, eventBus, artifactUploadState,
+                        softwareModuleAddUpdateWindow),
+                new SoftwareModuleTable(eventBus, i18n, uiNotification, artifactUploadState, softwareManagement,
+                        uploadViewAcceptCriteria, swMetadataPopupLayout),
+                new SoftwareModuleDetails(i18n, eventBus, permChecker, softwareModuleAddUpdateWindow,
+                        artifactUploadState, softwareManagement, swMetadataPopupLayout, entityFactory));
     }
 
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/CreateUpdateSoftwareTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/CreateUpdateSoftwareTypeLayout.java
@@ -11,7 +11,10 @@ package org.eclipse.hawkbit.ui.artifacts.smtype;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleTypeEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleTypeEvent.SoftwareModuleTypeEnum;
@@ -23,17 +26,17 @@ import org.eclipse.hawkbit.ui.common.builder.TextAreaBuilder;
 import org.eclipse.hawkbit.ui.common.builder.TextFieldBuilder;
 import org.eclipse.hawkbit.ui.layouts.CreateUpdateTypeLayout;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.data.Property.ValueChangeEvent;
 import com.vaadin.shared.ui.colorpicker.Color;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.OptionGroup;
 import com.vaadin.ui.TextField;
@@ -44,21 +47,25 @@ import com.vaadin.ui.themes.ValoTheme;
  * Layout for the create or update software module type.
  *
  */
-@SpringComponent
-@ViewScope
 public class CreateUpdateSoftwareTypeLayout extends CreateUpdateTypeLayout<SoftwareModuleType> {
 
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(CreateUpdateSoftwareTypeLayout.class);
 
-    @Autowired
-    private transient SoftwareManagement swTypeManagementService;
+    private final transient SoftwareManagement swTypeManagementService;
 
     private String singleAssignStr;
     private String multiAssignStr;
     private Label singleAssign;
     private Label multiAssign;
     private OptionGroup assignOptiongroup;
+
+    public CreateUpdateSoftwareTypeLayout(final I18N i18n, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UIEventBus eventBus, final SpPermissionChecker permChecker,
+            final UINotification uiNotification, final SoftwareManagement swTypeManagementService) {
+        super(i18n, tagManagement, entityFactory, eventBus, permChecker, uiNotification);
+        this.swTypeManagementService = swTypeManagementService;
+    }
 
     @Override
     protected void addListeners() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/SMTypeFilterButtonClick.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/SMTypeFilterButtonClick.java
@@ -15,52 +15,37 @@ import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 import org.eclipse.hawkbit.ui.artifacts.event.SMFilterEvent;
 import org.eclipse.hawkbit.ui.artifacts.state.ArtifactUploadState;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterSingleButtonClick;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 
 /**
  * Single button click behaviour of filter buttons layout.
- * 
- *
- * 
  */
-@SpringComponent
-@ViewScope
 public class SMTypeFilterButtonClick extends AbstractFilterSingleButtonClick implements Serializable {
 
     private static final long serialVersionUID = 3707945900524967887L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private ArtifactUploadState artifactUploadState;
+    private final ArtifactUploadState artifactUploadState;
 
-    @Autowired
-    private transient SoftwareManagement softwareManagement;
+    private final transient SoftwareManagement softwareManagement;
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.layouts.SPFilterButtonClickBehaviour#
-     * filterUnClicked(com.vaadin.ui. Button)
-     */
+    SMTypeFilterButtonClick(final UIEventBus eventBus, final ArtifactUploadState artifactUploadState,
+            final SoftwareManagement softwareManagement) {
+        this.eventBus = eventBus;
+        this.artifactUploadState = artifactUploadState;
+        this.softwareManagement = softwareManagement;
+    }
+
     @Override
     protected void filterUnClicked(final Button clickedButton) {
         artifactUploadState.getSoftwareModuleFilters().setSoftwareModuleType(null);
         eventBus.publish(this, SMFilterEvent.FILTER_BY_TYPE);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see hawkbit.server.ui.layouts.SPFilterButtonClickBehaviour#filterClicked
-     * (com.vaadin.ui.Button )
-     */
     @Override
     protected void filterClicked(final Button clickedButton) {
         final SoftwareModuleType softwareModuleType = softwareManagement

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/SMTypeFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/SMTypeFilterButtons.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.ui.artifacts.smtype;
 
 import java.util.EnumSet;
 
+import org.eclipse.hawkbit.repository.SoftwareManagement;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleTypeEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleTypeEvent.SoftwareModuleTypeEnum;
 import org.eclipse.hawkbit.ui.artifacts.event.UploadArtifactUIEvent;
@@ -19,35 +20,36 @@ import org.eclipse.hawkbit.ui.common.SoftwareModuleTypeBeanQuery;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterButtons;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 
 /**
  * Software module type filter buttons.
  * 
  */
-@SpringComponent
-@ViewScope
 public class SMTypeFilterButtons extends AbstractFilterButtons {
 
     private static final long serialVersionUID = 169198312654380358L;
 
-    @Autowired
-    private ArtifactUploadState artifactUploadState;
+    private final ArtifactUploadState artifactUploadState;
 
-    @Autowired
-    private UploadViewAcceptCriteria uploadViewAcceptCriteria;
+    private final UploadViewAcceptCriteria uploadViewAcceptCriteria;
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    SMTypeFilterButtons(final UIEventBus eventBus, final ArtifactUploadState artifactUploadState,
+            final UploadViewAcceptCriteria uploadViewAcceptCriteria, final SoftwareManagement softwareManagement) {
+        super(eventBus, new SMTypeFilterButtonClick(eventBus, artifactUploadState, softwareManagement));
+        this.artifactUploadState = artifactUploadState;
+        this.uploadViewAcceptCriteria = uploadViewAcceptCriteria;
+    }
+
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SoftwareModuleTypeEvent event) {
         if (event.getSoftwareModuleType() != null
                 && EnumSet.allOf(SoftwareModuleTypeEnum.class).contains(event.getSoftwareModuleTypeEnum())) {
@@ -56,7 +58,7 @@ public class SMTypeFilterButtons extends AbstractFilterButtons {
 
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final UploadArtifactUIEvent event) {
         if (event == UploadArtifactUIEvent.DELETED_ALL_SOFWARE_TYPE) {
             refreshTable();
@@ -70,14 +72,13 @@ public class SMTypeFilterButtons extends AbstractFilterButtons {
 
     @Override
     protected LazyQueryContainer createButtonsLazyQueryContainer() {
-        return HawkbitCommonUtil.createLazyQueryContainer(
-                new BeanQueryFactory<SoftwareModuleTypeBeanQuery>(SoftwareModuleTypeBeanQuery.class));
+        return HawkbitCommonUtil.createLazyQueryContainer(new BeanQueryFactory<>(SoftwareModuleTypeBeanQuery.class));
     }
 
     @Override
     protected boolean isClickedByDefault(final String typeName) {
-        return artifactUploadState.getSoftwareModuleFilters().getSoftwareModuleType().isPresent() && artifactUploadState
-                .getSoftwareModuleFilters().getSoftwareModuleType().get().getName().equals(typeName);
+        return artifactUploadState.getSoftwareModuleFilters().getSoftwareModuleType()
+                .map(type -> type.getName().equals(typeName)).orElse(false);
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/SMTypeFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/SMTypeFilterHeader.java
@@ -8,18 +8,20 @@
  */
 package org.eclipse.hawkbit.ui.artifacts.smtype;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.ui.artifacts.event.UploadArtifactUIEvent;
 import org.eclipse.hawkbit.ui.artifacts.state.ArtifactUploadState;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterHeader;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.Window;
@@ -27,25 +29,22 @@ import com.vaadin.ui.Window;
 /**
  * Software module type filter buttons header.
  */
-@SpringComponent
-@ViewScope
 public class SMTypeFilterHeader extends AbstractFilterHeader {
 
     private static final long serialVersionUID = -4855810338059032342L;
 
-    @Autowired
-    private ArtifactUploadState artifactUploadState;
+    private final ArtifactUploadState artifactUploadState;
+    private final CreateUpdateSoftwareTypeLayout createUpdateSWTypeLayout;
 
-    @Autowired
-    private CreateUpdateSoftwareTypeLayout createUpdateSWTypeLayout;
+    SMTypeFilterHeader(final I18N i18n, final SpPermissionChecker permChecker, final UIEventBus eventBus,
+            final ArtifactUploadState artifactUploadState, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UINotification uiNotification,
+            final SoftwareManagement softwareManagement) {
+        super(permChecker, eventBus, i18n);
+        this.artifactUploadState = artifactUploadState;
+        this.createUpdateSWTypeLayout = new CreateUpdateSoftwareTypeLayout(i18n, tagManagement, entityFactory, eventBus,
+                permChecker, uiNotification, softwareManagement);
 
-    /**
-     * Initialize the components.
-     */
-    @Override
-    @PostConstruct
-    protected void init() {
-        super.init();
         if (permChecker.hasCreateDistributionPermission() || permChecker.hasUpdateDistributionPermission()) {
             createUpdateSWTypeLayout.init();
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/SMTypeFilterLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/SMTypeFilterLayout.java
@@ -8,57 +8,44 @@
  */
 package org.eclipse.hawkbit.ui.artifacts.smtype;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.ui.artifacts.event.UploadArtifactUIEvent;
+import org.eclipse.hawkbit.ui.artifacts.event.UploadViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.artifacts.state.ArtifactUploadState;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterLayout;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.vaadin.spring.events.EventBus;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
-
 /**
  * Software module type filter buttons layout.
- * 
- *
- * 
  */
-@SpringComponent
-@ViewScope
 public class SMTypeFilterLayout extends AbstractFilterLayout {
 
     private static final long serialVersionUID = 1581066345157393665L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventbus;
+    private final ArtifactUploadState artifactUploadState;
 
-    @Autowired
-    private SMTypeFilterHeader smTypeFilterHeader;
+    public SMTypeFilterLayout(final ArtifactUploadState artifactUploadState, final I18N i18n,
+            final SpPermissionChecker permChecker, final UIEventBus eventBus, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UINotification uiNotification,
+            final SoftwareManagement softwareManagement, final UploadViewAcceptCriteria uploadViewAcceptCriteria) {
+        super(new SMTypeFilterHeader(i18n, permChecker, eventBus, artifactUploadState, tagManagement, entityFactory,
+                uiNotification, softwareManagement),
+                new SMTypeFilterButtons(eventBus, artifactUploadState, uploadViewAcceptCriteria, softwareManagement));
 
-    @Autowired
-    private SMTypeFilterButtons smTypeFilterButtons;
+        this.artifactUploadState = artifactUploadState;
+        restoreState();
 
-    @Autowired
-    private SMTypeFilterButtonClick smTypeFilterButtonClick;
-
-    @Autowired
-    private ArtifactUploadState artifactUploadState;
-
-    /**
-     * Initialize the filter layout.
-     */
-    @PostConstruct
-    void init() {
-        super.init(smTypeFilterHeader, smTypeFilterButtons, smTypeFilterButtonClick);
-        eventbus.subscribe(this);
+        eventBus.subscribe(this);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final UploadArtifactUIEvent event) {
         if (event == UploadArtifactUIEvent.HIDE_FILTER_BY_TYPE) {
             setVisible(false);
@@ -68,21 +55,6 @@ public class SMTypeFilterLayout extends AbstractFilterLayout {
         }
     }
 
-    @PreDestroy
-    void destroy() {
-        /*
-         * It's good manners to do this, even though vaadin-spring will
-         * automatically unsubscribe when this UI is garbage collected.
-         */
-        eventbus.unsubscribe(this);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.common.filterlayout.SPFilterLayout#
-     * onLoadIsTypeFilterIsClosed()
-     */
     @Override
     public Boolean onLoadIsTypeFilterIsClosed() {
         return artifactUploadState.isSwTypeFilterClosed();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/state/ArtifactUploadState.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/state/ArtifactUploadState.java
@@ -38,8 +38,7 @@ public class ArtifactUploadState implements ManagmentEntityState<Long>, Serializ
 
     private static final long serialVersionUID = 8273440375917450859L;
 
-    @Autowired
-    private SoftwareModuleFilters softwareModuleFilters;
+    private final SoftwareModuleFilters softwareModuleFilters;
 
     private final Map<Long, String> deleteSofwareModules = new HashMap<>();
 
@@ -74,6 +73,11 @@ public class ArtifactUploadState implements ManagmentEntityState<Long>, Serializ
     private final AtomicInteger numberOfFilesActuallyUpload = new AtomicInteger();
 
     private final AtomicInteger numberOfFileUploadsFailed = new AtomicInteger();
+
+    @Autowired
+    ArtifactUploadState(final SoftwareModuleFilters softwareModuleFilters) {
+        this.softwareModuleFilters = softwareModuleFilters;
+    }
 
     public AtomicInteger getNumberOfFileUploadsFailed() {
         return numberOfFileUploadsFailed;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/state/CustomFile.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/state/CustomFile.java
@@ -85,16 +85,6 @@ public class CustomFile implements Serializable {
         this.baseSoftwareModuleVersion = baseSoftwareModuleVersion;
     }
 
-    /**
-     * Default constructor with the immutable fileName set.
-     *
-     * @param fileName
-     *            uploaded file name
-     */
-    public CustomFile(final String fileName) {
-        this.fileName = fileName;
-    }
-
     public String getBaseSoftwareModuleName() {
         return baseSoftwareModuleName;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadConfirmationWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadConfirmationWindow.java
@@ -35,10 +35,10 @@ import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.data.Item;
 import com.vaadin.data.util.IndexedContainer;
@@ -116,6 +116,10 @@ public class UploadConfirmationWindow implements Button.ClickListener {
 
     private final ArtifactUploadState artifactUploadState;
 
+    private final transient UIEventBus eventBus;
+
+    private final transient ArtifactManagement artifactManagement;
+
     /**
      * Initialize the upload confirmation window.
      *
@@ -124,10 +128,12 @@ public class UploadConfirmationWindow implements Button.ClickListener {
      * @param artifactUploadState
      *            reference of session variable {@link ArtifactUploadState}.
      */
-    public UploadConfirmationWindow(final UploadLayout artifactUploadView,
-            final ArtifactUploadState artifactUploadState) {
+    UploadConfirmationWindow(final UploadLayout artifactUploadView, final ArtifactUploadState artifactUploadState,
+            final UIEventBus eventBus, final ArtifactManagement artifactManagement) {
         this.uploadLayout = artifactUploadView;
         this.artifactUploadState = artifactUploadState;
+        this.eventBus = eventBus;
+        this.artifactManagement = artifactManagement;
         i18n = artifactUploadView.getI18n();
         createRequiredComponents();
         buildLayout();
@@ -188,7 +194,6 @@ public class UploadConfirmationWindow implements Button.ClickListener {
      */
     private void setWarningIcon(final Label warningIconLabel, final String fileName, final Object itemId) {
         final Item item = uploadDetailsTable.getItem(itemId);
-        final ArtifactManagement artifactManagement = SpringContextHelper.getBean(ArtifactManagement.class);
         if (HawkbitCommonUtil.trimAndNullIfEmpty(fileName) != null) {
             final Long baseSwId = (Long) item.getItemProperty(BASE_SOFTWARE_ID).getValue();
             final List<Artifact> artifactList = artifactManagement.findByFilenameAndSoftwareModule(fileName, baseSwId);
@@ -432,7 +437,7 @@ public class UploadConfirmationWindow implements Button.ClickListener {
     private void hideErrorIcon(final Label warningLabel, final int errorLabelCount, final int duplicateCount,
             final Label errorLabel, final String oldFileName, final Long currentSwId) {
         if (warningLabel == null && (errorLabelCount > 1 || (duplicateCount == 1 && errorLabelCount == 1))) {
-            final ArtifactManagement artifactManagement = SpringContextHelper.getBean(ArtifactManagement.class);
+
             final List<Artifact> artifactList = artifactManagement.findByFilenameAndSoftwareModule(oldFileName,
                     currentSwId);
             errorLabel.removeStyleName(SPUIStyleDefinitions.ERROR_LABEL);
@@ -577,7 +582,6 @@ public class UploadConfirmationWindow implements Button.ClickListener {
     private void processArtifactUpload() {
         final List<String> itemIds = (List<String>) uploadDetailsTable.getItemIds();
         if (preUploadValidation(itemIds)) {
-            final ArtifactManagement artifactManagement = SpringContextHelper.getBean(ArtifactManagement.class);
             Boolean refreshArtifactDetailsLayout = false;
             for (final String itemId : itemIds) {
                 final String[] itemDet = itemId.split("/");
@@ -602,7 +606,7 @@ public class UploadConfirmationWindow implements Button.ClickListener {
             uploadLayout.clearFileList();
             window.close();
             // call upload result window
-            currentUploadResultWindow = new UploadResultWindow(uploadResultList, i18n);
+            currentUploadResultWindow = new UploadResultWindow(uploadResultList, i18n, eventBus);
             UI.getCurrent().addWindow(currentUploadResultWindow.getUploadResultsWindow());
             currentUploadResultWindow.getUploadResultsWindow().addCloseListener(event -> onResultDetailsPopupClose());
             uploadLayout.setResultPopupHeightWidth(Page.getCurrent().getBrowserWindowWidth(),

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadHandler.java
@@ -11,8 +11,6 @@ package org.eclipse.hawkbit.ui.artifacts.upload;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.exception.ArtifactUploadFailedException;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.ui.artifacts.event.UploadFileStatus;
@@ -60,15 +58,15 @@ public class UploadHandler implements StreamVariable, Receiver, SucceededListene
     private final long maxSize;
     private final Upload upload;
 
-    private volatile String fileName = null;
-    private volatile String mimeType = null;
-    private volatile boolean streamingInterrupted = false;
-    private volatile boolean uploadInterrupted = false;
-    private volatile boolean aborted = false;
+    private volatile String fileName;
+    private volatile String mimeType;
+    private volatile boolean streamingInterrupted;
+    private volatile boolean uploadInterrupted;
+    private volatile boolean aborted;
 
     private String failureReason;
     private final I18N i18n;
-    private transient EventBus.SessionEventBus eventBus;
+    private transient EventBus.UIEventBus eventBus;
     private final SoftwareModule selectedSw;
     private SoftwareModule selectedSwForUpload;
     private final ArtifactUploadState artifactUploadState;
@@ -85,21 +83,12 @@ public class UploadHandler implements StreamVariable, Receiver, SucceededListene
         this.mimeType = mimeType;
         this.selectedSw = selectedSw;
         this.i18n = SpringContextHelper.getBean(I18N.class);
-        this.eventBus = SpringContextHelper.getBean(EventBus.SessionEventBus.class);
+        this.eventBus = SpringContextHelper.getBean(EventBus.UIEventBus.class);
         this.artifactUploadState = SpringContextHelper.getBean(ArtifactUploadState.class);
         eventBus.subscribe(this);
     }
 
-    @PreDestroy
-    void destroy() {
-        /*
-         * It's good manners to do this, even though vaadin-spring will
-         * automatically unsubscribe when this UI is garbage collected.
-         */
-        eventBus.unsubscribe(this);
-    }
-
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final UploadStatusEventType event) {
         if (event == UploadStatusEventType.ABORT_UPLOAD) {
             aborted = true;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadLayout.java
@@ -17,10 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.apache.commons.io.FileUtils;
+import org.eclipse.hawkbit.repository.ArtifactManagement;
 import org.eclipse.hawkbit.repository.exception.ArtifactUploadFailedException;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent;
@@ -43,9 +41,9 @@ import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.eclipse.hawkbit.util.SPInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.StringUtils;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -58,8 +56,6 @@ import com.vaadin.server.FontAwesome;
 import com.vaadin.server.Page;
 import com.vaadin.server.StreamVariable;
 import com.vaadin.shared.ui.label.ContentMode;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.DragAndDropWrapper;
@@ -74,36 +70,24 @@ import com.vaadin.ui.VerticalLayout;
 /**
  * Upload files layout.
  */
-@ViewScope
-@SpringComponent
 public class UploadLayout extends VerticalLayout {
-
-    /**
-     * 
-     */
     private static final String HTML_DIV = "</div>";
 
     private static final long serialVersionUID = -566164756606779220L;
 
     private static final Logger LOG = LoggerFactory.getLogger(UploadLayout.class);
 
-    @Autowired
-    private UploadStatusInfoWindow uploadInfoWindow;
+    private final UploadStatusInfoWindow uploadInfoWindow;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient UINotification uiNotification;
+    private final UINotification uiNotification;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private ArtifactUploadState artifactUploadState;
+    private final ArtifactUploadState artifactUploadState;
 
-    @Autowired
-    private transient SPInfo spInfo;
+    private final transient SPInfo spInfo;
 
     private final List<String> duplicateFileNamesList = new ArrayList<>();
 
@@ -115,7 +99,7 @@ public class UploadLayout extends VerticalLayout {
 
     private VerticalLayout dropAreaLayout;
 
-    private UI ui;
+    private final UI ui;
 
     private HorizontalLayout fileUploadLayout;
 
@@ -125,11 +109,19 @@ public class UploadLayout extends VerticalLayout {
 
     private Button uploadStatusButton;
 
-    /**
-     * Initialize the upload layout.
-     */
-    @PostConstruct
-    void init() {
+    private final transient ArtifactManagement artifactManagement;
+
+    public UploadLayout(final I18N i18n, final UINotification uiNotification, final UIEventBus eventBus,
+            final ArtifactUploadState artifactUploadState, final SPInfo spInfo,
+            final ArtifactManagement artifactManagement) {
+        this.uploadInfoWindow = new UploadStatusInfoWindow(eventBus, artifactUploadState, i18n);
+        this.i18n = i18n;
+        this.uiNotification = uiNotification;
+        this.eventBus = eventBus;
+        this.artifactUploadState = artifactUploadState;
+        this.spInfo = spInfo;
+        this.artifactManagement = artifactManagement;
+
         createComponents();
         buildLayout();
         restoreState();
@@ -137,7 +129,7 @@ public class UploadLayout extends VerticalLayout {
         ui = UI.getCurrent();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final UploadArtifactUIEvent event) {
         if (event == UploadArtifactUIEvent.DELETED_ALL_SOFWARE) {
             ui.access(() -> updateActionCount());
@@ -150,30 +142,21 @@ public class UploadLayout extends VerticalLayout {
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final UploadStatusEvent event) {
         if (event.getUploadProgressEventType() == UploadStatusEventType.UPLOAD_STARTED) {
-            ui.access(() -> onStartOfUpload());
+            ui.access(this::onStartOfUpload);
         } else if (event.getUploadProgressEventType() == UploadStatusEventType.UPLOAD_FAILED) {
             ui.access(() -> onUploadFailure(event));
         } else if (event.getUploadProgressEventType() == UploadStatusEventType.UPLOAD_FINISHED) {
-            ui.access(() -> onUploadCompletion());
+            ui.access(this::onUploadCompletion);
         } else if (event.getUploadProgressEventType() == UploadStatusEventType.UPLOAD_SUCCESSFUL) {
             ui.access(() -> onUploadSuccess(event));
         } else if (event.getUploadProgressEventType() == UploadStatusEventType.UPLOAD_STREAMING_FAILED) {
             ui.access(() -> onUploadStreamingFailure(event));
         } else if (event.getUploadProgressEventType() == UploadStatusEventType.UPLOAD_STREAMING_FINISHED) {
-            ui.access(() -> onUploadStreamingSuccess());
+            ui.access(this::onUploadStreamingSuccess);
         }
-    }
-
-    @PreDestroy
-    void destroy() {
-        /*
-         * It's good manners to do this, even though vaadin-spring will
-         * automatically unsubscribe when this UI is garbage collected.
-         */
-        eventBus.unsubscribe(this);
     }
 
     private void createComponents() {
@@ -643,7 +626,8 @@ public class UploadLayout extends VerticalLayout {
             if (artifactUploadState.getFileSelected().isEmpty()) {
                 uiNotification.displayValidationError(i18n.get("message.error.noFileSelected"));
             } else {
-                currentUploadConfirmationwindow = new UploadConfirmationWindow(this, artifactUploadState);
+                currentUploadConfirmationwindow = new UploadConfirmationWindow(this, artifactUploadState, eventBus,
+                        artifactManagement);
                 UI.getCurrent().addWindow(currentUploadConfirmationwindow.getUploadConfrimationWindow());
                 setConfirmationPopupHeightWidth(Page.getCurrent().getBrowserWindowWidth(),
                         Page.getCurrent().getBrowserWindowHeight());

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadResultWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadResultWindow.java
@@ -19,7 +19,6 @@ import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.vaadin.spring.events.EventBus;
 
@@ -37,11 +36,6 @@ import com.vaadin.ui.themes.ValoTheme;
 
 /**
  * Upload status popup.
- *
- *
- *
- *
- *
  */
 public class UploadResultWindow implements Button.ClickListener {
 
@@ -66,9 +60,8 @@ public class UploadResultWindow implements Button.ClickListener {
     private static final String UPLOAD_RESULT = "uploadResult";
 
     private static final String REASON = "reason";
-    
-    private transient EventBus.SessionEventBus eventBus;
 
+    private transient EventBus.UIEventBus eventBus;
 
     /**
      * Initialize upload status popup.
@@ -78,10 +71,10 @@ public class UploadResultWindow implements Button.ClickListener {
      * @param i18n
      *            I18N
      */
-    public UploadResultWindow(final List<UploadStatus> uploadResultList, final I18N i18n) {
+    UploadResultWindow(final List<UploadStatus> uploadResultList, final I18N i18n, final EventBus.UIEventBus eventBus) {
         this.uploadResultList = uploadResultList;
         this.i18n = i18n;
-        eventBus = SpringContextHelper.getBean( EventBus.SessionEventBus.class);
+        this.eventBus = eventBus;
         createComponents();
         createLayout();
     }
@@ -190,7 +183,7 @@ public class UploadResultWindow implements Button.ClickListener {
         if (event.getComponent().getId().equals(UIComponentIdProvider.UPLOAD_ARTIFACT_RESULT_CLOSE)
                 || event.getComponent().getId().equals(UIComponentIdProvider.UPLOAD_ARTIFACT_RESULT_POPUP_CLOSE)) {
             uploadResultsWindow.close();
-            //close upload status popup if open
+            // close upload status popup if open
             eventBus.publish(this, UploadArtifactUIEvent.ARTIFACT_RESULT_POPUP_CLOSED);
         }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadStatusInfoWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadStatusInfoWindow.java
@@ -11,9 +11,6 @@ package org.eclipse.hawkbit.ui.artifacts.upload;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.ui.artifacts.event.UploadArtifactUIEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.UploadFileStatus;
@@ -28,8 +25,8 @@ import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -38,8 +35,6 @@ import com.vaadin.data.Item;
 import com.vaadin.data.util.IndexedContainer;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.shared.ui.window.WindowMode;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Grid;
@@ -58,18 +53,13 @@ import elemental.json.JsonValue;
 /**
  * Shows upload status during upload.
  */
-@ViewScope
-@SpringComponent
 public class UploadStatusInfoWindow extends Window {
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private ArtifactUploadState artifactUploadState;
+    private final ArtifactUploadState artifactUploadState;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
     private static final String PROGRESS = "Progress";
 
@@ -81,17 +71,17 @@ public class UploadStatusInfoWindow extends Window {
 
     private static final long serialVersionUID = 1L;
 
-    private Grid grid;
+    private final Grid grid;
 
-    private IndexedContainer uploads;
+    private final IndexedContainer uploads;
 
-    private volatile boolean errorOccured = false;
+    private volatile boolean errorOccured;
 
-    private volatile boolean uploadAborted = false;
+    private volatile boolean uploadAborted;
 
     private Button minimizeButton;
 
-    private VerticalLayout mainLayout;
+    private final VerticalLayout mainLayout;
 
     private Label windowCaption;
 
@@ -99,15 +89,14 @@ public class UploadStatusInfoWindow extends Window {
 
     private Button resizeButton;
 
-    private UI ui;
+    private final UI ui;
 
     private ConfirmationDialog confirmDialog;
 
-    /**
-     * Default Constructor.
-     */
-    @PostConstruct
-    void init() {
+    UploadStatusInfoWindow(final UIEventBus eventBus, final ArtifactUploadState artifactUploadState, final I18N i18n) {
+        this.eventBus = eventBus;
+        this.artifactUploadState = artifactUploadState;
+        this.i18n = i18n;
 
         setPopupProperties();
         createStatusPopupHeaderComponents();
@@ -130,7 +119,7 @@ public class UploadStatusInfoWindow extends Window {
         createConfirmDialog();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final UploadStatusEvent event) {
 
         final UploadFileStatus uploadStatus = event.getUploadStatus();
@@ -164,15 +153,6 @@ public class UploadStatusInfoWindow extends Window {
     private void onStartOfUpload(final UploadStatusEvent event) {
         uploadSessionStarted();
         uploadStarted(event.getUploadStatus().getFileName(), event.getUploadStatus().getSoftwareModule());
-    }
-
-    @PreDestroy
-    void destroy() {
-        /*
-         * It's good manners to do this, even though vaadin-spring will
-         * automatically unsubscribe when this UI is garbage collected.
-         */
-        eventBus.unsubscribe(this);
     }
 
     private void restoreState() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadStatusObject.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadStatusObject.java
@@ -27,15 +27,7 @@ public class UploadStatusObject implements Serializable {
     private String reason;
     private final SoftwareModule selectedSoftwareModule;
 
-    public UploadStatusObject(final String status, final Double progress, final String fileName, final String reason,
-            final SoftwareModule selectedSoftwareModule) {
-        this(fileName, selectedSoftwareModule);
-        this.status = status;
-        this.progress = progress;
-        this.reason = reason;
-    }
-
-    public UploadStatusObject(final String fileName, final SoftwareModule selectedSoftwareModule) {
+    UploadStatusObject(final String fileName, final SoftwareModule selectedSoftwareModule) {
         this.filename = fileName;
         this.selectedSoftwareModule = selectedSoftwareModule;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/colorpicker/ColorPickerLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/colorpicker/ColorPickerLayout.java
@@ -62,7 +62,7 @@ public class ColorPickerLayout extends GridLayout {
         addComponent(colorSelect, 1, 1, 1, 3);
     }
 
-    public void init() {
+    private void init() {
 
         selectors = new HashSet<>();
         selectedColor = getDefaultColor();
@@ -80,7 +80,7 @@ public class ColorPickerLayout extends GridLayout {
         selectors.add(colorSelect);
     }
 
-    public Slider createRGBSlider(final String caption, final String styleName) {
+    private Slider createRGBSlider(final String caption, final String styleName) {
         final Slider slider = new Slider(caption, 0, 255);
         slider.setImmediate(true);
         slider.setWidth("150px");

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/AbstractAcceptCriteria.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/AbstractAcceptCriteria.java
@@ -18,8 +18,8 @@ import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.event.dd.acceptcriteria.ServerSideCriterion;
@@ -39,11 +39,14 @@ public abstract class AbstractAcceptCriteria extends ServerSideCriterion {
 
     private int previousRowCount;
 
-    @Autowired
-    protected transient UINotification uiNotification;
+    protected UINotification uiNotification;
 
-    @Autowired
-    protected transient EventBus.SessionEventBus eventBus;
+    protected transient EventBus.UIEventBus eventBus;
+
+    protected AbstractAcceptCriteria(final UINotification uiNotification, final UIEventBus eventBus) {
+        this.uiNotification = uiNotification;
+        this.eventBus = eventBus;
+    }
 
     @Override
     public boolean accept(final DragAndDropEvent dragEvent) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/AbstractMetadataPopupLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/AbstractMetadataPopupLayout.java
@@ -11,8 +11,7 @@ package org.eclipse.hawkbit.ui.common;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.model.MetaData;
 import org.eclipse.hawkbit.repository.model.NamedVersionedEntity;
@@ -30,8 +29,8 @@ import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.data.Item;
 import com.vaadin.data.util.IndexedContainer;
@@ -73,14 +72,11 @@ public abstract class AbstractMetadataPopupLayout<E extends NamedVersionedEntity
 
     private static final String KEY = "key";
 
-    @Autowired
     protected I18N i18n;
 
-    @Autowired
-    private UINotification uiNotification;
+    private final UINotification uiNotification;
 
-    @Autowired
-    protected transient EventBus.SessionEventBus eventBus;
+    protected transient EventBus.UIEventBus eventBus;
 
     private TextField keyTextField;
 
@@ -97,6 +93,18 @@ public abstract class AbstractMetadataPopupLayout<E extends NamedVersionedEntity
     private E selectedEntity;
 
     private HorizontalLayout mainLayout;
+    protected SpPermissionChecker permChecker;
+
+    protected AbstractMetadataPopupLayout(final I18N i18n, final UINotification uiNotification,
+            final UIEventBus eventBus, final SpPermissionChecker permChecker) {
+        this.i18n = i18n;
+        this.uiNotification = uiNotification;
+        this.eventBus = eventBus;
+        this.permChecker = permChecker;
+
+        createComponents();
+        buildLayout();
+    }
 
     /**
      * Save the metadata and never close the window after saving.
@@ -116,13 +124,6 @@ public abstract class AbstractMetadataPopupLayout<E extends NamedVersionedEntity
         public boolean canWindowSaveOrUpdate() {
             return true;
         }
-
-    }
-
-    @PostConstruct
-    void init() {
-        createComponents();
-        buildLayout();
 
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/confirmwindow/layout/AbstractConfirmationWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/confirmwindow/layout/AbstractConfirmationWindowLayout.java
@@ -11,8 +11,6 @@ package org.eclipse.hawkbit.ui.common.confirmwindow.layout;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmallNoBorder;
@@ -20,8 +18,8 @@ import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.server.FontAwesome;
 import com.vaadin.ui.Accordion;
@@ -46,16 +44,15 @@ public abstract class AbstractConfirmationWindowLayout extends VerticalLayout {
 
     private String consolidatedMessage;
 
-    @Autowired
     protected I18N i18n;
 
-    @Autowired
-    protected transient EventBus.SessionEventBus eventBus;
+    protected transient EventBus.UIEventBus eventBus;
 
-    /**
-     * PostConstruct.
-     */
-    @PostConstruct
+    protected AbstractConfirmationWindowLayout(final I18N i18n, final UIEventBus eventBus) {
+        this.i18n = i18n;
+        this.eventBus = eventBus;
+    }
+
     public void initialize() {
         removeAllComponents();
         consolidatedMessage = "";
@@ -69,8 +66,7 @@ public abstract class AbstractConfirmationWindowLayout extends VerticalLayout {
     }
 
     private void createActionMessgaeLabel() {
-        actionMessage = new LabelBuilder().name("").id(UIComponentIdProvider.ACTION_LABEL).visible(false)
-                .buildLabel();
+        actionMessage = new LabelBuilder().name("").id(UIComponentIdProvider.ACTION_LABEL).visible(false).buildLabel();
         actionMessage.addStyleName(SPUIStyleDefinitions.CONFIRM_WINDOW_INFO_BOX);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractNamedVersionedEntityTableDetailsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractNamedVersionedEntityTableDetailsLayout.java
@@ -8,8 +8,12 @@
  */
 package org.eclipse.hawkbit.ui.common.detailslayout;
 
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.model.NamedVersionedEntity;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 /**
  *
@@ -19,6 +23,11 @@ public abstract class AbstractNamedVersionedEntityTableDetailsLayout<T extends N
         extends AbstractTableDetailsLayout<T> {
 
     private static final long serialVersionUID = 1L;
+
+    protected AbstractNamedVersionedEntityTableDetailsLayout(final I18N i18n, final UIEventBus eventBus,
+            final SpPermissionChecker permissionChecker, final ManagementUIState managementUIState) {
+        super(i18n, eventBus, permissionChecker, managementUIState);
+    }
 
     @Override
     protected String getName() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
@@ -10,9 +10,6 @@ package org.eclipse.hawkbit.ui.common.detailslayout;
 
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.model.NamedEntity;
@@ -22,13 +19,14 @@ import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
 import org.eclipse.hawkbit.ui.common.table.BaseUIEntityEvent;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmallNoBorder;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPDateTimeUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.server.FontAwesome;
 import com.vaadin.shared.ui.label.ContentMode;
@@ -48,14 +46,11 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
 
     private static final long serialVersionUID = 4862529368471627190L;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private SpPermissionChecker permissionChecker;
+    private final SpPermissionChecker permissionChecker;
 
     private T selectedBaseEntity;
 
@@ -65,37 +60,38 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
 
     private Button manageMetadataBtn;
 
-    private TabSheet detailsTab;
+    protected TabSheet detailsTab;
 
-    private VerticalLayout detailsLayout;
+    private final VerticalLayout detailsLayout;
 
-    private VerticalLayout descriptionLayout;
+    private final VerticalLayout descriptionLayout;
 
-    private VerticalLayout logLayout;
+    private final VerticalLayout logLayout;
 
-    private VerticalLayout attributesLayout;
+    private final VerticalLayout attributesLayout;
 
-    /**
-     * Initialize components.
-     */
-    @PostConstruct
-    protected void init() {
+    protected final ManagementUIState managementUIState;
+
+    protected AbstractTableDetailsLayout(final I18N i18n, final UIEventBus eventBus,
+            final SpPermissionChecker permissionChecker, final ManagementUIState managementUIState) {
+        this.i18n = i18n;
+        this.eventBus = eventBus;
+        this.permissionChecker = permissionChecker;
+        this.managementUIState = managementUIState;
+        detailsLayout = getTabLayout();
+        descriptionLayout = getTabLayout();
+        logLayout = getTabLayout();
+        attributesLayout = getTabLayout();
         createComponents();
         buildLayout();
-        restoreState();
         eventBus.subscribe(this);
-    }
-
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
     }
 
     protected SpPermissionChecker getPermissionChecker() {
         return permissionChecker;
     }
 
-    protected EventBus.SessionEventBus getEventBus() {
+    protected EventBus.UIEventBus getEventBus() {
         return eventBus;
     }
 
@@ -153,7 +149,6 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
         detailsTab.setHeight(90, Unit.PERCENTAGE);
         detailsTab.addStyleName(SPUIStyleDefinitions.DETAILS_LAYOUT_STYLE);
         detailsTab.setId(getTabSheetId());
-        addTabs(detailsTab);
     }
 
     private void buildLayout() {
@@ -196,7 +191,7 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
         caption.setValue(HawkbitCommonUtil.getSoftwareModuleName(headerCaption, value));
     }
 
-    private void restoreState() {
+    protected void restoreState() {
         if (onLoadIsTableRowSelected()) {
             populateData(null);
             editButton.setEnabled(true);
@@ -276,22 +271,18 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
     }
 
     protected VerticalLayout createLogLayout() {
-        logLayout = getTabLayout();
         return logLayout;
     }
 
     protected VerticalLayout createAttributesLayout() {
-        attributesLayout = getTabLayout();
         return attributesLayout;
     }
 
     protected VerticalLayout createDetailsLayout() {
-        detailsLayout = getTabLayout();
         return detailsLayout;
     }
 
     protected VerticalLayout createDescriptionLayout() {
-        descriptionLayout = getTabLayout();
         return descriptionLayout;
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/DistributionSetMetadatadetailslayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/DistributionSetMetadatadetailslayout.java
@@ -24,8 +24,6 @@ import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 
 import com.vaadin.data.Item;
 import com.vaadin.data.util.IndexedContainer;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.Table;
@@ -33,13 +31,9 @@ import com.vaadin.ui.UI;
 import com.vaadin.ui.themes.ValoTheme;
 
 /**
- *
  * DistributionSet Metadata details layout.
  *
  */
-
-@SpringComponent
-@ViewScope
 public class DistributionSetMetadatadetailslayout extends Table {
 
     private static final long serialVersionUID = 2913758299611837718L;
@@ -48,27 +42,19 @@ public class DistributionSetMetadatadetailslayout extends Table {
 
     private static final String VIEW = "view";
 
-    private transient DistributionSetManagement distributionSetManagement;
+    private final transient DistributionSetManagement distributionSetManagement;
 
-    private DsMetadataPopupLayout dsMetadataPopupLayout;
+    private final DsMetadataPopupLayout dsMetadataPopupLayout;
 
-    private SpPermissionChecker permissionChecker;
+    private final SpPermissionChecker permissionChecker;
 
-    private transient EntityFactory entityFactory;
+    private final transient EntityFactory entityFactory;
 
-    private I18N i18n;
+    private final I18N i18n;
 
     private Long selectedDistSetId;
 
-    /**
-     * 
-     * @param i18n
-     * @param permissionChecker
-     * @param distributionSetManagement
-     * @param dsMetadataPopupLayout
-     * @param entityFactory
-     */
-    public void init(final I18N i18n, final SpPermissionChecker permissionChecker,
+    public DistributionSetMetadatadetailslayout(final I18N i18n, final SpPermissionChecker permissionChecker,
             final DistributionSetManagement distributionSetManagement,
             final DsMetadataPopupLayout dsMetadataPopupLayout, final EntityFactory entityFactory) {
         this.i18n = i18n;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/SoftwareModuleDetailsTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/SoftwareModuleDetailsTable.java
@@ -26,11 +26,10 @@ import org.eclipse.hawkbit.ui.management.event.DistributionTableEvent;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.vaadin.spring.events.EventBus.SessionEventBus;
+import org.vaadin.spring.events.EventBus;
 
 import com.vaadin.data.Item;
 import com.vaadin.data.util.IndexedContainer;
@@ -46,9 +45,6 @@ import com.vaadin.ui.themes.ValoTheme;
 /**
  * Software module details table.
  * 
- *
- *
- *
  */
 public class SoftwareModuleDetailsTable extends Table {
 
@@ -64,18 +60,18 @@ public class SoftwareModuleDetailsTable extends Table {
 
     private boolean isTargetAssigned;
 
-    private boolean isUnassignSoftModAllowed;
-    private SpPermissionChecker permissionChecker;
+    private final boolean isUnassignSoftModAllowed;
+    private final SpPermissionChecker permissionChecker;
 
-    private transient DistributionSetManagement distributionSetManagement;
+    private final transient DistributionSetManagement distributionSetManagement;
 
-    private I18N i18n;
+    private final I18N i18n;
 
-    private transient SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    private transient ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
-    private transient UINotification uiNotification;
+    private final UINotification uiNotification;
 
     /**
      * Initialize software module table- to be displayed in details layout.
@@ -94,16 +90,17 @@ public class SoftwareModuleDetailsTable extends Table {
      * @param manageDistUIState
      *            ManageDistUIState
      */
-    public void init(final I18N i18n, final boolean isUnassignSoftModAllowed,
+    public SoftwareModuleDetailsTable(final I18N i18n, final boolean isUnassignSoftModAllowed,
             final SpPermissionChecker permissionChecker, final DistributionSetManagement distributionSetManagement,
-            final SessionEventBus eventBus, final ManageDistUIState manageDistUIState) {
+            final EventBus.UIEventBus eventBus, final ManageDistUIState manageDistUIState,
+            final UINotification uiNotification) {
         this.i18n = i18n;
         this.isUnassignSoftModAllowed = isUnassignSoftModAllowed;
         this.permissionChecker = permissionChecker;
         this.distributionSetManagement = distributionSetManagement;
         this.manageDistUIState = manageDistUIState;
         this.eventBus = eventBus;
-        this.uiNotification = SpringContextHelper.getBean(UINotification.class);
+        this.uiNotification = uiNotification;
         createSwModuleTable();
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/SoftwareModuleMetadatadetailslayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/SoftwareModuleMetadatadetailslayout.java
@@ -25,7 +25,7 @@ import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import com.vaadin.data.Item;
 import com.vaadin.data.util.IndexedContainer;
 import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Table;
 import com.vaadin.ui.UI;
@@ -38,7 +38,7 @@ import com.vaadin.ui.themes.ValoTheme;
  */
 
 @SpringComponent
-@ViewScope
+@UIScope
 public class SoftwareModuleMetadatadetailslayout extends Table {
 
     private static final long serialVersionUID = 2913758299611838818L;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/TargetFilterQueryDetailsTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/TargetFilterQueryDetailsTable.java
@@ -18,19 +18,13 @@ import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import com.vaadin.data.Container;
 import com.vaadin.data.Item;
 import com.vaadin.data.util.IndexedContainer;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.VaadinSessionScope;
 import com.vaadin.ui.Table;
 import com.vaadin.ui.themes.ValoTheme;
 
 /**
- *
  * DistributionSet TargetFilterQuery table
  *
  */
-
-@SpringComponent
-@VaadinSessionScope
 public class TargetFilterQueryDetailsTable extends Table {
 
     private static final long serialVersionUID = 2913758299611837718L;
@@ -38,13 +32,9 @@ public class TargetFilterQueryDetailsTable extends Table {
     private static final String TFQ_NAME = "name";
     private static final String TFQ_QUERY = "query";
 
-    private I18N i18n;
+    private final I18N i18n;
 
-    /**
-     * 
-     * @param i18n
-     */
-    public void init(final I18N i18n) {
+    public TargetFilterQueryDetailsTable(final I18N i18n) {
         this.i18n = i18n;
         createTable();
     }
@@ -52,7 +42,8 @@ public class TargetFilterQueryDetailsTable extends Table {
     /**
      * Populate software module metadata.
      *
-     * @param distributionSet the selected distribution set
+     * @param distributionSet
+     *            the selected distribution set
      */
     public void populateTableByDistributionSet(final DistributionSet distributionSet) {
         removeAllItems();
@@ -60,11 +51,11 @@ public class TargetFilterQueryDetailsTable extends Table {
             return;
         }
 
-        Container dataSource = getContainerDataSource();
-        List<TargetFilterQuery> filters = distributionSet.getAutoAssignFilters();
+        final Container dataSource = getContainerDataSource();
+        final List<TargetFilterQuery> filters = distributionSet.getAutoAssignFilters();
         filters.forEach(query -> {
-            Object itemId = dataSource.addItem();
-            Item item = dataSource.getItem(itemId);
+            final Object itemId = dataSource.addItem();
+            final Item item = dataSource.getItem(itemId);
             item.getItemProperty(TFQ_NAME).setValue(query.getName());
             item.getItemProperty(TFQ_QUERY).setValue(query.getQuery());
         });
@@ -102,6 +93,5 @@ public class TargetFilterQueryDetailsTable extends Table {
         setColumnHeader(TFQ_NAME, i18n.get("header.target.filter.name"));
         setColumnHeader(TFQ_QUERY, i18n.get("header.target.filter.query"));
     }
-
 
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtonClickBehaviour.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtonClickBehaviour.java
@@ -14,10 +14,6 @@ import com.vaadin.ui.Button;
 
 /**
  * Abstract button click behaviour of filter buttons layout.
- * 
- *
- *
- * 
  */
 public abstract class AbstractFilterButtonClickBehaviour implements Serializable {
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
@@ -13,17 +13,15 @@ import static org.eclipse.hawkbit.ui.utils.SPUIDefinitions.NO_TAG_BUTTON_ID;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUITagButtonStyle;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.data.Item;
 import com.vaadin.event.dd.DropHandler;
@@ -45,26 +43,17 @@ public abstract class AbstractFilterButtons extends Table {
 
     protected static final String FILTER_BUTTON_COLUMN = "filterButton";
 
-    @Autowired
-    protected transient EventBus.SessionEventBus eventBus;
+    protected transient EventBus.UIEventBus eventBus;
 
-    private AbstractFilterButtonClickBehaviour filterButtonClickBehaviour;
+    protected final AbstractFilterButtonClickBehaviour filterButtonClickBehaviour;
 
-    /**
-     * Initialize layout of filter buttons.
-     *
-     * @param filterButtonClickBehaviour
-     *            click behaviour of filter buttons.
-     */
-    public void init(final AbstractFilterButtonClickBehaviour filterButtonClickBehaviour) {
+    protected AbstractFilterButtons(final UIEventBus eventBus,
+            final AbstractFilterButtonClickBehaviour filterButtonClickBehaviour) {
+        this.eventBus = eventBus;
+
         this.filterButtonClickBehaviour = filterButtonClickBehaviour;
         createTable();
         eventBus.subscribe(this);
-    }
-
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
     }
 
     private void createTable() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterHeader.java
@@ -12,9 +12,10 @@ import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmallNoBorder;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.server.FontAwesome;
 import com.vaadin.ui.Alignment;
@@ -25,20 +26,14 @@ import com.vaadin.ui.VerticalLayout;
 
 /**
  * Parent class for filter button header layout.
- * 
- *
- *
- * 
  */
 public abstract class AbstractFilterHeader extends VerticalLayout {
 
     private static final long serialVersionUID = -1388340600522323332L;
 
-    @Autowired
     protected SpPermissionChecker permChecker;
 
-    @Autowired
-    protected transient EventBus.SessionEventBus eventBus;
+    protected transient EventBus.UIEventBus eventBus;
 
     private Label title;
 
@@ -46,10 +41,12 @@ public abstract class AbstractFilterHeader extends VerticalLayout {
 
     private Button hideIcon;
 
-    /**
-     * Initialize the header layout.
-     */
-    protected void init() {
+    protected final I18N i18n;
+
+    protected AbstractFilterHeader(final SpPermissionChecker permChecker, final UIEventBus eventBus, final I18N i18n) {
+        this.permChecker = permChecker;
+        this.eventBus = eventBus;
+        this.i18n = i18n;
         createComponents();
         buildLayout();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterLayout.java
@@ -15,35 +15,25 @@ import com.vaadin.ui.VerticalLayout;
 
 /**
  * Parent class for filter button layout.
- * 
- *
- *
- * 
  */
 public abstract class AbstractFilterLayout extends VerticalLayout {
 
     private static final long serialVersionUID = 9190616426688385851L;
 
-    private AbstractFilterHeader filterHeader;
+    private final AbstractFilterHeader filterHeader;
 
-    private AbstractFilterButtons filterButtons;
+    private final AbstractFilterButtons filterButtons;
 
-    /**
-     * Initialize the artifact details layout.
-     */
-    protected void init(final AbstractFilterHeader filterHeader, final AbstractFilterButtons filterButtons,
-            final AbstractFilterButtonClickBehaviour filterButtonClickBehaviour) {
+    protected AbstractFilterLayout(final AbstractFilterHeader filterHeader, final AbstractFilterButtons filterButtons) {
         this.filterHeader = filterHeader;
         this.filterButtons = filterButtons;
-        filterButtons.init(filterButtonClickBehaviour);
         buildLayout();
-        restoreState();
     }
 
     private void buildLayout() {
         setWidth(SPUIDefinitions.FILTER_BY_TYPE_WIDTH, Unit.PIXELS);
         setStyleName("filter-btns-main-layout");
-        setHeight(100.0f, Unit.PERCENTAGE);
+        setHeight(100.0F, Unit.PERCENTAGE);
         setSpacing(false);
         setMargin(false);
 
@@ -52,10 +42,10 @@ public abstract class AbstractFilterLayout extends VerticalLayout {
         setComponentAlignment(filterHeader, Alignment.TOP_CENTER);
         setComponentAlignment(filterButtons, Alignment.TOP_CENTER);
 
-        setExpandRatio(filterButtons, 1.0f);
+        setExpandRatio(filterButtons, 1.0F);
     }
 
-    private void restoreState() {
+    protected void restoreState() {
         if (onLoadIsTypeFilterIsClosed()) {
             setVisible(false);
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterMultiButtonClick.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterMultiButtonClick.java
@@ -25,12 +25,6 @@ public abstract class AbstractFilterMultiButtonClick extends AbstractFilterButto
     private static final long serialVersionUID = 1L;
     protected final transient Set<Button> alreadyClickedButtons = new HashSet<>();
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.layouts.SPFilterButtonClick#
-     * processFilterButtonClick(com.vaadin.ui. Button.ClickEvent)
-     */
     @Override
     public void processFilterButtonClick(final ClickEvent event) {
         final Button clickedButton = (Button) event.getComponent();
@@ -46,12 +40,6 @@ public abstract class AbstractFilterMultiButtonClick extends AbstractFilterButto
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.layouts.SPFilterButtonClickBehaviour#
-     * setDefaultClickedButton(com.vaadin .ui.Button)
-     */
     @Override
     protected void setDefaultClickedButton(final Button button) {
         if (button != null) {
@@ -60,10 +48,6 @@ public abstract class AbstractFilterMultiButtonClick extends AbstractFilterButto
         }
     }
 
-    /**
-     * @param clickedButton
-     * @return
-     */
     private boolean isButtonUnClicked(final Button clickedButton) {
         return !alreadyClickedButtons.isEmpty() && alreadyClickedButtons.contains(clickedButton);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterSingleButtonClick.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterSingleButtonClick.java
@@ -16,9 +16,6 @@ import com.vaadin.ui.Button.ClickEvent;
 /**
  * Abstract Single button click behaviour of filter buttons layout.
  *
- *
- *
- *
  */
 public abstract class AbstractFilterSingleButtonClick extends AbstractFilterButtonClickBehaviour {
 
@@ -26,12 +23,6 @@ public abstract class AbstractFilterSingleButtonClick extends AbstractFilterButt
 
     private Button alreadyClickedButton;
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.eclipse.hawkbit.server.ui.layouts.SPFilterButtonClick#
-     * processFilterButtonClick(com.vaadin.ui. Button.ClickEvent)
-     */
     @Override
     protected void processFilterButtonClick(final ClickEvent event) {
         final Button clickedButton = (Button) event.getComponent();
@@ -54,20 +45,10 @@ public abstract class AbstractFilterSingleButtonClick extends AbstractFilterButt
         }
     }
 
-    /**
-     * @param clickedButton
-     * @return
-     */
     private boolean isButtonUnClicked(final Button clickedButton) {
         return alreadyClickedButton != null && alreadyClickedButton.equals(clickedButton);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.eclipse.hawkbit.server.ui.layouts.SPFilterButtonClickBehaviour#
-     * setDefaultClickedButton(com.vaadin .ui.Button)
-     */
     @Override
     protected void setDefaultClickedButton(final Button button) {
         alreadyClickedButton = button;
@@ -76,17 +57,10 @@ public abstract class AbstractFilterSingleButtonClick extends AbstractFilterButt
         }
     }
 
-    /**
-     * @return the alreadyClickedButton
-     */
     public Button getAlreadyClickedButton() {
         return alreadyClickedButton;
     }
 
-    /**
-     * @param alreadyClickedButton
-     *            the alreadyClickedButton to set
-     */
     public void setAlreadyClickedButton(final Button alreadyClickedButton) {
         this.alreadyClickedButton = alreadyClickedButton;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/footer/AbstractDeleteActionsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/footer/AbstractDeleteActionsLayout.java
@@ -8,9 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.common.footer;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.builder.WindowBuilder;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
@@ -21,8 +18,8 @@ import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.event.dd.DropHandler;
@@ -48,17 +45,13 @@ public abstract class AbstractDeleteActionsLayout extends VerticalLayout impleme
 
     private static final long serialVersionUID = -6047975388519155509L;
 
-    @Autowired
     protected I18N i18n;
 
-    @Autowired
     protected SpPermissionChecker permChecker;
 
-    @Autowired
-    protected transient EventBus.SessionEventBus eventBus;
+    protected transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    protected transient UINotification notification;
+    protected UINotification notification;
 
     private DragAndDropWrapper deleteWrapper;
 
@@ -68,30 +61,30 @@ public abstract class AbstractDeleteActionsLayout extends VerticalLayout impleme
 
     private Button bulkUploadStatusButton;
 
-    /**
-     * Initialize.
-     */
-    @PostConstruct
+    protected AbstractDeleteActionsLayout(final I18N i18n, final SpPermissionChecker permChecker,
+            final UIEventBus eventBus, final UINotification notification) {
+        this.i18n = i18n;
+        this.permChecker = permChecker;
+        this.eventBus = eventBus;
+        this.notification = notification;
+
+        eventBus.subscribe(this);
+    }
+
     protected void init() {
         if (hasCountMessage() || hasDeletePermission() || hasUpdatePermission() || hasBulkUploadPermission()) {
             createComponents();
             buildLayout();
             reload();
         }
-        eventBus.subscribe(this);
     }
 
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
-    }
-
-    private void reload() {
+    protected void reload() {
         restoreActionCount();
         restoreBulkUploadStatusCount();
     }
 
-    private void createComponents() {
+    protected void createComponents() {
         if (hasDeletePermission()) {
             deleteWrapper = createDeleteWrapperLayout();
         }
@@ -103,7 +96,7 @@ public abstract class AbstractDeleteActionsLayout extends VerticalLayout impleme
         }
     }
 
-    private void buildLayout() {
+    protected void buildLayout() {
         final HorizontalLayout dropHintLayout = new HorizontalLayout();
         if (hasCountMessage()) {
             dropHintLayout.addComponent(getCountMessageLabel());

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGrid.java
@@ -8,13 +8,11 @@
  */
 package org.eclipse.hawkbit.ui.common.grid;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.data.Container;
 import com.vaadin.data.Container.Indexed;
@@ -27,19 +25,18 @@ import com.vaadin.ui.Grid;
 public abstract class AbstractGrid extends Grid {
 
     private static final long serialVersionUID = 4856562746502217630L;
-    
-    @Autowired
-    protected I18N i18n;
 
-    @Autowired
-    protected transient EventBus.SessionEventBus eventBus;
+    protected final I18N i18n;
 
+    protected final transient EventBus.UIEventBus eventBus;
 
-    /**
-     * Initialize the components.
-     */
-    @PostConstruct
-    protected void init() {
+    protected final SpPermissionChecker permissionChecker;
+
+    protected AbstractGrid(final I18N i18n, final UIEventBus eventBus, final SpPermissionChecker permissionChecker) {
+        this.i18n = i18n;
+        this.eventBus = eventBus;
+        this.permissionChecker = permissionChecker;
+
         setSizeFull();
         setImmediate(true);
         setId(getGridId());
@@ -48,13 +45,8 @@ public abstract class AbstractGrid extends Grid {
         addNewContainerDS();
         eventBus.subscribe(this);
     }
-    
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
-    }
 
-    public void addNewContainerDS() {
+    private void addNewContainerDS() {
         final Container container = createContainer();
         setContainerDataSource((Indexed) container);
         addContainerProperties();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGridHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGridHeader.java
@@ -8,10 +8,13 @@
  */
 package org.eclipse.hawkbit.ui.common.grid;
 
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.builder.TextFieldBuilder;
 import org.eclipse.hawkbit.ui.components.SPUIButton;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmallNoBorder;
+import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 
@@ -42,7 +45,17 @@ public abstract class AbstractGridHeader extends VerticalLayout {
 
     private Button closeButton;
 
-    protected void init() {
+    protected final SpPermissionChecker permissionChecker;
+
+    protected final RolloutUIState rolloutUIState;
+
+    protected final I18N i18n;
+
+    protected AbstractGridHeader(final SpPermissionChecker permissionChecker, final RolloutUIState rolloutUIState,
+            final I18N i18n) {
+        this.permissionChecker = permissionChecker;
+        this.rolloutUIState = rolloutUIState;
+        this.i18n = i18n;
         createComponents();
         buildLayout();
         restoreState();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGridLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGridLayout.java
@@ -18,27 +18,24 @@ import com.vaadin.ui.VerticalLayout;
 
 /**
  * 
- * Abstract grid layout class which builds layout with grid
- * {@link AbstractGrid} and table header
- * {@link AbstractGridHeader}.
+ * Abstract grid layout class which builds layout with grid {@link AbstractGrid}
+ * and table header {@link AbstractGridHeader}.
  *
  */
 public abstract class AbstractGridLayout extends VerticalLayout {
 
     private static final long serialVersionUID = 8611248179949245460L;
 
-    private AbstractGridHeader tableHeader;
-    
-    private AbstractGrid grid;
+    private final AbstractGridHeader tableHeader;
 
+    protected final AbstractGrid grid;
 
-    protected void init(final AbstractGridHeader tableHeader,final AbstractGrid grid) {
+    protected AbstractGridLayout(final AbstractGridHeader tableHeader, final AbstractGrid grid) {
         this.tableHeader = tableHeader;
         this.grid = grid;
-        buildLayout();
     }
 
-    private void buildLayout() {
+    protected void buildLayout() {
         setSizeFull();
         setSpacing(true);
         setMargin(false);
@@ -54,18 +51,17 @@ public abstract class AbstractGridLayout extends VerticalLayout {
         tableHeaderLayout.setComponentAlignment(tableHeader, Alignment.TOP_CENTER);
         tableHeaderLayout.addComponent(grid);
         tableHeaderLayout.setComponentAlignment(grid, Alignment.TOP_CENTER);
-        tableHeaderLayout.setExpandRatio(grid, 1.0f);
-        
+        tableHeaderLayout.setExpandRatio(grid, 1.0F);
 
         addComponent(tableHeaderLayout);
         setComponentAlignment(tableHeaderLayout, Alignment.TOP_CENTER);
-        setExpandRatio(tableHeaderLayout, 1.0f);
+        setExpandRatio(tableHeaderLayout, 1.0F);
         if (hasCountMessage()) {
             final HorizontalLayout rolloutGroupTargetsCountLayout = createCountMessageComponent();
             addComponent(rolloutGroupTargetsCountLayout);
             setComponentAlignment(rolloutGroupTargetsCountLayout, Alignment.BOTTOM_CENTER);
         }
-        
+
     }
 
     private HorizontalLayout createCountMessageComponent() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractNamedVersionTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractNamedVersionTable.java
@@ -11,8 +11,11 @@ package org.eclipse.hawkbit.ui.common.table;
 import java.util.List;
 
 import org.eclipse.hawkbit.repository.model.NamedVersionedEntity;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.TableColumn;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.data.Item;
 import com.vaadin.event.dd.DragAndDropEvent;
@@ -30,12 +33,8 @@ public abstract class AbstractNamedVersionTable<E extends NamedVersionedEntity, 
 
     private static final long serialVersionUID = 780050712209750719L;
 
-    /**
-     * Initialize the component.
-     */
-    @Override
-    protected void init() {
-        super.init();
+    protected AbstractNamedVersionTable(final UIEventBus eventBus, final I18N i18n, final UINotification notification) {
+        super(eventBus, i18n, notification);
         setMultiSelect(true);
         setSelectable(true);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTable.java
@@ -15,9 +15,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.model.NamedEntity;
 import org.eclipse.hawkbit.ui.artifacts.event.UploadArtifactUIEvent;
 import org.eclipse.hawkbit.ui.common.ManagmentEntityState;
@@ -28,8 +25,8 @@ import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.TableColumn;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
@@ -61,20 +58,16 @@ public abstract class AbstractTable<E extends NamedEntity, I> extends Table {
 
     protected static final String ACTION_NOT_ALLOWED_MSG = "message.action.not.allowed";
 
-    @Autowired
-    protected transient EventBus.SessionEventBus eventBus;
+    protected transient EventBus.UIEventBus eventBus;
 
-    @Autowired
     protected I18N i18n;
 
-    @Autowired
     protected UINotification notification;
 
-    /**
-     * Initialize the components.
-     */
-    @PostConstruct
-    protected void init() {
+    protected AbstractTable(final UIEventBus eventBus, final I18N i18n, final UINotification notification) {
+        this.eventBus = eventBus;
+        this.i18n = i18n;
+        this.notification = notification;
         setStyleName("sp-table");
         setSizeFull();
         setImmediate(true);
@@ -84,20 +77,11 @@ public abstract class AbstractTable<E extends NamedEntity, I> extends Table {
         setSortEnabled(false);
         setId(getTableId());
         addCustomGeneratedColumns();
-        addNewContainerDS();
-        setColumnProperties();
         setDefault();
         addValueChangeListener(event -> onValueChange());
-        selectRow();
         setPageLength(SPUIDefinitions.PAGE_SIZE);
 
-        setDataAvailable(getContainerDataSource().size() != 0);
         eventBus.subscribe(this);
-    }
-
-    @PreDestroy
-    protected void destroy() {
-        eventBus.unsubscribe(this);
     }
 
     /**
@@ -148,7 +132,7 @@ public abstract class AbstractTable<E extends NamedEntity, I> extends Table {
         setDropHandler(getTableDropHandler());
     }
 
-    private void addNewContainerDS() {
+    protected void addNewContainerDS() {
         final Container container = createContainer();
         addContainerProperties(container);
         setContainerDataSource(container);
@@ -178,7 +162,7 @@ public abstract class AbstractTable<E extends NamedEntity, I> extends Table {
         }
     }
 
-    private void setColumnProperties() {
+    protected void setColumnProperties() {
         final List<TableColumn> columnList = getTableVisibleColumns();
         final List<Object> swColumnIds = new ArrayList<>();
         for (final TableColumn column : columnList) {
@@ -249,9 +233,9 @@ public abstract class AbstractTable<E extends NamedEntity, I> extends Table {
 
     protected void onBaseEntityEvent(final BaseUIEntityEvent<E> event) {
         if (BaseEntityEventType.MINIMIZED == event.getEventType()) {
-            UI.getCurrent().access(() -> applyMinTableSettings());
+            UI.getCurrent().access(this::applyMinTableSettings);
         } else if (BaseEntityEventType.MAXIMIZED == event.getEventType()) {
-            UI.getCurrent().access(() -> applyMaxTableSettings());
+            UI.getCurrent().access(this::applyMaxTableSettings);
         } else if (BaseEntityEventType.NEW_ENTITY == event.getEventType()) {
             UI.getCurrent().access(() -> addEntity(event.getEntity()));
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableHeader.java
@@ -8,21 +8,21 @@
  */
 package org.eclipse.hawkbit.ui.common.table;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.ui.artifacts.state.ArtifactUploadState;
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.common.builder.TextFieldBuilder;
 import org.eclipse.hawkbit.ui.components.SPUIButton;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmallNoBorder;
+import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.server.FontAwesome;
@@ -41,14 +41,11 @@ public abstract class AbstractTableHeader extends VerticalLayout {
 
     private static final long serialVersionUID = 4881626370291837175L;
 
-    @Autowired
     protected I18N i18n;
 
-    @Autowired
     protected SpPermissionChecker permChecker;
 
-    @Autowired
-    protected transient EventBus.SessionEventBus eventbus;
+    protected transient EventBus.UIEventBus eventbus;
 
     private Label headerCaption;
 
@@ -64,24 +61,25 @@ public abstract class AbstractTableHeader extends VerticalLayout {
 
     private HorizontalLayout filterDroppedInfo;
 
-    private DragAndDropWrapper dropFilterLayout;
-
     private Button bulkUploadIcon;
 
-    /**
-     * Initialze components.
-     */
-    @PostConstruct
-    protected void init() {
+    protected final ManagementUIState managementUIState;
+    protected final ManageDistUIState manageDistUIstate;
+    protected final ArtifactUploadState artifactUploadState;
+
+    protected AbstractTableHeader(final I18N i18n, final SpPermissionChecker permChecker, final UIEventBus eventbus,
+            final ManagementUIState managementUIState, final ManageDistUIState manageDistUIstate,
+            final ArtifactUploadState artifactUploadState) {
+        this.i18n = i18n;
+        this.permChecker = permChecker;
+        this.eventbus = eventbus;
+        this.managementUIState = managementUIState;
+        this.manageDistUIstate = manageDistUIstate;
+        this.artifactUploadState = artifactUploadState;
         createComponents();
         buildLayout();
         restoreState();
         eventbus.subscribe(this);
-    }
-
-    @PreDestroy
-    void destroy() {
-        eventbus.unsubscribe(this);
     }
 
     private void createComponents() {
@@ -181,7 +179,7 @@ public abstract class AbstractTableHeader extends VerticalLayout {
             filterDroppedInfo.setHeightUndefined();
             filterDroppedInfo.setSizeUndefined();
             displayFilterDropedInfoOnLoad();
-            dropFilterLayout = new DragAndDropWrapper(filterDroppedInfo);
+            final DragAndDropWrapper dropFilterLayout = new DragAndDropWrapper(filterDroppedInfo);
             dropFilterLayout.setId(getDropFilterId());
             dropFilterLayout.setDropHandler(getDropFilterHandler());
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableLayout.java
@@ -38,6 +38,8 @@ public abstract class AbstractTableLayout extends VerticalLayout {
         this.table = table;
         this.detailsLayout = detailsLayout;
         buildLayout();
+
+        table.selectRow();
     }
 
     private void buildLayout() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/AbstractTagToken.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/AbstractTagToken.java
@@ -13,9 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.model.BaseEntity;
 import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
@@ -25,8 +22,8 @@ import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.tokenfield.TokenField;
 import org.vaadin.tokenfield.TokenField.InsertPosition;
 
@@ -65,19 +62,14 @@ public abstract class AbstractTagToken<T extends BaseEntity> implements Serializ
 
     protected CssLayout tokenLayout = new CssLayout();
 
-    @Autowired
     protected SpPermissionChecker checker;
 
-    @Autowired
     protected I18N i18n;
 
-    @Autowired
     protected UINotification uinotification;
 
-    @Autowired
-    protected transient EventBus.SessionEventBus eventBus;
+    protected transient EventBus.UIEventBus eventBus;
 
-    @Autowired
     protected ManagementUIState managementUIState;
 
     // BaseEntity implements Serializable so this entity is serializable. Maybe
@@ -85,16 +77,16 @@ public abstract class AbstractTagToken<T extends BaseEntity> implements Serializ
     @SuppressWarnings("squid:S1948")
     protected T selectedEntity;
 
-    @PostConstruct
-    protected void init() {
+    protected AbstractTagToken(final SpPermissionChecker checker, final I18N i18n, final UINotification uinotification,
+            final UIEventBus eventBus, final ManagementUIState managementUIState) {
+        this.checker = checker;
+        this.i18n = i18n;
+        this.uinotification = uinotification;
+        this.eventBus = eventBus;
+        this.managementUIState = managementUIState;
         createTokenField();
         checkIfTagAssignedIsAllowed();
         eventBus.subscribe(this);
-    }
-
-    @PreDestroy
-    protected void destroy() {
-        eventBus.unsubscribe(this);
     }
 
     protected void onBaseEntityEvent(final BaseUIEntityEvent<T> baseEntityEvent) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/AbstractTargetTagToken.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/AbstractTargetTagToken.java
@@ -10,12 +10,16 @@ package org.eclipse.hawkbit.ui.common.tagdetails;
 
 import java.util.List;
 
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetTagUpdateEvent;
 import org.eclipse.hawkbit.repository.model.BaseEntity;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.push.TargetTagCreatedEventContainer;
 import org.eclipse.hawkbit.ui.push.TargetTagDeletedEventContainer;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -31,24 +35,30 @@ public abstract class AbstractTargetTagToken<T extends BaseEntity> extends Abstr
 
     private static final long serialVersionUID = 7772876588903171201L;
 
-    @Autowired
-    protected transient TagManagement tagManagement;
+    protected final transient TagManagement tagManagement;
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    protected AbstractTargetTagToken(final SpPermissionChecker checker, final I18N i18n,
+            final UINotification uinotification, final UIEventBus eventBus, final ManagementUIState managementUIState,
+            final TagManagement tagManagement) {
+        super(checker, i18n, uinotification, eventBus, managementUIState);
+        this.tagManagement = tagManagement;
+    }
+
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEventTargetTagCreated(final TargetTagCreatedEventContainer container) {
         container.getEvents().stream().map(event -> event.getEntity())
                 .forEach(tag -> setContainerPropertValues(tag.getId(), tag.getName(), tag.getColour()));
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onTargetTagDeletedEvent(final TargetTagDeletedEventContainer container) {
         container.getEvents().stream().map(event -> getTagIdByTagName(event.getEntityId()))
                 .forEach(this::removeTagFromCombo);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onTargetTagUpdateEvent(final List<TargetTagUpdateEvent> events) {
-        events.stream().map(event -> event.getEntity()).forEach(entity -> {
+        events.stream().map(TargetTagUpdateEvent::getEntity).forEach(entity -> {
             final Item item = container.getItem(entity.getId());
             if (item != null) {
                 updateItem(entity.getName(), entity.getColour(), item);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/DistributionTagToken.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/DistributionTagToken.java
@@ -12,42 +12,49 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetTag;
 import org.eclipse.hawkbit.repository.model.DistributionSetTagAssignmentResult;
 import org.eclipse.hawkbit.ui.management.event.DistributionTableEvent;
 import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.push.DistributionSetTagCreatedEventContainer;
 import org.eclipse.hawkbit.ui.push.DistributionSetTagDeletedEventContainer;
 import org.eclipse.hawkbit.ui.push.DistributionSetTagUpdatedEventContainer;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.google.common.collect.Sets;
 import com.vaadin.data.Item;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 
 /**
  * Implementation of target/ds tag token layout.
  *
  */
-@SpringComponent
-@ViewScope
 public class DistributionTagToken extends AbstractTagToken<DistributionSet> {
 
     private static final long serialVersionUID = -8022738301736043396L;
-    @Autowired
-    private transient TagManagement tagManagement;
 
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
+    private final transient TagManagement tagManagement;
+
+    private final transient DistributionSetManagement distributionSetManagement;
 
     // To Be Done : have to set this value based on view???
     private static final Boolean NOTAGS_SELECTED = Boolean.FALSE;
+
+    public DistributionTagToken(final SpPermissionChecker checker, final I18N i18n, final UINotification uinotification,
+            final UIEventBus eventBus, final ManagementUIState managementUIState, final TagManagement tagManagement,
+            final DistributionSetManagement distributionSetManagement) {
+        super(checker, i18n, uinotification, eventBus, managementUIState);
+        this.tagManagement = tagManagement;
+        this.distributionSetManagement = distributionSetManagement;
+    }
 
     @Override
     protected String getTagStyleName() {
@@ -111,25 +118,25 @@ public class DistributionTagToken extends AbstractTagToken<DistributionSet> {
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DistributionTableEvent distributionTableEvent) {
         onBaseEntityEvent(distributionTableEvent);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onDistributionSetTagCreatedBulkEvent(final DistributionSetTagCreatedEventContainer eventContainer) {
         eventContainer.getEvents().stream().map(event -> event.getEntity())
                 .forEach(distributionSetTag -> setContainerPropertValues(distributionSetTag.getId(),
                         distributionSetTag.getName(), distributionSetTag.getColour()));
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onDistributionSetTagDeletedEvent(final DistributionSetTagDeletedEventContainer eventContainer) {
         eventContainer.getEvents().stream().map(event -> getTagIdByTagName(event.getEntityId()))
                 .forEach(this::removeTagFromCombo);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onDistributionSetTagUpdateEvent(final DistributionSetTagUpdatedEventContainer eventContainer) {
         eventContainer.getEvents().stream().map(event -> event.getEntity()).forEach(entity -> {
             final Item item = container.getItem(entity.getId());

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/TargetTagToken.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/TargetTagToken.java
@@ -11,27 +11,27 @@ package org.eclipse.hawkbit.ui.common.tagdetails;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 import org.eclipse.hawkbit.repository.model.TargetTagAssignmentResult;
 import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
 import org.eclipse.hawkbit.ui.management.event.TargetTableEvent;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 
 /**
  * Implementation of Target tag token.
  *
  *
  */
-@SpringComponent
-@ViewScope
 public class TargetTagToken extends AbstractTargetTagToken<Target> {
 
     private static final long serialVersionUID = 7124887018280196721L;
@@ -39,8 +39,14 @@ public class TargetTagToken extends AbstractTargetTagToken<Target> {
     // To Be Done : have to set this value based on view???
     private static final Boolean NOTAGS_SELECTED = Boolean.FALSE;
 
-    @Autowired
-    private transient TargetManagement targetManagement;
+    private final transient TargetManagement targetManagement;
+
+    public TargetTagToken(final SpPermissionChecker checker, final I18N i18n, final UINotification uinotification,
+            final UIEventBus eventBus, final ManagementUIState managementUIState, final TagManagement tagManagement,
+            final TargetManagement targetManagement) {
+        super(checker, i18n, uinotification, eventBus, managementUIState, tagManagement);
+        this.targetManagement = targetManagement;
+    }
 
     @Override
     protected String getTagStyleName() {
@@ -136,7 +142,7 @@ public class TargetTagToken extends AbstractTargetTagToken<Target> {
         return false;
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final TargetTableEvent targetTableEvent) {
         onBaseEntityEvent(targetTableEvent);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/DistributionSetInfoPanel.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/DistributionSetInfoPanel.java
@@ -19,9 +19,6 @@ import com.vaadin.ui.VerticalLayout;
 
 /**
  * Distribution set panel for Target.
- *
- *
- *
  */
 @SuppressWarnings("serial")
 public class DistributionSetInfoPanel extends Panel {
@@ -38,9 +35,8 @@ public class DistributionSetInfoPanel extends Panel {
      * @param style2
      *            as String
      */
-    public DistributionSetInfoPanel(final DistributionSet distributionSet, final String caption, final String style1,
+    DistributionSetInfoPanel(final DistributionSet distributionSet, final String caption, final String style1,
             final String style2) {
-        super();
         setImmediate(false);
         decorate(distributionSet, caption, style1, style2);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPTargetAttributesLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPTargetAttributesLayout.java
@@ -21,9 +21,6 @@ import com.vaadin.ui.VerticalLayout;
 
 /**
  * Attributes Vertical layout for Target.
- *
- *
- *
  */
 public class SPTargetAttributesLayout {
     private final VerticalLayout targetAttributesLayout;
@@ -35,7 +32,7 @@ public class SPTargetAttributesLayout {
      *            controller attributes
      *
      */
-    public SPTargetAttributesLayout(final Map<String, String> controllerAttibs) {
+    SPTargetAttributesLayout(final Map<String, String> controllerAttibs) {
         targetAttributesLayout = new VerticalLayout();
         targetAttributesLayout.setSpacing(true);
         targetAttributesLayout.setMargin(true);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPUIButton.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPUIButton.java
@@ -13,29 +13,11 @@ import com.vaadin.ui.Button;
 
 /**
  * Basic button for SPUI. Any commonality can be decorated.
- * 
- *
- *
  */
-
 public class SPUIButton extends Button {
-
-    /**
-     * ID.
-     */
     private static final long serialVersionUID = -7327726430436273739L;
 
-    /**
-     * Parametric constructor.
-     * 
-     * @param id
-     *            as String
-     * @param buttonName
-     *            as String
-     * @param buttonDesc
-     *            as String
-     */
-    public SPUIButton(final String id, final String buttonName, final String buttonDesc) {
+    SPUIButton(final String id, final String buttonName, final String buttonDesc) {
         super(buttonName);
         setDescription(buttonDesc);
         setImmediate(false);
@@ -50,7 +32,7 @@ public class SPUIButton extends Button {
      * @param icon
      *            as Resource
      */
-    public void togleIcon(Resource icon) {
+    public void togleIcon(final Resource icon) {
         setIcon(icon);
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPUICheckBox.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPUICheckBox.java
@@ -13,32 +13,13 @@ import com.vaadin.ui.themes.ValoTheme;
 
 /**
  * ComboBox with required style.
- * 
- *
- *
  */
 public class SPUICheckBox extends CheckBox {
 
     private static final long serialVersionUID = 2270323611612189225L;
 
-    /**
-     * Parametric constructor to decorate.
-     * 
-     * @param caption
-     *            as caption for checkbox
-     * @param style
-     *            style of the CheckBox
-     * @param styleName
-     *            styleName of the CheckBox
-     * @param required
-     *            required check for Checkbox
-     * @param data
-     *            data of the CheckBox
-     * 
-     */
-    public SPUICheckBox(final String caption, final String style, final String styleName, final boolean required,
+    SPUICheckBox(final String caption, final String style, final String styleName, final boolean required,
             final String data) {
-        super();
         decorate(caption, style, styleName, required, data);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/DistributionsView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/DistributionsView.java
@@ -8,14 +8,24 @@
  */
 package org.eclipse.hawkbit.ui.distributions;
 
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.eclipse.hawkbit.repository.ArtifactManagement;
+import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SoftwareManagement;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.SystemManagement;
+import org.eclipse.hawkbit.repository.TagManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.ui.HawkbitUI;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent;
+import org.eclipse.hawkbit.ui.artifacts.state.ArtifactUploadState;
 import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
 import org.eclipse.hawkbit.ui.distributions.disttype.DSTypeFilterLayout;
 import org.eclipse.hawkbit.ui.distributions.dstable.DistributionSetTableLayout;
+import org.eclipse.hawkbit.ui.distributions.event.DistributionsViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.distributions.event.DragEvent;
 import org.eclipse.hawkbit.ui.distributions.footer.DSDeleteActionsLayout;
 import org.eclipse.hawkbit.ui.distributions.smtable.SwModuleTableLayout;
@@ -27,6 +37,7 @@ import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -37,7 +48,7 @@ import com.vaadin.server.Page;
 import com.vaadin.server.Page.BrowserWindowResizeEvent;
 import com.vaadin.server.Page.BrowserWindowResizeListener;
 import com.vaadin.spring.annotation.SpringView;
-import com.vaadin.spring.annotation.ViewScope;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.UI;
@@ -45,58 +56,67 @@ import com.vaadin.ui.VerticalLayout;
 
 /**
  * Manage distributions and distributions type view.
- * 
- *
- * 
  */
+@UIScope
 @SpringView(name = DistributionsView.VIEW_NAME, ui = HawkbitUI.class)
-@ViewScope
 public class DistributionsView extends VerticalLayout implements View, BrowserWindowResizeListener {
 
     public static final String VIEW_NAME = "distributions";
     private static final long serialVersionUID = 3887435076372276300L;
 
-    @Autowired
-    private SpPermissionChecker permChecker;
+    private final SpPermissionChecker permChecker;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient UINotification uiNotification;
+    private final UINotification uiNotification;
 
-    @Autowired
-    private DSTypeFilterLayout filterByDSTypeLayout;
+    private final DSTypeFilterLayout filterByDSTypeLayout;
 
-    @Autowired
-    private DistributionSetTableLayout distributionTableLayout;
+    private final DistributionSetTableLayout distributionTableLayout;
 
-    @Autowired
-    private SwModuleTableLayout softwareModuleTableLayout;
+    private final SwModuleTableLayout softwareModuleTableLayout;
 
-    @Autowired
-    private DistSMTypeFilterLayout filterBySMTypeLayout;
+    private final DistSMTypeFilterLayout filterBySMTypeLayout;
 
-    @Autowired
-    private DSDeleteActionsLayout deleteActionsLayout;
+    private final DSDeleteActionsLayout deleteActionsLayout;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
     private GridLayout mainLayout;
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * com.vaadin.navigator.View#enter(com.vaadin.navigator.ViewChangeListener.
-     * ViewChangeEvent)
-     */
-    @Override
-    public void enter(final ViewChangeEvent event) {
+    @Autowired
+    DistributionsView(final SpPermissionChecker permChecker, final UIEventBus eventBus, final I18N i18n,
+            final UINotification uiNotification, final ManageDistUIState manageDistUIState,
+            final SoftwareManagement softwareManagement, final DistributionSetManagement distributionSetManagement,
+            final TargetManagement targetManagement, final EntityFactory entityFactory,
+            final TagManagement tagManagement, final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria,
+            final ArtifactUploadState artifactUploadState, final SystemManagement systemManagement,
+            final ArtifactManagement artifactManagement) {
+        this.permChecker = permChecker;
+        this.eventBus = eventBus;
+        this.i18n = i18n;
+        this.uiNotification = uiNotification;
+        this.filterByDSTypeLayout = new DSTypeFilterLayout(manageDistUIState, i18n, permChecker, eventBus,
+                tagManagement, entityFactory, uiNotification, softwareManagement, distributionSetManagement,
+                distributionsViewAcceptCriteria);
+        this.distributionTableLayout = new DistributionSetTableLayout(i18n, eventBus, permChecker, manageDistUIState,
+                softwareManagement, distributionSetManagement, targetManagement, entityFactory, uiNotification,
+                tagManagement, distributionsViewAcceptCriteria, systemManagement);
+        this.softwareModuleTableLayout = new SwModuleTableLayout(i18n, uiNotification, eventBus, softwareManagement,
+                entityFactory, manageDistUIState, permChecker, distributionsViewAcceptCriteria, artifactUploadState,
+                artifactManagement);
+        this.filterBySMTypeLayout = new DistSMTypeFilterLayout(eventBus, i18n, permChecker, manageDistUIState,
+                tagManagement, entityFactory, uiNotification, softwareManagement, distributionsViewAcceptCriteria);
+        this.deleteActionsLayout = new DSDeleteActionsLayout(i18n, permChecker, eventBus, uiNotification,
+                systemManagement, manageDistUIState, distributionsViewAcceptCriteria, distributionSetManagement,
+                softwareManagement);
+        this.manageDistUIState = manageDistUIState;
+    }
+
+    @PostConstruct
+    void init() {
         // Build the Distributions view layout with all the required components.
         buildLayout();
         restoreState();
@@ -142,9 +162,9 @@ public class DistributionsView extends VerticalLayout implements View, BrowserWi
         mainLayout.addComponent(softwareModuleTableLayout, 2, 0);
         mainLayout.addComponent(filterBySMTypeLayout, 3, 0);
         mainLayout.addComponent(deleteActionsLayout, 1, 1, 2, 1);
-        mainLayout.setRowExpandRatio(0, 1.0f);
-        mainLayout.setColumnExpandRatio(1, 0.5f);
-        mainLayout.setColumnExpandRatio(2, 0.5f);
+        mainLayout.setRowExpandRatio(0, 1.0F);
+        mainLayout.setColumnExpandRatio(1, 0.5F);
+        mainLayout.setColumnExpandRatio(2, 0.5F);
         mainLayout.setComponentAlignment(deleteActionsLayout, Alignment.BOTTOM_CENTER);
     }
 
@@ -157,7 +177,7 @@ public class DistributionsView extends VerticalLayout implements View, BrowserWi
         });
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DistributionTableEvent event) {
         if (BaseEntityEventType.MINIMIZED == event.getEventType()) {
             minimizeDistTable();
@@ -166,7 +186,7 @@ public class DistributionsView extends VerticalLayout implements View, BrowserWi
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SoftwareModuleEvent event) {
         if (BaseEntityEventType.MINIMIZED == event.getEventType()) {
             minimizeSwTable();
@@ -179,17 +199,17 @@ public class DistributionsView extends VerticalLayout implements View, BrowserWi
         mainLayout.removeComponent(filterByDSTypeLayout);
         mainLayout.removeComponent(distributionTableLayout);
         mainLayout.removeComponent(deleteActionsLayout);
-        mainLayout.setColumnExpandRatio(2, 1f);
-        mainLayout.setColumnExpandRatio(0, 0f);
-        mainLayout.setColumnExpandRatio(1, 0f);
+        mainLayout.setColumnExpandRatio(2, 1F);
+        mainLayout.setColumnExpandRatio(0, 0F);
+        mainLayout.setColumnExpandRatio(1, 0F);
     }
 
     private void minimizeSwTable() {
         mainLayout.addComponent(filterByDSTypeLayout, 0, 0);
         mainLayout.addComponent(distributionTableLayout, 1, 0);
         mainLayout.addComponent(deleteActionsLayout, 1, 1, 2, 1);
-        mainLayout.setColumnExpandRatio(1, 0.5f);
-        mainLayout.setColumnExpandRatio(2, 0.5f);
+        mainLayout.setColumnExpandRatio(1, 0.5F);
+        mainLayout.setColumnExpandRatio(2, 0.5F);
         mainLayout.setComponentAlignment(deleteActionsLayout, Alignment.BOTTOM_CENTER);
     }
 
@@ -197,8 +217,8 @@ public class DistributionsView extends VerticalLayout implements View, BrowserWi
         mainLayout.addComponent(softwareModuleTableLayout, 2, 0);
         mainLayout.addComponent(filterBySMTypeLayout, 3, 0);
         mainLayout.addComponent(deleteActionsLayout, 1, 1, 2, 1);
-        mainLayout.setColumnExpandRatio(1, 0.5f);
-        mainLayout.setColumnExpandRatio(2, 0.5f);
+        mainLayout.setColumnExpandRatio(1, 0.5F);
+        mainLayout.setColumnExpandRatio(2, 0.5F);
         mainLayout.setComponentAlignment(deleteActionsLayout, Alignment.BOTTOM_CENTER);
     }
 
@@ -206,9 +226,9 @@ public class DistributionsView extends VerticalLayout implements View, BrowserWi
         mainLayout.removeComponent(softwareModuleTableLayout);
         mainLayout.removeComponent(filterBySMTypeLayout);
         mainLayout.removeComponent(deleteActionsLayout);
-        mainLayout.setColumnExpandRatio(1, 1f);
-        mainLayout.setColumnExpandRatio(2, 0f);
-        mainLayout.setColumnExpandRatio(3, 0f);
+        mainLayout.setColumnExpandRatio(1, 1F);
+        mainLayout.setColumnExpandRatio(2, 0F);
+        mainLayout.setColumnExpandRatio(3, 0F);
     }
 
     private void checkNoDataAvaialble() {
@@ -241,6 +261,11 @@ public class DistributionsView extends VerticalLayout implements View, BrowserWi
                 softwareModuleTableLayout.setShowFilterButtonVisible(false);
             }
         }
+    }
+
+    @Override
+    public void enter(final ViewChangeEvent event) {
+        // This view is constructed in the init() method()
     }
 
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/CreateUpdateDistSetTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/CreateUpdateDistSetTypeLayout.java
@@ -13,7 +13,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.builder.DistributionSetTypeUpdate;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
@@ -28,21 +31,21 @@ import org.eclipse.hawkbit.ui.distributions.event.DistributionSetTypeEvent;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionSetTypeEvent.DistributionSetTypeEnum;
 import org.eclipse.hawkbit.ui.layouts.CreateUpdateTypeLayout;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.springframework.data.domain.PageRequest;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.data.Item;
 import com.vaadin.data.Property.ValueChangeEvent;
 import com.vaadin.data.util.IndexedContainer;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.shared.ui.colorpicker.Color;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.AbstractSelect.ItemDescriptionGenerator;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
@@ -57,8 +60,6 @@ import com.vaadin.ui.themes.ValoTheme;
 /**
  * Window for create update Distribution Set Type.
  */
-@SpringComponent
-@ViewScope
 public class CreateUpdateDistSetTypeLayout extends CreateUpdateTypeLayout<DistributionSetType> {
 
     private static final long serialVersionUID = 1L;
@@ -67,11 +68,9 @@ public class CreateUpdateDistSetTypeLayout extends CreateUpdateTypeLayout<Distri
     private static final String DIST_TYPE_MANDATORY = "mandatory";
     private static final String STAR = " * ";
 
-    @Autowired
-    private transient SoftwareManagement softwareManagement;
+    private final transient SoftwareManagement softwareManagement;
 
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
+    private final transient DistributionSetManagement distributionSetManagement;
 
     private HorizontalLayout distTypeSelectLayout;
     private Table sourceTable;
@@ -81,6 +80,15 @@ public class CreateUpdateDistSetTypeLayout extends CreateUpdateTypeLayout<Distri
     private IndexedContainer sourceTableContainer;
 
     private IndexedContainer originalSelectedTableContainer;
+
+    public CreateUpdateDistSetTypeLayout(final I18N i18n, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UIEventBus eventBus, final SpPermissionChecker permChecker,
+            final UINotification uiNotification, final SoftwareManagement softwareManagement,
+            final DistributionSetManagement distributionSetManagement) {
+        super(i18n, tagManagement, entityFactory, eventBus, permChecker, uiNotification);
+        this.softwareManagement = softwareManagement;
+        this.distributionSetManagement = distributionSetManagement;
+    }
 
     @Override
     protected void createRequiredComponents() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/DSTypeFilterButtonClick.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/DSTypeFilterButtonClick.java
@@ -15,41 +15,31 @@ import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterSingleButtonClick;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.management.event.DistributionTableFilterEvent;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 
 /**
  * Single button click behaviour of filter buttons layout.
- * 
- *
- * 
  */
-
-@SpringComponent
-@ViewScope
 public class DSTypeFilterButtonClick extends AbstractFilterSingleButtonClick implements Serializable {
 
     private static final long serialVersionUID = -584783755917528648L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
+    private final transient DistributionSetManagement distributionSetManagement;
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.common.filterlayout.
-     * AbstractFilterButtonClickBehaviour#filterUnClicked (com.vaadin.ui.Button)
-     */
+    DSTypeFilterButtonClick(final UIEventBus eventBus, final ManageDistUIState manageDistUIState,
+            final DistributionSetManagement distributionSetManagement) {
+        this.eventBus = eventBus;
+        this.manageDistUIState = manageDistUIState;
+        this.distributionSetManagement = distributionSetManagement;
+    }
+
     @Override
     protected void filterUnClicked(final Button clickedButton) {
         manageDistUIState.getManageDistFilters().setClickedDistSetType(null);
@@ -57,12 +47,6 @@ public class DSTypeFilterButtonClick extends AbstractFilterSingleButtonClick imp
 
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.common.filterlayout.
-     * AbstractFilterButtonClickBehaviour#filterClicked (com.vaadin.ui.Button)
-     */
     @Override
     protected void filterClicked(final Button clickedButton) {
         final DistributionSetType distSetType = distributionSetManagement

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/DSTypeFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/DSTypeFilterButtons.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ui.distributions.disttype;
 
+import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.ui.common.DistributionSetTypeBeanQuery;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterButtons;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionSetTypeEvent;
@@ -17,32 +18,34 @@ import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 
 /**
  * Distribution Set Type filter buttons.
  */
-@SpringComponent
-@ViewScope
 public class DSTypeFilterButtons extends AbstractFilterButtons {
 
     private static final long serialVersionUID = 771251569981876005L;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
-    @Autowired
-    private DistributionsViewAcceptCriteria distributionsViewAcceptCriteria;
+    private final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria;
+
+    DSTypeFilterButtons(final UIEventBus eventBus, final ManageDistUIState manageDistUIState,
+            final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria,
+            final DistributionSetManagement distributionSetManagement) {
+        super(eventBus, new DSTypeFilterButtonClick(eventBus, manageDistUIState, distributionSetManagement));
+        this.manageDistUIState = manageDistUIState;
+        this.distributionsViewAcceptCriteria = distributionsViewAcceptCriteria;
+    }
 
     @Override
     protected String getButtonsTableId() {
@@ -52,8 +55,7 @@ public class DSTypeFilterButtons extends AbstractFilterButtons {
 
     @Override
     protected LazyQueryContainer createButtonsLazyQueryContainer() {
-        return HawkbitCommonUtil.createLazyQueryContainer(
-                new BeanQueryFactory<DistributionSetTypeBeanQuery>(DistributionSetTypeBeanQuery.class));
+        return HawkbitCommonUtil.createLazyQueryContainer(new BeanQueryFactory<>(DistributionSetTypeBeanQuery.class));
     }
 
     @Override
@@ -97,7 +99,7 @@ public class DSTypeFilterButtons extends AbstractFilterButtons {
         return SPUIDefinitions.DISTRIBUTION_SET_TYPE_ID_PREFIXS;
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DistributionSetTypeEvent event) {
         if (event.getDistributionSetTypeEnum() == DistributionSetTypeEvent.DistributionSetTypeEnum.ADD_DIST_SET_TYPE
                 || event.getDistributionSetTypeEnum() == DistributionSetTypeEvent.DistributionSetTypeEnum.UPDATE_DIST_SET_TYPE) {
@@ -106,7 +108,7 @@ public class DSTypeFilterButtons extends AbstractFilterButtons {
 
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SaveActionWindowEvent event) {
         if (event == SaveActionWindowEvent.SAVED_DELETE_DIST_SET_TYPES) {
             refreshTypeTable();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/DSTypeFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/DSTypeFilterHeader.java
@@ -8,42 +8,43 @@
  */
 package org.eclipse.hawkbit.ui.distributions.disttype;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.ui.common.CommonDialogWindow;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterHeader;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionsUIEvent;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.UI;
 
 /**
  * Distribution Set Type filter buttons header.
  */
-@SpringComponent
-@ViewScope
 public class DSTypeFilterHeader extends AbstractFilterHeader {
 
     private static final long serialVersionUID = 3433417459392880222L;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
-    @Autowired
-    private CreateUpdateDistSetTypeLayout createUpdateDistSetTypeLayout;
+    private final CreateUpdateDistSetTypeLayout createUpdateDistSetTypeLayout;
 
-    private CommonDialogWindow addUpdateWindow;
-
-    @Override
-    @PostConstruct
-    public void init() {
-        super.init();
+    DSTypeFilterHeader(final I18N i18n, final SpPermissionChecker permChecker, final UIEventBus eventBus,
+            final ManageDistUIState manageDistUIState, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UINotification uiNotification,
+            final SoftwareManagement softwareManagement, final DistributionSetManagement distributionSetManagement) {
+        super(permChecker, eventBus, i18n);
+        this.manageDistUIState = manageDistUIState;
+        this.createUpdateDistSetTypeLayout = new CreateUpdateDistSetTypeLayout(i18n, tagManagement, entityFactory,
+                eventBus, permChecker, uiNotification, softwareManagement, distributionSetManagement);
         if (hasCreateUpdatePermission()) {
             createUpdateDistSetTypeLayout.init();
         }
@@ -61,7 +62,7 @@ public class DSTypeFilterHeader extends AbstractFilterHeader {
 
     @Override
     protected void settingsIconClicked(final ClickEvent event) {
-        addUpdateWindow = createUpdateDistSetTypeLayout.getWindow();
+        final CommonDialogWindow addUpdateWindow = createUpdateDistSetTypeLayout.getWindow();
         UI.getCurrent().addWindow(addUpdateWindow);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/DSTypeFilterLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/DSTypeFilterLayout.java
@@ -8,58 +8,46 @@
  */
 package org.eclipse.hawkbit.ui.distributions.disttype;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
+import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterLayout;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionsUIEvent;
+import org.eclipse.hawkbit.ui.distributions.event.DistributionsViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.vaadin.spring.events.EventBus;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
-
 /**
  * Distribution Set Type filter buttons layout.
- * 
- *
- * 
  */
-
-@SpringComponent
-@ViewScope
 public class DSTypeFilterLayout extends AbstractFilterLayout {
 
     private static final long serialVersionUID = 2689002932344750781L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventbus;
+    private final ManageDistUIState manageDistUIState;
 
-    @Autowired
-    private DSTypeFilterHeader dsTypeFilterHeader;
+    public DSTypeFilterLayout(final ManageDistUIState manageDistUIState, final I18N i18n,
+            final SpPermissionChecker permChecker, final UIEventBus eventBus, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UINotification uiNotification,
+            final SoftwareManagement softwareManagement, final DistributionSetManagement distributionSetManagement,
+            final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria) {
+        super(new DSTypeFilterHeader(i18n, permChecker, eventBus, manageDistUIState, tagManagement, entityFactory,
+                uiNotification, softwareManagement, distributionSetManagement),
+                new DSTypeFilterButtons(eventBus, manageDistUIState, distributionsViewAcceptCriteria,
+                        distributionSetManagement));
+        this.manageDistUIState = manageDistUIState;
 
-    @Autowired
-    private DSTypeFilterButtons dsTypeFilterButtons;
-
-    @Autowired
-    private DSTypeFilterButtonClick dsTypeFilterButtonClick;
-
-    @Autowired
-    private ManageDistUIState manageDistUIState;
-
-    /**
-     * Initialize the filter layout.
-     */
-    @PostConstruct
-    public void init() {
-        super.init(dsTypeFilterHeader, dsTypeFilterButtons, dsTypeFilterButtonClick);
-        eventbus.subscribe(this);
+        restoreState();
+        eventBus.subscribe(this);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DistributionsUIEvent event) {
         if (event == DistributionsUIEvent.HIDE_DIST_FILTER_BY_TYPE) {
             setVisible(false);
@@ -69,22 +57,6 @@ public class DSTypeFilterLayout extends AbstractFilterLayout {
         }
     }
 
-    @PreDestroy
-    void destroy() {
-        /*
-         * It's good manners to do this, even though vaadin-spring will
-         * automatically unsubscribe when this UI is garbage collected.
-         */
-        eventbus.unsubscribe(this);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.eclipse.hawkbit.server.ui.common.filterlayout.AbstractFilterLayout#
-     * onLoadIsTypeFilterIsClosed()
-     */
     @Override
     public Boolean onLoadIsTypeFilterIsClosed() {
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetDetails.java
@@ -16,6 +16,9 @@ import java.util.Set;
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleIdName;
@@ -33,16 +36,17 @@ import org.eclipse.hawkbit.ui.distributions.event.SaveActionWindowEvent;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.management.dstable.DistributionAddUpdateWindowLayout;
 import org.eclipse.hawkbit.ui.management.event.DistributionTableEvent;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.data.Item;
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.HorizontalLayout;
@@ -54,66 +58,63 @@ import com.vaadin.ui.Window;
 
 /**
  * Distribution set details layout.
- *
- *
- *
  */
-@SpringComponent
-@ViewScope
 public class DistributionSetDetails extends AbstractNamedVersionedEntityTableDetailsLayout<DistributionSet> {
 
     private static final long serialVersionUID = -4595004466943546669L;
 
     private static final String SOFT_MODULE = "softwareModule";
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
-    @Autowired
-    private DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout;
+    private final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout;
 
-    @Autowired
-    private DistributionTagToken distributionTagToken;
+    private final DistributionTagToken distributionTagToken;
 
-    @Autowired
-    private transient SoftwareManagement softwareManagement;
+    private final transient SoftwareManagement softwareManagement;
 
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
+    private final transient DistributionSetManagement distributionSetManagement;
 
-    @Autowired
-    private DsMetadataPopupLayout dsMetadataPopupLayout;
+    private final transient TargetManagement targetManagement;
 
-    @Autowired
-    private transient EntityFactory entityFactory;
+    private final DsMetadataPopupLayout dsMetadataPopupLayout;
 
-    private SoftwareModuleDetailsTable softwareModuleTable;
+    private final SoftwareModuleDetailsTable softwareModuleTable;
 
-    private DistributionSetMetadatadetailslayout dsMetadataTable;
+    private final DistributionSetMetadatadetailslayout dsMetadataTable;
 
-    private TargetFilterQueryDetailsTable tfqDetailsTable;
+    private final TargetFilterQueryDetailsTable tfqDetailsTable;
 
     private VerticalLayout tagsLayout;
 
     private Map<String, StringBuilder> assignedSWModule;
 
-    /**
-     * softwareLayout Initialize the component.
-     */
-    @Override
-    protected void init() {
-        softwareModuleTable = new SoftwareModuleDetailsTable();
-        softwareModuleTable.init(getI18n(), true, getPermissionChecker(), distributionSetManagement, getEventBus(),
-                manageDistUIState);
+    DistributionSetDetails(final I18N i18n, final UIEventBus eventBus, final SpPermissionChecker permissionChecker,
+            final ManageDistUIState manageDistUIState, final ManagementUIState managementUIState,
+            final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout,
+            final SoftwareManagement softwareManagement, final DistributionSetManagement distributionSetManagement,
+            final TargetManagement targetManagement, final EntityFactory entityFactory,
+            final UINotification uinotification, final TagManagement tagManagement,
+            final DsMetadataPopupLayout popupLayout, final UINotification uiNotification) {
+        super(i18n, eventBus, permissionChecker, managementUIState);
+        this.manageDistUIState = manageDistUIState;
+        this.distributionAddUpdateWindowLayout = distributionAddUpdateWindowLayout;
+        this.distributionTagToken = new DistributionTagToken(permissionChecker, i18n, uinotification, eventBus,
+                managementUIState, tagManagement, distributionSetManagement);
+        this.softwareManagement = softwareManagement;
+        this.distributionSetManagement = distributionSetManagement;
+        this.targetManagement = targetManagement;
+        this.dsMetadataPopupLayout = popupLayout;
 
-        dsMetadataTable = new DistributionSetMetadatadetailslayout();
-        dsMetadataTable.init(getI18n(), getPermissionChecker(), distributionSetManagement, dsMetadataPopupLayout,
-                entityFactory);
+        softwareModuleTable = new SoftwareModuleDetailsTable(i18n, true, permissionChecker, distributionSetManagement,
+                eventBus, manageDistUIState, uiNotification);
 
-        tfqDetailsTable = new TargetFilterQueryDetailsTable();
-        tfqDetailsTable.init(getI18n());
+        dsMetadataTable = new DistributionSetMetadatadetailslayout(i18n, permissionChecker, distributionSetManagement,
+                dsMetadataPopupLayout, entityFactory);
 
-        super.init();
+        tfqDetailsTable = new TargetFilterQueryDetailsTable(i18n);
+        addTabs(detailsTab);
+        restoreState();
     }
 
     protected VerticalLayout createTagsLayout() {
@@ -183,9 +184,8 @@ public class DistributionSetDetails extends AbstractNamedVersionedEntityTableDet
     private Button assignSoftModuleButton(final String softwareModuleName) {
         if (getPermissionChecker().hasUpdateDistributionPermission()
                 && manageDistUIState.getLastSelectedDistribution().isPresent()
-                && distributionSetManagement
-                        .findDistributionSetById(manageDistUIState.getLastSelectedDistribution().get().getId())
-                        .getAssignedTargets().isEmpty()) {
+                && targetManagement.countTargetByAssignedDistributionSet(
+                        manageDistUIState.getLastSelectedDistribution().get().getId()) <= 0) {
             final Button reassignSoftModule = SPUIComponentProvider.getButton(softwareModuleName, "", "", "", true,
                     FontAwesome.TIMES, SPUIButtonStyleSmallNoBorder.class);
             reassignSoftModule.setEnabled(false);
@@ -352,19 +352,19 @@ public class DistributionSetDetails extends AbstractNamedVersionedEntityTableDet
         return getPermissionChecker().hasUpdateDistributionPermission();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SoftwareModuleEvent event) {
         if (event.getSoftwareModuleEventType() == SoftwareModuleEventType.ASSIGN_SOFTWARE_MODULE) {
             UI.getCurrent().access(() -> updateSoftwareModule(event.getEntity()));
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DistributionTableEvent distributionTableEvent) {
         onBaseEntityEvent(distributionTableEvent);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SaveActionWindowEvent saveActionWindowEvent) {
         if ((saveActionWindowEvent == SaveActionWindowEvent.SAVED_ASSIGNMENTS
                 || saveActionWindowEvent == SaveActionWindowEvent.DISCARD_ALL_ASSIGNMENTS)
@@ -374,11 +374,11 @@ public class DistributionSetDetails extends AbstractNamedVersionedEntityTableDet
             }
             setSelectedBaseEntity(
                     distributionSetManagement.findDistributionSetByIdWithDetails(getSelectedBaseEntityId()));
-            UI.getCurrent().access(() -> populateModule());
+            UI.getCurrent().access(this::populateModule);
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEventDiscard(final SaveActionWindowEvent saveActionWindowEvent) {
         if (saveActionWindowEvent == SaveActionWindowEvent.DISCARD_ASSIGNMENT
                 || saveActionWindowEvent == SaveActionWindowEvent.DISCARD_ALL_ASSIGNMENTS

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
@@ -45,17 +45,19 @@ import org.eclipse.hawkbit.ui.push.DistributionCreatedEventContainer;
 import org.eclipse.hawkbit.ui.push.DistributionDeletedEventContainer;
 import org.eclipse.hawkbit.ui.push.DistributionSetUpdatedEventContainer;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.TableColumn;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -65,8 +67,6 @@ import com.vaadin.data.Item;
 import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Table;
@@ -75,8 +75,6 @@ import com.vaadin.ui.UI;
 /**
  * Distribution set table.
  */
-@SpringComponent
-@ViewScope
 public class DistributionSetTable extends AbstractNamedVersionTable<DistributionSet, DistributionSetIdName> {
 
     private static final long serialVersionUID = -7731776093470487988L;
@@ -86,37 +84,41 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
     private static final List<Object> DISPLAY_DROP_HINT_EVENTS = new ArrayList<>(
             Arrays.asList(DragEvent.SOFTWAREMODULE_DRAG));
 
-    @Autowired
-    private SpPermissionChecker permissionChecker;
+    private final SpPermissionChecker permissionChecker;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
+    private final transient DistributionSetManagement distributionSetManagement;
 
-    @Autowired
-    private transient SoftwareManagement softwareManagement;
+    private final transient SoftwareManagement softwareManagement;
 
-    @Autowired
-    private DistributionsViewAcceptCriteria distributionsViewAcceptCriteria;
+    private final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria;
 
-    @Autowired
-    private transient TargetManagement targetManagement;
+    private final transient TargetManagement targetManagement;
 
-    @Autowired
-    private DsMetadataPopupLayout dsMetadataPopupLayout;
+    private final DsMetadataPopupLayout dsMetadataPopupLayout;
 
-    /**
-     * Initialize the component.
-     */
-    @Override
-    protected void init() {
-        super.init();
+    DistributionSetTable(final UIEventBus eventBus, final I18N i18n, final UINotification notification,
+            final SpPermissionChecker permissionChecker, final ManageDistUIState manageDistUIState,
+            final DistributionSetManagement distributionSetManagement, final SoftwareManagement softwareManagement,
+            final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria,
+            final TargetManagement targetManagement, final DsMetadataPopupLayout dsMetadataPopupLayout) {
+        super(eventBus, i18n, notification);
+        this.permissionChecker = permissionChecker;
+        this.manageDistUIState = manageDistUIState;
+        this.distributionSetManagement = distributionSetManagement;
+        this.softwareManagement = softwareManagement;
+        this.distributionsViewAcceptCriteria = distributionsViewAcceptCriteria;
+        this.targetManagement = targetManagement;
+        this.dsMetadataPopupLayout = dsMetadataPopupLayout;
         addTableStyleGenerator();
+
+        addNewContainerDS();
+        setColumnProperties();
+        setDataAvailable(getContainerDataSource().size() != 0);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DragEvent event) {
         if (event == DragEvent.HIDE_DROP_HINT) {
             UI.getCurrent().access(() -> removeStyleName(SPUIStyleDefinitions.SHOW_DROP_HINT_TABLE));
@@ -125,7 +127,7 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onDistributionSetUpdateEvents(final DistributionSetUpdatedEventContainer eventContainer) {
 
         final List<DistributionSetIdName> visibleItemIds = (List<DistributionSetIdName>) getVisibleItemIds();
@@ -150,12 +152,12 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
                 .forEach(event -> updateDistributionInTable(event.getEntity()));
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onDistributionCreatedEvents(final DistributionCreatedEventContainer eventContainer) {
         refreshDistributions();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onDistributionDeletedEvents(final DistributionDeletedEventContainer eventContainer) {
         final LazyQueryContainer dsContainer = (LazyQueryContainer) getContainerDataSource();
         final List<Object> visibleItemIds = (List<Object>) getVisibleItemIds();
@@ -470,7 +472,7 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         });
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DistributionTableEvent event) {
         onBaseEntityEvent(event);
         if (BaseEntityEventType.UPDATED_ENTITY != event.getEventType()) {
@@ -479,7 +481,7 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         UI.getCurrent().access(() -> updateDistributionInTable(event.getEntity()));
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SaveActionWindowEvent event) {
         if (event == SaveActionWindowEvent.DELETED_DISTRIBUTIONS || event == SaveActionWindowEvent.SAVED_ASSIGNMENTS) {
             UI.getCurrent().access(this::refreshFilter);
@@ -492,7 +494,7 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
      * @param event
      *            as instance of {@link DistributionTableFilterEvent}
      */
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     public void onEvent(final DistributionTableFilterEvent event) {
         if (event == DistributionTableFilterEvent.FILTER_BY_TEXT
                 || event == DistributionTableFilterEvent.REMOVE_FILTER_BY_TEXT

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ui.distributions.dstable;
 
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.table.AbstractTableHeader;
 import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionsUIEvent;
@@ -16,14 +17,13 @@ import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.management.dstable.DistributionAddUpdateWindowLayout;
 import org.eclipse.hawkbit.ui.management.event.DistributionTableEvent;
 import org.eclipse.hawkbit.ui.management.event.DistributionTableFilterEvent;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.event.dd.DropHandler;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.Window;
@@ -31,19 +31,19 @@ import com.vaadin.ui.Window;
 /**
  * Distribution table header.
  */
-@SpringComponent
-@ViewScope
 public class DistributionSetTableHeader extends AbstractTableHeader {
 
     private static final long serialVersionUID = -3483238438474530748L;
 
-    @Autowired
-    private ManageDistUIState manageDistUIstate;
+    private final DistributionAddUpdateWindowLayout addUpdateWindowLayout;
 
-    @Autowired
-    private DistributionAddUpdateWindowLayout addUpdateWindowLayout;
+    DistributionSetTableHeader(final I18N i18n, final SpPermissionChecker permChecker, final UIEventBus eventbus,
+            final ManageDistUIState manageDistUIstate, final DistributionAddUpdateWindowLayout addUpdateWindowLayout) {
+        super(i18n, permChecker, eventbus, null, manageDistUIstate, null);
+        this.addUpdateWindowLayout = addUpdateWindowLayout;
+    }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DistributionsUIEvent event) {
         if (event == DistributionsUIEvent.HIDE_DIST_FILTER_BY_TYPE) {
             setFilterButtonsIconVisible(true);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableLayout.java
@@ -8,42 +8,54 @@
  */
 package org.eclipse.hawkbit.ui.distributions.dstable;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.SystemManagement;
+import org.eclipse.hawkbit.repository.TagManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.ui.common.table.AbstractTableLayout;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import org.eclipse.hawkbit.ui.distributions.event.DistributionsViewAcceptCriteria;
+import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
+import org.eclipse.hawkbit.ui.management.dstable.DistributionAddUpdateWindowLayout;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 /**
  * DistributionSet table layout
  */
-@SpringComponent
-@ViewScope
 public class DistributionSetTableLayout extends AbstractTableLayout {
 
     private static final long serialVersionUID = 6464291374980641235L;
 
-    /**
-     * Details to be autowired before table as details listens to value change
-     * of table.
-     */
-    @Autowired
-    private DistributionSetDetails distributionDetails;
+    public DistributionSetTableLayout(final I18N i18n, final UIEventBus eventBus,
+            final SpPermissionChecker permissionChecker, final ManageDistUIState manageDistUIState,
+            final SoftwareManagement softwareManagement, final DistributionSetManagement distributionSetManagement,
+            final TargetManagement targetManagement, final EntityFactory entityFactory,
+            final UINotification uiNotification, final TagManagement tagManagement,
+            final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria,
+            final SystemManagement systemManagement) {
 
-    @Autowired
-    private DistributionSetTableHeader dsTableHeader;
+        final DsMetadataPopupLayout popupLayout = new DsMetadataPopupLayout(i18n, uiNotification, eventBus,
+                distributionSetManagement, entityFactory, permissionChecker);
 
-    @Autowired
-    private DistributionSetTable dsTable;
+        final DistributionSetTable distributionSetTable = new DistributionSetTable(eventBus, i18n, uiNotification,
+                permissionChecker, manageDistUIState, distributionSetManagement, softwareManagement,
+                distributionsViewAcceptCriteria, targetManagement, popupLayout);
 
-    /**
-     * Initialize the filter layout.
-     */
-    @PostConstruct
-    void init() {
-        super.init(dsTableHeader, dsTable, distributionDetails);
+        final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout = new DistributionAddUpdateWindowLayout(
+                i18n, uiNotification, eventBus, distributionSetManagement, systemManagement, entityFactory,
+                distributionSetTable);
+
+        super.init(
+                new DistributionSetTableHeader(i18n, permissionChecker, eventBus, manageDistUIState,
+                        distributionAddUpdateWindowLayout),
+                distributionSetTable,
+                new DistributionSetDetails(i18n, eventBus, permissionChecker, manageDistUIState, null,
+                        distributionAddUpdateWindowLayout, softwareManagement, distributionSetManagement,
+                        targetManagement, entityFactory, uiNotification, tagManagement, popupLayout, uiNotification));
     }
 
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DsMetadataPopupLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DsMetadataPopupLayout.java
@@ -18,29 +18,30 @@ import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetMetadata;
 import org.eclipse.hawkbit.repository.model.MetaData;
 import org.eclipse.hawkbit.ui.common.AbstractMetadataPopupLayout;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.google.common.collect.Lists;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 
 /**
  * Pop up layout to display distribution metadata.
  */
-@SpringComponent
-@ViewScope
 public class DsMetadataPopupLayout extends AbstractMetadataPopupLayout<DistributionSet, MetaData> {
 
     private static final long serialVersionUID = -7778944849012048106L;
 
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
+    private final transient DistributionSetManagement distributionSetManagement;
 
-    @Autowired
-    private transient EntityFactory entityFactory;
+    private final transient EntityFactory entityFactory;
 
-    @Autowired
-    protected SpPermissionChecker permChecker;
+    public DsMetadataPopupLayout(final I18N i18n, final UINotification uiNotification, final UIEventBus eventBus,
+            final DistributionSetManagement distributionSetManagement, final EntityFactory entityFactory,
+            final SpPermissionChecker permChecker) {
+        super(i18n, uiNotification, eventBus, permChecker);
+        this.distributionSetManagement = distributionSetManagement;
+        this.entityFactory = entityFactory;
+    }
 
     @Override
     protected void checkForDuplicate(final DistributionSet entity, final String value) {
@@ -73,7 +74,8 @@ public class DsMetadataPopupLayout extends AbstractMetadataPopupLayout<Distribut
 
     @Override
     protected List<MetaData> getMetadataList() {
-        return Collections.unmodifiableList(getSelectedEntity().getMetadata());
+        return Collections.unmodifiableList(
+                distributionSetManagement.findDistributionSetMetadataByDistributionSetId(getSelectedEntity().getId()));
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/event/DistributionsViewAcceptCriteria.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/event/DistributionsViewAcceptCriteria.java
@@ -15,10 +15,13 @@ import java.util.Map;
 import org.eclipse.hawkbit.ui.common.AbstractAcceptCriteria;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.google.common.collect.Maps;
 import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.Component;
 
 /**
@@ -26,7 +29,7 @@ import com.vaadin.ui.Component;
  * 
  */
 @SpringComponent
-@ViewScope
+@UIScope
 public class DistributionsViewAcceptCriteria extends AbstractAcceptCriteria {
 
     private static final long serialVersionUID = -7686564967583118935L;
@@ -34,6 +37,11 @@ public class DistributionsViewAcceptCriteria extends AbstractAcceptCriteria {
     private static final Map<String, Object> DROP_HINTS_CONFIGS = createDropHintConfigurations();
 
     private static final Map<String, List<String>> DROP_CONFIGS = createDropConfigurations();
+
+    @Autowired
+    DistributionsViewAcceptCriteria(final UINotification uiNotification, final UIEventBus eventBus) {
+        super(uiNotification, eventBus);
+    }
 
     @Override
     protected String getComponentId(final Component component) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/footer/DistributionsConfirmationWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/footer/DistributionsConfirmationWindowLayout.java
@@ -26,11 +26,12 @@ import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmallNoBorder;
 import org.eclipse.hawkbit.ui.distributions.event.SaveActionWindowEvent;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -39,7 +40,6 @@ import com.vaadin.data.Container;
 import com.vaadin.data.Item;
 import com.vaadin.data.util.IndexedContainer;
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickListener;
 import com.vaadin.ui.Table.Align;
@@ -48,11 +48,7 @@ import com.vaadin.ui.themes.ValoTheme;
 /**
  * Abstract layout of confirm actions window.
  *
- *
- *
  */
-@org.springframework.stereotype.Component
-@ViewScope
 public class DistributionsConfirmationWindowLayout extends AbstractConfirmationWindowLayout {
 
     private static final long serialVersionUID = 3641621131320823058L;
@@ -77,14 +73,20 @@ public class DistributionsConfirmationWindowLayout extends AbstractConfirmationW
 
     private ConfirmationTab assignmnetTab;
 
-    @Autowired
-    private transient DistributionSetManagement dsManagement;
+    private final transient DistributionSetManagement dsManagement;
 
-    @Autowired
-    private transient SoftwareManagement softwareManagement;
+    private final transient SoftwareManagement softwareManagement;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
+
+    DistributionsConfirmationWindowLayout(final I18N i18n, final UIEventBus eventBus,
+            final DistributionSetManagement dsManagement, final SoftwareManagement softwareManagement,
+            final ManageDistUIState manageDistUIState) {
+        super(i18n, eventBus);
+        this.dsManagement = dsManagement;
+        this.softwareManagement = softwareManagement;
+        this.manageDistUIState = manageDistUIState;
+    }
 
     @Override
     protected Map<String, ConfirmationTab> getConfimrationTabs() {
@@ -630,7 +632,7 @@ public class DistributionsConfirmationWindowLayout extends AbstractConfirmationW
 
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEventDiscard(final SaveActionWindowEvent saveActionWindowEvent) {
         if (saveActionWindowEvent == SaveActionWindowEvent.DELETE_ALL_SOFWARE) {
             getSWAssignmentsTableContainer();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwMetadataPopupLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwMetadataPopupLayout.java
@@ -20,28 +20,28 @@ import org.eclipse.hawkbit.repository.model.SoftwareModuleMetadata;
 import org.eclipse.hawkbit.ui.common.AbstractMetadataPopupLayout;
 import org.eclipse.hawkbit.ui.distributions.event.MetadataEvent;
 import org.eclipse.hawkbit.ui.distributions.event.MetadataEvent.MetadataUIEvent;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 /**
  * Pop up layout to display software module metadata.
  */
-@SpringComponent
-@ViewScope
 public class SwMetadataPopupLayout extends AbstractMetadataPopupLayout<SoftwareModule, MetaData> {
 
     private static final long serialVersionUID = -1252090014161012563L;
 
-    @Autowired
-    private transient SoftwareManagement softwareManagement;
+    private final transient SoftwareManagement softwareManagement;
 
-    @Autowired
-    private transient EntityFactory entityFactory;
+    private final transient EntityFactory entityFactory;
 
-    @Autowired
-    protected SpPermissionChecker permChecker;
+    public SwMetadataPopupLayout(final I18N i18n, final UINotification uiNotification, final UIEventBus eventBus,
+            final SoftwareManagement softwareManagement, final EntityFactory entityFactory,
+            final SpPermissionChecker permChecker) {
+        super(i18n, uiNotification, eventBus, permChecker);
+        this.softwareManagement = softwareManagement;
+        this.entityFactory = entityFactory;
+    }
 
     @Override
     protected void checkForDuplicate(final SoftwareModule entity, final String value) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleBeanQuery.java
@@ -57,7 +57,7 @@ public class SwModuleBeanQuery extends AbstractBeanQuery<ProxyBaseSwModuleItem> 
         super(definition, queryConfig, sortIds, sortStates);
         if (HawkbitCommonUtil.isNotNullOrEmpty(queryConfig)) {
             type = Optional.ofNullable((SoftwareModuleType) queryConfig.get(SPUIDefinitions.BY_SOFTWARE_MODULE_TYPE))
-                    .map(t -> t.getId()).orElse(null);
+                    .map(SoftwareModuleType::getId).orElse(null);
             final String text = (String) queryConfig.get(SPUIDefinitions.FILTER_BY_TEXT);
             if (!Strings.isNullOrEmpty(text)) {
                 searchText = String.format("%%%s%%", text);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleDetails.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.ui.distributions.smtable;
 
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.model.MetaData;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent;
@@ -20,13 +21,12 @@ import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.distributions.event.MetadataEvent;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.TabSheet;
@@ -38,38 +38,35 @@ import com.vaadin.ui.Window;
  * Implementation of software module details block using generic abstract
  * details style .
  */
-@SpringComponent
-@ViewScope
 public class SwModuleDetails extends AbstractNamedVersionedEntityTableDetailsLayout<SoftwareModule> {
 
     private static final long serialVersionUID = -1052279281066089812L;
 
-    @Autowired
-    private SoftwareModuleAddUpdateWindow softwareModuleAddUpdateWindow;
+    private final SoftwareModuleAddUpdateWindow softwareModuleAddUpdateWindow;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
-    @Autowired
-    private transient SoftwareManagement softwareManagement;
+    private final transient SoftwareManagement softwareManagement;
 
-    @Autowired
-    private SwMetadataPopupLayout swMetadataPopupLayout;
+    private final SwMetadataPopupLayout swMetadataPopupLayout;
 
-    @Autowired
-    private transient EntityFactory entityFactory;
+    private final SoftwareModuleMetadatadetailslayout swmMetadataTable;
 
-    private SoftwareModuleMetadatadetailslayout swmMetadataTable;
+    SwModuleDetails(final I18N i18n, final UIEventBus eventBus, final SpPermissionChecker permissionChecker,
+            final SoftwareModuleAddUpdateWindow softwareModuleAddUpdateWindow,
+            final ManageDistUIState manageDistUIState, final SoftwareManagement softwareManagement,
+            final SwMetadataPopupLayout swMetadataPopupLayout, final EntityFactory entityFactory) {
+        super(i18n, eventBus, permissionChecker, null);
+        this.softwareModuleAddUpdateWindow = softwareModuleAddUpdateWindow;
+        this.manageDistUIState = manageDistUIState;
+        this.softwareManagement = softwareManagement;
+        this.swMetadataPopupLayout = swMetadataPopupLayout;
 
-    /**
-     * softwareLayout Initialize the component.
-     */
-    @Override
-    protected void init() {
         swmMetadataTable = new SoftwareModuleMetadatadetailslayout();
         swmMetadataTable.init(getI18n(), getPermissionChecker(), softwareManagement, swMetadataPopupLayout,
                 entityFactory);
-        super.init();
+        addTabs(detailsTab);
+        restoreState();
     }
 
     /**
@@ -79,7 +76,7 @@ public class SwModuleDetails extends AbstractNamedVersionedEntityTableDetailsLay
      *            as instance of {@link MetadataEvent}
      */
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final MetadataEvent event) {
         UI.getCurrent().access(() -> {
             final MetaData softwareModuleMetadata = event.getMetaData();
@@ -94,7 +91,7 @@ public class SwModuleDetails extends AbstractNamedVersionedEntityTableDetailsLay
         });
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SoftwareModuleEvent softwareModuleEvent) {
         onBaseEntityEvent(softwareModuleEvent);
     }
@@ -203,10 +200,12 @@ public class SwModuleDetails extends AbstractNamedVersionedEntityTableDetailsLay
     }
 
     private boolean isSoftwareModuleSelected(final SoftwareModule softwareModule) {
-        final Long selectedDistSWModuleId = manageDistUIState.getSelectedBaseSwModuleId().isPresent()
-                ? manageDistUIState.getSelectedBaseSwModuleId().get() : null;
-        return softwareModule != null && selectedDistSWModuleId != null
-                && selectedDistSWModuleId.equals(softwareModule.getId());
+        if (softwareModule == null) {
+            return false;
+        }
+
+        return manageDistUIState.getSelectedBaseSwModuleId().map(module -> module.equals(softwareModule.getId()))
+                .orElse(false);
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTable.java
@@ -12,11 +12,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.hawkbit.repository.ArtifactManagement;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.ui.artifacts.details.ArtifactDetailsLayout;
 import org.eclipse.hawkbit.ui.artifacts.event.SMFilterEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent;
+import org.eclipse.hawkbit.ui.artifacts.state.ArtifactUploadState;
 import org.eclipse.hawkbit.ui.common.ManagmentEntityState;
 import org.eclipse.hawkbit.ui.common.table.AbstractNamedVersionTable;
 import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
@@ -27,15 +29,17 @@ import org.eclipse.hawkbit.ui.distributions.event.DistributionsViewAcceptCriteri
 import org.eclipse.hawkbit.ui.distributions.event.SaveActionWindowEvent;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.TableColumn;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -47,8 +51,6 @@ import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.server.Page;
 import com.vaadin.shared.ui.window.WindowMode;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.JavaScript;
@@ -60,39 +62,42 @@ import com.vaadin.ui.Window;
  * Implementation of software module table using generic abstract table styles .
  *
  */
-@SpringComponent
-@ViewScope
 public class SwModuleTable extends AbstractNamedVersionTable<SoftwareModule, Long> {
 
     private static final long serialVersionUID = 6785314784507424750L;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
-    @Autowired
-    private transient SoftwareManagement softwareManagement;
+    private final transient SoftwareManagement softwareManagement;
 
-    @Autowired
-    private DistributionsViewAcceptCriteria distributionsViewAcceptCriteria;
+    private final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria;
 
-    @Autowired
-    private ArtifactDetailsLayout artifactDetailsLayout;
+    private final ArtifactDetailsLayout artifactDetailsLayout;
 
-    @Autowired
-    private SwMetadataPopupLayout swMetadataPopupLayout;
+    private final SwMetadataPopupLayout swMetadataPopupLayout;
 
-    /**
-     * Initialize the filter layout.
-     */
-    @Override
-    protected void init() {
-        super.init();
+    SwModuleTable(final UIEventBus eventBus, final I18N i18n, final UINotification uiNotification,
+            final ManageDistUIState manageDistUIState, final SoftwareManagement softwareManagement,
+            final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria,
+            final ArtifactManagement artifactManagement, final SwMetadataPopupLayout swMetadataPopupLayout,
+            final ArtifactUploadState artifactUploadState) {
+        super(eventBus, i18n, uiNotification);
+        this.manageDistUIState = manageDistUIState;
+        this.softwareManagement = softwareManagement;
+        this.distributionsViewAcceptCriteria = distributionsViewAcceptCriteria;
+        this.artifactDetailsLayout = new ArtifactDetailsLayout(i18n, eventBus, artifactUploadState, uiNotification,
+                artifactManagement);
+        this.swMetadataPopupLayout = swMetadataPopupLayout;
+
+        addNewContainerDS();
+        setColumnProperties();
+        setDataAvailable(getContainerDataSource().size() != 0);
         styleTableOnDistSelection();
     }
 
     /* All event Listeners */
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SMFilterEvent filterEvent) {
         UI.getCurrent().access(() -> {
 
@@ -105,7 +110,7 @@ public class SwModuleTable extends AbstractNamedVersionTable<SoftwareModule, Lon
         });
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DistributionsUIEvent event) {
         UI.getCurrent().access(() -> {
             if (event == DistributionsUIEvent.ORDER_BY_DISTRIBUTION) {
@@ -115,14 +120,14 @@ public class SwModuleTable extends AbstractNamedVersionTable<SoftwareModule, Lon
         });
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SaveActionWindowEvent event) {
         if (event == SaveActionWindowEvent.DELETE_ALL_SOFWARE) {
             UI.getCurrent().access(this::refreshFilter);
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SoftwareModuleEvent event) {
         onBaseEntityEvent(event);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTableHeader.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ui.distributions.smtable;
 
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.artifacts.event.SMFilterEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent;
 import org.eclipse.hawkbit.ui.artifacts.smtable.SoftwareModuleAddUpdateWindow;
@@ -15,14 +16,13 @@ import org.eclipse.hawkbit.ui.common.table.AbstractTableHeader;
 import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionsUIEvent;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.event.dd.DropHandler;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.Window;
@@ -31,19 +31,20 @@ import com.vaadin.ui.Window;
  * Implementation of software module Header block using generic abstract details
  * style .
  */
-@SpringComponent
-@ViewScope
 public class SwModuleTableHeader extends AbstractTableHeader {
 
     private static final long serialVersionUID = 242961845006626297L;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final SoftwareModuleAddUpdateWindow softwareModuleAddUpdateWindow;
 
-    @Autowired
-    private SoftwareModuleAddUpdateWindow softwareModuleAddUpdateWindow;
+    SwModuleTableHeader(final I18N i18n, final SpPermissionChecker permChecker, final UIEventBus eventbus,
+            final ManageDistUIState manageDistUIstate,
+            final SoftwareModuleAddUpdateWindow softwareModuleAddUpdateWindow) {
+        super(i18n, permChecker, eventbus, null, manageDistUIstate, null);
+        this.softwareModuleAddUpdateWindow = softwareModuleAddUpdateWindow;
+    }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DistributionsUIEvent event) {
         if (event == DistributionsUIEvent.HIDE_SM_FILTER_BY_TYPE) {
             setFilterButtonsIconVisible(true);
@@ -72,10 +73,7 @@ public class SwModuleTableHeader extends AbstractTableHeader {
 
     @Override
     protected String onLoadSearchBoxValue() {
-        if (manageDistUIState.getSoftwareModuleFilters().getSearchText().isPresent()) {
-            return manageDistUIState.getSoftwareModuleFilters().getSearchText().get();
-        }
-        return null;
+        return manageDistUIstate.getSoftwareModuleFilters().getSearchText().orElse(null);
     }
 
     @Override
@@ -102,14 +100,14 @@ public class SwModuleTableHeader extends AbstractTableHeader {
 
     @Override
     protected void showFilterButtonsLayout() {
-        manageDistUIState.setSwTypeFilterClosed(false);
+        manageDistUIstate.setSwTypeFilterClosed(false);
         eventbus.publish(this, DistributionsUIEvent.SHOW_SM_FILTER_BY_TYPE);
     }
 
     @Override
     protected void resetSearchText() {
-        if (manageDistUIState.getSoftwareModuleFilters().getSearchText().isPresent()) {
-            manageDistUIState.getSoftwareModuleFilters().setSearchText(null);
+        if (manageDistUIstate.getSoftwareModuleFilters().getSearchText().isPresent()) {
+            manageDistUIstate.getSoftwareModuleFilters().setSearchText(null);
             eventbus.publish(this, SMFilterEvent.REMOVER_FILTER_BY_TEXT);
         }
     }
@@ -121,30 +119,30 @@ public class SwModuleTableHeader extends AbstractTableHeader {
 
     @Override
     public void maximizeTable() {
-        manageDistUIState.setSwModuleTableMaximized(Boolean.TRUE);
+        manageDistUIstate.setSwModuleTableMaximized(Boolean.TRUE);
         eventbus.publish(this, new SoftwareModuleEvent(BaseEntityEventType.MAXIMIZED, null));
 
     }
 
     @Override
     public void minimizeTable() {
-        manageDistUIState.setSwModuleTableMaximized(Boolean.FALSE);
+        manageDistUIstate.setSwModuleTableMaximized(Boolean.FALSE);
         eventbus.publish(this, new SoftwareModuleEvent(BaseEntityEventType.MINIMIZED, null));
     }
 
     @Override
     public Boolean onLoadIsTableMaximized() {
-        return manageDistUIState.isSwModuleTableMaximized();
+        return manageDistUIstate.isSwModuleTableMaximized();
     }
 
     @Override
     public Boolean onLoadIsShowFilterButtonDisplayed() {
-        return manageDistUIState.isSwTypeFilterClosed();
+        return manageDistUIstate.isSwTypeFilterClosed();
     }
 
     @Override
     protected void searchBy(final String newSearchText) {
-        manageDistUIState.getSoftwareModuleFilters().setSearchText(newSearchText);
+        manageDistUIstate.getSoftwareModuleFilters().setSearchText(newSearchText);
         eventbus.publish(this, SMFilterEvent.FILTER_BY_TEXT);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTableLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTableLayout.java
@@ -8,37 +8,44 @@
  */
 package org.eclipse.hawkbit.ui.distributions.smtable;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.ArtifactManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.ui.artifacts.smtable.SoftwareModuleAddUpdateWindow;
+import org.eclipse.hawkbit.ui.artifacts.state.ArtifactUploadState;
 import org.eclipse.hawkbit.ui.common.table.AbstractTableLayout;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import org.eclipse.hawkbit.ui.distributions.event.DistributionsViewAcceptCriteria;
+import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 /**
  * Implementation of software module Layout
  */
-@SpringComponent
-@ViewScope
 public class SwModuleTableLayout extends AbstractTableLayout {
 
     private static final long serialVersionUID = 6464291374980641235L;
 
-    @Autowired
-    private SwModuleTableHeader swModuleTableHeader;
+    public SwModuleTableLayout(final I18N i18n, final UINotification uiNotification, final UIEventBus eventBus,
+            final SoftwareManagement softwareManagement, final EntityFactory entityFactory,
+            final ManageDistUIState manageDistUIState, final SpPermissionChecker permChecker,
+            final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria,
+            final ArtifactUploadState artifactUploadState, final ArtifactManagement artifactManagement) {
 
-    @Autowired
-    private SwModuleDetails swModuleDetails;
+        final SoftwareModuleAddUpdateWindow softwareModuleAddUpdateWindow = new SoftwareModuleAddUpdateWindow(i18n,
+                uiNotification, eventBus, softwareManagement, entityFactory);
 
-    @Autowired
-    private SwModuleTable swModuleTable;
+        final SwMetadataPopupLayout swMetadataPopupLayout = new SwMetadataPopupLayout(i18n, uiNotification, eventBus,
+                softwareManagement, entityFactory, permChecker);
 
-    /**
-     * Initialize the filter layout.
-     */
-    @PostConstruct
-    void init() {
-        super.init(swModuleTableHeader, swModuleTable, swModuleDetails);
+        super.init(
+                new SwModuleTableHeader(i18n, permChecker, eventBus, manageDistUIState, softwareModuleAddUpdateWindow),
+                new SwModuleTable(eventBus, i18n, uiNotification, manageDistUIState, softwareManagement,
+                        distributionsViewAcceptCriteria, artifactManagement, swMetadataPopupLayout,
+                        artifactUploadState),
+                new SwModuleDetails(i18n, eventBus, permChecker, softwareModuleAddUpdateWindow, manageDistUIState,
+                        softwareManagement, swMetadataPopupLayout, entityFactory));
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtype/DistSMTypeFilterButtonClick.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtype/DistSMTypeFilterButtonClick.java
@@ -15,54 +15,37 @@ import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 import org.eclipse.hawkbit.ui.artifacts.event.SMFilterEvent;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterSingleButtonClick;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 
 /**
  * Single button click behaviour of filter buttons layout.
- * 
- *
- * 
  */
-
-@SpringComponent
-@ViewScope
 public class DistSMTypeFilterButtonClick extends AbstractFilterSingleButtonClick implements Serializable {
 
     private static final long serialVersionUID = -4166632002904286983L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
-    @Autowired
-    private transient SoftwareManagement softwareManagement;
+    private final transient SoftwareManagement softwareManagement;
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.common.filterlayout.
-     * AbstractFilterButtonClickBehaviour#filterUnClicked (com.vaadin.ui.Button)
-     */
+    DistSMTypeFilterButtonClick(final UIEventBus eventBus, final ManageDistUIState manageDistUIState,
+            final SoftwareManagement softwareManagement) {
+        this.eventBus = eventBus;
+        this.manageDistUIState = manageDistUIState;
+        this.softwareManagement = softwareManagement;
+    }
+
     @Override
     protected void filterUnClicked(final Button clickedButton) {
         manageDistUIState.getSoftwareModuleFilters().setSoftwareModuleType(null);
         eventBus.publish(this, SMFilterEvent.FILTER_BY_TYPE);
-
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.common.filterlayout.
-     * AbstractFilterButtonClickBehaviour#filterClicked (com.vaadin.ui.Button)
-     */
     @Override
     protected void filterClicked(final Button clickedButton) {
         final SoftwareModuleType smType = softwareManagement

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtype/DistSMTypeFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtype/DistSMTypeFilterButtons.java
@@ -15,6 +15,7 @@ import static org.eclipse.hawkbit.ui.utils.UIComponentIdProvider.SW_MODULE_TYPE_
 
 import java.util.Collections;
 
+import org.eclipse.hawkbit.repository.SoftwareManagement;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleTypeEvent;
 import org.eclipse.hawkbit.ui.common.SoftwareModuleTypeBeanQuery;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterButtons;
@@ -23,33 +24,35 @@ import org.eclipse.hawkbit.ui.distributions.event.SaveActionWindowEvent;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 
 /**
  * Software Module Type filter buttons.
  */
-@ViewScope
-@SpringComponent
 public class DistSMTypeFilterButtons extends AbstractFilterButtons {
 
     private static final long serialVersionUID = 6804534533362387433L;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
-    @Autowired
-    private DistributionsViewAcceptCriteria distributionsViewAcceptCriteria;
+    private final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria;
+
+    DistSMTypeFilterButtons(final UIEventBus eventBus, final ManageDistUIState manageDistUIState,
+            final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria,
+            final SoftwareManagement softwareManagement) {
+        super(eventBus, new DistSMTypeFilterButtonClick(eventBus, manageDistUIState, softwareManagement));
+        this.manageDistUIState = manageDistUIState;
+        this.distributionsViewAcceptCriteria = distributionsViewAcceptCriteria;
+    }
 
     @Override
     protected String getButtonsTableId() {
@@ -103,7 +106,7 @@ public class DistSMTypeFilterButtons extends AbstractFilterButtons {
         return SPUIDefinitions.SOFTWARE_MODULE_TAG_ID_PREFIXS;
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SoftwareModuleTypeEvent event) {
         if (isCreateOrUpdate(event) && event.getSoftwareModuleType() != null) {
             refreshTypeTable();
@@ -115,7 +118,7 @@ public class DistSMTypeFilterButtons extends AbstractFilterButtons {
                 || event.getSoftwareModuleTypeEnum() == UPDATE_SOFTWARE_MODULE_TYPE;
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SaveActionWindowEvent event) {
         if (event == SaveActionWindowEvent.SAVED_DELETE_SW_MODULE_TYPES) {
             refreshTypeTable();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtype/DistSMTypeFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtype/DistSMTypeFilterHeader.java
@@ -8,19 +8,21 @@
  */
 package org.eclipse.hawkbit.ui.distributions.smtype;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.ui.artifacts.smtype.CreateUpdateSoftwareTypeLayout;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterHeader;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionsUIEvent;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.Window;
@@ -28,22 +30,21 @@ import com.vaadin.ui.Window;
 /**
  * Software Module Type filter buttons header.
  */
-@SpringComponent
-@ViewScope
 public class DistSMTypeFilterHeader extends AbstractFilterHeader {
-
     private static final long serialVersionUID = -8763788280848718344L;
 
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
+    private final CreateUpdateSoftwareTypeLayout createUpdateSWTypeLayout;
 
-    @Autowired
-    private CreateUpdateSoftwareTypeLayout createUpdateSWTypeLayout;
+    DistSMTypeFilterHeader(final I18N i18n, final SpPermissionChecker permChecker, final UIEventBus eventBus,
+            final ManageDistUIState manageDistUIState, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UINotification uiNotification,
+            final SoftwareManagement swTypeManagementService) {
+        super(permChecker, eventBus, i18n);
+        this.manageDistUIState = manageDistUIState;
+        this.createUpdateSWTypeLayout = new CreateUpdateSoftwareTypeLayout(i18n, tagManagement, entityFactory, eventBus,
+                permChecker, uiNotification, swTypeManagementService);
 
-    @Override
-    @PostConstruct
-    public void init() {
-        super.init();
         if (hasCreateUpdatePermission()) {
             createUpdateSWTypeLayout.init();
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtype/DistSMTypeFilterLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtype/DistSMTypeFilterLayout.java
@@ -8,58 +8,45 @@
  */
 package org.eclipse.hawkbit.ui.distributions.smtype;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SoftwareManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterLayout;
 import org.eclipse.hawkbit.ui.distributions.event.DistributionsUIEvent;
+import org.eclipse.hawkbit.ui.distributions.event.DistributionsViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.vaadin.spring.events.EventBus;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
-
 /**
  * Software Module Type filter layout.
- * 
- *
- * 
  */
-
-@SpringComponent
-@ViewScope
 public class DistSMTypeFilterLayout extends AbstractFilterLayout {
 
     private static final long serialVersionUID = 3042297420534417538L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventbus;
+    private final ManageDistUIState manageDistUIState;
 
-    @Autowired
-    private DistSMTypeFilterHeader smTypeFilterHeader;
+    public DistSMTypeFilterLayout(final UIEventBus eventBus, final I18N i18n, final SpPermissionChecker permChecker,
+            final ManageDistUIState manageDistUIState, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UINotification uiNotification,
+            final SoftwareManagement softwareManagement,
+            final DistributionsViewAcceptCriteria distributionsViewAcceptCriteria) {
+        super(new DistSMTypeFilterHeader(i18n, permChecker, eventBus, manageDistUIState, tagManagement, entityFactory,
+                uiNotification, softwareManagement),
+                new DistSMTypeFilterButtons(eventBus, manageDistUIState, distributionsViewAcceptCriteria,
+                        softwareManagement));
+        this.manageDistUIState = manageDistUIState;
 
-    @Autowired
-    private DistSMTypeFilterButtons smTypeFilterButtons;
-
-    @Autowired
-    private DistSMTypeFilterButtonClick smTypeFilterButtonClick;
-
-    @Autowired
-    private ManageDistUIState manageDistUIState;
-
-    /**
-     * Initialize the filter layout.
-     */
-    @PostConstruct
-    public void init() {
-        super.init(smTypeFilterHeader, smTypeFilterButtons, smTypeFilterButtonClick);
-        eventbus.subscribe(this);
+        restoreState();
+        eventBus.subscribe(this);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DistributionsUIEvent event) {
         if (event == DistributionsUIEvent.HIDE_SM_FILTER_BY_TYPE) {
             setVisible(false);
@@ -69,22 +56,6 @@ public class DistSMTypeFilterLayout extends AbstractFilterLayout {
         }
     }
 
-    @PreDestroy
-    void destroy() {
-        /*
-         * It's good manners to do this, even though vaadin-spring will
-         * automatically unsubscribe when this UI is garbage collected.
-         */
-        eventbus.unsubscribe(this);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.eclipse.hawkbit.server.ui.common.filterlayout.AbstractFilterLayout#
-     * onLoadIsTypeFilterIsClosed()
-     */
     @Override
     public Boolean onLoadIsTypeFilterIsClosed() {
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/state/ManageDistUIState.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/state/ManageDistUIState.java
@@ -36,11 +36,9 @@ public class ManageDistUIState implements ManagmentEntityState<DistributionSetId
 
     private static final long serialVersionUID = -7569047247017742928L;
 
-    @Autowired
-    private ManageDistFilters manageDistFilters;
+    private final ManageDistFilters manageDistFilters;
 
-    @Autowired
-    private ManageSoftwareModuleFilters softwareModuleFilters;
+    private final ManageSoftwareModuleFilters softwareModuleFilters;
 
     private final Map<DistributionSetIdName, HashSet<SoftwareModuleIdName>> assignedList = new HashMap<>();
 
@@ -75,6 +73,13 @@ public class ManageDistUIState implements ManagmentEntityState<DistributionSetId
     private boolean noDataAvilableSwModule;
 
     private boolean noDataAvailableDist;
+
+    @Autowired
+    ManageDistUIState(final ManageDistFilters manageDistFilters,
+            final ManageSoftwareModuleFilters softwareModuleFilters) {
+        this.manageDistFilters = manageDistFilters;
+        this.softwareModuleFilters = softwareModuleFilters;
+    }
 
     /**
      * @return the manageDistFilters

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CreateOrUpdateFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CreateOrUpdateFilterHeader.java
@@ -10,9 +10,6 @@ package org.eclipse.hawkbit.ui.filtermanagement;
 
 import java.util.Optional;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
@@ -30,8 +27,8 @@ import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -40,8 +37,6 @@ import com.vaadin.event.FieldEvents.BlurListener;
 import com.vaadin.event.FieldEvents.TextChangeEvent;
 import com.vaadin.event.LayoutEvents.LayoutClickListener;
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
@@ -56,40 +51,29 @@ import com.vaadin.ui.themes.ValoTheme;
 /**
  * A Vaadin layout for create or update the target filter.
  */
-@SpringComponent
-@ViewScope
 public class CreateOrUpdateFilterHeader extends VerticalLayout implements Button.ClickListener {
 
     private static final long serialVersionUID = 7474232427119031474L;
 
     private static final String BREADCRUMB_CUSTOM_FILTERS = "breadcrumb.target.filter.custom.filters";
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private FilterManagementUIState filterManagementUIState;
+    private final FilterManagementUIState filterManagementUIState;
 
-    @Autowired
-    private transient TargetFilterQueryManagement targetFilterQueryManagement;
+    private final transient TargetFilterQueryManagement targetFilterQueryManagement;
 
-    @Autowired
-    private SpPermissionChecker permissionChecker;
+    private final SpPermissionChecker permissionChecker;
 
-    @Autowired
-    private UINotification notification;
+    private final UINotification notification;
 
-    @Autowired
-    private transient UiProperties uiProperties;
+    private final UiProperties uiProperties;
 
-    @Autowired
-    private transient EntityFactory entityFactory;
+    private final transient EntityFactory entityFactory;
 
-    @Autowired
-    private AutoCompleteTextFieldComponent queryTextField;
+    private final AutoCompleteTextFieldComponent queryTextField;
 
     private Button breadcrumbButton;
 
@@ -121,11 +105,21 @@ public class CreateOrUpdateFilterHeader extends VerticalLayout implements Button
 
     private LayoutClickListener nameLayoutClickListner;
 
-    /**
-     * Initialize the Campaign Status History Header.
-     */
-    @PostConstruct
-    public void init() {
+    CreateOrUpdateFilterHeader(final I18N i18n, final UIEventBus eventBus,
+            final FilterManagementUIState filterManagementUIState,
+            final TargetFilterQueryManagement targetFilterQueryManagement, final SpPermissionChecker permissionChecker,
+            final UINotification notification, final UiProperties uiProperties, final EntityFactory entityFactory,
+            final AutoCompleteTextFieldComponent queryTextField) {
+        this.i18n = i18n;
+        this.eventBus = eventBus;
+        this.filterManagementUIState = filterManagementUIState;
+        this.targetFilterQueryManagement = targetFilterQueryManagement;
+        this.permissionChecker = permissionChecker;
+        this.notification = notification;
+        this.uiProperties = uiProperties;
+        this.entityFactory = entityFactory;
+        this.queryTextField = queryTextField;
+
         createComponents();
         createListeners();
         buildLayout();
@@ -140,12 +134,7 @@ public class CreateOrUpdateFilterHeader extends VerticalLayout implements Button
         }
     }
 
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
-    }
-
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final CustomFilterUIEvent custFUIEvent) {
         if (custFUIEvent == CustomFilterUIEvent.TARGET_FILTER_DETAIL_VIEW) {
             populateComponents();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/DistributionSetSelectTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/DistributionSetSelectTable.java
@@ -13,9 +13,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.event.remote.DistributionSetDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetCreatedEvent;
 import org.eclipse.hawkbit.ui.distributions.dstable.ManageDistBeanQuery;
@@ -25,45 +22,33 @@ import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.TableColumn;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
-import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.data.Container;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Table;
 import com.vaadin.ui.themes.ValoTheme;
 
 /**
  * Table for selecting a distribution set.
  */
-@SpringComponent
-@ViewScope
 public class DistributionSetSelectTable extends Table {
 
     private static final long serialVersionUID = -4307487829435471759L;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
-
-    @Autowired
-    private ManageDistUIState manageDistUIState;
+    private final ManageDistUIState manageDistUIState;
 
     private Container container;
 
-    /**
-     * Initialize the component.
-     */
-    @PostConstruct
-    protected void init() {
+    DistributionSetSelectTable(final I18N i18n, final UIEventBus eventBus, final ManageDistUIState manageDistUIState) {
+        this.i18n = i18n;
+        this.manageDistUIState = manageDistUIState;
         setStyleName("sp-table");
         setSizeFull();
         setSelectable(true);
@@ -78,12 +63,7 @@ public class DistributionSetSelectTable extends Table {
         eventBus.subscribe(this);
     }
 
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
-    }
-
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvents(final List<?> events) {
         final Object firstEvent = events.get(0);
         if (DistributionSetCreatedEvent.class.isInstance(firstEvent)

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/DistributionSetSelectWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/DistributionSetSelectWindow.java
@@ -10,7 +10,6 @@ package org.eclipse.hawkbit.ui.filtermanagement;
 
 import java.io.Serializable;
 
-import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
@@ -20,18 +19,17 @@ import org.eclipse.hawkbit.ui.common.DistributionSetIdName;
 import org.eclipse.hawkbit.ui.common.builder.WindowBuilder;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleNoBorderWithIcon;
+import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.filtermanagement.event.CustomFilterUIEvent;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.data.Property;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.server.Sizeable;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.CheckBox;
@@ -45,36 +43,35 @@ import com.vaadin.ui.Window;
  * Creates a dialog window to select the distribution set for a target filter
  * query.
  */
-@SpringComponent
-@ViewScope
 public class DistributionSetSelectWindow
         implements CommonDialogWindow.SaveDialogCloseListener, Property.ValueChangeListener {
 
     private static final long serialVersionUID = 4752345414134989396L;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private DistributionSetSelectTable dsTable;
+    private final DistributionSetSelectTable dsTable;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
+    private final transient TargetManagement targetManagement;
 
-    @Autowired
-    private transient TargetManagement targetManagement;
-
-    @Autowired
-    private transient TargetFilterQueryManagement targetFilterQueryManagement;
+    private final transient TargetFilterQueryManagement targetFilterQueryManagement;
 
     private CommonDialogWindow window;
     private CheckBox checkBox;
     private Long tfqId;
 
-    private void init() {
+    DistributionSetSelectWindow(final I18N i18n, final UIEventBus eventBus, final TargetManagement targetManagement,
+            final TargetFilterQueryManagement targetFilterQueryManagement, final ManageDistUIState manageDistUIState) {
+        this.i18n = i18n;
+        this.dsTable = new DistributionSetSelectTable(i18n, eventBus, manageDistUIState);
+        this.eventBus = eventBus;
+        this.targetManagement = targetManagement;
+        this.targetFilterQueryManagement = targetFilterQueryManagement;
+    }
+
+    private void initLocal() {
         final Label label = new Label(i18n.get("label.auto.assign.description"));
 
         checkBox = new CheckBox(i18n.get("label.auto.assign.enable"));
@@ -120,7 +117,7 @@ public class DistributionSetSelectWindow
             throw new IllegalStateException("TargetFilterQuery does not exist for the given id");
         }
 
-        init();
+        initLocal();
 
         final DistributionSet distributionSet = tfq.getAutoAssignDistributionSet();
         if (distributionSet != null) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/FilterManagementView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/FilterManagementView.java
@@ -8,64 +8,83 @@
  */
 package org.eclipse.hawkbit.ui.filtermanagement;
 
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.ui.HawkbitUI;
+import org.eclipse.hawkbit.ui.UiProperties;
+import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.filtermanagement.event.CustomFilterUIEvent;
 import org.eclipse.hawkbit.ui.filtermanagement.footer.TargetFilterCountMessageLabel;
 import org.eclipse.hawkbit.ui.filtermanagement.state.FilterManagementUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
 import com.vaadin.spring.annotation.SpringView;
-import com.vaadin.spring.annotation.ViewScope;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
 /**
- * 
- *
- *
+ * View for custom target filter management.
  */
-
+@UIScope
 @SpringView(name = FilterManagementView.VIEW_NAME, ui = HawkbitUI.class)
-@ViewScope
 public class FilterManagementView extends VerticalLayout implements View {
 
     private static final long serialVersionUID = 8751545414237389386L;
 
     public static final String VIEW_NAME = "targetFilters";
 
-    @Autowired
-    private TargetFilterHeader targetFilterHeader;
+    private final TargetFilterHeader targetFilterHeader;
+
+    private final TargetFilterTable targetFilterTable;
+
+    private final CreateOrUpdateFilterHeader createNewFilterHeader;
+
+    private final CreateOrUpdateFilterTable createNewFilterTable;
+
+    private final FilterManagementUIState filterManagementUIState;
+
+    private final TargetFilterCountMessageLabel targetFilterCountMessageLabel;
+
+    private final transient EventBus.UIEventBus eventBus;
 
     @Autowired
-    private TargetFilterTable targetFilterTable;
+    FilterManagementView(final I18N i18n, final UIEventBus eventBus,
+            final FilterManagementUIState filterManagementUIState,
+            final TargetFilterQueryManagement targetFilterQueryManagement, final SpPermissionChecker permissionChecker,
+            final UINotification notification, final UiProperties uiProperties, final EntityFactory entityFactory,
+            final AutoCompleteTextFieldComponent queryTextField, final ManageDistUIState manageDistUIState,
+            final TargetManagement targetManagement) {
+        this.targetFilterHeader = new TargetFilterHeader(eventBus, filterManagementUIState, permissionChecker);
+        this.targetFilterTable = new TargetFilterTable(i18n, notification, eventBus, filterManagementUIState,
+                targetFilterQueryManagement, manageDistUIState, targetManagement);
+        this.createNewFilterHeader = new CreateOrUpdateFilterHeader(i18n, eventBus, filterManagementUIState,
+                targetFilterQueryManagement, permissionChecker, notification, uiProperties, entityFactory,
+                queryTextField);
+        this.createNewFilterTable = new CreateOrUpdateFilterTable(i18n, eventBus, filterManagementUIState);
+        this.filterManagementUIState = filterManagementUIState;
+        this.targetFilterCountMessageLabel = new TargetFilterCountMessageLabel(filterManagementUIState, i18n, eventBus);
+        this.eventBus = eventBus;
+    }
 
-    @Autowired
-    private CreateOrUpdateFilterHeader createNewFilterHeader;
-
-    @Autowired
-    private CreateOrUpdateFilterTable createNewFilterTable;
-
-    @Autowired
-    private FilterManagementUIState filterManagementUIState;
-
-    @Autowired
-    private TargetFilterCountMessageLabel targetFilterCountMessageLabel;
-
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
-
-    @Override
-    public void enter(final ViewChangeEvent event) {
+    @PostConstruct
+    void init() {
         setSizeFull();
         setImmediate(true);
         buildLayout();
@@ -90,7 +109,7 @@ public class FilterManagementView extends VerticalLayout implements View {
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final CustomFilterUIEvent custFilterUIEvent) {
         if (custFilterUIEvent == CustomFilterUIEvent.TARGET_FILTER_DETAIL_VIEW) {
             viewTargetFilterDetailLayout();
@@ -154,6 +173,11 @@ public class FilterManagementView extends VerticalLayout implements View {
         messageLabelLayout.addComponent(targetFilterCountMessageLabel);
         messageLabelLayout.addStyleName(SPUIStyleDefinitions.FOOTER_LAYOUT);
         return messageLabelLayout;
+    }
+
+    @Override
+    public void enter(final ViewChangeEvent event) {
+        // This view is constructed in the init() method()
     }
 
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterHeader.java
@@ -8,8 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.filtermanagement;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.common.builder.TextFieldBuilder;
@@ -21,12 +19,10 @@ import org.eclipse.hawkbit.ui.filtermanagement.state.FilterManagementUIState;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.HorizontalLayout;
@@ -38,20 +34,15 @@ import com.vaadin.ui.VerticalLayout;
  *
  *
  */
-@SpringComponent
-@ViewScope
 public class TargetFilterHeader extends VerticalLayout {
 
     private static final long serialVersionUID = -7022704971955491673L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private FilterManagementUIState filterManagementUIState;
+    private final FilterManagementUIState filterManagementUIState;
 
-    @Autowired
-    private SpPermissionChecker permissionChecker;
+    private final SpPermissionChecker permissionChecker;
 
     private Label headerCaption;
 
@@ -61,11 +52,12 @@ public class TargetFilterHeader extends VerticalLayout {
 
     private SPUIButton searchResetIcon;
 
-    /**
-     * Initialize the Campaign Status History Header.
-     */
-    @PostConstruct
-    public void init() {
+    public TargetFilterHeader(final UIEventBus eventBus, final FilterManagementUIState filterManagementUIState,
+            final SpPermissionChecker permissionChecker) {
+        this.eventBus = eventBus;
+        this.filterManagementUIState = filterManagementUIState;
+        this.permissionChecker = permissionChecker;
+
         createComponents();
         buildLayout();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterTable.java
@@ -13,16 +13,14 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
-import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.eclipse.hawkbit.ui.common.ConfirmationDialog;
 import org.eclipse.hawkbit.ui.components.ProxyDistribution;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmallNoBorder;
+import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.filtermanagement.event.CustomFilterUIEvent;
 import org.eclipse.hawkbit.ui.filtermanagement.state.FilterManagementUIState;
 import org.eclipse.hawkbit.ui.utils.I18N;
@@ -31,11 +29,11 @@ import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.TableColumn;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -43,8 +41,6 @@ import com.google.common.collect.Maps;
 import com.vaadin.data.Container;
 import com.vaadin.data.Item;
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Link;
@@ -56,39 +52,38 @@ import com.vaadin.ui.themes.ValoTheme;
  * Displays list of target filter queries
  *
  */
-@SpringComponent
-@ViewScope
 public class TargetFilterTable extends Table {
 
     private static final long serialVersionUID = -4307487829435474759L;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private UINotification notification;
+    private final UINotification notification;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private FilterManagementUIState filterManagementUIState;
+    private final FilterManagementUIState filterManagementUIState;
 
-    @Autowired
-    private transient TargetFilterQueryManagement targetFilterQueryManagement;
+    private final transient TargetFilterQueryManagement targetFilterQueryManagement;
 
-    @Autowired
-    private DistributionSetSelectWindow dsSelectWindow;
+    private final DistributionSetSelectWindow dsSelectWindow;
 
     private Container container;
 
     private static final int PROPERTY_DEPT = 3;
 
-    /**
-     * Initialize the Action History Table.
-     */
-    @PostConstruct
-    public void init() {
+    public TargetFilterTable(final I18N i18n, final UINotification notification, final UIEventBus eventBus,
+            final FilterManagementUIState filterManagementUIState,
+            final TargetFilterQueryManagement targetFilterQueryManagement, final ManageDistUIState manageDistUIState,
+            final TargetManagement targetManagement) {
+        this.i18n = i18n;
+        this.notification = notification;
+        this.eventBus = eventBus;
+        this.filterManagementUIState = filterManagementUIState;
+        this.targetFilterQueryManagement = targetFilterQueryManagement;
+        this.dsSelectWindow = new DistributionSetSelectWindow(i18n, eventBus, targetManagement,
+                targetFilterQueryManagement, manageDistUIState);
+
         setStyleName("sp-table");
         setSizeFull();
         setImmediate(true);
@@ -103,12 +98,7 @@ public class TargetFilterTable extends Table {
         eventBus.subscribe(this);
     }
 
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
-    }
-
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final CustomFilterUIEvent filterEvent) {
         if (filterEvent == CustomFilterUIEvent.FILTER_BY_CUST_FILTER_TEXT
                 || filterEvent == CustomFilterUIEvent.FILTER_BY_CUST_FILTER_TEXT_REMOVE
@@ -156,7 +146,8 @@ public class TargetFilterTable extends Table {
         columnList.add(new TableColumn(SPUILabelDefinitions.VAR_CREATED_DATE, i18n.get("header.createdDate"), 0.2F));
         columnList.add(new TableColumn(SPUILabelDefinitions.VAR_MODIFIED_BY, i18n.get("header.modifiedBy"), 0.1F));
         columnList.add(new TableColumn(SPUILabelDefinitions.VAR_MODIFIED_DATE, i18n.get("header.modifiedDate"), 0.2F));
-        columnList.add(new TableColumn(SPUILabelDefinitions.AUTO_ASSIGN_DISTRIBUTION_SET, i18n.get("header.auto.assignment.ds"), 0.1F));
+        columnList.add(new TableColumn(SPUILabelDefinitions.AUTO_ASSIGN_DISTRIBUTION_SET,
+                i18n.get("header.auto.assignment.ds"), 0.1F));
         columnList.add(new TableColumn(SPUIDefinitions.CUSTOM_FILTER_DELETE, i18n.get("header.delete"), 0.1F));
         return columnList;
 
@@ -233,10 +224,11 @@ public class TargetFilterTable extends Table {
 
     private Button customFilterDistributionSetButton(final Long itemId) {
         final Item row1 = getItem(itemId);
-        final ProxyDistribution distSet = (ProxyDistribution) row1.getItemProperty(SPUILabelDefinitions.AUTO_ASSIGN_DISTRIBUTION_SET).getValue();
+        final ProxyDistribution distSet = (ProxyDistribution) row1
+                .getItemProperty(SPUILabelDefinitions.AUTO_ASSIGN_DISTRIBUTION_SET).getValue();
         final String buttonId = "distSetButton";
         Button updateIcon;
-        if(distSet == null) {
+        if (distSet == null) {
             updateIcon = SPUIComponentProvider.getButton(buttonId, i18n.get("button.no.auto.assignment"),
                     i18n.get("button.auto.assignment.desc"), null, false, null, SPUIButtonStyleSmallNoBorder.class);
         } else {
@@ -253,7 +245,7 @@ public class TargetFilterTable extends Table {
 
     private void onClickOfDistributionSetButton(final ClickEvent event) {
         final Item item = (Item) ((Button) event.getComponent()).getData();
-        final Long tfqId = (Long)item.getItemProperty(SPUILabelDefinitions.VAR_ID).getValue();
+        final Long tfqId = (Long) item.getItemProperty(SPUILabelDefinitions.VAR_ID).getValue();
 
         dsSelectWindow.showForTargetFilter(tfqId);
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/footer/TargetFilterCountMessageLabel.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/footer/TargetFilterCountMessageLabel.java
@@ -8,9 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.filtermanagement.footer;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.ui.filtermanagement.event.CustomFilterUIEvent;
 import org.eclipse.hawkbit.ui.filtermanagement.state.FilterManagementUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
@@ -18,15 +15,12 @@ import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.server.FontAwesome;
 import com.vaadin.shared.ui.label.ContentMode;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.UI;
 
@@ -36,37 +30,25 @@ import com.vaadin.ui.UI;
  *         Count message label which display current filter details and details
  *         on pinning.
  */
-@SpringComponent
-@ViewScope
 public class TargetFilterCountMessageLabel extends Label {
 
     private static final long serialVersionUID = -7188528790042766877L;
 
-    @Autowired
-    private FilterManagementUIState filterManagementUIState;
+    private final FilterManagementUIState filterManagementUIState;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    public TargetFilterCountMessageLabel(final FilterManagementUIState filterManagementUIState, final I18N i18n,
+            final UIEventBus eventBus) {
+        this.filterManagementUIState = filterManagementUIState;
+        this.i18n = i18n;
 
-    /**
-     * PostConstruct method called by spring after bean has been initialized.
-     */
-    @PostConstruct
-    public void postConstruct() {
         applyStyle();
         displayTargetFilterMessage();
         eventBus.subscribe(this);
     }
 
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
-    }
-
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final CustomFilterUIEvent custFUIEvent) {
         if (custFUIEvent == CustomFilterUIEvent.TARGET_DETAILS_VIEW
                 || custFUIEvent == CustomFilterUIEvent.CREATE_NEW_FILTER_CLICK

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/AbstractCreateUpdateTagLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/AbstractCreateUpdateTagLayout.java
@@ -8,8 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.layouts;
 
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.TagManagement;
@@ -33,8 +31,8 @@ import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.data.Property.ValueChangeEvent;
 import com.vaadin.data.Property.ValueChangeListener;
@@ -59,7 +57,6 @@ import com.vaadin.ui.components.colorpicker.ColorSelector;
 import com.vaadin.ui.themes.ValoTheme;
 
 /**
- * 
  * Abstract class for create/update target tag layout.
  *
  * @param <E>
@@ -73,23 +70,17 @@ public abstract class AbstractCreateUpdateTagLayout<E extends NamedEntity> exten
     protected static final String TAG_DYNAMIC_STYLE = "tag-color-preview";
     protected static final String MESSAGE_ERROR_MISSING_TAGNAME = "message.error.missing.tagname";
 
-    @Autowired
     protected I18N i18n;
 
-    @Autowired
     protected transient TagManagement tagManagement;
 
-    @Autowired
     protected transient EntityFactory entityFactory;
 
-    @Autowired
-    protected transient EventBus.SessionEventBus eventBus;
+    protected transient EventBus.UIEventBus eventBus;
 
-    @Autowired
     protected SpPermissionChecker permChecker;
 
-    @Autowired
-    protected transient UINotification uiNotification;
+    protected UINotification uiNotification;
 
     private final FormLayout formLayout = new FormLayout();
 
@@ -115,6 +106,17 @@ public abstract class AbstractCreateUpdateTagLayout<E extends NamedEntity> exten
     private String colorPicked;
     protected String tagNameValue;
     protected String tagDescValue;
+
+    public AbstractCreateUpdateTagLayout(final I18N i18n, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UIEventBus eventBus, final SpPermissionChecker permChecker,
+            final UINotification uiNotification) {
+        this.i18n = i18n;
+        this.tagManagement = tagManagement;
+        this.entityFactory = entityFactory;
+        this.eventBus = eventBus;
+        this.permChecker = permChecker;
+        this.uiNotification = uiNotification;
+    }
 
     /**
      * 
@@ -167,11 +169,6 @@ public abstract class AbstractCreateUpdateTagLayout<E extends NamedEntity> exten
         buildLayout();
         addListeners();
         eventBus.subscribe(this);
-    }
-
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
     }
 
     protected void createRequiredComponents() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/CreateUpdateTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/CreateUpdateTypeLayout.java
@@ -8,14 +8,20 @@
  */
 package org.eclipse.hawkbit.ui.layouts;
 
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.model.NamedEntity;
 import org.eclipse.hawkbit.ui.colorpicker.ColorPickerConstants;
 import org.eclipse.hawkbit.ui.colorpicker.ColorPickerHelper;
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.data.Property.ValueChangeEvent;
 import com.vaadin.server.Page;
@@ -38,6 +44,11 @@ public abstract class CreateUpdateTypeLayout<E extends NamedEntity> extends Abst
 
     public static final String TYPE_NAME_DYNAMIC_STYLE = "new-tag-name";
     private static final String TYPE_DESC_DYNAMIC_STYLE = "new-tag-desc";
+
+    public CreateUpdateTypeLayout(final I18N i18n, final TagManagement tagManagement, final EntityFactory entityFactory,
+            final UIEventBus eventBus, final SpPermissionChecker permChecker, final UINotification uiNotification) {
+        super(i18n, tagManagement, entityFactory, eventBus, permChecker, uiNotification);
+    }
 
     @Override
     protected void addListeners() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/HawkbitLoginUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/HawkbitLoginUI.java
@@ -33,23 +33,22 @@ import com.vaadin.ui.VerticalLayout;
 /**
  * Login UI window that is independent of the {@link HawkbitUI} itself.
  *
- *
- *
  */
 @Title("hawkBit UI - Login")
 public class HawkbitLoginUI extends DefaultHawkbitUI {
     private static final Logger LOG = LoggerFactory.getLogger(HawkbitLoginUI.class);
 
-    /**
-    *
-    */
     private static final long serialVersionUID = 1L;
 
-    @Autowired
-    private SpringViewProvider viewProvider;
+    private final SpringViewProvider viewProvider;
+
+    private final transient ApplicationContext context;
 
     @Autowired
-    private transient ApplicationContext context;
+    protected HawkbitLoginUI(final SpringViewProvider viewProvider, final ApplicationContext context) {
+        this.viewProvider = viewProvider;
+        this.context = context;
+    }
 
     @Override
     protected void init(final VaadinRequest request) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/LoginView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/LoginView.java
@@ -39,7 +39,6 @@ import com.vaadin.server.VaadinService;
 import com.vaadin.server.WebBrowser;
 import com.vaadin.shared.Position;
 import com.vaadin.spring.annotation.SpringView;
-import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Component;
@@ -56,7 +55,6 @@ import com.vaadin.ui.themes.ValoTheme;
  * Login view for login credentials.
  */
 @SpringView(name = "")
-@UIScope
 public class LoginView extends VerticalLayout implements View {
     private static final String TENANT_PATTERN_PLACEHOLDER = "tenant";
     private static final String USER_PATTERN_PLACEHOLDER = "user";
@@ -71,17 +69,13 @@ public class LoginView extends VerticalLayout implements View {
     private static final String SP_LOGIN_USER = "sp-login-user";
     private static final String SP_LOGIN_TENANT = "sp-login-tenant";
 
-    @Autowired
-    private transient VaadinSecurity vaadinSecurity;
+    private final transient VaadinSecurity vaadinSecurity;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient UiProperties uiProperties;
+    private final UiProperties uiProperties;
 
-    @Autowired
-    private transient MultitenancyIndicator multiTenancyIndicator;
+    private final transient MultitenancyIndicator multiTenancyIndicator;
 
     private final transient AntPathMatcher matcher = new AntPathMatcher();
     private boolean useCookie = true;
@@ -90,6 +84,15 @@ public class LoginView extends VerticalLayout implements View {
     private TextField tenant;
     private PasswordField password;
     private Button signin;
+
+    @Autowired
+    LoginView(final VaadinSecurity vaadinSecurity, final I18N i18n, final UiProperties uiProperties,
+            final MultitenancyIndicator multiTenancyIndicator) {
+        this.vaadinSecurity = vaadinSecurity;
+        this.i18n = i18n;
+        this.uiProperties = uiProperties;
+        this.multiTenancyIndicator = multiTenancyIndicator;
+    }
 
     void loginAuthenticationFailedNotification() {
         final Notification notification = new Notification(i18n.get("notification.login.failed.title"));

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/DeploymentView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/DeploymentView.java
@@ -8,10 +8,19 @@
  */
 package org.eclipse.hawkbit.ui.management;
 
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.eclipse.hawkbit.repository.DeploymentManagement;
+import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.SystemManagement;
+import org.eclipse.hawkbit.repository.TagManagement;
+import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.ui.HawkbitUI;
+import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
 import org.eclipse.hawkbit.ui.management.actionhistory.ActionHistoryComponent;
 import org.eclipse.hawkbit.ui.management.dstable.DistributionTableLayout;
@@ -19,16 +28,21 @@ import org.eclipse.hawkbit.ui.management.dstag.DistributionTagLayout;
 import org.eclipse.hawkbit.ui.management.event.DistributionTableEvent;
 import org.eclipse.hawkbit.ui.management.event.DragEvent;
 import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
+import org.eclipse.hawkbit.ui.management.event.ManagementViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.management.event.TargetTableEvent;
 import org.eclipse.hawkbit.ui.management.footer.DeleteActionsLayout;
+import org.eclipse.hawkbit.ui.management.state.DistributionTableFilters;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
+import org.eclipse.hawkbit.ui.management.targettable.TargetTable;
 import org.eclipse.hawkbit.ui.management.targettable.TargetTableLayout;
+import org.eclipse.hawkbit.ui.management.targettag.CreateUpdateTargetTagLayoutWindow;
 import org.eclipse.hawkbit.ui.management.targettag.TargetTagFilterLayout;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -39,60 +53,88 @@ import com.vaadin.server.Page;
 import com.vaadin.server.Page.BrowserWindowResizeEvent;
 import com.vaadin.server.Page.BrowserWindowResizeListener;
 import com.vaadin.spring.annotation.SpringView;
-import com.vaadin.spring.annotation.ViewScope;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 
 /**
- *
+ * Target status and deployment management view.
  *
  */
+@UIScope
 @SpringView(name = DeploymentView.VIEW_NAME, ui = HawkbitUI.class)
-@ViewScope
 public class DeploymentView extends VerticalLayout implements View, BrowserWindowResizeListener {
 
     public static final String VIEW_NAME = "deployment";
     private static final long serialVersionUID = 1847434723456644998L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventbus;
+    private final transient EventBus.UIEventBus eventbus;
 
-    @Autowired
-    private SpPermissionChecker permChecker;
+    private final SpPermissionChecker permChecker;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient UINotification uiNotification;
+    private final UINotification uiNotification;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final ManagementUIState managementUIState;
 
-    @Autowired
-    private ActionHistoryComponent actionHistoryComponent;
+    private final ActionHistoryComponent actionHistoryComponent;
 
-    @Autowired
-    private TargetTagFilterLayout targetTagFilterLayout;
+    private final TargetTagFilterLayout targetTagFilterLayout;
 
-    @Autowired
-    private TargetTableLayout targetTableLayout;
+    private final TargetTableLayout targetTableLayout;
 
-    @Autowired
-    private DistributionTagLayout distributionTagLayout;
+    private final DistributionTagLayout distributionTagLayout;
 
-    @Autowired
-    private DistributionTableLayout distributionTableLayoutNew;
+    private final DistributionTableLayout distributionTableLayoutNew;
 
-    @Autowired
-    private DeleteActionsLayout deleteAndActionsLayout;
+    private final DeleteActionsLayout deleteAndActionsLayout;
 
     private GridLayout mainLayout;
 
-    @Override
-    public void enter(final ViewChangeEvent event) {
+    @Autowired
+    DeploymentView(final UIEventBus eventbus, final SpPermissionChecker permChecker, final I18N i18n,
+            final UINotification uiNotification, final ManagementUIState managementUIState,
+            final DeploymentManagement deploymentManagement, final UIEventBus eventBus,
+            final DistributionTableFilters distFilterParameters,
+            final DistributionSetManagement distributionSetManagement, final TargetManagement targetManagement,
+            final EntityFactory entityFactory, final UiProperties uiproperties,
+            final ManagementViewAcceptCriteria managementViewAcceptCriteria, final TagManagement tagManagement,
+            final TargetFilterQueryManagement targetFilterQueryManagement, final SystemManagement systemManagement) {
+        this.eventbus = eventbus;
+        this.permChecker = permChecker;
+        this.i18n = i18n;
+        this.uiNotification = uiNotification;
+        this.managementUIState = managementUIState;
+        this.actionHistoryComponent = new ActionHistoryComponent(i18n, deploymentManagement, eventBus, uiNotification,
+                managementUIState);
+        final CreateUpdateTargetTagLayoutWindow createUpdateTargetTagLayout = new CreateUpdateTargetTagLayoutWindow(
+                i18n, tagManagement, entityFactory, eventBus, permChecker, uiNotification);
+        this.targetTagFilterLayout = new TargetTagFilterLayout(i18n, createUpdateTargetTagLayout, managementUIState,
+                managementViewAcceptCriteria, permChecker, eventBus, uiNotification, entityFactory, targetManagement,
+                targetFilterQueryManagement);
+        final TargetTable targetTable = new TargetTable(eventBus, i18n, uiNotification, targetManagement,
+                managementUIState, permChecker, managementViewAcceptCriteria);
+
+        this.targetTableLayout = new TargetTableLayout(eventbus, targetTable, targetManagement, entityFactory, i18n,
+                eventBus, uiNotification, managementUIState, managementViewAcceptCriteria, deploymentManagement,
+                uiproperties, permChecker, uiNotification, tagManagement);
+
+        this.distributionTagLayout = new DistributionTagLayout(eventbus, managementUIState, i18n, permChecker, eventBus,
+                tagManagement, entityFactory, uiNotification, distFilterParameters, distributionSetManagement,
+                managementViewAcceptCriteria);
+        this.distributionTableLayoutNew = new DistributionTableLayout(i18n, eventBus, permChecker, managementUIState,
+                distributionSetManagement, managementViewAcceptCriteria, entityFactory, uiNotification, tagManagement,
+                systemManagement, targetManagement);
+        this.deleteAndActionsLayout = new DeleteActionsLayout(i18n, permChecker, eventBus, uiNotification,
+                tagManagement, managementViewAcceptCriteria, managementUIState, targetManagement, targetTable,
+                deploymentManagement, distributionSetManagement);
+    }
+
+    @PostConstruct
+    void init() {
         buildLayout();
         restoreState();
         checkNoDataAvaialble();
@@ -107,7 +149,7 @@ public class DeploymentView extends VerticalLayout implements View, BrowserWindo
         eventbus.unsubscribe(this);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DistributionTableEvent event) {
         if (BaseEntityEventType.MINIMIZED == event.getEventType()) {
             minimizeDistTable();
@@ -116,7 +158,7 @@ public class DeploymentView extends VerticalLayout implements View, BrowserWindo
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final TargetTableEvent event) {
         if (BaseEntityEventType.MINIMIZED == event.getEventType()) {
             minimizeTargetTable();
@@ -125,13 +167,13 @@ public class DeploymentView extends VerticalLayout implements View, BrowserWindo
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final ManagementUIEvent mgmtUIEvent) {
         if (mgmtUIEvent == ManagementUIEvent.MAX_ACTION_HISTORY) {
-            UI.getCurrent().access(() -> maximizeActionHistory());
+            UI.getCurrent().access(this::maximizeActionHistory);
         }
         if (mgmtUIEvent == ManagementUIEvent.MIN_ACTION_HISTORY) {
-            UI.getCurrent().access(() -> minimizeActionHistory());
+            UI.getCurrent().access(this::minimizeActionHistory);
         }
     }
 
@@ -163,7 +205,7 @@ public class DeploymentView extends VerticalLayout implements View, BrowserWindo
         layoutWidgets();
         mainLayout.setSizeFull();
         mainLayout.setSpacing(true);
-        mainLayout.setRowExpandRatio(0, 1f);
+        mainLayout.setRowExpandRatio(0, 1F);
     }
 
     private void layoutWidgets() {
@@ -185,9 +227,9 @@ public class DeploymentView extends VerticalLayout implements View, BrowserWindo
         mainLayout.addComponent(actionHistoryComponent, 4, 0);
         mainLayout.addComponent(distributionTableLayoutNew, 2, 0);
         mainLayout.addComponent(distributionTagLayout, 3, 0);
-        mainLayout.setColumnExpandRatio(1, 0.275f);
-        mainLayout.setColumnExpandRatio(2, 0.275f);
-        mainLayout.setColumnExpandRatio(4, 0.45f);
+        mainLayout.setColumnExpandRatio(1, 0.275F);
+        mainLayout.setColumnExpandRatio(2, 0.275F);
+        mainLayout.setColumnExpandRatio(4, 0.45F);
         if (showFooterLayout()) {
             mainLayout.addComponent(deleteAndActionsLayout, 1, 1, 2, 1);
             mainLayout.setComponentAlignment(deleteAndActionsLayout, Alignment.BOTTOM_CENTER);
@@ -199,7 +241,7 @@ public class DeploymentView extends VerticalLayout implements View, BrowserWindo
         mainLayout.setRows(2);
         mainLayout.addComponent(distributionTableLayoutNew, 0, 0);
         mainLayout.addComponent(distributionTagLayout, 1, 0);
-        mainLayout.setColumnExpandRatio(0, 1f);
+        mainLayout.setColumnExpandRatio(0, 1F);
         if (showFooterLayout()) {
             mainLayout.addComponent(deleteAndActionsLayout, 0, 1);
             mainLayout.setComponentAlignment(deleteAndActionsLayout, Alignment.BOTTOM_CENTER);
@@ -225,8 +267,8 @@ public class DeploymentView extends VerticalLayout implements View, BrowserWindo
         mainLayout.addComponent(targetTagFilterLayout, 0, 0);
         mainLayout.addComponent(targetTableLayout, 1, 0);
         mainLayout.addComponent(actionHistoryComponent, 2, 0);
-        mainLayout.setColumnExpandRatio(1, 0.4f);
-        mainLayout.setColumnExpandRatio(2, 0.6f);
+        mainLayout.setColumnExpandRatio(1, 0.4F);
+        mainLayout.setColumnExpandRatio(2, 0.6F);
         if (showFooterLayout()) {
             mainLayout.addComponent(deleteAndActionsLayout, 1, 1);
             mainLayout.setComponentAlignment(deleteAndActionsLayout, Alignment.BOTTOM_CENTER);
@@ -249,10 +291,10 @@ public class DeploymentView extends VerticalLayout implements View, BrowserWindo
         }
         mainLayout.removeComponent(actionHistoryComponent);
         mainLayout.removeComponent(deleteAndActionsLayout);
-        mainLayout.setColumnExpandRatio(1, 1f);
-        mainLayout.setColumnExpandRatio(2, 0f);
-        mainLayout.setColumnExpandRatio(3, 0f);
-        mainLayout.setColumnExpandRatio(4, 0f);
+        mainLayout.setColumnExpandRatio(1, 1F);
+        mainLayout.setColumnExpandRatio(2, 0F);
+        mainLayout.setColumnExpandRatio(3, 0F);
+        mainLayout.setColumnExpandRatio(4, 0F);
     }
 
     private void maximizeDistTable() {
@@ -262,10 +304,10 @@ public class DeploymentView extends VerticalLayout implements View, BrowserWindo
             mainLayout.removeComponent(actionHistoryComponent);
         }
         mainLayout.removeComponent(deleteAndActionsLayout);
-        mainLayout.setColumnExpandRatio(0, 0f);
-        mainLayout.setColumnExpandRatio(1, 0f);
-        mainLayout.setColumnExpandRatio(2, 1f);
-        mainLayout.setColumnExpandRatio(4, 0f);
+        mainLayout.setColumnExpandRatio(0, 0F);
+        mainLayout.setColumnExpandRatio(1, 0F);
+        mainLayout.setColumnExpandRatio(2, 1F);
+        mainLayout.setColumnExpandRatio(4, 0F);
     }
 
     private void maximizeActionHistory() {
@@ -276,11 +318,11 @@ public class DeploymentView extends VerticalLayout implements View, BrowserWindo
             mainLayout.removeComponent(distributionTableLayoutNew);
             mainLayout.removeComponent(distributionTagLayout);
         }
-        mainLayout.setColumnExpandRatio(0, 0f);
-        mainLayout.setColumnExpandRatio(1, 0f);
-        mainLayout.setColumnExpandRatio(2, 0f);
-        mainLayout.setColumnExpandRatio(3, 0f);
-        mainLayout.setColumnExpandRatio(4, 1f);
+        mainLayout.setColumnExpandRatio(0, 0F);
+        mainLayout.setColumnExpandRatio(1, 0F);
+        mainLayout.setColumnExpandRatio(2, 0F);
+        mainLayout.setColumnExpandRatio(3, 0F);
+        mainLayout.setColumnExpandRatio(4, 1F);
         mainLayout.removeComponent(deleteAndActionsLayout);
         mainLayout.setComponentAlignment(actionHistoryComponent, Alignment.TOP_LEFT);
     }
@@ -327,6 +369,11 @@ public class DeploymentView extends VerticalLayout implements View, BrowserWindo
                 distributionTableLayoutNew.setShowFilterButtonVisible(false);
             }
         }
+    }
+
+    @Override
+    public void enter(final ViewChangeEvent event) {
+        // This view is constructed in the init() method()
     }
 
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionHistoryComponent.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionHistoryComponent.java
@@ -8,20 +8,18 @@
  */
 package org.eclipse.hawkbit.ui.management.actionhistory;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
+import org.eclipse.hawkbit.repository.DeploymentManagement;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
 import org.eclipse.hawkbit.ui.management.event.TargetTableEvent;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.vaadin.spring.events.EventBus;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
@@ -30,37 +28,24 @@ import com.vaadin.ui.VerticalLayout;
  *
  *
  */
-@SpringComponent
-@ViewScope
 public class ActionHistoryComponent extends VerticalLayout {
     private static final long serialVersionUID = -3766179797384539821L;
 
-    @Autowired
-    private ActionHistoryHeader actionHistoryHeader;
+    private final ActionHistoryHeader actionHistoryHeader;
+    private final ActionHistoryTable actionHistoryTable;
 
-    @Autowired
-    private ActionHistoryTable actionHistoryTable;
-
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
-
-    /**
-     * Initialize the Action History Component.
-     */
-    @PostConstruct
-    public void init() {
+    public ActionHistoryComponent(final I18N i18n, final DeploymentManagement deploymentManagement,
+            final UIEventBus eventBus, final UINotification notification, final ManagementUIState managementUIState) {
+        this.actionHistoryHeader = new ActionHistoryHeader(eventBus, managementUIState);
+        this.actionHistoryTable = new ActionHistoryTable(i18n, deploymentManagement, eventBus, notification,
+                managementUIState);
         buildLayout();
         setSizeFull();
         setImmediate(true);
         eventBus.subscribe(this);
     }
 
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
-    }
-
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final TargetTableEvent targetUIEvent) {
         if (BaseEntityEventType.SELECTED_ENTITY == targetUIEvent.getEventType()) {
             setData(SPUIDefinitions.DATA_AVAILABLE);
@@ -76,7 +61,7 @@ public class ActionHistoryComponent extends VerticalLayout {
         addComponents(actionHistoryHeader, actionHistoryTable);
         setComponentAlignment(actionHistoryHeader, Alignment.TOP_CENTER);
         setComponentAlignment(actionHistoryTable, Alignment.TOP_CENTER);
-        setExpandRatio(actionHistoryTable, 1.0f);
+        setExpandRatio(actionHistoryTable, 1.0F);
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionHistoryHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionHistoryHeader.java
@@ -8,8 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.management.actionhistory;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.components.SPUIButton;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
@@ -19,13 +17,11 @@ import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.server.FontAwesome;
 import com.vaadin.shared.ui.label.ContentMode;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
@@ -35,26 +31,18 @@ import com.vaadin.ui.VerticalLayout;
  *
  *
  */
-@SpringComponent
-@ViewScope
 public class ActionHistoryHeader extends VerticalLayout {
-
     private static final long serialVersionUID = -6276188234115774351L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
-
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final transient EventBus.UIEventBus eventBus;
+    private final ManagementUIState managementUIState;
 
     private Label titleOfActionHistory;
     private SPUIButton maxMinButton;
 
-    /**
-     * Initialize the Action History Header.
-     */
-    @PostConstruct
-    public void init() {
+    ActionHistoryHeader(final UIEventBus eventBus, final ManagementUIState managementUIState) {
+        this.eventBus = eventBus;
+        this.managementUIState = managementUIState;
         buildComponent();
         buildLayout();
         restorePreviousState();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
@@ -10,8 +10,6 @@ package org.eclipse.hawkbit.ui.management.dstable;
 
 import java.util.Collections;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SystemManagement;
@@ -35,18 +33,15 @@ import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.google.common.collect.Sets;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.ComboBox;
 import com.vaadin.ui.CustomComponent;
@@ -58,29 +53,18 @@ import com.vaadin.ui.themes.ValoTheme;
 /**
  * WindowContent for adding/editing a Distribution
  */
-@SpringComponent
-@ViewScope
 public class DistributionAddUpdateWindowLayout extends CustomComponent {
 
     private static final long serialVersionUID = -5602182034230568435L;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
+    private final UINotification notificationMessage;
+    private final transient EventBus.UIEventBus eventBus;
+    private final transient DistributionSetManagement distributionSetManagement;
+    private final transient SystemManagement systemManagement;
+    private final transient EntityFactory entityFactory;
 
-    @Autowired
-    private transient UINotification notificationMessage;
-
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
-
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
-
-    @Autowired
-    private transient SystemManagement systemManagement;
-
-    @Autowired
-    private transient EntityFactory entityFactory;
+    private final DistributionSetTable distributionSetTable;
 
     private TextField distNameTextField;
     private TextField distVersionTextField;
@@ -91,6 +75,21 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
     private Long editDistId;
 
     private FormLayout formLayout;
+
+    public DistributionAddUpdateWindowLayout(final I18N i18n, final UINotification notificationMessage,
+            final UIEventBus eventBus, final DistributionSetManagement distributionSetManagement,
+            final SystemManagement systemManagement, final EntityFactory entityFactory,
+            final DistributionSetTable distributionSetTable) {
+        this.i18n = i18n;
+        this.notificationMessage = notificationMessage;
+        this.eventBus = eventBus;
+        this.distributionSetManagement = distributionSetManagement;
+        this.systemManagement = systemManagement;
+        this.entityFactory = entityFactory;
+        this.distributionSetTable = distributionSetTable;
+        createRequiredComponents();
+        buildLayout();
+    }
 
     /**
      * Save or update distribution set.
@@ -111,15 +110,6 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
             return !isDuplicate();
         }
 
-    }
-
-    /**
-     * Initialize Distribution Add and Edit Window.
-     */
-    @PostConstruct
-    void init() {
-        createRequiredComponents();
-        buildLayout();
     }
 
     private void buildLayout() {
@@ -149,7 +139,6 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
         distsetTypeNameComboBox.setImmediate(true);
         distsetTypeNameComboBox.setNullSelectionAllowed(false);
         distsetTypeNameComboBox.setId(UIComponentIdProvider.DIST_ADD_DISTSETTYPE);
-        populateDistSetTypeNameCombo();
 
         descTextArea = new TextAreaBuilder().caption(i18n.get("textfield.description")).style("text-area-style")
                 .prompt(i18n.get("textfield.description")).immediate(true).id(UIComponentIdProvider.DIST_ADD_DESC)
@@ -235,7 +224,6 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
         notificationMessage.displaySuccess(
                 i18n.get("message.new.dist.save.success", new Object[] { newDist.getName(), newDist.getVersion() }));
 
-        final DistributionSetTable distributionSetTable = SpringContextHelper.getBean(DistributionSetTable.class);
         distributionSetTable.setValue(
                 Sets.newHashSet(new DistributionSetIdName(newDist.getId(), newDist.getName(), newDist.getVersion())));
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionDetails.java
@@ -10,6 +10,8 @@ package org.eclipse.hawkbit.ui.management.dstable;
 
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.ui.common.DistributionSetIdName;
 import org.eclipse.hawkbit.ui.common.detailslayout.AbstractNamedVersionedEntityTableDetailsLayout;
@@ -20,13 +22,13 @@ import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.distributions.dstable.DsMetadataPopupLayout;
 import org.eclipse.hawkbit.ui.management.event.DistributionTableEvent;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.TabSheet;
@@ -37,48 +39,44 @@ import com.vaadin.ui.Window;
 /**
  * Distribution set details layout.
  */
-@SpringComponent
-@ViewScope
 public class DistributionDetails extends AbstractNamedVersionedEntityTableDetailsLayout<DistributionSet> {
 
     private static final long serialVersionUID = 350360207334118826L;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout;
+    private final DistributionTagToken distributionTagToken;
+    private final transient DistributionSetManagement distributionSetManagement;
+    private final DsMetadataPopupLayout dsMetadataPopupLayout;
 
-    @Autowired
-    private DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout;
+    private final SoftwareModuleDetailsTable softwareModuleTable;
 
-    @Autowired
-    private DistributionTagToken distributionTagToken;
+    private final DistributionSetMetadatadetailslayout dsMetadataTable;
 
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
+    DistributionDetails(final I18N i18n, final UIEventBus eventBus, final SpPermissionChecker permissionChecker,
+            final ManagementUIState managementUIState, final DistributionSetManagement distributionSetManagement,
+            final DsMetadataPopupLayout dsMetadataPopupLayout, final EntityFactory entityFactory,
+            final UINotification notificationMessage, final TagManagement tagManagement,
+            final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout) {
+        super(i18n, eventBus, permissionChecker, managementUIState);
 
-    @Autowired
-    private DsMetadataPopupLayout dsMetadataPopupLayout;
+        this.distributionTagToken = new DistributionTagToken(permissionChecker, i18n, notificationMessage, eventBus,
+                managementUIState, tagManagement, distributionSetManagement);
+        this.distributionSetManagement = distributionSetManagement;
+        this.dsMetadataPopupLayout = new DsMetadataPopupLayout(i18n, notificationMessage, eventBus,
+                distributionSetManagement, entityFactory, permissionChecker);
+        this.distributionAddUpdateWindowLayout = distributionAddUpdateWindowLayout;
 
-    @Autowired
-    private transient EntityFactory entityFactory;
+        softwareModuleTable = new SoftwareModuleDetailsTable(i18n, false, permissionChecker, null, null, null,
+                notificationMessage);
 
-    private SoftwareModuleDetailsTable softwareModuleTable;
-
-    private DistributionSetMetadatadetailslayout dsMetadataTable;
-
-    @Override
-    protected void init() {
-        softwareModuleTable = new SoftwareModuleDetailsTable();
-        softwareModuleTable.init(getI18n(), false, getPermissionChecker(), null, null, null);
-
-        dsMetadataTable = new DistributionSetMetadatadetailslayout();
-        dsMetadataTable.init(getI18n(), getPermissionChecker(), distributionSetManagement, dsMetadataPopupLayout,
-                entityFactory);
-
-        super.init();
+        dsMetadataTable = new DistributionSetMetadatadetailslayout(i18n, permissionChecker, distributionSetManagement,
+                dsMetadataPopupLayout, entityFactory);
+        addTabs(detailsTab);
+        restoreState();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
-    void onEvent(final DistributionTableEvent distributionTableEvent) {
+    @EventBusListenerMethod(scope = EventScope.UI)
+    private void onEvent(final DistributionTableEvent distributionTableEvent) {
         onBaseEntityEvent(distributionTableEvent);
     }
 
@@ -202,8 +200,7 @@ public class DistributionDetails extends AbstractNamedVersionedEntityTableDetail
 
     @Override
     protected void showMetadata(final ClickEvent event) {
-        final DistributionSet ds = distributionSetManagement
-                .findDistributionSetByIdWithDetails(getSelectedBaseEntityId());
+        final DistributionSet ds = distributionSetManagement.findDistributionSetById(getSelectedBaseEntityId());
         UI.getCurrent().addWindow(dsMetadataPopupLayout.getWindow(ds, null));
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTable.java
@@ -556,6 +556,9 @@ public class DistributionTable extends AbstractNamedVersionTable<DistributionSet
     private void updateDistributionInTable(final DistributionSet editedDs) {
         final Item item = getContainerDataSource()
                 .getItem(new DistributionSetIdName(editedDs.getId(), editedDs.getName(), editedDs.getVersion()));
+        if (item == null) {
+            return;
+        }
         updateEntity(editedDs, item);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTableHeader.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ui.management.dstable;
 
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.table.AbstractTableHeader;
 import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
 import org.eclipse.hawkbit.ui.management.event.DistributionTableEvent;
@@ -15,35 +16,34 @@ import org.eclipse.hawkbit.ui.management.event.DistributionTableFilterEvent;
 import org.eclipse.hawkbit.ui.management.event.DragEvent;
 import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.event.dd.DropHandler;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.Window;
 
 /**
  * Distribution table header.
- * 
  *
  */
-@SpringComponent
-@ViewScope
 public class DistributionTableHeader extends AbstractTableHeader {
     private static final long serialVersionUID = 7597766804650170127L;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout;
 
-    @Autowired
-    private DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout;
+    DistributionTableHeader(final I18N i18n, final SpPermissionChecker permChecker, final UIEventBus eventbus,
+            final ManagementUIState managementUIState,
+            final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout) {
+        super(i18n, permChecker, eventbus, managementUIState, null, null);
+        this.distributionAddUpdateWindowLayout = distributionAddUpdateWindowLayout;
+    }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final ManagementUIEvent event) {
         if (event == ManagementUIEvent.HIDE_DISTRIBUTION_TAG_LAYOUT) {
             setFilterButtonsIconVisible(true);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTableLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTableLayout.java
@@ -8,38 +8,51 @@
  */
 package org.eclipse.hawkbit.ui.management.dstable;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.SystemManagement;
+import org.eclipse.hawkbit.repository.TagManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.ui.common.table.AbstractTableLayout;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import org.eclipse.hawkbit.ui.distributions.dstable.DsMetadataPopupLayout;
+import org.eclipse.hawkbit.ui.management.event.ManagementViewAcceptCriteria;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 /**
  * Software module table layout.
  */
-@SpringComponent
-@ViewScope
 public class DistributionTableLayout extends AbstractTableLayout {
 
     private static final long serialVersionUID = 6464291374980641235L;
 
-    @Autowired
-    private DistributionDetails distributionDetails;
+    public DistributionTableLayout(final I18N i18n, final UIEventBus eventBus,
+            final SpPermissionChecker permissionChecker, final ManagementUIState managementUIState,
+            final DistributionSetManagement distributionSetManagement,
+            final ManagementViewAcceptCriteria managementViewAcceptCriteria, final EntityFactory entityFactory,
+            final UINotification notification, final TagManagement tagManagement,
+            final SystemManagement systemManagement, final TargetManagement targetService) {
 
-    @Autowired
-    private DistributionTableHeader dsTableHeader;
+        final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout = new DistributionAddUpdateWindowLayout(
+                i18n, notification, eventBus, distributionSetManagement, systemManagement, entityFactory, null);
 
-    @Autowired
-    private DistributionTable dsTable;
+        final DsMetadataPopupLayout dsMetadataPopupLayout = new DsMetadataPopupLayout(i18n, notification, eventBus,
+                distributionSetManagement, entityFactory, permissionChecker);
 
-    /**
-     * Initialize the filter layout.
-     */
-    @PostConstruct
-    void init() {
-        super.init(dsTableHeader, dsTable, distributionDetails);
+        final DistributionTable distributionTable = new DistributionTable(eventBus, i18n, permissionChecker,
+                notification, managementUIState, managementViewAcceptCriteria, targetService, dsMetadataPopupLayout,
+                distributionSetManagement);
+
+        super.init(
+                new DistributionTableHeader(i18n, permissionChecker, eventBus, managementUIState,
+                        distributionAddUpdateWindowLayout),
+                distributionTable,
+                new DistributionDetails(i18n, eventBus, permissionChecker, managementUIState, distributionSetManagement,
+                        dsMetadataPopupLayout, entityFactory, notification, tagManagement,
+                        distributionAddUpdateWindowLayout));
     }
 
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
@@ -12,6 +12,9 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.util.List;
 
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSetTag;
 import org.eclipse.hawkbit.ui.colorpicker.ColorPickerConstants;
 import org.eclipse.hawkbit.ui.colorpicker.ColorPickerHelper;
@@ -19,20 +22,19 @@ import org.eclipse.hawkbit.ui.layouts.AbstractCreateUpdateTagLayout;
 import org.eclipse.hawkbit.ui.push.DistributionSetTagCreatedEventContainer;
 import org.eclipse.hawkbit.ui.push.DistributionSetTagDeletedEventContainer;
 import org.eclipse.hawkbit.ui.push.DistributionSetTagUpdatedEventContainer;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.UI;
 
 /**
  * Class for Create/Update Tag Layout of distribution set
  */
-@SpringComponent
-@ViewScope
 public class CreateUpdateDistributionTagLayoutWindow extends AbstractCreateUpdateTagLayout<DistributionSetTag> {
 
     private static final long serialVersionUID = 444276149954167545L;
@@ -40,21 +42,27 @@ public class CreateUpdateDistributionTagLayoutWindow extends AbstractCreateUpdat
     private static final String TARGET_TAG_NAME_DYNAMIC_STYLE = "new-target-tag-name";
     private static final String MSG_TEXTFIELD_NAME = "textfield.name";
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    CreateUpdateDistributionTagLayoutWindow(final I18N i18n, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UIEventBus eventBus, final SpPermissionChecker permChecker,
+            final UINotification uiNotification) {
+        super(i18n, tagManagement, entityFactory, eventBus, permChecker, uiNotification);
+    }
+
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagCreatedBulkEvent(final DistributionSetTagCreatedEventContainer eventContainer) {
         populateTagNameCombo();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagDeletedEvent(final DistributionSetTagDeletedEventContainer eventContainer) {
         populateTagNameCombo();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagUpdateEvent(final DistributionSetTagUpdatedEventContainer eventContainer) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtonClick.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtonClick.java
@@ -12,38 +12,26 @@ import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterMultiButtonClick
 import org.eclipse.hawkbit.ui.management.event.DistributionTableFilterEvent;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 
 /**
  *
  *
  */
-@SpringComponent
-@ViewScope
 public class DistributionTagButtonClick extends AbstractFilterMultiButtonClick {
-
-    /**
-    * 
-    */
     private static final long serialVersionUID = 4120296456125178019L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
+    private final ManagementUIState managementUIState;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    DistributionTagButtonClick(final UIEventBus eventBus, final ManagementUIState managementUIState) {
+        this.eventBus = eventBus;
+        this.managementUIState = managementUIState;
+    }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.common.filterlayout.
-     * AbstractFilterButtonClickBehaviour#filterUnClicked (com.vaadin.ui.Button)
-     */
     @Override
     protected void filterUnClicked(final Button clickedButton) {
         if (clickedButton.getData().equals(SPUIDefinitions.NO_TAG_BUTTON_ID)) {
@@ -54,12 +42,6 @@ public class DistributionTagButtonClick extends AbstractFilterMultiButtonClick {
         eventBus.publish(this, DistributionTableFilterEvent.FILTER_BY_TAG);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.common.filterlayout.
-     * AbstractFilterButtonClickBehaviour#filterClicked (com.vaadin.ui.Button)
-     */
     @Override
     protected void filterClicked(final Button clickedButton) {
         if (clickedButton.getData().equals(SPUIDefinitions.NO_TAG_BUTTON_ID)) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtons.java
@@ -10,83 +10,86 @@ package org.eclipse.hawkbit.ui.management.dstag;
 
 import java.util.Collections;
 
+import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.model.Tag;
-import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterButtonClickBehaviour;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterButtons;
 import org.eclipse.hawkbit.ui.management.event.DistributionTagDropEvent;
 import org.eclipse.hawkbit.ui.management.event.DragEvent;
+import org.eclipse.hawkbit.ui.management.event.ManagementViewAcceptCriteria;
+import org.eclipse.hawkbit.ui.management.state.DistributionTableFilters;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.management.tag.TagIdName;
 import org.eclipse.hawkbit.ui.push.DistributionSetTagCreatedEventContainer;
 import org.eclipse.hawkbit.ui.push.DistributionSetTagDeletedEventContainer;
 import org.eclipse.hawkbit.ui.push.DistributionSetTagUpdatedEventContainer;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.data.Item;
 import com.vaadin.event.dd.DropHandler;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.UI;
 
 /**
  *
  *
  */
-@SpringComponent
-@ViewScope
 public class DistributionTagButtons extends AbstractFilterButtons {
 
     private static final String NO_TAG = "NO TAG";
-
     private static final long serialVersionUID = 1L;
 
-    @Autowired
-    private DistributionTagDropEvent spDistTagDropEvent;
+    private final DistributionTagDropEvent spDistTagDropEvent;
+    private final ManagementUIState managementUIState;
+    private final transient EntityFactory entityFactory;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    DistributionTagButtons(final UIEventBus eventBus, final ManagementUIState managementUIState,
+            final EntityFactory entityFactory, final I18N i18n, final UINotification notification,
+            final SpPermissionChecker permChecker, final DistributionTableFilters distFilterParameters,
+            final DistributionSetManagement distributionSetManagement,
+            final ManagementViewAcceptCriteria managementViewAcceptCriteria) {
+        super(eventBus, new DistributionTagButtonClick(eventBus, managementUIState));
+        this.spDistTagDropEvent = new DistributionTagDropEvent(i18n, notification, permChecker, distFilterParameters,
+                distributionSetManagement, eventBus, managementViewAcceptCriteria);
+        this.managementUIState = managementUIState;
+        this.entityFactory = entityFactory;
 
-    @Autowired
-    private transient EntityFactory entityFactory;
-
-    @Override
-    public void init(final AbstractFilterButtonClickBehaviour filterButtonClickBehaviour) {
-        super.init(filterButtonClickBehaviour);
         addNewTag(entityFactory.tag().create().name(NO_TAG).build());
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagCreatedBulkEvent(final DistributionSetTagCreatedEventContainer eventContainer) {
         refreshTagTable();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagDeletedEvent(final DistributionSetTagDeletedEventContainer eventContainer) {
         refreshTagTable();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onDistributionSetTagUpdateEvent(final DistributionSetTagUpdatedEventContainer eventContainer) {
         refreshTagTable();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DragEvent dragEvent) {
         if (dragEvent == DragEvent.DISTRIBUTION_DRAG) {
             UI.getCurrent().access(() -> addStyleName(SPUIStyleDefinitions.SHOW_DROP_HINT_FILTER_BUTTON));

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagHeader.java
@@ -8,17 +8,17 @@
  */
 package org.eclipse.hawkbit.ui.management.dstag;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterHeader;
 import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.Window;
@@ -27,25 +27,20 @@ import com.vaadin.ui.Window;
  *
  *
  */
-@SpringComponent
-@ViewScope
 public class DistributionTagHeader extends AbstractFilterHeader {
 
     private static final long serialVersionUID = -1439667766337270066L;
 
-    @Autowired
-    private I18N i18n;
+    private final ManagementUIState managementUIState;
+    private final CreateUpdateDistributionTagLayoutWindow createORUpdateDistributionTagLayout;
 
-    @Autowired
-    private ManagementUIState managementUIState;
-
-    @Autowired
-    private CreateUpdateDistributionTagLayoutWindow createORUpdateDistributionTagLayout;
-
-    @Override
-    @PostConstruct
-    public void init() {
-        super.init();
+    DistributionTagHeader(final I18N i18n, final ManagementUIState managementUIState,
+            final SpPermissionChecker permChecker, final UIEventBus eventBus, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UINotification uiNotification) {
+        super(permChecker, eventBus, i18n);
+        this.managementUIState = managementUIState;
+        this.createORUpdateDistributionTagLayout = new CreateUpdateDistributionTagLayoutWindow(i18n, tagManagement,
+                entityFactory, eventBus, permChecker, uiNotification);
         if (hasCreateUpdatePermission()) {
             createORUpdateDistributionTagLayout.init();
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagLayout.java
@@ -8,66 +8,49 @@
  */
 package org.eclipse.hawkbit.ui.management.dstag;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
+import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterLayout;
 import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
+import org.eclipse.hawkbit.ui.management.event.ManagementViewAcceptCriteria;
+import org.eclipse.hawkbit.ui.management.state.DistributionTableFilters;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.vaadin.spring.events.EventBus;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 
 /**
  *
  *
  */
-@SpringComponent
-@ViewScope
 public class DistributionTagLayout extends AbstractFilterLayout {
 
-    /**
-    * 
-    */
     private static final long serialVersionUID = 4363033587261057567L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventbus;
+    private final ManagementUIState managementUIState;
 
-    @Autowired
-    private DistributionTagHeader distributionTagHeader;
+    public DistributionTagLayout(final UIEventBus eventbus, final ManagementUIState managementUIState, final I18N i18n,
+            final SpPermissionChecker permChecker, final UIEventBus eventBus, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UINotification uiNotification,
+            final DistributionTableFilters distFilterParameters,
+            final DistributionSetManagement distributionSetManagement,
+            final ManagementViewAcceptCriteria managementViewAcceptCriteria) {
 
-    @Autowired
-    private DistributionTagButtons distributionTagButtons;
+        super(new DistributionTagHeader(i18n, managementUIState, permChecker, eventBus, tagManagement, entityFactory,
+                uiNotification),
+                new DistributionTagButtons(eventBus, managementUIState, entityFactory, i18n, uiNotification,
+                        permChecker, distFilterParameters, distributionSetManagement, managementViewAcceptCriteria));
+        this.managementUIState = managementUIState;
 
-    @Autowired
-    private DistributionTagButtonClick distributionTagButtonClick;
-
-    @Autowired
-    private ManagementUIState managementUIState;
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.eclipse.hawkbit.server.ui.common.filterlayout.AbstractFilterLayout#
-     * onLoadIsTypeFilterIsClosed()
-     */
-
-    /**
-     * Initialize the filter layout.
-     */
-    @PostConstruct
-    public void init() {
-        super.init(distributionTagHeader, distributionTagButtons, distributionTagButtonClick);
+        restoreState();
         eventbus.subscribe(this);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final ManagementUIEvent event) {
         if (event == ManagementUIEvent.HIDE_DISTRIBUTION_TAG_LAYOUT) {
             managementUIState.setDistTagFilterClosed(true);
@@ -77,15 +60,6 @@ public class DistributionTagLayout extends AbstractFilterLayout {
             managementUIState.setDistTagFilterClosed(false);
             setVisible(true);
         }
-    }
-
-    @PreDestroy
-    void destroy() {
-        /*
-         * It's good manners to do this, even though vaadin-spring will
-         * automatically unsubscribe when this UI is garbage collected.
-         */
-        eventbus.unsubscribe(this);
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/event/DistributionTagDropEvent.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/event/DistributionTagDropEvent.java
@@ -24,14 +24,12 @@ import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.DragAndDropWrapper;
 import com.vaadin.ui.Table;
@@ -41,32 +39,36 @@ import com.vaadin.ui.Table.TableTransferable;
  *
  *
  */
-@SpringComponent
-@ViewScope
 public class DistributionTagDropEvent implements DropHandler {
 
     private static final long serialVersionUID = 7338133229709850212L;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient UINotification notification;
+    private final UINotification notification;
 
-    @Autowired
-    private SpPermissionChecker permChecker;
+    private final SpPermissionChecker permChecker;
 
-    @Autowired
-    private DistributionTableFilters distFilterParameters;
+    private final DistributionTableFilters distFilterParameters;
 
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
+    private final transient DistributionSetManagement distributionSetManagement;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private ManagementViewAcceptCriteria managementViewAcceptCriteria;
+    private final ManagementViewAcceptCriteria managementViewAcceptCriteria;
+
+    public DistributionTagDropEvent(final I18N i18n, final UINotification notification,
+            final SpPermissionChecker permChecker, final DistributionTableFilters distFilterParameters,
+            final DistributionSetManagement distributionSetManagement, final UIEventBus eventBus,
+            final ManagementViewAcceptCriteria managementViewAcceptCriteria) {
+        this.i18n = i18n;
+        this.notification = notification;
+        this.permChecker = permChecker;
+        this.distFilterParameters = distFilterParameters;
+        this.distributionSetManagement = distributionSetManagement;
+        this.eventBus = eventBus;
+        this.managementViewAcceptCriteria = managementViewAcceptCriteria;
+    }
 
     @Override
     public void drop(final DragAndDropEvent event) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/event/ManagementViewAcceptCriteria.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/event/ManagementViewAcceptCriteria.java
@@ -15,20 +15,20 @@ import java.util.Map;
 import org.eclipse.hawkbit.ui.common.AbstractAcceptCriteria;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.google.common.collect.Maps;
 import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.Component;
 
 /**
  * Management View for Accept criteria.
- * 
- *
- * 
  */
 @SpringComponent
-@ViewScope
+@UIScope
 public class ManagementViewAcceptCriteria extends AbstractAcceptCriteria {
 
     private static final long serialVersionUID = 1718217664674701006L;
@@ -36,6 +36,11 @@ public class ManagementViewAcceptCriteria extends AbstractAcceptCriteria {
     private static final Map<String, List<String>> DROP_CONFIGS = createDropConfigurations();
 
     private static final Map<String, Object> DROP_HINTS_CONFIGS = createDropHintConfigurations();
+
+    @Autowired
+    ManagementViewAcceptCriteria(final UINotification uiNotification, final UIEventBus eventBus) {
+        super(uiNotification, eventBus);
+    }
 
     @Override
     protected String getComponentId(final Component component) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/ActionTypeOptionGroupLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/ActionTypeOptionGroupLayout.java
@@ -12,13 +12,10 @@ import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.TimeZone;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.repository.model.Action.ActionType;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPDateTimeUtil;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.hene.flexibleoptiongroup.FlexibleOptionGroup;
 import org.vaadin.hene.flexibleoptiongroup.FlexibleOptionGroupItemComponent;
 
@@ -26,8 +23,6 @@ import com.vaadin.data.Property.ValueChangeEvent;
 import com.vaadin.data.Property.ValueChangeListener;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.shared.ui.datefield.Resolution;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.DateField;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
@@ -38,22 +33,20 @@ import com.vaadin.ui.themes.ValoTheme;
  * 
  *
  */
-@SpringComponent
-@ViewScope
 public class ActionTypeOptionGroupLayout extends HorizontalLayout {
 
     private static final long serialVersionUID = -5624576558669213864L;
     private static final String STYLE_DIST_WINDOW_ACTIONTYPE = "dist-window-actiontype";
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
     private FlexibleOptionGroup actionTypeOptionGroup;
 
     private DateField forcedTimeDateField;
 
-    @PostConstruct
-    void init() {
+    public ActionTypeOptionGroupLayout(final I18N i18n) {
+        this.i18n = i18n;
+
         createOptionGroup();
         addValueChangeListener();
         setStyleName("dist-window-actiontype-horz-layout");

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/CountMessageLabel.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/CountMessageLabel.java
@@ -10,9 +10,6 @@ package org.eclipse.hawkbit.ui.management.footer;
 
 import java.util.List;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
@@ -27,56 +24,39 @@ import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.google.common.base.Optional;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.shared.ui.label.ContentMode;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Label;
 
 /**
  * Count message label which display current filter details and details on
  * pinning.
- *
- *
  */
-@SpringComponent
-@ViewScope
 public class CountMessageLabel extends Label {
     private static final long serialVersionUID = -1533826352473259653L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient TargetManagement targetManagement;
 
-    @Autowired
-    private transient TargetManagement targetManagement;
+    private final I18N i18n;
 
-    @Autowired
-    private I18N i18n;
+    private final ManagementUIState managementUIState;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final TargetTable targetTable;
 
-    @Autowired
-    private TargetTable targetTable;
+    public CountMessageLabel(final UIEventBus eventBus, final TargetManagement targetManagement, final I18N i18n,
+            final ManagementUIState managementUIState, final TargetTable targetTable) {
+        this.targetManagement = targetManagement;
+        this.i18n = i18n;
+        this.managementUIState = managementUIState;
+        this.targetTable = targetTable;
 
-    /**
-     * PostConstruct method called by spring after bean has been initialized.
-     */
-    @PostConstruct
-    public void postConstruct() {
         applyStyle();
         eventBus.subscribe(this);
-    }
-
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
     }
 
     /**
@@ -84,7 +64,7 @@ public class CountMessageLabel extends Label {
      *
      * @param event
      */
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     public void onEvent(final ManagementUIEvent event) {
         if (event == ManagementUIEvent.TARGET_TABLE_FILTER || event == ManagementUIEvent.SHOW_COUNT_MESSAGE) {
             displayTargetCountStatus();
@@ -92,7 +72,7 @@ public class CountMessageLabel extends Label {
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final TargetTableEvent event) {
         if (TargetTableEvent.TargetComponentEvent.SELECT_ALL == event.getTargetComponentEvent()
                 || TargetComponentEvent.REFRESH_TARGETS == event.getTargetComponentEvent()) {
@@ -106,7 +86,7 @@ public class CountMessageLabel extends Label {
      *
      * @param event
      */
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     public void onEvent(final PinUnpinEvent event) {
         if (event == PinUnpinEvent.PIN_DISTRIBUTION
                 && managementUIState.getTargetTableFilters().getPinnedDistId().isPresent()) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/DeleteActionsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/DeleteActionsLayout.java
@@ -10,7 +10,11 @@ package org.eclipse.hawkbit.ui.management.footer;
 
 import java.util.Set;
 
+import org.eclipse.hawkbit.repository.DeploymentManagement;
+import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.repository.TagManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.TargetIdName;
 import org.eclipse.hawkbit.ui.common.DistributionSetIdName;
 import org.eclipse.hawkbit.ui.common.footer.AbstractDeleteActionsLayout;
@@ -23,17 +27,18 @@ import org.eclipse.hawkbit.ui.management.event.SaveActionWindowEvent;
 import org.eclipse.hawkbit.ui.management.event.TargetTableEvent;
 import org.eclipse.hawkbit.ui.management.event.TargetTableEvent.TargetComponentEvent;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
+import org.eclipse.hawkbit.ui.management.targettable.TargetTable;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.Table;
@@ -44,35 +49,46 @@ import com.vaadin.ui.UI;
  *
  *
  */
-@SpringComponent
-@ViewScope
 public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
 
     private static final long serialVersionUID = -8112907467821886253L;
 
-    @Autowired
-    private transient TagManagement tagManagementService;
+    private final transient TagManagement tagManagementService;
 
-    @Autowired
-    private ManagementViewAcceptCriteria managementViewAcceptCriteria;
+    private final ManagementViewAcceptCriteria managementViewAcceptCriteria;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final ManagementUIState managementUIState;
 
-    @Autowired
-    private ManangementConfirmationWindowLayout manangementConfirmationWindowLayout;
+    private final ManangementConfirmationWindowLayout manangementConfirmationWindowLayout;
 
-    @Autowired
-    private CountMessageLabel countMessageLabel;
+    private final CountMessageLabel countMessageLabel;
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    public DeleteActionsLayout(final I18N i18n, final SpPermissionChecker permChecker, final UIEventBus eventBus,
+            final UINotification notification, final TagManagement tagManagementService,
+            final ManagementViewAcceptCriteria managementViewAcceptCriteria, final ManagementUIState managementUIState,
+            final TargetManagement targetManagement, final TargetTable targetTable,
+            final DeploymentManagement deploymentManagement,
+            final DistributionSetManagement distributionSetManagement) {
+        super(i18n, permChecker, eventBus, notification);
+        this.tagManagementService = tagManagementService;
+        this.managementViewAcceptCriteria = managementViewAcceptCriteria;
+        this.managementUIState = managementUIState;
+        this.manangementConfirmationWindowLayout = new ManangementConfirmationWindowLayout(i18n, eventBus,
+                managementUIState, targetManagement, deploymentManagement, distributionSetManagement);
+        this.countMessageLabel = new CountMessageLabel(eventBus, targetManagement, i18n, managementUIState,
+                targetTable);
+
+        init();
+    }
+
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final ManagementUIEvent event) {
         if (event == ManagementUIEvent.UPDATE_COUNT) {
-            UI.getCurrent().access(() -> updateActionCount());
+            UI.getCurrent().access(this::updateActionCount);
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DragEvent event) {
         if (event == DragEvent.HIDE_DROP_HINT) {
             hideDropHints();
@@ -94,7 +110,7 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SaveActionWindowEvent event) {
         if (event != null) {
             UI.getCurrent().access(() -> {
@@ -110,7 +126,7 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final BulkUploadPopupEvent event) {
         if (BulkUploadPopupEvent.MINIMIZED == event) {
             UI.getCurrent().access(() -> enableBulkUploadStatusButton());
@@ -119,7 +135,7 @@ public class DeleteActionsLayout extends AbstractDeleteActionsLayout {
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final TargetTableEvent event) {
         if (!managementUIState.isTargetTableMaximized()) {
             if (TargetComponentEvent.BULK_TARGET_CREATED == event.getTargetComponentEvent()) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/ManangementConfirmationWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/ManangementConfirmationWindowLayout.java
@@ -33,17 +33,16 @@ import org.eclipse.hawkbit.ui.management.event.SaveActionWindowEvent;
 import org.eclipse.hawkbit.ui.management.footer.ActionTypeOptionGroupLayout.ActionTypeOption;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.google.common.collect.Maps;
 import com.vaadin.data.Item;
 import com.vaadin.data.util.IndexedContainer;
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickListener;
 import com.vaadin.ui.Table.Align;
@@ -53,8 +52,6 @@ import com.vaadin.ui.Table.Align;
  * 
  *
  */
-@SpringComponent
-@ViewScope
 public class ManangementConfirmationWindowLayout extends AbstractConfirmationWindowLayout {
 
     private static final long serialVersionUID = 2114943830055679554L;
@@ -69,22 +66,29 @@ public class ManangementConfirmationWindowLayout extends AbstractConfirmationWin
 
     private static final String TARGET_ID = "TargetId";
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final ManagementUIState managementUIState;
 
-    @Autowired
-    private transient TargetManagement targetManagement;
+    private final transient TargetManagement targetManagement;
 
-    @Autowired
-    private transient DeploymentManagement deploymentManagement;
+    private final transient DeploymentManagement deploymentManagement;
 
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
+    private final transient DistributionSetManagement distributionSetManagement;
 
-    @Autowired
-    private ActionTypeOptionGroupLayout actionTypeOptionGroupLayout;
+    private final ActionTypeOptionGroupLayout actionTypeOptionGroupLayout;
 
     private ConfirmationTab assignmnetTab;
+
+    public ManangementConfirmationWindowLayout(final I18N i18n, final UIEventBus eventBus,
+            final ManagementUIState managementUIState, final TargetManagement targetManagement,
+            final DeploymentManagement deploymentManagement,
+            final DistributionSetManagement distributionSetManagement) {
+        super(i18n, eventBus);
+        this.managementUIState = managementUIState;
+        this.targetManagement = targetManagement;
+        this.deploymentManagement = deploymentManagement;
+        this.distributionSetManagement = distributionSetManagement;
+        this.actionTypeOptionGroupLayout = new ActionTypeOptionGroupLayout(i18n);
+    }
 
     @Override
     protected Map<String, ConfirmationTab> getConfimrationTabs() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/state/ManagementUIState.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/state/ManagementUIState.java
@@ -38,11 +38,9 @@ public class ManagementUIState implements ManagmentEntityState<DistributionSetId
 
     private final transient Set<Object> expandParentActionRowId = new HashSet<>();
 
-    @Autowired
-    private DistributionTableFilters distributionTableFilters;
+    private final DistributionTableFilters distributionTableFilters;
 
-    @Autowired
-    private TargetTableFilters targetTableFilters;
+    private final TargetTableFilters targetTableFilters;
 
     private final Map<TargetIdName, DistributionSetIdName> assignedList = new HashMap<>();
 
@@ -59,7 +57,7 @@ public class ManagementUIState implements ManagmentEntityState<DistributionSetId
     // Contains list of ID and Names of all the selected Targets
     private Set<TargetIdName> selectedTargetIdName = Collections.emptySet();
 
-    private boolean targetTagFilterClosed = false;
+    private boolean targetTagFilterClosed;
 
     private boolean distTagFilterClosed = true;
 
@@ -67,20 +65,20 @@ public class ManagementUIState implements ManagmentEntityState<DistributionSetId
 
     private final AtomicLong targetsCountAll = new AtomicLong();
 
-    private boolean dsTableMaximized = Boolean.FALSE;
+    private boolean dsTableMaximized;
 
     // Contains ID and NAme of last selected target
     private DistributionSetIdName lastSelectedDsIdName;
     // Contains list of ID and Names of all the selected Targets
     private Set<DistributionSetIdName> selectedDsIdName = Collections.emptySet();
 
-    private boolean targetTableMaximized = Boolean.FALSE;
+    private boolean targetTableMaximized;
 
-    private boolean actionHistoryMaximized = Boolean.FALSE;
+    private boolean actionHistoryMaximized;
 
-    private boolean noDataAvilableTarget = Boolean.FALSE;
+    private boolean noDataAvilableTarget;
 
-    private boolean noDataAvailableDistribution = Boolean.FALSE;
+    private boolean noDataAvailableDistribution;
 
     private final Set<String> canceledTargetName = new HashSet<>();
 
@@ -89,6 +87,13 @@ public class ManagementUIState implements ManagmentEntityState<DistributionSetId
     private boolean bulkUploadWindowMinimised;
 
     private DistributionSetIdName lastSelectedDistribution;
+
+    @Autowired
+    ManagementUIState(final DistributionTableFilters distributionTableFilters,
+            final TargetTableFilters targetTableFilters) {
+        this.distributionTableFilters = distributionTableFilters;
+        this.targetTableFilters = targetTableFilters;
+    }
 
     /**
      * @return the lastSelectedDistribution

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
@@ -95,25 +95,14 @@ public class BulkUploadHandler extends CustomComponent
     private long successfullTargetCount;
 
     private final transient Executor executor;
-    private transient EventBus.SessionEventBus eventBus;
-
-    final TargetBulkUpdateWindowLayout targetBulkUpdateWindowLayout;
+    private final transient EventBus.UIEventBus eventBus;
 
     private transient EntityFactory entityFactory;
     private final UI uiInstance;
 
-    /**
-     *
-     * @param targetBulkUpdateWindowLayout
-     * @param targetManagement
-     * @param managementUIState
-     * @param deploymentManagement
-     * @param i18n
-     */
-    public BulkUploadHandler(final TargetBulkUpdateWindowLayout targetBulkUpdateWindowLayout,
+    BulkUploadHandler(final TargetBulkUpdateWindowLayout targetBulkUpdateWindowLayout,
             final TargetManagement targetManagement, final ManagementUIState managementUIState,
             final DeploymentManagement deploymentManagement, final I18N i18n, final UI uiInstance) {
-        this.targetBulkUpdateWindowLayout = targetBulkUpdateWindowLayout;
         this.uiInstance = uiInstance;
         this.comboBox = targetBulkUpdateWindowLayout.getDsNamecomboBox();
         this.descTextArea = targetBulkUpdateWindowLayout.getDescTextArea();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetAddUpdateWindowLayout.java
@@ -27,15 +27,12 @@ import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.data.validator.RegexpValidator;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.CustomComponent;
 import com.vaadin.ui.FormLayout;
 import com.vaadin.ui.TextArea;
@@ -45,26 +42,21 @@ import com.vaadin.ui.Window;
 /**
  * Add and Update Target.
  */
-@SpringComponent
-@ViewScope
 public class TargetAddUpdateWindowLayout extends CustomComponent {
 
     private static final long serialVersionUID = -6659290471705262389L;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient TargetManagement targetManagement;
+    private final transient TargetManagement targetManagement;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private transient UINotification uINotification;
+    private final UINotification uINotification;
 
-    @Autowired
-    private transient EntityFactory entityFactory;
+    private final transient EntityFactory entityFactory;
+
+    private final TargetTable targetTable;
 
     private TextField controllerIDTextField;
     private TextField nameTextField;
@@ -73,6 +65,19 @@ public class TargetAddUpdateWindowLayout extends CustomComponent {
     private String controllerId;
     private FormLayout formLayout;
     private CommonDialogWindow window;
+
+    TargetAddUpdateWindowLayout(final I18N i18n, final TargetManagement targetManagement, final UIEventBus eventBus,
+            final UINotification uINotification, final EntityFactory entityFactory, final TargetTable targetTable) {
+        this.i18n = i18n;
+        this.targetManagement = targetManagement;
+        this.eventBus = eventBus;
+        this.uINotification = uINotification;
+        this.entityFactory = entityFactory;
+        this.targetTable = targetTable;
+        createRequiredComponents();
+        buildLayout();
+        setCompositionRoot(formLayout);
+    }
 
     /**
      * Save or update the target.
@@ -92,15 +97,6 @@ public class TargetAddUpdateWindowLayout extends CustomComponent {
             return editTarget || !isDuplicate();
         }
 
-    }
-
-    /**
-     * Initialize the Add Update Window Component for Target.
-     */
-    public void init() {
-        createRequiredComponents();
-        buildLayout();
-        setCompositionRoot(formLayout);
     }
 
     private void createRequiredComponents() {
@@ -151,7 +147,7 @@ public class TargetAddUpdateWindowLayout extends CustomComponent {
         /* save new target */
         final Target newTarget = targetManagement.createTarget(
                 entityFactory.target().create().controllerId(newControllerId).name(newName).description(newDesc));
-        final TargetTable targetTable = SpringContextHelper.getBean(TargetTable.class);
+
         final Set<TargetIdName> s = new HashSet<>();
         s.add(newTarget.getTargetIdName());
         targetTable.setValue(s);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkTokenTags.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkTokenTags.java
@@ -10,50 +10,38 @@ package org.eclipse.hawkbit.ui.management.targettable;
 
 import java.util.Map;
 
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 import org.eclipse.hawkbit.ui.common.tagdetails.AbstractTargetTagToken;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 /**
  * Target tag layout in bulk upload popup.
  *
  */
-@SpringComponent
-@ViewScope
 public class TargetBulkTokenTags extends AbstractTargetTagToken {
     private static final long serialVersionUID = 4159616629565523717L;
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see hawkbit.server.ui.common.tagdetails.TargetTagToken#assignTag(java.
-     * lang.String)
-     */
+    TargetBulkTokenTags(final SpPermissionChecker checker, final I18N i18n, final UINotification uinotification,
+            final UIEventBus eventBus, final ManagementUIState managementUIState, final TagManagement tagManagement) {
+        super(checker, i18n, uinotification, eventBus, managementUIState, tagManagement);
+    }
+
     @Override
     protected void assignTag(final String tagNameSelected) {
         managementUIState.getTargetTableFilters().getBulkUpload().getAssignedTagNames().add(tagNameSelected);
 
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see hawkbit.server.ui.common.tagdetails.TargetTagToken#unassignTag(java.
-     * lang.String)
-     */
     @Override
     protected void unassignTag(final String tagName) {
         managementUIState.getTargetTableFilters().getBulkUpload().getAssignedTagNames().remove(tagName);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see hawkbit.server.ui.common.tagdetails.AbstractTagToken#getTagStyleName
-     * ()
-     */
     @Override
     protected String getTagStyleName() {
         return "target-tag-";
@@ -64,12 +52,6 @@ public class TargetBulkTokenTags extends AbstractTargetTagToken {
         return i18n.get("combo.type.tag.name");
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.common.tagdetails.AbstractTagToken#
-     * hasUpdatePermission()
-     */
     @Override
     protected Boolean isToggleTagAssignmentAllowed() {
         return checker.hasCreateTargetPermission();
@@ -87,12 +69,6 @@ public class TargetBulkTokenTags extends AbstractTargetTagToken {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.common.tagdetails.AbstractTagToken#
-     * populateContainer()
-     */
     @Override
     protected void populateContainer() {
         container.removeAllItems();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.hawkbit.repository.DeploymentManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.DistributionSetIdName;
@@ -30,19 +32,18 @@ import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.tokenfield.TokenField;
 
 import com.google.common.collect.Maps;
 import com.vaadin.data.Container;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.shared.ui.combobox.FilteringMode;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.ComboBox;
@@ -59,34 +60,21 @@ import com.vaadin.ui.themes.ValoTheme;
 
 /**
  * Bulk target upload layout.
- * 
- *
- *
  */
-@SpringComponent
-@ViewScope
 public class TargetBulkUpdateWindowLayout extends CustomComponent {
+    private final I18N i18n;
 
-    @Autowired
-    private I18N i18n;
+    private final transient TargetManagement targetManagement;
 
-    @Autowired
-    private transient TargetManagement targetManagement;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final TargetBulkTokenTags targetBulkTokenTags;
 
-    @Autowired
-    private TargetBulkTokenTags targetBulkTokenTags;
+    private final ManagementUIState managementUIState;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final transient DeploymentManagement deploymentManagement;
 
-    @Autowired
-    private transient DeploymentManagement deploymentManagement;
-
-    @Autowired
-    private transient UiProperties uiproperties;
+    private final UiProperties uiproperties;
 
     private static final long serialVersionUID = -6659290471705262389L;
     private VerticalLayout tokenVerticalLayout;
@@ -102,10 +90,19 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
     private Button minimizeButton;
     private Button closeButton;
 
-    /**
-     * Initialize the Add Update Window Component for Target.
-     */
-    public void init() {
+    TargetBulkUpdateWindowLayout(final I18N i18n, final TargetManagement targetManagement, final UIEventBus eventBus,
+            final ManagementUIState managementUIState, final DeploymentManagement deploymentManagement,
+            final UiProperties uiproperties, final SpPermissionChecker checker, final UINotification uinotification,
+            final TagManagement tagManagement) {
+        this.i18n = i18n;
+        this.targetManagement = targetManagement;
+        this.eventBus = eventBus;
+        this.targetBulkTokenTags = new TargetBulkTokenTags(checker, i18n, uinotification, eventBus, managementUIState,
+                tagManagement);
+        this.managementUIState = managementUIState;
+        this.deploymentManagement = deploymentManagement;
+        this.uiproperties = uiproperties;
+
         createRequiredComponents();
         buildLayout();
         setImmediate(true);
@@ -158,9 +155,8 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
     }
 
     private Button getMinimizeButton() {
-        final Button minimizeBtn = SPUIComponentProvider.getButton(
-                UIComponentIdProvider.BULK_UPLOAD_MINIMIZE_BUTTON_ID, "", "", "", true, FontAwesome.MINUS,
-                SPUIButtonStyleSmallNoBorder.class);
+        final Button minimizeBtn = SPUIComponentProvider.getButton(UIComponentIdProvider.BULK_UPLOAD_MINIMIZE_BUTTON_ID,
+                "", "", "", true, FontAwesome.MINUS, SPUIButtonStyleSmallNoBorder.class);
         minimizeBtn.addStyleName(ValoTheme.BUTTON_BORDERLESS);
         minimizeBtn.addClickListener(event -> minimizeWindow());
         minimizeBtn.setEnabled(false);
@@ -412,7 +408,7 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
     /**
      * @return the eventBus
      */
-    public EventBus.SessionEventBus getEventBus() {
+    public EventBus.UIEventBus getEventBus() {
         return eventBus;
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
@@ -11,6 +11,10 @@ package org.eclipse.hawkbit.ui.management.targettable;
 import java.net.URI;
 
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.Target;
@@ -20,16 +24,16 @@ import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.management.event.TargetTableEvent;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPDateTimeUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.shared.ui.label.ContentMode;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.HorizontalLayout;
@@ -44,28 +48,28 @@ import com.vaadin.ui.themes.ValoTheme;
 /**
  * Target details layout.
  */
-@SpringComponent
-@ViewScope
 public class TargetDetails extends AbstractTableDetailsLayout<Target> {
 
     private static final long serialVersionUID = 4571732743399605843L;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final TargetTagToken targetTagToken;
 
-    @Autowired
-    private TargetAddUpdateWindowLayout targetAddUpdateWindowLayout;
-
-    @Autowired
-    private TargetTagToken targetTagToken;
+    private final TargetAddUpdateWindowLayout targetAddUpdateWindowLayout;
 
     private VerticalLayout assignedDistLayout;
     private VerticalLayout installedDistLayout;
 
-    @Override
-    public void init() {
-        super.init();
-        targetAddUpdateWindowLayout.init();
+    TargetDetails(final I18N i18n, final UIEventBus eventBus, final SpPermissionChecker permissionChecker,
+            final ManagementUIState managementUIState, final UINotification uiNotification,
+            final TagManagement tagManagement, final TargetManagement targetManagement,
+            final EntityFactory entityFactory, final TargetTable targetTable) {
+        super(i18n, eventBus, permissionChecker, managementUIState);
+        this.targetTagToken = new TargetTagToken(permissionChecker, i18n, uiNotification, eventBus, managementUIState,
+                tagManagement, targetManagement);
+        targetAddUpdateWindowLayout = new TargetAddUpdateWindowLayout(i18n, targetManagement, eventBus, uiNotification,
+                entityFactory, targetTable);
+        addTabs(detailsTab);
+        restoreState();
     }
 
     @Override
@@ -237,7 +241,7 @@ public class TargetDetails extends AbstractTableDetailsLayout<Target> {
         return getPermissionChecker().hasUpdateTargetPermission();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final TargetTableEvent targetTableEvent) {
         onBaseEntityEvent(targetTableEvent);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
@@ -59,18 +59,20 @@ import org.eclipse.hawkbit.ui.push.TargetDeletedEventContainer;
 import org.eclipse.hawkbit.ui.push.TargetUpdatedEventContainer;
 import org.eclipse.hawkbit.ui.utils.AssignInstalledDSTooltipGenerator;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPDateTimeUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.TableColumn;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -83,8 +85,6 @@ import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.shared.ui.label.ContentMode;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.DragAndDropWrapper;
@@ -96,8 +96,6 @@ import com.vaadin.ui.themes.ValoTheme;
 /**
  * Concrete implementation of Target table.
  */
-@SpringComponent
-@ViewScope
 public class TargetTable extends AbstractTable<Target, TargetIdName> {
 
     private static final Logger LOG = LoggerFactory.getLogger(TargetTable.class);
@@ -105,28 +103,34 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
     private static final long serialVersionUID = -2300392868806614568L;
     private static final int PROPERTY_DEPT = 3;
 
-    @Autowired
-    private transient TargetManagement targetManagement;
+    private final transient TargetManagement targetManagement;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final SpPermissionChecker permChecker;
 
-    @Autowired
-    private SpPermissionChecker permChecker;
+    private final ManagementViewAcceptCriteria managementViewAcceptCriteria;
 
-    @Autowired
-    private ManagementViewAcceptCriteria managementViewAcceptCriteria;
+    private final ManagementUIState managementUIState;
 
     private Button targetPinnedBtn;
-    private Boolean isTargetPinned = Boolean.FALSE;
+    private boolean isTargetPinned;
 
-    @Override
-    protected void init() {
-        super.init();
+    public TargetTable(final UIEventBus eventBus, final I18N i18n, final UINotification notification,
+            final TargetManagement targetManagement, final ManagementUIState managementUIState,
+            final SpPermissionChecker permChecker, final ManagementViewAcceptCriteria managementViewAcceptCriteria) {
+        super(eventBus, i18n, notification);
+        this.targetManagement = targetManagement;
+        this.permChecker = permChecker;
+        this.managementViewAcceptCriteria = managementViewAcceptCriteria;
+        this.managementUIState = managementUIState;
+
         setItemDescriptionGenerator(new AssignInstalledDSTooltipGenerator());
+
+        addNewContainerDS();
+        setColumnProperties();
+        setDataAvailable(getContainerDataSource().size() != 0);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onTargetDeletedEvents(final TargetDeletedEventContainer eventContainer) {
         final LazyQueryContainer targetContainer = (LazyQueryContainer) getContainerDataSource();
         final List<Object> visibleItemIds = (List<Object>) getVisibleItemIds();
@@ -149,7 +153,7 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
         reSelectItemsAfterDeletionEvent();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onCancelTargetAssignmentEvents(final CancelTargetAssignmentEventContainer eventContainer) {
         // workaround until push is available for action
         // history, re-select
@@ -158,7 +162,7 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
         reselectTargetIfSelectedInStream(eventContainer.getEvents().stream().map(event -> event.getEntity()));
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onTargetUpdatedEvents(final TargetUpdatedEventContainer eventContainer) {
         final LazyQueryContainer targetContainer = (LazyQueryContainer) getContainerDataSource();
         @SuppressWarnings("unchecked")
@@ -185,12 +189,12 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
                 target -> eventBus.publish(this, new TargetTableEvent(BaseEntityEventType.SELECTED_ENTITY, target)));
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onTargetCreatedEvents(final TargetCreatedEventContainer holder) {
         refreshTargets();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DragEvent dragEvent) {
         if (dragEvent == DragEvent.TARGET_TAG_DRAG || dragEvent == DragEvent.DISTRIBUTION_DRAG) {
             UI.getCurrent().access(() -> addStyleName(SPUIStyleDefinitions.SHOW_DROP_HINT_TABLE));
@@ -199,7 +203,7 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
         }
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final PinUnpinEvent pinUnpinEvent) {
         UI.getCurrent().access(() -> {
             if (pinUnpinEvent == PinUnpinEvent.PIN_DISTRIBUTION) {
@@ -212,7 +216,7 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
         });
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void addOrEditEvent(final TargetAddUpdateWindowEvent targetUIEvent) {
         if (BaseEntityEventType.UPDATED_ENTITY != targetUIEvent.getEventType()) {
             return;
@@ -220,7 +224,7 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
         UI.getCurrent().access(() -> updateTarget(targetUIEvent.getEntity()));
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final TargetFilterEvent filterEvent) {
         UI.getCurrent().access(() -> {
             if (checkFilterEvent(filterEvent)) {
@@ -230,7 +234,7 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
         });
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final ManagementUIEvent managementUIEvent) {
         UI.getCurrent().access(() -> {
             if (managementUIEvent == ManagementUIEvent.UNASSIGN_TARGET_TAG
@@ -240,7 +244,7 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
         });
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final SaveActionWindowEvent event) {
         if (event == SaveActionWindowEvent.SAVED_ASSIGNMENTS) {
             refreshTablecontainer();
@@ -253,7 +257,7 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
         selectRow();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final TargetTableEvent event) {
         onBaseEntityEvent(event);
     }
@@ -539,8 +543,8 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
     }
 
     private void tagAssignment(final DragAndDropEvent event) {
-        final List<String> targetList = getDraggedTargetList(event).stream()
-                .map(targetIdName -> targetIdName.getControllerId()).collect(Collectors.toList());
+        final List<String> targetList = getDraggedTargetList(event).stream().map(TargetIdName::getControllerId)
+                .collect(Collectors.toList());
 
         final String targTagName = HawkbitCommonUtil.removePrefix(event.getTransferable().getSourceComponent().getId(),
                 SPUIDefinitions.TARGET_TAG_ID_PREFIXS);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableLayout.java
@@ -8,43 +8,48 @@
  */
 package org.eclipse.hawkbit.ui.management.targettable;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.DeploymentManagement;
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.table.AbstractTableLayout;
+import org.eclipse.hawkbit.ui.management.event.ManagementViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.management.event.TargetTableEvent;
 import org.eclipse.hawkbit.ui.management.event.TargetTableEvent.TargetComponentEvent;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.vaadin.spring.events.EventBus;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 /**
  * Target table layout.
  */
-@SpringComponent
-@ViewScope
 public class TargetTableLayout extends AbstractTableLayout {
 
     private static final long serialVersionUID = 2248703121998709112L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private TargetDetails targetDetails;
+    private final TargetDetails targetDetails;
 
-    @Autowired
-    private TargetTableHeader targetTableHeader;
+    private final TargetTableHeader targetTableHeader;
 
-    @Autowired
-    private TargetTable targetTable;
-
-    /**
-     * Initialize the filter layout.
-     */
-    @PostConstruct
-    void init() {
+    public TargetTableLayout(final UIEventBus eventBus, final TargetTable targetTable,
+            final TargetManagement targetManagement, final EntityFactory entityFactory, final I18N i18n,
+            final UIEventBus eventbus, final UINotification notification, final ManagementUIState managementUIState,
+            final ManagementViewAcceptCriteria managementViewAcceptCriteria,
+            final DeploymentManagement deploymentManagement, final UiProperties uiproperties,
+            final SpPermissionChecker permissionChecker, final UINotification uinotification,
+            final TagManagement tagManagement) {
+        this.eventBus = eventBus;
+        this.targetDetails = new TargetDetails(i18n, eventbus, permissionChecker, managementUIState, uinotification,
+                tagManagement, targetManagement, entityFactory, targetTable);
+        this.targetTableHeader = new TargetTableHeader(i18n, permissionChecker, eventBus, notification,
+                managementUIState, managementViewAcceptCriteria, targetManagement, deploymentManagement, uiproperties,
+                eventbus, entityFactory, uinotification, tagManagement, targetTable);
 
         super.init(targetTableHeader, targetTable, targetDetails);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/AbstractTargetTagFilterLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/AbstractTargetTagFilterLayout.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.ui.management.targettag;
 
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterHeader;
+import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 
 import com.vaadin.ui.Alignment;
@@ -17,23 +18,25 @@ import com.vaadin.ui.VerticalLayout;
 /**
  * Parent class for custom target filter button layout.
  * 
- *
- * 
  */
 public abstract class AbstractTargetTagFilterLayout extends VerticalLayout {
 
     private static final long serialVersionUID = 9190616426688385851L;
 
-    private AbstractFilterHeader filterHeader;
+    private final AbstractFilterHeader filterHeader;
 
-    private MultipleTargetFilter multipleFilterTabs;
+    private final MultipleTargetFilter multipleFilterTabs;
+
+    protected final ManagementUIState managementUIState;
 
     /**
      * Initialize the artifact details layout.
      */
-    protected void init(final AbstractFilterHeader filterHeader, final MultipleTargetFilter multipleFilterTabs) {
+    protected AbstractTargetTagFilterLayout(final AbstractFilterHeader filterHeader,
+            final MultipleTargetFilter multipleFilterTabs, final ManagementUIState managementUIState) {
         this.filterHeader = filterHeader;
         this.multipleFilterTabs = multipleFilterTabs;
+        this.managementUIState = managementUIState;
         buildLayout();
         restoreState();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CreateUpdateTargetTagLayoutWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CreateUpdateTargetTagLayoutWindow.java
@@ -12,6 +12,9 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.util.List;
 
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 import org.eclipse.hawkbit.ui.colorpicker.ColorPickerConstants;
 import org.eclipse.hawkbit.ui.colorpicker.ColorPickerHelper;
@@ -19,37 +22,41 @@ import org.eclipse.hawkbit.ui.layouts.AbstractCreateUpdateTagLayout;
 import org.eclipse.hawkbit.ui.push.TargetTagCreatedEventContainer;
 import org.eclipse.hawkbit.ui.push.TargetTagDeletedEventContainer;
 import org.eclipse.hawkbit.ui.push.TargetTagUpdatedEventContainer;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 
 /**
  *
  * Class for Create / Update Tag Layout of target
  */
-@SpringComponent
-@ViewScope
 public class CreateUpdateTargetTagLayoutWindow extends AbstractCreateUpdateTagLayout<TargetTag> {
 
     private static final long serialVersionUID = 2446682350481560235L;
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    public CreateUpdateTargetTagLayoutWindow(final I18N i18n, final TagManagement tagManagement,
+            final EntityFactory entityFactory, final UIEventBus eventBus, final SpPermissionChecker permChecker,
+            final UINotification uiNotification) {
+        super(i18n, tagManagement, entityFactory, eventBus, permChecker, uiNotification);
+    }
+
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onEventTargetTagCreated(final TargetTagCreatedEventContainer eventContainer) {
         populateTagNameCombo();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onEventTargetDeletedEvent(final TargetTagDeletedEventContainer eventContainer) {
         populateTagNameCombo();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onEventTargetTagUpdateEvent(final TargetTagUpdatedEventContainer eventContainer) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CustomTargetTagFilterButtonClick.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CustomTargetTagFilterButtonClick.java
@@ -16,53 +16,39 @@ import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterSingleButtonClic
 import org.eclipse.hawkbit.ui.management.event.TargetFilterEvent;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
 
 /**
  * Single button click behaviour of custom target filter buttons layout.
  *
- *
- *
  */
-@SpringComponent
-@ViewScope
 public class CustomTargetTagFilterButtonClick extends AbstractFilterSingleButtonClick implements Serializable {
 
     private static final long serialVersionUID = -6173433602055291533L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private transient ManagementUIState managementUIState;
+    private final ManagementUIState managementUIState;
 
-    @Autowired
-    private transient TargetFilterQueryManagement targetFilterQueryManagement;
+    private final transient TargetFilterQueryManagement targetFilterQueryManagement;
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.eclipse.hawkbit.server.ui.common.filterlayout.
-     * AbstractFilterButtonClickBehaviour#filterUnClicked (com.vaadin.ui.Button)
-     */
+    public CustomTargetTagFilterButtonClick(final UIEventBus eventBus, final ManagementUIState managementUIState,
+            final TargetFilterQueryManagement targetFilterQueryManagement) {
+        this.eventBus = eventBus;
+        this.managementUIState = managementUIState;
+        this.targetFilterQueryManagement = targetFilterQueryManagement;
+    }
+
     @Override
     protected void filterUnClicked(final Button clickedButton) {
         this.managementUIState.getTargetTableFilters().setTargetFilterQuery(null);
         this.eventBus.publish(this, TargetFilterEvent.REMOVE_FILTER_BY_TARGET_FILTER_QUERY);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see hawkbit.server.ui.layouts.SPFilterButtonClickBehaviour#filterClicked
-     * (com.vaadin.ui.Button )
-     */
     @Override
     protected void filterClicked(final Button clickedButton) {
         final TargetFilterQuery targetFilterQuery = this.targetFilterQueryManagement

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/FilterByStatusLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/FilterByStatusLayout.java
@@ -8,9 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.management.targettag;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
@@ -21,14 +18,12 @@ import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIButtonDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
@@ -40,19 +35,14 @@ import com.vaadin.ui.VerticalLayout;
  *
  *
  */
-@SpringComponent
-@ViewScope
 public class FilterByStatusLayout extends VerticalLayout implements Button.ClickListener {
     private static final long serialVersionUID = -6930348859189929850L;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final ManagementUIState managementUIState;
 
     private static final String OVERDUE_CAPTION = "overdue";
 
@@ -62,19 +52,24 @@ public class FilterByStatusLayout extends VerticalLayout implements Button.Click
     private Button error;
     private Button registered;
     private Button overdue;
-    private Boolean unknownBtnClicked = false;
-    private Boolean errorBtnClicked = false;
-    private Boolean pendingBtnClicked = false;
-    private Boolean inSyncBtnClicked = false;
-    private Boolean registeredBtnClicked = false;
-    private Boolean overdueBtnClicked = false;
+    private boolean unknownBtnClicked;
+    private boolean errorBtnClicked;
+    private boolean pendingBtnClicked;
+    private boolean inSyncBtnClicked;
+    private boolean registeredBtnClicked;
+    private boolean overdueBtnClicked;
     private Button buttonClicked;
     private static final String BTN_CLICKED = "btnClicked";
+
+    FilterByStatusLayout(final I18N i18n, final UIEventBus eventBus, final ManagementUIState managementUIState) {
+        this.i18n = i18n;
+        this.eventBus = eventBus;
+        this.managementUIState = managementUIState;
+    }
 
     /**
      * Initialize the Status Layout Component.
      */
-    @PostConstruct
     public void init() {
         getFilterTargetsStatusLayout();
         restorePreviousState();
@@ -296,7 +291,7 @@ public class FilterByStatusLayout extends VerticalLayout implements Button.Click
 
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final ManagementUIEvent event) {
         if (event == ManagementUIEvent.RESET_SIMPLE_FILTERS && isStatusFilterApplied()) {
             removeClickedStyle();
@@ -329,10 +324,5 @@ public class FilterByStatusLayout extends VerticalLayout implements Button.Click
 
     private boolean isErrorOrRegisteredBtnClicked() {
         return errorBtnClicked || registeredBtnClicked;
-    }
-
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/MultipleTargetFilter.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/MultipleTargetFilter.java
@@ -8,22 +8,23 @@
  */
 package org.eclipse.hawkbit.ui.management.targettag;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmallNoBorder;
 import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
+import org.eclipse.hawkbit.ui.management.event.ManagementViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Accordion;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
@@ -36,56 +37,49 @@ import com.vaadin.ui.themes.ValoTheme;
 
 /**
  * Target filter tabsheet with 'simple' and 'complex' filter options.
- * 
- *
- *
  */
-@SpringComponent
-@ViewScope
 public class MultipleTargetFilter extends Accordion implements SelectedTabChangeListener {
 
     private static final long serialVersionUID = -2887693289126893943L;
 
-    @Autowired
-    private TargetTagFilterButtons filterByButtons;
+    private final TargetTagFilterButtons filterByButtons;
+    private final TargetFilterQueryButtons targetFilterQueryButtonsTab;
+    private final FilterByStatusLayout filterByStatusFotter;
+    private final CustomTargetTagFilterButtonClick customTargetTagFilterButtonClick;
+    private final CreateUpdateTargetTagLayoutWindow createUpdateTargetTagLayout;
+    private final SpPermissionChecker permChecker;
+    private final ManagementUIState managementUIState;
+    private final I18N i18n;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private TargetTagFilterButtonClick filterButtonClick;
-
-    @Autowired
-    private TargetFilterQueryButtons targetFilterQueryButtonsTab;
-
-    @Autowired
-    private FilterByStatusLayout filterByStatusFotter;
-
-    @Autowired
-    private CustomTargetTagFilterButtonClick customTargetTagFilterButtonClick;
-
-    @Autowired
-    private CreateUpdateTargetTagLayoutWindow createUpdateTargetTagLayout;
-
-    @Autowired
-    private SpPermissionChecker permChecker;
-
-    @Autowired
-    private ManagementUIState managementUIState;
-
-    @Autowired
-    private I18N i18n;
-
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
-
-    VerticalLayout simpleFilterTab;
+    private VerticalLayout simpleFilterTab;
 
     private Button config;
+
+    MultipleTargetFilter(final CreateUpdateTargetTagLayoutWindow createUpdateTargetTagLayout,
+            final SpPermissionChecker permChecker, final ManagementUIState managementUIState, final I18N i18n,
+            final UIEventBus eventBus, final ManagementViewAcceptCriteria managementViewAcceptCriteria,
+            final UINotification notification, final EntityFactory entityFactory,
+            final TargetManagement targetManagement, final TargetFilterQueryManagement targetFilterQueryManagement) {
+        this.filterByButtons = new TargetTagFilterButtons(eventBus, managementUIState, managementViewAcceptCriteria,
+                i18n, notification, permChecker, entityFactory, targetManagement);
+        this.targetFilterQueryButtonsTab = new TargetFilterQueryButtons(managementUIState, eventBus);
+        this.filterByStatusFotter = new FilterByStatusLayout(i18n, eventBus, managementUIState);
+        this.customTargetTagFilterButtonClick = new CustomTargetTagFilterButtonClick(eventBus, managementUIState,
+                targetFilterQueryManagement);
+        this.createUpdateTargetTagLayout = createUpdateTargetTagLayout;
+        this.permChecker = permChecker;
+        this.managementUIState = managementUIState;
+        this.i18n = i18n;
+        this.eventBus = eventBus;
+        buildComponents();
+    }
 
     /**
      * Intialize component.
      */
-    @PostConstruct
-    public void init() {
-        filterByButtons.init(filterButtonClick);
+    private void buildComponents() {
+        filterByStatusFotter.init();
 
         filterByButtons.addStyleName(SPUIStyleDefinitions.NO_TOP_BORDER);
         targetFilterQueryButtonsTab.init(customTargetTagFilterButtonClick);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetFilterQueryButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetFilterQueryButtons.java
@@ -12,8 +12,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUITagButtonStyle;
@@ -22,17 +20,15 @@ import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.data.Item;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Table;
 import com.vaadin.ui.themes.ValoTheme;
@@ -40,26 +36,27 @@ import com.vaadin.ui.themes.ValoTheme;
 /**
  * Target filter query{#link {@link TargetFilterQuery} buttons layout.
  */
-@SpringComponent
-@ViewScope
 public class TargetFilterQueryButtons extends Table {
     private static final long serialVersionUID = 9188095103191937850L;
     protected static final String FILTER_BUTTON_COLUMN = "filterButton";
 
-    @Autowired
-    ManagementUIState managementUIState;
+    private final ManagementUIState managementUIState;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private transient EventBus.UIEventBus eventBus;
 
-    CustomTargetTagFilterButtonClick customTargetTagFilterButtonClick;
+    private CustomTargetTagFilterButtonClick customTargetTagFilterButtonClick;
+
+    TargetFilterQueryButtons(final ManagementUIState managementUIState, final UIEventBus eventBus) {
+        this.managementUIState = managementUIState;
+        this.eventBus = eventBus;
+    }
 
     /**
      * initializing table.
      * 
      * @param filterButtonClickBehaviour
      */
-    public void init(final CustomTargetTagFilterButtonClick filterButtonClickBehaviour) {
+    void init(final CustomTargetTagFilterButtonClick filterButtonClickBehaviour) {
         this.customTargetTagFilterButtonClick = filterButtonClickBehaviour;
         createTable();
         eventBus.subscribe(this);
@@ -147,15 +144,10 @@ public class TargetFilterQueryButtons extends Table {
         setColumnHeaderMode(ColumnHeaderMode.HIDDEN);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final ManagementUIEvent event) {
         if (event == ManagementUIEvent.RESET_TARGET_FILTER_QUERY) {
             customTargetTagFilterButtonClick.clearAppliedTargetFilterQuery();
         }
-    }
-
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterButtonClick.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterButtonClick.java
@@ -15,38 +15,27 @@ import org.eclipse.hawkbit.ui.management.event.TargetFilterEvent;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 
 /**
  * Multi button click behaviour of filter buttons layout.
- * 
- *
- * 
  */
-
-@SpringComponent
-@ViewScope
 public class TargetTagFilterButtonClick extends AbstractFilterMultiButtonClick implements Serializable {
 
     private static final long serialVersionUID = -6173433602055291533L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final ManagementUIState managementUIState;
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.common.filterlayout.
-     * AbstractFilterButtonClickBehaviour#filterUnClicked (com.vaadin.ui.Button)
-     */
+    TargetTagFilterButtonClick(final UIEventBus eventBus, final ManagementUIState managementUIState) {
+        this.eventBus = eventBus;
+        this.managementUIState = managementUIState;
+    }
+
     @Override
     protected void filterUnClicked(final Button clickedButton) {
         if (clickedButton.getData().equals(SPUIDefinitions.NO_TAG_BUTTON_ID)) {
@@ -64,12 +53,6 @@ public class TargetTagFilterButtonClick extends AbstractFilterMultiButtonClick i
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.hawkbit.server.ui.common.filterlayout.
-     * AbstractFilterButtonClickBehaviour#filterClicked (com.vaadin.ui.Button)
-     */
     @Override
     protected void filterClicked(final Button clickedButton) {
         if (clickedButton.getData().equals(SPUIDefinitions.NO_TAG_BUTTON_ID)) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterButtons.java
@@ -34,9 +34,9 @@ import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -46,8 +46,6 @@ import com.vaadin.event.dd.DragAndDropEvent;
 import com.vaadin.event.dd.DropHandler;
 import com.vaadin.event.dd.acceptcriteria.AcceptCriterion;
 import com.vaadin.server.Page;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.DragAndDropWrapper;
 import com.vaadin.ui.Table;
@@ -56,50 +54,42 @@ import com.vaadin.ui.UI;
 /**
  * Target Tag filter buttons table.
  */
-@SpringComponent
-@ViewScope
 public class TargetTagFilterButtons extends AbstractFilterButtons {
     private static final String NO_TAG = "NO TAG";
 
     private static final long serialVersionUID = 1L;
 
-    @Autowired
-    private ManagementUIState managementUIState;
+    private final ManagementUIState managementUIState;
 
-    @Autowired
-    private ManagementViewAcceptCriteria managementViewAcceptCriteria;
+    private final ManagementViewAcceptCriteria managementViewAcceptCriteria;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient UINotification notification;
+    private final UINotification notification;
 
-    @Autowired
-    private SpPermissionChecker permChecker;
+    private final SpPermissionChecker permChecker;
 
-    @Autowired
-    private transient EntityFactory entityFactory;
+    private final transient EntityFactory entityFactory;
 
-    @Autowired
-    private transient TargetManagement targetManagement;
+    private final transient TargetManagement targetManagement;
 
-    TargetTagFilterButtonClick filterButtonClickBehaviour;
+    TargetTagFilterButtons(final UIEventBus eventBus, final ManagementUIState managementUIState,
+            final ManagementViewAcceptCriteria managementViewAcceptCriteria, final I18N i18n,
+            final UINotification notification, final SpPermissionChecker permChecker, final EntityFactory entityFactory,
+            final TargetManagement targetManagement) {
+        super(eventBus, new TargetTagFilterButtonClick(eventBus, managementUIState));
+        this.managementUIState = managementUIState;
+        this.managementViewAcceptCriteria = managementViewAcceptCriteria;
+        this.i18n = i18n;
+        this.notification = notification;
+        this.permChecker = permChecker;
+        this.entityFactory = entityFactory;
+        this.targetManagement = targetManagement;
 
-    /**
-     * Initialize component.
-     * 
-     * @param filterButtonClickBehaviour
-     *            the clickable behaviour.
-     */
-
-    public void init(final TargetTagFilterButtonClick filterButtonClickBehaviour) {
-        this.filterButtonClickBehaviour = filterButtonClickBehaviour;
-        super.init(filterButtonClickBehaviour);
         addNewTargetTag(entityFactory.tag().create().name(NO_TAG).build());
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final DragEvent dragEvent) {
         /*
          * this has some flickering issue for addStyleName(
@@ -283,21 +273,21 @@ public class TargetTagFilterButtons extends AbstractFilterButtons {
         return SPUIDefinitions.TARGET_TAG_ID_PREFIXS;
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onEvent(final TargetTagUpdatedEventContainer eventContainer) {
         refreshContainer();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onEventTargetTagCreated(final TargetTagCreatedEventContainer eventContainer) {
         refreshContainer();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     // Exception squid:S1172 - event not needed
     @SuppressWarnings({ "squid:S1172" })
     void onEventTargetDeletedEvent(final TargetTagDeletedEventContainer eventContainer) {
@@ -311,11 +301,11 @@ public class TargetTagFilterButtons extends AbstractFilterButtons {
         addColumn();
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final ManagementUIEvent event) {
         if (event == ManagementUIEvent.RESET_SIMPLE_FILTERS
                 && !managementUIState.getTargetTableFilters().getClickedTargetTags().isEmpty()) {
-            filterButtonClickBehaviour.clearTargetTagFilters();
+            ((TargetTagFilterButtonClick) filterButtonClickBehaviour).clearTargetTagFilters();
         }
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterHeader.java
@@ -8,41 +8,30 @@
  */
 package org.eclipse.hawkbit.ui.management.targettag;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.filterlayout.AbstractFilterHeader;
 import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 
 /**
  * Target Tag filter by Tag Header.
  */
-@SpringComponent
-@ViewScope
 public class TargetTagFilterHeader extends AbstractFilterHeader {
 
     private static final long serialVersionUID = 3046367045669148009L;
 
-    @Autowired
-    private I18N i18n;
+    private final ManagementUIState managementUIState;
 
-    @Autowired
-    private CreateUpdateTargetTagLayoutWindow createUpdateTargetTagLayout;
-
-    @Autowired
-    private ManagementUIState managementUIState;
-
-    @Override
-    @PostConstruct
-    public void init() {
-        super.init();
+    TargetTagFilterHeader(final I18N i18n, final CreateUpdateTargetTagLayoutWindow createUpdateTargetTagLayout,
+            final ManagementUIState managementUIState, final SpPermissionChecker permChecker,
+            final UIEventBus eventBus) {
+        super(permChecker, eventBus, i18n);
+        this.managementUIState = managementUIState;
         if (permChecker.hasCreateTargetPermission() || permChecker.hasUpdateTargetPermission()) {
             createUpdateTargetTagLayout.init();
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/TargetTagFilterLayout.java
@@ -8,55 +8,40 @@
  */
 package org.eclipse.hawkbit.ui.management.targettag;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
+import org.eclipse.hawkbit.ui.management.event.ManagementViewAcceptCriteria;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.vaadin.spring.events.EventBus;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
-
 /**
  * Target Tag filter layout.
- * 
- *
- *
- * 
  */
-
-@SpringComponent
-@ViewScope
 public class TargetTagFilterLayout extends AbstractTargetTagFilterLayout {
 
     private static final long serialVersionUID = 2153612878428575009L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventbus;
-
-    @Autowired
-    private ManagementUIState managementUIState;
-
-    @Autowired
-    private TargetTagFilterHeader filterByHeader;
-
-    @Autowired
-    private MultipleTargetFilter multipleTargetFilter;
-
-    /**
-     * Initialize the filter layout.
-     */
-    @PostConstruct
-    public void init() {
-        super.init(filterByHeader, multipleTargetFilter);
-        eventbus.subscribe(this);
-
+    public TargetTagFilterLayout(final I18N i18n, final CreateUpdateTargetTagLayoutWindow createUpdateTargetTagLayout,
+            final ManagementUIState managementUIState, final ManagementViewAcceptCriteria managementViewAcceptCriteria,
+            final SpPermissionChecker permChecker, final UIEventBus eventBus, final UINotification notification,
+            final EntityFactory entityFactory, final TargetManagement targetManagement,
+            final TargetFilterQueryManagement targetFilterQueryManagement) {
+        super(new TargetTagFilterHeader(i18n, createUpdateTargetTagLayout, managementUIState, permChecker, eventBus),
+                new MultipleTargetFilter(createUpdateTargetTagLayout, permChecker, managementUIState, i18n, eventBus,
+                        managementViewAcceptCriteria, notification, entityFactory, targetManagement,
+                        targetFilterQueryManagement),
+                managementUIState);
+        eventBus.subscribe(this);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final ManagementUIEvent event) {
         if (event == ManagementUIEvent.HIDE_TARGET_TAG_LAYOUT) {
             setVisible(false);
@@ -66,16 +51,8 @@ public class TargetTagFilterLayout extends AbstractTargetTagFilterLayout {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.eclipse.hawkbit.server.ui.common.filterlayout.AbstractFilterLayout#
-     * onLoadIsTypeFilterIsClosed()
-     */
     @Override
     public Boolean onLoadIsTypeFilterIsClosed() {
-
         return managementUIState.isTargetTagFilterClosed();
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardEvent.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardEvent.java
@@ -18,8 +18,6 @@ package org.eclipse.hawkbit.ui.menu;
  */
 /**
  * Containing all dashboard events.
- * 
- *
  *
  */
 public final class DashboardEvent {
@@ -48,7 +46,8 @@ public final class DashboardEvent {
     }
 
     /**
-     * TenantAwareEvent to indicate that the current shown view has been changed.
+     * TenantAwareEvent to indicate that the current shown view has been
+     * changed.
      * 
      *
      *

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
@@ -60,14 +60,11 @@ public final class DashboardMenu extends CustomComponent {
 
     private static final String ID = "dashboard-menu";
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient UiProperties uiProperties;
+    private final UiProperties uiProperties;
 
-    @Autowired
-    private transient HawkbitServerProperties serverProperties;
+    private final transient HawkbitServerProperties serverProperties;
 
     private static final long serialVersionUID = 5394474618559481462L;
 
@@ -75,15 +72,23 @@ public final class DashboardMenu extends CustomComponent {
     // the buttons directly via events
     private final List<ValoMenuItemButton> menuButtons = new ArrayList<>();
 
-    @Autowired
-    private transient PermissionService permissionService;
+    private final transient PermissionService permissionService;
 
-    @Autowired
-    private final List<DashboardMenuItem> dashboardVaadinViews = new ArrayList<>();
+    private final List<DashboardMenuItem> dashboardVaadinViews;
 
     private String initialViewName;
 
     private boolean accessibleViewsEmpty;
+
+    @Autowired
+    DashboardMenu(final I18N i18n, final UiProperties uiProperties, final HawkbitServerProperties serverProperties,
+            final PermissionService permissionService, final List<DashboardMenuItem> dashboardVaadinViews) {
+        this.i18n = i18n;
+        this.uiProperties = uiProperties;
+        this.serverProperties = serverProperties;
+        this.permissionService = permissionService;
+        this.dashboardVaadinViews = dashboardVaadinViews;
+    }
 
     /**
      * initializing the view and creating the layout, cannot be done in the

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/GravatarResource.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/GravatarResource.java
@@ -24,14 +24,14 @@ public class GravatarResource extends ExternalResource {
 
     /**
      * Construct based on given email address. Generates external resource
-     * pointing to gravatar with rating
-     * "g: suitable for display on all websites with any audience type." and
-     * "mystery-man" icon as backup as secure request.
+     * pointing to gravatar with rating "g: suitable for display on all websites
+     * with any audience type." and "mystery-man" icon as backup as secure
+     * request.
      * 
      * @param email
      *            to generate resource for
      */
-    public GravatarResource(final String email) {
+    GravatarResource(final String email) {
         super("https://www.gravatar.com/avatar/" + DigestUtils.md5DigestAsHex(email.getBytes()) + ".jpg?s=56&r=g&d=mm");
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/push/DelayedEventBusPushStrategy.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/push/DelayedEventBusPushStrategy.java
@@ -32,7 +32,6 @@ import org.eclipse.hawkbit.ui.push.event.RolloutChangeEvent;
 import org.eclipse.hawkbit.ui.push.event.RolloutGroupChangeEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.scheduling.annotation.Async;
@@ -41,6 +40,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.vaadin.spring.events.EventBus;
 import org.vaadin.spring.events.EventBus.SessionEventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.vaadin.server.VaadinSession;
 import com.vaadin.server.VaadinSession.State;
@@ -71,15 +71,19 @@ public class DelayedEventBusPushStrategy implements EventPushStrategy, Applicati
             BLOCK_SIZE);
     private int uiid = -1;
 
-    @Autowired
-    private ScheduledExecutorService executorService;
+    private final ScheduledExecutorService executorService;
 
-    @Autowired
-    private EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private UIEventProvider eventProvider;
+    private final UIEventProvider eventProvider;
     private ScheduledFuture<?> jobHandle;
+
+    public DelayedEventBusPushStrategy(final ScheduledExecutorService executorService, final UIEventBus eventBus,
+            final UIEventProvider eventProvider) {
+        this.executorService = executorService;
+        this.eventBus = eventBus;
+        this.eventProvider = eventProvider;
+    }
 
     private boolean isEventProvided(final org.eclipse.hawkbit.repository.event.TenantAwareEvent event) {
         return eventProvider.getEvents().containsKey(event.getClass());

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/RolloutView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/RolloutView.java
@@ -8,60 +8,79 @@
  */
 package org.eclipse.hawkbit.ui.rollout;
 
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.RolloutGroupManagement;
+import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.ui.HawkbitUI;
+import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.rollout.event.RolloutEvent;
 import org.eclipse.hawkbit.ui.rollout.rollout.RolloutListView;
 import org.eclipse.hawkbit.ui.rollout.rolloutgroup.RolloutGroupsListView;
 import org.eclipse.hawkbit.ui.rollout.rolloutgrouptargets.RolloutGroupTargetsListView;
 import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
 import com.vaadin.spring.annotation.SpringView;
-import com.vaadin.spring.annotation.ViewScope;
+import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.VerticalLayout;
 
 /**
  * Rollout management view.
  */
+@UIScope
 @SpringView(name = RolloutView.VIEW_NAME, ui = HawkbitUI.class)
-@ViewScope
 public class RolloutView extends VerticalLayout implements View {
 
     private static final long serialVersionUID = -6199789714170913988L;
 
     public static final String VIEW_NAME = "rollout";
 
-    @Autowired
-    private SpPermissionChecker permChecker;
+    private final SpPermissionChecker permChecker;
+
+    private final RolloutListView rolloutListView;
+
+    private final RolloutGroupsListView rolloutGroupsListView;
+
+    private final RolloutGroupTargetsListView rolloutGroupTargetsListView;
+
+    private final RolloutUIState rolloutUIState;
+
+    private final transient EventBus.UIEventBus eventBus;
 
     @Autowired
-    private RolloutListView rolloutListView;
+    RolloutView(final SpPermissionChecker permissionChecker, final RolloutUIState rolloutUIState,
+            final UIEventBus eventBus, final RolloutManagement rolloutManagement,
+            final RolloutGroupManagement rolloutGroupManagement, final TargetManagement targetManagement,
+            final UINotification uiNotification, final UiProperties uiProperties, final EntityFactory entityFactory,
+            final I18N i18n) {
+        this.permChecker = permissionChecker;
+        this.rolloutListView = new RolloutListView(permissionChecker, rolloutUIState, eventBus, rolloutManagement,
+                targetManagement, uiNotification, uiProperties, entityFactory, i18n);
+        this.rolloutGroupsListView = new RolloutGroupsListView(i18n, eventBus, rolloutGroupManagement, rolloutUIState,
+                permissionChecker);
+        this.rolloutGroupTargetsListView = new RolloutGroupTargetsListView(eventBus, i18n, rolloutUIState);
+        this.rolloutUIState = rolloutUIState;
+        this.eventBus = eventBus;
+    }
 
-    @Autowired
-    private RolloutGroupsListView rolloutGroupsListView;
-
-    @Autowired
-    private RolloutGroupTargetsListView rolloutGroupTargetsListView;
-
-    @Autowired
-    private transient RolloutUIState rolloutUIState;
-
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
-
-    @Override
-    public void enter(final ViewChangeEvent event) {
+    @PostConstruct
+    void init() {
         setSizeFull();
-        if (!(rolloutUIState.isShowRollOuts() || rolloutUIState.isShowRolloutGroups() || rolloutUIState
-                .isShowRolloutGroupTargets())) {
+        if (!(rolloutUIState.isShowRollOuts() || rolloutUIState.isShowRolloutGroups()
+                || rolloutUIState.isShowRolloutGroupTargets())) {
             rolloutUIState.setShowRollOuts(true);
         }
         buildLayout();
@@ -73,7 +92,7 @@ public class RolloutView extends VerticalLayout implements View {
         eventBus.unsubscribe(this);
     }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final RolloutEvent event) {
         if (event == RolloutEvent.SHOW_ROLLOUTS) {
             rolloutUIState.setShowRollOuts(true);
@@ -103,9 +122,6 @@ public class RolloutView extends VerticalLayout implements View {
         }
     }
 
-    /**
-     * 
-     */
     private void showRolloutGroupTargetsListView() {
         rolloutGroupTargetsListView.setVisible(true);
         if (rolloutListView.isVisible()) {
@@ -118,9 +134,6 @@ public class RolloutView extends VerticalLayout implements View {
         setExpandRatio(rolloutGroupTargetsListView, 1.0f);
     }
 
-    /**
-     * 
-     */
     private void showRolloutGroupListView() {
         rolloutGroupsListView.setVisible(true);
         if (rolloutListView.isVisible()) {
@@ -133,9 +146,6 @@ public class RolloutView extends VerticalLayout implements View {
         setExpandRatio(rolloutGroupsListView, 1.0f);
     }
 
-    /**
-     * 
-     */
     private void showRolloutListView() {
         rolloutListView.setVisible(true);
         if (rolloutGroupsListView.isVisible()) {
@@ -146,6 +156,11 @@ public class RolloutView extends VerticalLayout implements View {
         }
         addComponent(rolloutListView);
         setExpandRatio(rolloutListView, 1.0f);
+    }
+
+    @Override
+    public void enter(final ViewChangeEvent event) {
+        // This view is constructed in the init() method()
     }
 
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/StatusFontIcon.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/StatusFontIcon.java
@@ -25,7 +25,7 @@ public class StatusFontIcon {
     final FontAwesome fontIcon;
     final String style;
 
-    public StatusFontIcon(FontAwesome fontIcon, String style) {
+    public StatusFontIcon(final FontAwesome fontIcon, final String style) {
         super();
         this.fontIcon = fontIcon;
         this.style = style;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
@@ -46,11 +46,11 @@ import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
 import com.google.common.base.Strings;
 import com.vaadin.data.Container;
@@ -61,8 +61,6 @@ import com.vaadin.data.util.converter.StringToIntegerConverter;
 import com.vaadin.data.validator.IntegerRangeValidator;
 import com.vaadin.data.validator.NullValidator;
 import com.vaadin.shared.ui.label.ContentMode;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.ComboBox;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Label;
@@ -74,8 +72,6 @@ import com.vaadin.ui.themes.ValoTheme;
 /**
  * Rollout add or update popup layout.
  */
-@SpringComponent
-@ViewScope
 public class AddUpdateRolloutWindowLayout extends GridLayout {
 
     private static final long serialVersionUID = 2999293468801479916L;
@@ -84,29 +80,21 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
 
     private static final String MESSAGE_ENTER_NUMBER = "message.enter.number";
 
-    @Autowired
-    private ActionTypeOptionGroupLayout actionTypeOptionGroupLayout;
+    private final ActionTypeOptionGroupLayout actionTypeOptionGroupLayout;
 
-    @Autowired
-    private transient RolloutManagement rolloutManagement;
+    private final transient RolloutManagement rolloutManagement;
 
-    @Autowired
-    private transient TargetManagement targetManagement;
+    private final transient TargetManagement targetManagement;
 
-    @Autowired
-    private UINotification uiNotification;
+    private final UINotification uiNotification;
 
-    @Autowired
-    private transient UiProperties uiProperties;
+    private final UiProperties uiProperties;
 
-    @Autowired
-    private transient EntityFactory entityFactory;
+    private final transient EntityFactory entityFactory;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    private final transient EventBus.UIEventBus eventBus;
 
     private TextField rolloutName;
 
@@ -140,6 +128,23 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
 
     private final NullValidator nullValidator = new NullValidator(null, false);
 
+    AddUpdateRolloutWindowLayout(final RolloutManagement rolloutManagement, final TargetManagement targetManagement,
+            final UINotification uiNotification, final UiProperties uiProperties, final EntityFactory entityFactory,
+            final I18N i18n, final UIEventBus eventBus) {
+        this.actionTypeOptionGroupLayout = new ActionTypeOptionGroupLayout(i18n);
+        this.rolloutManagement = rolloutManagement;
+        this.targetManagement = targetManagement;
+        this.uiNotification = uiNotification;
+        this.uiProperties = uiProperties;
+        this.entityFactory = entityFactory;
+        this.i18n = i18n;
+        this.eventBus = eventBus;
+
+        setSizeUndefined();
+        createRequiredComponents();
+        buildLayout();
+    }
+
     /**
      * Save or update the rollout.
      */
@@ -160,15 +165,6 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
             }
             return duplicateCheck();
         }
-    }
-
-    /**
-     * Create components and layout.
-     */
-    public void init() {
-        setSizeUndefined();
-        createRequiredComponents();
-        buildLayout();
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/DistributionBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/DistributionBeanQuery.java
@@ -69,24 +69,11 @@ public class DistributionBeanQuery extends AbstractBeanQuery<ProxyDistribution> 
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery#constructBean()
-     */
     @Override
     protected ProxyDistribution constructBean() {
         return new ProxyDistribution();
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery#loadBeans(int,
-     * int)
-     */
     @Override
     protected List<ProxyDistribution> loadBeans(final int startIndex, final int count) {
         Page<DistributionSet> distBeans;
@@ -121,24 +108,12 @@ public class DistributionBeanQuery extends AbstractBeanQuery<ProxyDistribution> 
         return proxyDistributions;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery#saveBeans(java.
-     * util.List, java.util.List, java.util.List)
-     */
     @Override
     protected void saveBeans(final List<ProxyDistribution> arg0, final List<ProxyDistribution> arg1,
             final List<ProxyDistribution> arg2) {
         // Add,Delete and Update are performed through repository methods
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery#size()
-     */
     @Override
     public int size() {
         final DistributionSetFilter distributionSetFilter = new DistributionSetFilterBuilder().setIsDeleted(false)

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
@@ -84,10 +84,7 @@ public class RolloutBeanQuery extends AbstractBeanQuery<ProxyRollout> {
     }
 
     private String getSearchText() {
-        if (getRolloutUIState().getSearchText().isPresent()) {
-            return String.format("%%%s%%", getRolloutUIState().getSearchText().get());
-        }
-        return null;
+        return getRolloutUIState().getSearchText().map(value -> String.format("%%%s%%", value)).orElse(null);
     }
 
     @Override
@@ -95,13 +92,6 @@ public class RolloutBeanQuery extends AbstractBeanQuery<ProxyRollout> {
         return new ProxyRollout();
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery#loadBeans(int,
-     * int)
-     */
     @Override
     protected List<ProxyRollout> loadBeans(final int startIndex, final int count) {
         final Slice<Rollout> rolloutBeans;
@@ -164,11 +154,6 @@ public class RolloutBeanQuery extends AbstractBeanQuery<ProxyRollout> {
          */
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery#size()
-     */
     @Override
     public int size() {
         int size = getRolloutManagement().countRolloutsAll().intValue();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
@@ -35,12 +35,15 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.Rollout.RolloutStatus;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus;
+import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.CommonDialogWindow;
 import org.eclipse.hawkbit.ui.common.grid.AbstractGrid;
 import org.eclipse.hawkbit.ui.customrenderers.client.renderers.RolloutRendererData;
@@ -54,14 +57,15 @@ import org.eclipse.hawkbit.ui.rollout.StatusFontIcon;
 import org.eclipse.hawkbit.ui.rollout.event.RolloutEvent;
 import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
@@ -70,8 +74,6 @@ import com.vaadin.data.Container;
 import com.vaadin.data.Item;
 import com.vaadin.data.util.converter.Converter;
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.renderers.ClickableRenderer.RendererClickEvent;
 import com.vaadin.ui.renderers.HtmlRenderer;
@@ -79,8 +81,6 @@ import com.vaadin.ui.renderers.HtmlRenderer;
 /**
  * Rollout list grid component.
  */
-@SpringComponent
-@ViewScope
 public class RolloutListGrid extends AbstractGrid {
 
     private static final long serialVersionUID = 4060904914954370524L;
@@ -99,28 +99,51 @@ public class RolloutListGrid extends AbstractGrid {
 
     private static final String ROLLOUT_RENDERER_DATA = "rolloutRendererData";
 
-    @Autowired
-    private transient RolloutManagement rolloutManagement;
+    private final transient RolloutManagement rolloutManagement;
 
-    @Autowired
-    private AddUpdateRolloutWindowLayout addUpdateRolloutWindow;
+    private final AddUpdateRolloutWindowLayout addUpdateRolloutWindow;
 
-    @Autowired
-    private UINotification uiNotification;
+    private final UINotification uiNotification;
 
-    @Autowired
-    private transient RolloutUIState rolloutUIState;
+    private final RolloutUIState rolloutUIState;
 
-    @Autowired
-    private transient SpPermissionChecker permissionChecker;
+    private static final Map<RolloutStatus, StatusFontIcon> statusIconMap = new EnumMap<>(RolloutStatus.class);
 
-    private transient Map<RolloutStatus, StatusFontIcon> statusIconMap = new EnumMap<>(RolloutStatus.class);
+    static {
+        statusIconMap.put(RolloutStatus.FINISHED,
+                new StatusFontIcon(FontAwesome.CHECK_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_GREEN));
+        statusIconMap.put(RolloutStatus.PAUSED,
+                new StatusFontIcon(FontAwesome.PAUSE, SPUIStyleDefinitions.STATUS_ICON_BLUE));
+        statusIconMap.put(RolloutStatus.RUNNING, new StatusFontIcon(null, SPUIStyleDefinitions.STATUS_SPINNER_YELLOW));
+        statusIconMap.put(RolloutStatus.READY,
+                new StatusFontIcon(FontAwesome.DOT_CIRCLE_O, SPUIStyleDefinitions.STATUS_ICON_LIGHT_BLUE));
+        statusIconMap.put(RolloutStatus.STOPPED,
+                new StatusFontIcon(FontAwesome.STOP, SPUIStyleDefinitions.STATUS_ICON_RED));
+        statusIconMap.put(RolloutStatus.CREATING, new StatusFontIcon(null, SPUIStyleDefinitions.STATUS_SPINNER_GREY));
+        statusIconMap.put(RolloutStatus.STARTING, new StatusFontIcon(null, SPUIStyleDefinitions.STATUS_SPINNER_BLUE));
+        statusIconMap.put(RolloutStatus.ERROR_CREATING,
+                new StatusFontIcon(FontAwesome.EXCLAMATION_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_RED));
+        statusIconMap.put(RolloutStatus.ERROR_STARTING,
+                new StatusFontIcon(FontAwesome.EXCLAMATION_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_RED));
+    }
+
+    RolloutListGrid(final I18N i18n, final UIEventBus eventBus, final RolloutManagement rolloutManagement,
+            final UINotification uiNotification, final RolloutUIState rolloutUIState,
+            final SpPermissionChecker permissionChecker, final TargetManagement targetManagement,
+            final EntityFactory entityFactory, final UiProperties uiProperties) {
+        super(i18n, eventBus, permissionChecker);
+        this.rolloutManagement = rolloutManagement;
+        this.addUpdateRolloutWindow = new AddUpdateRolloutWindowLayout(rolloutManagement, targetManagement,
+                uiNotification, uiProperties, entityFactory, i18n, eventBus);
+        this.uiNotification = uiNotification;
+        this.rolloutUIState = rolloutUIState;
+    }
 
     /**
      * Handles the RolloutEvent to refresh Grid.
      *
      */
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final RolloutEvent event) {
         switch (event) {
         case FILTER_BY_TEXT:
@@ -141,7 +164,7 @@ public class RolloutListGrid extends AbstractGrid {
      *            the event which contains the rollout which has been changed
      */
     @SuppressWarnings("unchecked")
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     public void onRolloutChangeEvent(final RolloutChangeEventContainer eventContainer) {
         eventContainer.getEvents().forEach(this::handleEvent);
     }
@@ -333,7 +356,6 @@ public class RolloutListGrid extends AbstractGrid {
         getColumn(VAR_TOTAL_TARGETS_COUNT_STATUS).setRenderer(new HtmlRenderer(),
                 new TotalTargetCountStatusConverter());
 
-        createRolloutStatusToFontMap();
         getColumn(VAR_STATUS).setRenderer(new HtmlLabelRenderer(), new RolloutStatusConverter());
 
         final RolloutRenderer customObjectRenderer = new RolloutRenderer(RolloutRendererData.class);
@@ -351,24 +373,6 @@ public class RolloutListGrid extends AbstractGrid {
                     .setRenderer(new HtmlButtonRenderer(clickEvent -> updateRollout((Long) clickEvent.getItemId())));
         }
 
-    }
-
-    private void createRolloutStatusToFontMap() {
-        statusIconMap.put(RolloutStatus.FINISHED,
-                new StatusFontIcon(FontAwesome.CHECK_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_GREEN));
-        statusIconMap.put(RolloutStatus.PAUSED,
-                new StatusFontIcon(FontAwesome.PAUSE, SPUIStyleDefinitions.STATUS_ICON_BLUE));
-        statusIconMap.put(RolloutStatus.RUNNING, new StatusFontIcon(null, SPUIStyleDefinitions.STATUS_SPINNER_YELLOW));
-        statusIconMap.put(RolloutStatus.READY,
-                new StatusFontIcon(FontAwesome.DOT_CIRCLE_O, SPUIStyleDefinitions.STATUS_ICON_LIGHT_BLUE));
-        statusIconMap.put(RolloutStatus.STOPPED,
-                new StatusFontIcon(FontAwesome.STOP, SPUIStyleDefinitions.STATUS_ICON_RED));
-        statusIconMap.put(RolloutStatus.CREATING, new StatusFontIcon(null, SPUIStyleDefinitions.STATUS_SPINNER_GREY));
-        statusIconMap.put(RolloutStatus.STARTING, new StatusFontIcon(null, SPUIStyleDefinitions.STATUS_SPINNER_BLUE));
-        statusIconMap.put(RolloutStatus.ERROR_CREATING,
-                new StatusFontIcon(FontAwesome.EXCLAMATION_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_RED));
-        statusIconMap.put(RolloutStatus.ERROR_STARTING,
-                new StatusFontIcon(FontAwesome.EXCLAMATION_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_RED));
     }
 
     private void alignColumns() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListHeader.java
@@ -8,20 +8,22 @@
  */
 package org.eclipse.hawkbit.ui.rollout.rollout;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.common.grid.AbstractGridHeader;
 import org.eclipse.hawkbit.ui.rollout.event.RolloutEvent;
 import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
@@ -29,32 +31,23 @@ import com.vaadin.ui.UI;
 import com.vaadin.ui.Window;
 
 /**
- * 
  * Header layout of rollout list view.
- *
  */
-@SpringComponent
-@ViewScope
 public class RolloutListHeader extends AbstractGridHeader {
     private static final long serialVersionUID = 2365400733081333174L;
 
-    @Autowired
-    private SpPermissionChecker permissionChecker;
+    private final transient EventBus.UIEventBus eventBus;
 
-    @Autowired
-    private transient RolloutUIState rolloutUIState;
+    private final AddUpdateRolloutWindowLayout addUpdateRolloutWindow;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
-
-    @Autowired
-    private AddUpdateRolloutWindowLayout addUpdateRolloutWindow;
-
-    @Override
-    @PostConstruct
-    protected void init() {
-        super.init();
-        addUpdateRolloutWindow.init();
+    RolloutListHeader(final SpPermissionChecker permissionChecker, final RolloutUIState rolloutUIState,
+            final UIEventBus eventBus, final RolloutManagement rolloutManagement,
+            final TargetManagement targetManagement, final UINotification uiNotification,
+            final UiProperties uiProperties, final EntityFactory entityFactory, final I18N i18n) {
+        super(permissionChecker, rolloutUIState, i18n);
+        this.eventBus = eventBus;
+        this.addUpdateRolloutWindow = new AddUpdateRolloutWindowLayout(rolloutManagement, targetManagement,
+                uiNotification, uiProperties, entityFactory, i18n, eventBus);
     }
 
     @Override
@@ -123,7 +116,7 @@ public class RolloutListHeader extends AbstractGridHeader {
 
     @Override
     protected String onLoadSearchBoxValue() {
-        return rolloutUIState.getSearchText().isPresent() ? rolloutUIState.getSearchText().get() : null;
+        return rolloutUIState.getSearchText().orElse(null);
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListView.java
@@ -8,35 +8,36 @@
  */
 package org.eclipse.hawkbit.ui.rollout.rollout;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.RolloutManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
+import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.grid.AbstractGridLayout;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Label;
 
 /**
- * 
  * Rollout list view.
- *
  */
-@SpringComponent
-@ViewScope
 public class RolloutListView extends AbstractGridLayout {
 
     private static final long serialVersionUID = -2703552177439393208L;
 
-    @Autowired
-    private RolloutListHeader rolloutListHeader;
+    public RolloutListView(final SpPermissionChecker permissionChecker, final RolloutUIState rolloutUIState,
+            final UIEventBus eventBus, final RolloutManagement rolloutManagement,
+            final TargetManagement targetManagement, final UINotification uiNotification,
+            final UiProperties uiProperties, final EntityFactory entityFactory, final I18N i18n) {
+        super(new RolloutListHeader(permissionChecker, rolloutUIState, eventBus, rolloutManagement, targetManagement,
+                uiNotification, uiProperties, entityFactory, i18n),
+                new RolloutListGrid(i18n, eventBus, rolloutManagement, uiNotification, rolloutUIState,
+                        permissionChecker, targetManagement, entityFactory, uiProperties));
 
-    @Autowired
-    private RolloutListGrid rolloutListGrid;
-
-    @PostConstruct
-    void init() {
-        super.init(rolloutListHeader, rolloutListGrid);
+        buildLayout();
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupBeanQuery.java
@@ -84,7 +84,7 @@ public class RolloutGroupBeanQuery extends AbstractBeanQuery<ProxyRolloutGroup> 
     }
 
     private Long getRolloutId() {
-        return getRolloutUIState().getRolloutId().isPresent() ? getRolloutUIState().getRolloutId().get() : null;
+        return getRolloutUIState().getRolloutId().orElse(null);
     }
 
     @Override
@@ -163,9 +163,6 @@ public class RolloutGroupBeanQuery extends AbstractBeanQuery<ProxyRolloutGroup> 
         return (int) size;
     }
 
-    /**
-     * @return the rolloutManagement
-     */
     public RolloutManagement getRolloutManagement() {
         if (null == rolloutManagement) {
             rolloutManagement = SpringContextHelper.getBean(RolloutManagement.class);
@@ -173,9 +170,6 @@ public class RolloutGroupBeanQuery extends AbstractBeanQuery<ProxyRolloutGroup> 
         return rolloutManagement;
     }
 
-    /**
-     * @return the rolloutManagement
-     */
     public RolloutGroupManagement getRolloutGroupManagement() {
         if (null == rolloutGroupManagement) {
             rolloutGroupManagement = SpringContextHelper.getBean(RolloutGroupManagement.class);
@@ -183,9 +177,6 @@ public class RolloutGroupBeanQuery extends AbstractBeanQuery<ProxyRolloutGroup> 
         return rolloutGroupManagement;
     }
 
-    /**
-     * @return the rolloutUIState
-     */
     public RolloutUIState getRolloutUIState() {
         if (null == rolloutUIState) {
             rolloutUIState = SpringContextHelper.getBean(RolloutUIState.class);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupListGrid.java
@@ -30,50 +30,62 @@ import org.eclipse.hawkbit.ui.rollout.StatusFontIcon;
 import org.eclipse.hawkbit.ui.rollout.event.RolloutEvent;
 import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.data.Container;
 import com.vaadin.data.util.converter.Converter;
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.renderers.ClickableRenderer.RendererClickEvent;
 import com.vaadin.ui.renderers.ClickableRenderer.RendererClickListener;
 import com.vaadin.ui.renderers.HtmlRenderer;
 
 /**
- *
  * Rollout group list grid component.
- *
  */
-@SpringComponent
-@ViewScope
 public class RolloutGroupListGrid extends AbstractGrid {
     private static final long serialVersionUID = 4060904914954370524L;
 
     private static final String ROLLOUT_RENDERER_DATA = "rolloutRendererData";
 
-    @Autowired
-    private transient RolloutGroupManagement rolloutGroupManagement;
+    private final transient RolloutGroupManagement rolloutGroupManagement;
 
-    @Autowired
-    private transient RolloutUIState rolloutUIState;
+    private final RolloutUIState rolloutUIState;
 
-    @Autowired
-    private transient SpPermissionChecker permissionChecker;
+    private static final Map<RolloutGroupStatus, StatusFontIcon> statusIconMap = new EnumMap<>(
+            RolloutGroupStatus.class);
 
-    private transient Map<RolloutGroupStatus, StatusFontIcon> statusIconMap = new EnumMap<>(RolloutGroupStatus.class);
+    static {
+        statusIconMap.put(RolloutGroupStatus.FINISHED,
+                new StatusFontIcon(FontAwesome.CHECK_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_GREEN));
+        statusIconMap.put(RolloutGroupStatus.SCHEDULED,
+                new StatusFontIcon(FontAwesome.HOURGLASS_1, SPUIStyleDefinitions.STATUS_ICON_PENDING));
+        statusIconMap.put(RolloutGroupStatus.RUNNING,
+                new StatusFontIcon(FontAwesome.ADJUST, SPUIStyleDefinitions.STATUS_ICON_YELLOW));
+        statusIconMap.put(RolloutGroupStatus.READY,
+                new StatusFontIcon(FontAwesome.DOT_CIRCLE_O, SPUIStyleDefinitions.STATUS_ICON_LIGHT_BLUE));
+        statusIconMap.put(RolloutGroupStatus.ERROR,
+                new StatusFontIcon(FontAwesome.EXCLAMATION_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_RED));
+    }
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    public RolloutGroupListGrid(final I18N i18n, final UIEventBus eventBus,
+            final RolloutGroupManagement rolloutGroupManagement, final RolloutUIState rolloutUIState,
+            final SpPermissionChecker permissionChecker) {
+        super(i18n, eventBus, permissionChecker);
+        this.rolloutGroupManagement = rolloutGroupManagement;
+        this.rolloutUIState = rolloutUIState;
+    }
+
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final RolloutEvent event) {
         if (RolloutEvent.SHOW_ROLLOUT_GROUPS != event) {
             return;
@@ -90,7 +102,7 @@ public class RolloutGroupListGrid extends AbstractGrid {
      *            the event which contains the rollout group which has been
      *            change
      */
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     public void onRolloutGroupChangeEvent(final RolloutGroupChangeEventContainer eventContainer) {
         if (!rolloutUIState.isShowRolloutGroups()) {
             return;
@@ -211,7 +223,6 @@ public class RolloutGroupListGrid extends AbstractGrid {
 
     @Override
     protected void addColumnRenderes() {
-        createRolloutGroupStatusToFontMap();
         getColumn(SPUILabelDefinitions.VAR_STATUS).setRenderer(new HtmlLabelRenderer(),
                 new RolloutGroupStatusConverter());
 
@@ -239,19 +250,6 @@ public class RolloutGroupListGrid extends AbstractGrid {
     @Override
     protected CellDescriptionGenerator getDescriptionGenerator() {
         return this::getDescription;
-    }
-
-    private void createRolloutGroupStatusToFontMap() {
-        statusIconMap.put(RolloutGroupStatus.FINISHED,
-                new StatusFontIcon(FontAwesome.CHECK_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_GREEN));
-        statusIconMap.put(RolloutGroupStatus.SCHEDULED,
-                new StatusFontIcon(FontAwesome.HOURGLASS_1, SPUIStyleDefinitions.STATUS_ICON_PENDING));
-        statusIconMap.put(RolloutGroupStatus.RUNNING,
-                new StatusFontIcon(FontAwesome.ADJUST, SPUIStyleDefinitions.STATUS_ICON_YELLOW));
-        statusIconMap.put(RolloutGroupStatus.READY,
-                new StatusFontIcon(FontAwesome.DOT_CIRCLE_O, SPUIStyleDefinitions.STATUS_ICON_LIGHT_BLUE));
-        statusIconMap.put(RolloutGroupStatus.ERROR,
-                new StatusFontIcon(FontAwesome.EXCLAMATION_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_RED));
     }
 
     private String getDescription(final CellReference cell) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupsListHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupsListHeader.java
@@ -8,9 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.rollout.rolloutgroup;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.common.grid.AbstractGridHeader;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
@@ -19,13 +16,11 @@ import org.eclipse.hawkbit.ui.rollout.event.RolloutEvent;
 import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.HorizontalLayout;
@@ -34,38 +29,22 @@ import com.vaadin.ui.themes.ValoTheme;
 
 /**
  * Header Layout of Rollout Group list view.
- *
  */
-@SpringComponent
-@ViewScope
 public class RolloutGroupsListHeader extends AbstractGridHeader {
 
     private static final long serialVersionUID = 5077741997839715209L;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
-
-    @Autowired
-    private RolloutUIState rolloutUiState;
-
-    @Autowired
-    private I18N i18n;
+    private final transient EventBus.UIEventBus eventBus;
 
     private Label headerCaption;
 
-    @Override
-    @PostConstruct
-    protected void init() {
-        super.init();
+    public RolloutGroupsListHeader(final UIEventBus eventBus, final RolloutUIState rolloutUiState, final I18N i18n) {
+        super(null, rolloutUiState, i18n);
+        this.eventBus = eventBus;
         eventBus.subscribe(this);
     }
 
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
-    }
-
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final RolloutEvent event) {
         if (event == RolloutEvent.SHOW_ROLLOUT_GROUPS) {
             setCaptionDetails();
@@ -73,8 +52,7 @@ public class RolloutGroupsListHeader extends AbstractGridHeader {
     }
 
     private void setCaptionDetails() {
-        headerCaption
-                .setCaption(rolloutUiState.getRolloutName().isPresent() ? rolloutUiState.getRolloutName().get() : "");
+        headerCaption.setCaption(rolloutUIState.getRolloutName().orElse(""));
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupsListView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupsListView.java
@@ -8,34 +8,29 @@
  */
 package org.eclipse.hawkbit.ui.rollout.rolloutgroup;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.RolloutGroupManagement;
+import org.eclipse.hawkbit.repository.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.grid.AbstractGridLayout;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Label;
 
 /**
  * Groups List View.
- *
  */
-@SpringComponent
-@ViewScope
 public class RolloutGroupsListView extends AbstractGridLayout {
 
     private static final long serialVersionUID = 7252345838154270259L;
 
-    @Autowired
-    private RolloutGroupsListHeader rolloutGroupListHeader;
+    public RolloutGroupsListView(final I18N i18n, final UIEventBus eventBus,
+            final RolloutGroupManagement rolloutGroupManagement, final RolloutUIState rolloutUIState,
+            final SpPermissionChecker permissionChecker) {
+        super(new RolloutGroupsListHeader(eventBus, rolloutUIState, i18n),
+                new RolloutGroupListGrid(i18n, eventBus, rolloutGroupManagement, rolloutUIState, permissionChecker));
 
-    @Autowired
-    private RolloutGroupListGrid rolloutListGrid;
-
-    @PostConstruct
-    protected void init() {
-        super.init(rolloutGroupListHeader, rolloutListGrid);
+        buildLayout();
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsBeanQuery.java
@@ -8,9 +8,11 @@
  */
 package org.eclipse.hawkbit.ui.rollout.rolloutgrouptargets;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.RolloutManagement;
@@ -39,9 +41,9 @@ public class RolloutGroupTargetsBeanQuery extends AbstractBeanQuery<ProxyTarget>
 
     private static final long serialVersionUID = -8841076207255485907L;
 
-    private final Sort sort = new Sort(Direction.ASC, "id");
+    private static final Sort sort = new Sort(Direction.ASC, "id");
 
-    private transient Page<TargetWithActionStatus> firstPageTargetSets = null;
+    private transient Page<TargetWithActionStatus> firstPageTargetSets;
 
     private transient RolloutManagement rolloutManagement;
 
@@ -49,7 +51,7 @@ public class RolloutGroupTargetsBeanQuery extends AbstractBeanQuery<ProxyTarget>
 
     private transient RolloutUIState rolloutUIState;
 
-    private final RolloutGroup rolloutGroup;
+    private final transient Optional<RolloutGroup> rolloutGroup;
 
     /**
      * Parametric Constructor.
@@ -67,10 +69,7 @@ public class RolloutGroupTargetsBeanQuery extends AbstractBeanQuery<ProxyTarget>
             final Object[] sortPropertyIds, final boolean[] sortStates) {
 
         super(definition, queryConfig, sortPropertyIds, sortStates);
-
-        rolloutGroup = getRolloutUIState().getRolloutGroup().isPresent() ? getRolloutUIState().getRolloutGroup().get()
-                : null;
-
+        rolloutGroup = getRolloutUIState().getRolloutGroup();
     }
 
     @Override
@@ -80,48 +79,48 @@ public class RolloutGroupTargetsBeanQuery extends AbstractBeanQuery<ProxyTarget>
 
     @Override
     protected List<ProxyTarget> loadBeans(final int startIndex, final int count) {
-        List<TargetWithActionStatus> rolloutGroupTargetsList = new ArrayList<>();
         if (startIndex == 0 && firstPageTargetSets != null) {
-            rolloutGroupTargetsList = firstPageTargetSets.getContent();
-        } else if (null != rolloutGroup) {
-            rolloutGroupTargetsList = getRolloutGroupManagement()
-                    .findAllTargetsWithActionStatus(new PageRequest(startIndex / count, count), rolloutGroup)
-                    .getContent();
+            return getProxyRolloutGroupTargetsList(firstPageTargetSets.getContent());
         }
-        return getProxyRolloutGroupTargetsList(rolloutGroupTargetsList);
+
+        return rolloutGroup.map(group -> getProxyRolloutGroupTargetsList(getRolloutGroupManagement()
+                .findAllTargetsWithActionStatus(new PageRequest(startIndex / count, count), group).getContent()))
+                .orElse(Collections.emptyList());
     }
 
-    private List<ProxyTarget> getProxyRolloutGroupTargetsList(final List<TargetWithActionStatus> rolloutGroupTargets) {
-        final List<ProxyTarget> proxyTargetBeans = new ArrayList<>();
-        for (final TargetWithActionStatus targetWithActionStatus : rolloutGroupTargets) {
-            final Target targ = targetWithActionStatus.getTarget();
-            final ProxyTarget prxyTarget = new ProxyTarget();
-            prxyTarget.setTargetIdName(targ.getTargetIdName());
-            prxyTarget.setName(targ.getName());
-            prxyTarget.setDescription(targ.getDescription());
-            prxyTarget.setControllerId(targ.getControllerId());
-            prxyTarget.setInstallationDate(targ.getTargetInfo().getInstallationDate());
-            prxyTarget.setAddress(targ.getTargetInfo().getAddress());
-            prxyTarget.setLastTargetQuery(targ.getTargetInfo().getLastTargetQuery());
-            prxyTarget.setLastModifiedDate(SPDateTimeUtil.getFormattedDate(targ.getLastModifiedAt()));
-            prxyTarget.setCreatedDate(SPDateTimeUtil.getFormattedDate(targ.getCreatedAt()));
-            prxyTarget.setCreatedAt(targ.getCreatedAt());
-            prxyTarget.setCreatedByUser(UserDetailsFormatter.loadAndFormatCreatedBy(targ));
-            prxyTarget.setModifiedByUser(UserDetailsFormatter.loadAndFormatLastModifiedBy(targ));
-            if (targetWithActionStatus.getStatus() != null) {
-                prxyTarget.setStatus(targetWithActionStatus.getStatus());
-            }
-            prxyTarget.setLastTargetQuery(targ.getTargetInfo().getLastTargetQuery());
-            prxyTarget.setTargetInfo(targ.getTargetInfo());
-            prxyTarget.setId(targ.getId());
-            if (targ.getAssignedDistributionSet() != null) {
-                prxyTarget.setAssignedDistNameVersion(HawkbitCommonUtil.getFormattedNameVersion(
-                        targ.getAssignedDistributionSet().getName(), targ.getAssignedDistributionSet().getVersion()));
-            }
-            proxyTargetBeans.add(prxyTarget);
+    private static List<ProxyTarget> getProxyRolloutGroupTargetsList(
+            final List<TargetWithActionStatus> rolloutGroupTargets) {
 
+        return rolloutGroupTargets.stream().map(RolloutGroupTargetsBeanQuery::mapTargetToProxy)
+                .collect(Collectors.toList());
+    }
+
+    private static ProxyTarget mapTargetToProxy(final TargetWithActionStatus targetWithActionStatus) {
+        final Target targ = targetWithActionStatus.getTarget();
+        final ProxyTarget prxyTarget = new ProxyTarget();
+        prxyTarget.setTargetIdName(targ.getTargetIdName());
+        prxyTarget.setName(targ.getName());
+        prxyTarget.setDescription(targ.getDescription());
+        prxyTarget.setControllerId(targ.getControllerId());
+        prxyTarget.setInstallationDate(targ.getTargetInfo().getInstallationDate());
+        prxyTarget.setAddress(targ.getTargetInfo().getAddress());
+        prxyTarget.setLastTargetQuery(targ.getTargetInfo().getLastTargetQuery());
+        prxyTarget.setLastModifiedDate(SPDateTimeUtil.getFormattedDate(targ.getLastModifiedAt()));
+        prxyTarget.setCreatedDate(SPDateTimeUtil.getFormattedDate(targ.getCreatedAt()));
+        prxyTarget.setCreatedAt(targ.getCreatedAt());
+        prxyTarget.setCreatedByUser(UserDetailsFormatter.loadAndFormatCreatedBy(targ));
+        prxyTarget.setModifiedByUser(UserDetailsFormatter.loadAndFormatLastModifiedBy(targ));
+        if (targetWithActionStatus.getStatus() != null) {
+            prxyTarget.setStatus(targetWithActionStatus.getStatus());
         }
-        return proxyTargetBeans;
+        prxyTarget.setLastTargetQuery(targ.getTargetInfo().getLastTargetQuery());
+        prxyTarget.setTargetInfo(targ.getTargetInfo());
+        prxyTarget.setId(targ.getId());
+        if (targ.getAssignedDistributionSet() != null) {
+            prxyTarget.setAssignedDistNameVersion(HawkbitCommonUtil.getFormattedNameVersion(
+                    targ.getAssignedDistributionSet().getName(), targ.getAssignedDistributionSet().getVersion()));
+        }
+        return prxyTarget;
     }
 
     @Override
@@ -134,9 +133,10 @@ public class RolloutGroupTargetsBeanQuery extends AbstractBeanQuery<ProxyTarget>
     @Override
     public int size() {
         long size = 0;
-        if (null != rolloutGroup) {
-            firstPageTargetSets = getRolloutGroupManagement()
-                    .findAllTargetsWithActionStatus(new PageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), rolloutGroup);
+
+        if (rolloutGroup.isPresent()) {
+            firstPageTargetSets = getRolloutGroupManagement().findAllTargetsWithActionStatus(
+                    new PageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), rolloutGroup.get());
             size = firstPageTargetSets.getTotalElements();
         }
         getRolloutUIState().setRolloutGroupTargetsTotalCount(size);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsCountLabelMessage.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsCountLabelMessage.java
@@ -8,9 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.rollout.rolloutgrouptargets;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.ui.rollout.event.RolloutEvent;
 import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
@@ -18,51 +15,36 @@ import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.server.FontAwesome;
 import com.vaadin.shared.ui.label.ContentMode;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Label;
 
 /**
  * Count message label for the targets of the rollout group.
  */
-@SpringComponent
-@ViewScope
 public class RolloutGroupTargetsCountLabelMessage extends Label {
 
     private static final long serialVersionUID = -3876685878918411453L;
 
-    @Autowired
-    private transient RolloutUIState rolloutUIState;
+    private final RolloutUIState rolloutUIState;
 
-    @Autowired
-    private transient RolloutGroupTargetsListGrid rolloutGroupTargetsListGrid;
+    private final RolloutGroupTargetsListGrid rolloutGroupTargetsListGrid;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
+    public RolloutGroupTargetsCountLabelMessage(final RolloutUIState rolloutUIState,
+            final RolloutGroupTargetsListGrid rolloutGroupTargetsListGrid, final I18N i18n, final UIEventBus eventBus) {
+        this.rolloutUIState = rolloutUIState;
+        this.rolloutGroupTargetsListGrid = rolloutGroupTargetsListGrid;
+        this.i18n = i18n;
 
-    /**
-     * PostConstruct method called by spring after bean has been initialized.
-     */
-    @PostConstruct
-    public void postConstruct() {
         applyStyle();
         displayRolloutGroupTargetMessage();
         eventBus.subscribe(this);
-    }
-
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
     }
 
     /**
@@ -70,7 +52,7 @@ public class RolloutGroupTargetsCountLabelMessage extends Label {
      * 
      * @param event
      */
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     public void onEvent(final RolloutEvent event) {
         if (event == RolloutEvent.SHOW_ROLLOUT_GROUP_TARGETS_COUNT) {
             displayRolloutGroupTargetMessage();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListGrid.java
@@ -23,40 +23,61 @@ import org.eclipse.hawkbit.ui.rollout.StatusFontIcon;
 import org.eclipse.hawkbit.ui.rollout.event.RolloutEvent;
 import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
 import com.vaadin.data.Container;
 import com.vaadin.data.util.converter.Converter;
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 
 /**
- * 
  * Grid component with targets of rollout group.
- *
  */
-@SpringComponent
-@ViewScope
 public class RolloutGroupTargetsListGrid extends AbstractGrid {
 
     private static final long serialVersionUID = -2244756637458984597L;
 
-    @Autowired
-    private transient RolloutUIState rolloutUIState;
+    private final RolloutUIState rolloutUIState;
 
-    private transient Map<Status, StatusFontIcon> statusIconMap = new EnumMap<>(Status.class);
+    private static final Map<Status, StatusFontIcon> statusIconMap = new EnumMap<>(Status.class);
 
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    static {
+        statusIconMap.put(Status.FINISHED,
+                new StatusFontIcon(FontAwesome.CHECK_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_GREEN));
+        statusIconMap.put(Status.SCHEDULED,
+                new StatusFontIcon(FontAwesome.HOURGLASS_1, SPUIStyleDefinitions.STATUS_ICON_PENDING));
+        statusIconMap.put(Status.RUNNING,
+                new StatusFontIcon(FontAwesome.ADJUST, SPUIStyleDefinitions.STATUS_ICON_YELLOW));
+        statusIconMap.put(Status.RETRIEVED,
+                new StatusFontIcon(FontAwesome.ADJUST, SPUIStyleDefinitions.STATUS_ICON_YELLOW));
+        statusIconMap.put(Status.WARNING,
+                new StatusFontIcon(FontAwesome.ADJUST, SPUIStyleDefinitions.STATUS_ICON_YELLOW));
+        statusIconMap.put(Status.DOWNLOAD,
+                new StatusFontIcon(FontAwesome.ADJUST, SPUIStyleDefinitions.STATUS_ICON_YELLOW));
+        statusIconMap.put(Status.CANCELING,
+                new StatusFontIcon(FontAwesome.TIMES_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_PENDING));
+        statusIconMap.put(Status.CANCELED,
+                new StatusFontIcon(FontAwesome.TIMES_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_GREEN));
+        statusIconMap.put(Status.ERROR,
+                new StatusFontIcon(FontAwesome.EXCLAMATION_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_RED));
+    }
+
+    public RolloutGroupTargetsListGrid(final I18N i18n, final UIEventBus eventBus,
+            final RolloutUIState rolloutUIState) {
+        super(i18n, eventBus, null);
+        this.rolloutUIState = rolloutUIState;
+    }
+
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final RolloutEvent event) {
         if (RolloutEvent.SHOW_ROLLOUT_GROUP_TARGETS != event) {
             return;
@@ -149,7 +170,6 @@ public class RolloutGroupTargetsListGrid extends AbstractGrid {
 
     @Override
     protected void addColumnRenderes() {
-        createRolloutStatusToFontMap();
         getColumn(SPUILabelDefinitions.VAR_STATUS).setRenderer(new HtmlLabelRenderer(), new StatusConverter());
     }
 
@@ -220,8 +240,7 @@ public class RolloutGroupTargetsListGrid extends AbstractGrid {
         }
 
         private String getStatus() {
-            final RolloutGroup rolloutGroup = rolloutUIState.getRolloutGroup().isPresent()
-                    ? rolloutUIState.getRolloutGroup().get() : null;
+            final RolloutGroup rolloutGroup = rolloutUIState.getRolloutGroup().orElse(null);
             if (rolloutGroup != null && rolloutGroup.getStatus() == RolloutGroupStatus.READY) {
                 return HawkbitCommonUtil.getStatusLabelDetailsInString(
                         Integer.toString(FontAwesome.DOT_CIRCLE_O.getCodepoint()), "statusIconLightBlue", null);
@@ -236,27 +255,6 @@ public class RolloutGroupTargetsListGrid extends AbstractGrid {
 
     }
 
-    private void createRolloutStatusToFontMap() {
-        statusIconMap.put(Status.FINISHED,
-                new StatusFontIcon(FontAwesome.CHECK_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_GREEN));
-        statusIconMap.put(Status.SCHEDULED,
-                new StatusFontIcon(FontAwesome.HOURGLASS_1, SPUIStyleDefinitions.STATUS_ICON_PENDING));
-        statusIconMap.put(Status.RUNNING,
-                new StatusFontIcon(FontAwesome.ADJUST, SPUIStyleDefinitions.STATUS_ICON_YELLOW));
-        statusIconMap.put(Status.RETRIEVED,
-                new StatusFontIcon(FontAwesome.ADJUST, SPUIStyleDefinitions.STATUS_ICON_YELLOW));
-        statusIconMap.put(Status.WARNING,
-                new StatusFontIcon(FontAwesome.ADJUST, SPUIStyleDefinitions.STATUS_ICON_YELLOW));
-        statusIconMap.put(Status.DOWNLOAD,
-                new StatusFontIcon(FontAwesome.ADJUST, SPUIStyleDefinitions.STATUS_ICON_YELLOW));
-        statusIconMap.put(Status.CANCELING,
-                new StatusFontIcon(FontAwesome.TIMES_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_PENDING));
-        statusIconMap.put(Status.CANCELED,
-                new StatusFontIcon(FontAwesome.TIMES_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_GREEN));
-        statusIconMap.put(Status.ERROR,
-                new StatusFontIcon(FontAwesome.EXCLAMATION_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_RED));
-    }
-
     private String getDescription(final CellReference cell) {
         if (!SPUILabelDefinitions.VAR_STATUS.equals(cell.getPropertyId())) {
             return null;
@@ -269,13 +267,11 @@ public class RolloutGroupTargetsListGrid extends AbstractGrid {
     }
 
     private String getDescriptionWhenNoAction() {
-        final RolloutGroup rolloutGroup = rolloutUIState.getRolloutGroup().isPresent()
-                ? rolloutUIState.getRolloutGroup().get() : null;
+        final RolloutGroup rolloutGroup = rolloutUIState.getRolloutGroup().orElse(null);
         if (rolloutGroup != null && rolloutGroup.getStatus() == RolloutGroupStatus.READY) {
             return RolloutGroupStatus.READY.toString().toLowerCase();
         } else if (rolloutGroup != null && rolloutGroup.getStatus() == RolloutGroupStatus.FINISHED) {
-            final String ds = rolloutUIState.getRolloutDistributionSet().isPresent()
-                    ? rolloutUIState.getRolloutDistributionSet().get() : "";
+            final String ds = rolloutUIState.getRolloutDistributionSet().orElse("");
             return i18n.get("message.dist.already.assigned", new Object[] { ds });
         }
         return "unknown";

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListHeader.java
@@ -8,9 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.rollout.rolloutgrouptargets;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.common.grid.AbstractGridHeader;
@@ -20,13 +17,11 @@ import org.eclipse.hawkbit.ui.rollout.event.RolloutEvent;
 import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.HorizontalLayout;
@@ -35,38 +30,25 @@ import com.vaadin.ui.themes.ValoTheme;
 
 /**
  * Header Layout of Rollout Group Targets list view.
- *
  */
-@SpringComponent
-@ViewScope
 public class RolloutGroupTargetsListHeader extends AbstractGridHeader {
 
     private static final long serialVersionUID = 5613986489156507581L;
-    @Autowired
-    private transient EventBus.SessionEventBus eventBus;
 
-    @Autowired
-    private I18N i18n;
-
-    @Autowired
-    private RolloutUIState rolloutUiState;
+    private final transient EventBus.UIEventBus eventBus;
 
     private Button rolloutsGroupViewLink;
     private Label headerCaption;
 
-    @Override
-    @PostConstruct
-    protected void init() {
-        super.init();
+    public RolloutGroupTargetsListHeader(final UIEventBus eventBus, final I18N i18n,
+            final RolloutUIState rolloutUiState) {
+        super(null, rolloutUiState, i18n);
+        this.eventBus = eventBus;
+
         eventBus.subscribe(this);
     }
 
-    @PreDestroy
-    void destroy() {
-        eventBus.unsubscribe(this);
-    }
-
-    @EventBusListenerMethod(scope = EventScope.SESSION)
+    @EventBusListenerMethod(scope = EventScope.UI)
     void onEvent(final RolloutEvent event) {
         if (event == RolloutEvent.SHOW_ROLLOUT_GROUP_TARGETS) {
             setCaptionDetails();
@@ -74,19 +56,13 @@ public class RolloutGroupTargetsListHeader extends AbstractGridHeader {
     }
 
     private void setCaptionDetails() {
-        RolloutGroup rolloutGroup;
-        if (rolloutUiState.getRolloutGroup().isPresent()) {
-            rolloutGroup = rolloutUiState.getRolloutGroup().get();
-            headerCaption.setCaption(rolloutGroup.getName());
-        }
-
-        rolloutsGroupViewLink
-                .setCaption(rolloutUiState.getRolloutName().isPresent() ? rolloutUiState.getRolloutName().get() : "");
+        rolloutUIState.getRolloutGroup().map(RolloutGroup::getName).ifPresent(headerCaption::setCaption);
+        rolloutsGroupViewLink.setCaption(rolloutUIState.getRolloutGroup().map(RolloutGroup::getName).orElse(""));
     }
 
     @Override
     protected void resetSearchText() {
-        /**
+        /*
          * No implementation required.
          */
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListView.java
@@ -8,39 +8,31 @@
  */
 package org.eclipse.hawkbit.ui.rollout.rolloutgrouptargets;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.ui.common.grid.AbstractGridLayout;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
+import org.eclipse.hawkbit.ui.utils.I18N;
+import org.vaadin.spring.events.EventBus.UIEventBus;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Label;
 
 /**
  * Rollout Group Targets List View.
  */
-@SpringComponent
-@ViewScope
 public class RolloutGroupTargetsListView extends AbstractGridLayout {
 
     private static final long serialVersionUID = 26089134783467012L;
 
-    @Autowired
-    private RolloutGroupTargetsListHeader rolloutGroupTargetsListHeader;
+    private final RolloutGroupTargetsCountLabelMessage rolloutGroupTargetsCountLabelMessage;
 
-    @Autowired
-    private RolloutGroupTargetsCountLabelMessage rolloutGroupTargetsCountLabelMessage;
-    
-    @Autowired
-    private RolloutGroupTargetsListGrid rolloutListGrid;
+    public RolloutGroupTargetsListView(final UIEventBus eventBus, final I18N i18n,
+            final RolloutUIState rolloutUIState) {
+        super(new RolloutGroupTargetsListHeader(eventBus, i18n, rolloutUIState),
+                new RolloutGroupTargetsListGrid(i18n, eventBus, rolloutUIState));
 
-    /**
-     * Initialization of Rollout group component.
-     */
-    @PostConstruct
-    protected void init() {
-        super.init(rolloutGroupTargetsListHeader, rolloutListGrid);
+        this.rolloutGroupTargetsCountLabelMessage = new RolloutGroupTargetsCountLabelMessage(rolloutUIState,
+                (RolloutGroupTargetsListGrid) grid, i18n, eventBus);
+
+        buildLayout();
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/state/RolloutUIState.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/state/RolloutUIState.java
@@ -184,7 +184,7 @@ public class RolloutUIState implements Serializable {
     /**
      * @return rolloutDistributionSet
      */
-    public Optional<String>  getRolloutDistributionSet() {
+    public Optional<String> getRolloutDistributionSet() {
         return rolloutDistributionSet == null ? Optional.empty() : Optional.of(rolloutDistributionSet);
     }
 
@@ -193,7 +193,7 @@ public class RolloutUIState implements Serializable {
      * @param rolloutDistributionSet
      *            the distribution set of the rollout
      */
-    public void setRolloutDistributionSet(String rolloutDistributionSet) {
+    public void setRolloutDistributionSet(final String rolloutDistributionSet) {
         this.rolloutDistributionSet = rolloutDistributionSet;
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/AuthenticationConfigurationView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/AuthenticationConfigurationView.java
@@ -8,8 +8,8 @@
  */
 package org.eclipse.hawkbit.ui.tenantconfiguration;
 
-import javax.annotation.PostConstruct;
-
+import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.security.SecurityTokenGenerator;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.tenantconfiguration.authentication.AnonymousDownloadAuthenticationConfigurationItem;
 import org.eclipse.hawkbit.ui.tenantconfiguration.authentication.AuthenticationConfigurationItem;
@@ -18,12 +18,9 @@ import org.eclipse.hawkbit.ui.tenantconfiguration.authentication.GatewaySecurity
 import org.eclipse.hawkbit.ui.tenantconfiguration.authentication.TargetSecurityTokenAuthenticationConfigurationItem;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import com.vaadin.data.Property.ValueChangeEvent;
 import com.vaadin.data.Property.ValueChangeListener;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Label;
@@ -33,8 +30,6 @@ import com.vaadin.ui.VerticalLayout;
 /**
  * View to configure the authentication mode.
  */
-@SpringComponent
-@ViewScope
 public class AuthenticationConfigurationView extends BaseConfigurationView
         implements ConfigurationGroup, ConfigurationItem.ConfigurationItemChangeListener, ValueChangeListener {
 
@@ -42,20 +37,15 @@ public class AuthenticationConfigurationView extends BaseConfigurationView
 
     private static final long serialVersionUID = 1L;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
-    @Autowired
-    private CertificateAuthenticationConfigurationItem certificateAuthenticationConfigurationItem;
+    private final CertificateAuthenticationConfigurationItem certificateAuthenticationConfigurationItem;
 
-    @Autowired
-    private TargetSecurityTokenAuthenticationConfigurationItem targetSecurityTokenAuthenticationConfigurationItem;
+    private final TargetSecurityTokenAuthenticationConfigurationItem targetSecurityTokenAuthenticationConfigurationItem;
 
-    @Autowired
-    private GatewaySecurityTokenAuthenticationConfigurationItem gatewaySecurityTokenAuthenticationConfigurationItem;
+    private final GatewaySecurityTokenAuthenticationConfigurationItem gatewaySecurityTokenAuthenticationConfigurationItem;
 
-    @Autowired
-    private AnonymousDownloadAuthenticationConfigurationItem anonymousDownloadAuthenticationConfigurationItem;
+    private final AnonymousDownloadAuthenticationConfigurationItem anonymousDownloadAuthenticationConfigurationItem;
 
     private CheckBox gatewaySecTokenCheckBox;
 
@@ -65,11 +55,22 @@ public class AuthenticationConfigurationView extends BaseConfigurationView
 
     private CheckBox downloadAnonymousCheckBox;
 
-    /**
-     * Initialize Authentication Configuration layout.
-     */
-    @PostConstruct
-    public void init() {
+    AuthenticationConfigurationView(final I18N i18n, final TenantConfigurationManagement tenantConfigurationManagement,
+            final SecurityTokenGenerator securityTokenGenerator) {
+        this.i18n = i18n;
+        this.certificateAuthenticationConfigurationItem = new CertificateAuthenticationConfigurationItem(
+                tenantConfigurationManagement, i18n);
+        this.targetSecurityTokenAuthenticationConfigurationItem = new TargetSecurityTokenAuthenticationConfigurationItem(
+                tenantConfigurationManagement, i18n);
+        this.gatewaySecurityTokenAuthenticationConfigurationItem = new GatewaySecurityTokenAuthenticationConfigurationItem(
+                tenantConfigurationManagement, i18n, securityTokenGenerator);
+        this.anonymousDownloadAuthenticationConfigurationItem = new AnonymousDownloadAuthenticationConfigurationItem(
+                tenantConfigurationManagement, i18n);
+
+        init();
+    }
+
+    private void init() {
 
         final Panel rootPanel = new Panel();
         rootPanel.setSizeFull();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/DefaultDistributionSetTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/DefaultDistributionSetTypeLayout.java
@@ -8,8 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.tenantconfiguration;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
@@ -17,13 +15,10 @@ import org.eclipse.hawkbit.repository.model.TenantMetaData;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.ComboBox;
 import com.vaadin.ui.HorizontalLayout;
@@ -34,20 +29,11 @@ import com.vaadin.ui.VerticalLayout;
 /**
  * Default DistributionSet Panel.
  */
-@SpringComponent
-@ViewScope
 public class DefaultDistributionSetTypeLayout extends BaseConfigurationView implements ConfigurationGroup {
 
     private static final long serialVersionUID = 17896542758L;
 
-    @Autowired
-    private transient SystemManagement systemManagement;
-
-    @Autowired
-    private transient DistributionSetManagement distributionSetManagement;
-
-    @Autowired
-    private I18N i18n;
+    private final transient SystemManagement systemManagement;
 
     private Long currentDefaultDisSetType;
 
@@ -55,15 +41,13 @@ public class DefaultDistributionSetTypeLayout extends BaseConfigurationView impl
 
     private TenantMetaData tenantMetaData;
 
-    private ComboBox combobox;
+    private final ComboBox combobox;
 
-    private Label changeIcon;
+    private final Label changeIcon;
 
-    /**
-     * Initialize Default Distribution Set layout.
-     */
-    @PostConstruct
-    public void init() {
+    DefaultDistributionSetTypeLayout(final SystemManagement systemManagement,
+            final DistributionSetManagement distributionSetManagement, final I18N i18n) {
+        this.systemManagement = systemManagement;
 
         final Panel rootPanel = new Panel();
         rootPanel.setSizeFull();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/PollingConfigurationView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/PollingConfigurationView.java
@@ -10,8 +10,6 @@ package org.eclipse.hawkbit.ui.tenantconfiguration;
 
 import java.time.Duration;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.ControllerPollProperties;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.repository.model.TenantConfigurationValue;
@@ -19,10 +17,7 @@ import org.eclipse.hawkbit.tenancy.configuration.DurationHelper;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
 import org.eclipse.hawkbit.ui.tenantconfiguration.polling.DurationConfigField;
 import org.eclipse.hawkbit.ui.utils.I18N;
-import org.springframework.beans.factory.annotation.Autowired;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.Panel;
 import com.vaadin.ui.VerticalLayout;
@@ -30,44 +25,30 @@ import com.vaadin.ui.VerticalLayout;
 /**
  * View to configure the polling interval and the overdue time.
  */
-@SpringComponent
-@ViewScope
 public class PollingConfigurationView extends BaseConfigurationView
         implements ConfigurationGroup, ConfigurationItem.ConfigurationItemChangeListener {
 
     private static final long serialVersionUID = 1L;
 
-    @Autowired
-    private I18N i18n;
+    private final transient TenantConfigurationManagement tenantConfigurationManagement;
 
-    @Autowired
-    private transient ControllerPollProperties controllerPollProperties;
+    private final DurationConfigField fieldPollTime;
+    private final DurationConfigField fieldPollingOverdueTime;
 
-    @Autowired
-    private transient TenantConfigurationManagement tenantConfigurationManagement;
+    private Duration tenantPollTime;
+    private Duration tenantOverdueTime;
 
-    private DurationConfigField fieldPollTime = null;
-    private DurationConfigField fieldPollingOverdueTime = null;
+    PollingConfigurationView(final I18N i18n, final ControllerPollProperties controllerPollProperties,
+            final TenantConfigurationManagement tenantConfigurationManagement) {
+        this.tenantConfigurationManagement = tenantConfigurationManagement;
 
-    private Duration minDuration;
-    private Duration maxDuration;
-    private Duration globalPollTime;
-    private Duration globalOverdueTime;
-
-    private Duration tenantPollTime = null;
-    private Duration tenantOverdueTime = null;
-
-    /**
-     * Initialize Authentication Configuration layout.
-     */
-    @PostConstruct
-    public void init() {
-
-        minDuration = DurationHelper.formattedStringToDuration(controllerPollProperties.getMinPollingTime());
-        maxDuration = DurationHelper.formattedStringToDuration(controllerPollProperties.getMaxPollingTime());
-        globalPollTime = DurationHelper.formattedStringToDuration(tenantConfigurationManagement
+        final Duration minDuration = DurationHelper
+                .formattedStringToDuration(controllerPollProperties.getMinPollingTime());
+        final Duration maxDuration = DurationHelper
+                .formattedStringToDuration(controllerPollProperties.getMaxPollingTime());
+        final Duration globalPollTime = DurationHelper.formattedStringToDuration(tenantConfigurationManagement
                 .getGlobalConfigurationValue(TenantConfigurationKey.POLLING_TIME_INTERVAL, String.class));
-        globalOverdueTime = DurationHelper.formattedStringToDuration(tenantConfigurationManagement
+        final Duration globalOverdueTime = DurationHelper.formattedStringToDuration(tenantConfigurationManagement
                 .getGlobalConfigurationValue(TenantConfigurationKey.POLLING_OVERDUE_TIME_INTERVAL, String.class));
 
         final TenantConfigurationValue<String> pollTimeConfValue = tenantConfigurationManagement
@@ -149,7 +130,7 @@ public class PollingConfigurationView extends BaseConfigurationView
         notifyConfigurationChanged();
     }
 
-    private boolean compareDurations(final Duration d1, final Duration d2) {
+    private static boolean compareDurations(final Duration d1, final Duration d2) {
         if (d1 == null && d2 == null) {
             return true;
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/AbstractAuthenticationTenantConfigurationItem.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/AbstractAuthenticationTenantConfigurationItem.java
@@ -15,24 +15,18 @@ import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.utils.I18N;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import com.vaadin.ui.VerticalLayout;
 
 /**
  * abstract authentication configuration item.
- *
- *
- *
- *
  */
 abstract class AbstractAuthenticationTenantConfigurationItem extends VerticalLayout
         implements AuthenticationConfigurationItem {
 
     private static final long serialVersionUID = 1L;
 
-    @Autowired
-    private I18N i18n;
+    private final I18N i18n;
 
     private final TenantConfigurationKey configurationKey;
     private final transient TenantConfigurationManagement tenantConfigurationManagement;
@@ -47,9 +41,10 @@ abstract class AbstractAuthenticationTenantConfigurationItem extends VerticalLay
      *            configuration value
      */
     public AbstractAuthenticationTenantConfigurationItem(final TenantConfigurationKey configurationKey,
-            final TenantConfigurationManagement tenantConfigurationManagement) {
+            final TenantConfigurationManagement tenantConfigurationManagement, final I18N i18n) {
         this.configurationKey = configurationKey;
         this.tenantConfigurationManagement = tenantConfigurationManagement;
+        this.i18n = i18n;
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/AnonymousDownloadAuthenticationConfigurationItem.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/AnonymousDownloadAuthenticationConfigurationItem.java
@@ -8,36 +8,25 @@
  */
 package org.eclipse.hawkbit.ui.tenantconfiguration.authentication;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import org.eclipse.hawkbit.ui.utils.I18N;
 
 /**
  * This class represents the UI item for the anonymous download by in the
  * authentication configuration view.
  */
-@SpringComponent
-@ViewScope
 public class AnonymousDownloadAuthenticationConfigurationItem extends AbstractAuthenticationTenantConfigurationItem {
 
     private static final long serialVersionUID = 1L;
 
-    private boolean configurationEnabled = false;
-    private boolean configurationEnabledChange = false;
+    private boolean configurationEnabled;
+    private boolean configurationEnabledChange;
 
-    @Autowired
     public AnonymousDownloadAuthenticationConfigurationItem(
-            final TenantConfigurationManagement tenantConfigurationManagement) {
-        super(TenantConfigurationKey.ANONYMOUS_DOWNLOAD_MODE_ENABLED, tenantConfigurationManagement);
-    }
+            final TenantConfigurationManagement tenantConfigurationManagement, final I18N i18n) {
+        super(TenantConfigurationKey.ANONYMOUS_DOWNLOAD_MODE_ENABLED, tenantConfigurationManagement, i18n);
 
-    @PostConstruct
-    public void init() {
         super.init("label.configuration.anonymous.download");
         configurationEnabled = isConfigEnabled();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/CertificateAuthenticationConfigurationItem.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/CertificateAuthenticationConfigurationItem.java
@@ -8,16 +8,12 @@
  */
 package org.eclipse.hawkbit.ui.tenantconfiguration.authentication;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.common.builder.TextFieldBuilder;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.I18N;
 
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.TextField;
@@ -27,30 +23,21 @@ import com.vaadin.ui.VerticalLayout;
  * This class represents the UI item for the certificate authenticated by an
  * reverse proxy in the authentication configuration view.
  */
-@SpringComponent
-@ViewScope
 public class CertificateAuthenticationConfigurationItem extends AbstractAuthenticationTenantConfigurationItem {
 
     private static final long serialVersionUID = 1L;
 
-    private boolean configurationEnabled = false;
-    private boolean configurationEnabledChange = false;
-    private boolean configurationCaRootAuthorityChanged = false;
+    private boolean configurationEnabled;
+    private boolean configurationEnabledChange;
+    private boolean configurationCaRootAuthorityChanged;
 
-    private VerticalLayout detailLayout;
-    private TextField caRootAuthorityTextField;
+    private final VerticalLayout detailLayout;
+    private final TextField caRootAuthorityTextField;
 
-    @Autowired
-    public CertificateAuthenticationConfigurationItem(
-            final TenantConfigurationManagement tenantConfigurationManagement) {
-        super(TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_ENABLED, tenantConfigurationManagement);
-    }
+    public CertificateAuthenticationConfigurationItem(final TenantConfigurationManagement tenantConfigurationManagement,
+            final I18N i18n) {
+        super(TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_ENABLED, tenantConfigurationManagement, i18n);
 
-    /**
-     * Init mehotd called by spring.
-     */
-    @PostConstruct
-    public void init() {
         super.init("label.configuration.auth.header");
         configurationEnabled = isConfigEnabled();
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/GatewaySecurityTokenAuthenticationConfigurationItem.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/GatewaySecurityTokenAuthenticationConfigurationItem.java
@@ -8,8 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.tenantconfiguration.authentication;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.security.SecurityTokenGenerator;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
@@ -17,11 +15,9 @@ import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
 import org.eclipse.hawkbit.ui.common.builder.TextFieldBuilder;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmall;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.hawkbit.ui.utils.I18N;
 
 import com.vaadin.server.FontAwesome;
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
@@ -33,18 +29,15 @@ import com.vaadin.ui.themes.ValoTheme;
  * This class represents the UI item for the gateway security token section in
  * the authentication configuration view.
  */
-@SpringComponent
-@ViewScope
 public class GatewaySecurityTokenAuthenticationConfigurationItem extends AbstractAuthenticationTenantConfigurationItem {
 
     private static final long serialVersionUID = 1L;
 
-    @Autowired
-    private transient SecurityTokenGenerator securityTokenGenerator;
+    private final transient SecurityTokenGenerator securityTokenGenerator;
 
-    private TextField gatewayTokenNameTextField;
+    private final TextField gatewayTokenNameTextField;
 
-    private Label gatewayTokenkeyLabel;
+    private final Label gatewayTokenkeyLabel;
 
     private boolean configurationEnabled;
     private boolean configurationEnabledChange;
@@ -53,24 +46,17 @@ public class GatewaySecurityTokenAuthenticationConfigurationItem extends Abstrac
 
     private boolean keyChanged;
 
-    private VerticalLayout detailLayout;
+    private final VerticalLayout detailLayout;
 
-    /**
-     * @param tenantConfigurationManagement
-     */
-    @Autowired
     public GatewaySecurityTokenAuthenticationConfigurationItem(
-            final TenantConfigurationManagement tenantConfigurationManagement) {
-        super(TenantConfigurationKey.AUTHENTICATION_MODE_GATEWAY_SECURITY_TOKEN_ENABLED, tenantConfigurationManagement);
-    }
-
-    /**
-     * Init mehotd called by spring.
-     */
-    @PostConstruct
-    public void init() {
+            final TenantConfigurationManagement tenantConfigurationManagement, final I18N i18n,
+            final SecurityTokenGenerator securityTokenGenerator) {
+        super(TenantConfigurationKey.AUTHENTICATION_MODE_GATEWAY_SECURITY_TOKEN_ENABLED, tenantConfigurationManagement,
+                i18n);
+        this.securityTokenGenerator = securityTokenGenerator;
 
         super.init("label.configuration.auth.gatewaytoken");
+
         configurationEnabled = isConfigEnabled();
 
         detailLayout = new VerticalLayout();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/TargetSecurityTokenAuthenticationConfigurationItem.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/authentication/TargetSecurityTokenAuthenticationConfigurationItem.java
@@ -8,43 +8,26 @@
  */
 package org.eclipse.hawkbit.ui.tenantconfiguration.authentication;
 
-import javax.annotation.PostConstruct;
-
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationKey;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import org.eclipse.hawkbit.ui.utils.I18N;
 
 /**
  * This class represents the UI item for the target security token section in
  * the authentication configuration view.
  */
-@SpringComponent
-@ViewScope
 public class TargetSecurityTokenAuthenticationConfigurationItem extends AbstractAuthenticationTenantConfigurationItem {
 
     private static final long serialVersionUID = 1L;
 
-    private boolean configurationEnabled = false;
-    private boolean configurationEnabledChange = false;
+    private boolean configurationEnabled;
+    private boolean configurationEnabledChange;
 
-    /**
-     * @param systemManagement
-     *            the system management to retrie the configuration
-     */
-    @Autowired
     public TargetSecurityTokenAuthenticationConfigurationItem(
-            final TenantConfigurationManagement tenantConfigurationManagement) {
-        super(TenantConfigurationKey.AUTHENTICATION_MODE_TARGET_SECURITY_TOKEN_ENABLED, tenantConfigurationManagement);
-    }
+            final TenantConfigurationManagement tenantConfigurationManagement, final I18N i18n) {
+        super(TenantConfigurationKey.AUTHENTICATION_MODE_TARGET_SECURITY_TOKEN_ENABLED, tenantConfigurationManagement,
+                i18n);
 
-    /**
-     * Init mehotd called by spring.
-     */
-    @PostConstruct
-    public void init() {
         super.init("label.configuration.auth.targettoken");
         configurationEnabled = isConfigEnabled();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/I18N.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/I18N.java
@@ -38,9 +38,6 @@ import com.vaadin.ui.UI;
  * Utility class leveraging Spring Boot auto configuration of
  * {@link MessageSource}.
  *
- *
- *
- *
  */
 @Service
 public class I18N implements Serializable {
@@ -48,8 +45,12 @@ public class I18N implements Serializable {
 
     private static final Logger LOG = LoggerFactory.getLogger(I18N.class);
 
+    private final transient MessageSource source;
+
     @Autowired
-    private transient MessageSource source;
+    I18N(final MessageSource source) {
+        this.source = source;
+    }
 
     /**
      * Tries to resolve the message.

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPDateTimeUtil.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPDateTimeUtil.java
@@ -199,7 +199,7 @@ public final class SPDateTimeUtil {
         /**
          * 
          */
-        private CalendarI18N(final String single, final String plural) {
+        CalendarI18N(final String single, final String plural) {
             this.single = single;
             this.plural = plural;
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UINotification.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UINotification.java
@@ -14,19 +14,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.vaadin.server.FontAwesome;
 import com.vaadin.spring.annotation.SpringComponent;
-import com.vaadin.spring.annotation.ViewScope;
+import com.vaadin.spring.annotation.UIScope;
 
 /**
  * Show success and error messages.
  */
-@ViewScope
+@UIScope
 @SpringComponent
 public class UINotification implements Serializable {
 
     private static final long serialVersionUID = -9030485417988977466L;
 
+    private final NotificationMessage notificationMessage;
+
     @Autowired
-    private NotificationMessage notificationMessage;
+    UINotification(final NotificationMessage notificationMessage) {
+        this.notificationMessage = notificationMessage;
+    }
 
     /**
      * Display success type of notification message.

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
       <!-- Spring boot version overrides - END -->
 
       <!-- Vaadin versions - START -->
-      <vaadin.spring.version>1.0.2</vaadin.spring.version>
+      <vaadin.spring.version>1.1.1</vaadin.spring.version>
       <vaadin.spring.addon.version>0.0.6.RELEASE</vaadin.spring.addon.version>
       <vaadin.version>7.7.3</vaadin.version>
       <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>


### PR DESCRIPTION
The UI is getting slower and slower by means of both login as well as open view performance in general.

I optimised in the following directions:
* Switched view to Ui scope to ensure that they do not get garbage collected when the user switches the view.
* Reduced the number of prototype beans drastically to reduce pressure on the bean factory. New strategy is to have primarily only the views themselves and everything in sessions cope as bean.
* A new minor tweaks on repository access to reduce DB calls.
* UI internal events switched to Ui scope to ensure that multiple UIs in the same session are not flooded by duplicate events by DelayedEventBusPushStrategy (which is running per UI and not session).
* While at it I migrated most of the remaining beans to constructor injection.