### PR TITLE
Search string in target table searches now also for the controller id

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -309,7 +309,7 @@ public class JpaTargetManagement implements TargetManagement {
                     .hasInstalledOrAssignedDistributionSet(filterParams.getFilterByDistributionId()));
         }
         if (StringUtils.isNotEmpty(filterParams.getFilterBySearchText())) {
-            specList.add(TargetSpecifications.likeNameOrDescriptionOrIp(filterParams.getFilterBySearchText()));
+            specList.add(TargetSpecifications.likeIdOrNameOrDescription(filterParams.getFilterBySearchText()));
         }
         if (isHasTagsFilterActive(filterParams)) {
             specList.add(TargetSpecifications.hasTags(filterParams.getFilterByTagNames(),

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
@@ -142,16 +142,17 @@ public final class TargetSpecifications {
 
     /**
      * {@link Specification} for retrieving {@link Target}s by
-     * "like controllerId or like description or like ip address".
+     * "like controllerId or like name or like description".
      *
      * @param searchText
      *            to be filtered on
      * @return the {@link Target} {@link Specification}
      */
-    public static Specification<JpaTarget> likeNameOrDescriptionOrIp(final String searchText) {
+    public static Specification<JpaTarget> likeIdOrNameOrDescription(final String searchText) {
         return (targetRoot, query, cb) -> {
             final String searchTextToLower = searchText.toLowerCase();
-            return cb.or(cb.like(cb.lower(targetRoot.get(JpaTarget_.name)), searchTextToLower),
+            return cb.or(cb.like(cb.lower(targetRoot.get(JpaTarget_.controllerId)), searchTextToLower),
+                    cb.like(cb.lower(targetRoot.get(JpaTarget_.name)), searchTextToLower),
                     cb.like(cb.lower(targetRoot.get(JpaTarget_.description)), searchTextToLower));
         };
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementSearchTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementSearchTest.java
@@ -67,6 +67,9 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 targetDsAIdPref.concat(" description"), lastTargetQueryNotOverdue);
         targAs = targetManagement.toggleTagAssignment(targAs, targTagX).getAssignedEntity();
 
+        final Target targSpecialName = targetManagement
+                .updateTarget(entityFactory.target().update(targAs.get(0).getControllerId()).name("targ-A-special"));
+
         final String targetDsBIdPref = "targ-B";
         List<Target> targBs = testdataFactory.createTargets(100, targetDsBIdPref,
                 targetDsBIdPref.concat(" description"), lastTargetQueryAlwaysOverdue);
@@ -113,6 +116,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findTargetByControllerID(targCs.stream().map(Target::getControllerId).collect(Collectors.toList()));
 
         // try to find several targets with different filter settings
+        verifyThat1TargetHasNameAndId("targ-A-special", targSpecialName.getControllerId());
         verifyThatRepositoryContains400Targets();
         verifyThat200TargetsHaveTagD(targTagW, concat(targBs, targCs));
         verifyThat100TargetsContainsGivenTextAndHaveTagAssigned(targTagY, targTagW, targBs);
@@ -633,6 +637,23 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         .as("and contains the following elements").containsExactly(expectedIdName)
                         .as("and NAMED filter query returns the same result").containsAll(targetManagement
                                 .findAllTargetIdsByTargetFilterQuery(pageReq, new JpaTargetFilterQuery("test", query)));
+    }
+
+    @Step
+    private void verifyThat1TargetHasNameAndId(final String name, final String controllerId) {
+        assertThat(targetManagement
+                .findTargetByFilters(pageReq, null, null, name, null, Boolean.FALSE)
+                .getContent()).as("has number of elements").hasSize(1)
+                .as("that number is also returned by count query")
+                .hasSize(Ints.saturatedCast(targetManagement.countTargetByFilters(null, null, name,
+                        null, Boolean.FALSE)));
+
+        assertThat(targetManagement
+                .findTargetByFilters(pageReq, null, null, controllerId, null, Boolean.FALSE)
+                .getContent()).as("has number of elements").hasSize(1)
+                .as("that number is also returned by count query")
+                .hasSize(Ints.saturatedCast(targetManagement.countTargetByFilters(null, null, controllerId,
+                        null, Boolean.FALSE)));
     }
 
     @Step


### PR DESCRIPTION
Enabled the search for targets by their controller id.
Previously it was only possible to search by name and description.