### PR TITLE
Introduce optional throttled DMF requeuing

### DIFF
--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
@@ -51,7 +51,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.util.ErrorHandler;
 
 import com.google.common.collect.Maps;
 
@@ -329,9 +328,8 @@ public class AmqpConfiguration {
      *         AMQP messages
      */
     @Bean(name = { "listenerContainerFactory" })
-    public RabbitListenerContainerFactory<SimpleMessageListenerContainer> listenerContainerFactory(
-            final ErrorHandler errorHandler) {
-        return new ConfigurableRabbitListenerContainerFactory(amqpProperties, rabbitConnectionFactory, errorHandler);
+    public RabbitListenerContainerFactory<SimpleMessageListenerContainer> listenerContainerFactory() {
+        return new ConfigurableRabbitListenerContainerFactory(amqpProperties, rabbitConnectionFactory);
     }
 
     /**

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -28,8 +28,6 @@ import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.RepositoryConstants;
 import org.eclipse.hawkbit.repository.builder.ActionStatusCreate;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
-import org.eclipse.hawkbit.repository.exception.TenantNotExistException;
-import org.eclipse.hawkbit.repository.exception.TooManyStatusEntriesException;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
 import org.eclipse.hawkbit.repository.model.Target;
@@ -138,8 +136,6 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
             }
         } catch (final IllegalArgumentException ex) {
             throw new AmqpRejectAndDontRequeueException("Invalid message!", ex);
-        } catch (final TenantNotExistException | TooManyStatusEntriesException e) {
-            throw new AmqpRejectAndDontRequeueException(e);
         } finally {
             SecurityContextHolder.setContext(oldContext);
         }

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
@@ -30,6 +30,8 @@ public class AmqpProperties {
 
     private static final int DEFAULT_MAX_CONSUMERS = 10;
 
+    private static final long DEFAULT_REQUEUE_DELAY = 0;
+
     /**
      * Enable DMF API based on AMQP 0.9
      */
@@ -90,6 +92,19 @@ public class AmqpProperties {
      * initialization.
      */
     private int declarationRetries = DEFAULT_QUEUE_DECLARATION_RETRIES;
+
+    /**
+     * Delay for messages that are requeued.
+     */
+    private long requeueDelay = DEFAULT_REQUEUE_DELAY;
+
+    public long getRequeueDelay() {
+        return requeueDelay;
+    }
+
+    public void setRequeueDelay(final long requeueDelay) {
+        this.requeueDelay = requeueDelay;
+    }
 
     public int getDeclarationRetries() {
         return declarationRetries;

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpProperties.java
@@ -94,7 +94,7 @@ public class AmqpProperties {
     private int declarationRetries = DEFAULT_QUEUE_DECLARATION_RETRIES;
 
     /**
-     * Delay for messages that are requeued.
+     * Delay for messages that are requeued in milliseconds.
      */
     private long requeueDelay = DEFAULT_REQUEUE_DELAY;
 

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
@@ -10,9 +10,9 @@ package org.eclipse.hawkbit.amqp;
 
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.util.ErrorHandler;
 
 /**
  * {@link RabbitListenerContainerFactory} that can be configured through
@@ -28,13 +28,14 @@ public class ConfigurableRabbitListenerContainerFactory extends SimpleRabbitList
      * @param rabbitConnectionFactory
      *            for the container factory
      * @param amqpProperties
-     *            to configure the container factory *
+     *            to configure the container factory
+     * @param errorHandler
+     *            the error handler which should be use
      */
     public ConfigurableRabbitListenerContainerFactory(final AmqpProperties amqpProperties,
-            final ConnectionFactory rabbitConnectionFactory) {
+            final ConnectionFactory rabbitConnectionFactory, final ErrorHandler errorHandler) {
         this.amqpProperties = amqpProperties;
-        setErrorHandler(new ConditionalRejectingErrorHandler(
-                new DelayedRequeueExceptionStrategy(amqpProperties.getRequeueDelay())));
+        setErrorHandler(errorHandler);
         setDefaultRequeueRejected(true);
         setConnectionFactory(rabbitConnectionFactory);
         setMissingQueuesFatal(amqpProperties.isMissingQueuesFatal());

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/ConfigurableRabbitListenerContainerFactory.java
@@ -10,9 +10,9 @@ package org.eclipse.hawkbit.amqp;
 
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
-import org.springframework.util.ErrorHandler;
 
 /**
  * {@link RabbitListenerContainerFactory} that can be configured through
@@ -28,14 +28,13 @@ public class ConfigurableRabbitListenerContainerFactory extends SimpleRabbitList
      * @param rabbitConnectionFactory
      *            for the container factory
      * @param amqpProperties
-     *            to configure the container factory
-     * @param errorHandler
-     *            the error handler which should be use
+     *            to configure the container factory *
      */
     public ConfigurableRabbitListenerContainerFactory(final AmqpProperties amqpProperties,
-            final ConnectionFactory rabbitConnectionFactory, final ErrorHandler errorHandler) {
+            final ConnectionFactory rabbitConnectionFactory) {
         this.amqpProperties = amqpProperties;
-        setErrorHandler(errorHandler);
+        setErrorHandler(new ConditionalRejectingErrorHandler(
+                new DelayedRequeueExceptionStrategy(amqpProperties.getRequeueDelay())));
         setDefaultRequeueRejected(true);
         setConnectionFactory(rabbitConnectionFactory);
         setMissingQueuesFatal(amqpProperties.isMissingQueuesFatal());

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/DelayedRequeueExceptionStrategy.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/DelayedRequeueExceptionStrategy.java
@@ -30,7 +30,11 @@ public class DelayedRequeueExceptionStrategy extends ConditionalRejectingErrorHa
 
     private final long delay;
 
-    DelayedRequeueExceptionStrategy(final long delay) {
+    /**
+     * @param delay
+     *            in {@link TimeUnit#MILLISECONDS} before requeue.
+     */
+    public DelayedRequeueExceptionStrategy(final long delay) {
         this.delay = delay;
     }
 

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/DelayedRequeueExceptionStrategy.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/DelayedRequeueExceptionStrategy.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.amqp;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hawkbit.repository.exception.InvalidTargetAddressException;
+import org.eclipse.hawkbit.repository.exception.TenantNotExistException;
+import org.eclipse.hawkbit.repository.exception.TooManyStatusEntriesException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler;
+import org.springframework.amqp.rabbit.listener.FatalExceptionStrategy;
+
+/**
+ * Custom {@link FatalExceptionStrategy} that markes defined hawkBit internal
+ * exceptions not to be requeued. In addition it throttles in case of a requeue
+ * by means of blocking the processing thread for a certain amount of time. That
+ * avoids a back and forth between broker and hawkBit at maximum speed.
+ *
+ */
+public class DelayedRequeueExceptionStrategy extends ConditionalRejectingErrorHandler.DefaultExceptionStrategy {
+    private static final Logger LOG = LoggerFactory.getLogger(DelayedRequeueExceptionStrategy.class);
+
+    private final long delay;
+
+    DelayedRequeueExceptionStrategy(final long delay) {
+        this.delay = delay;
+    }
+
+    @Override
+    protected boolean isUserCauseFatal(final Throwable cause) {
+        if (cause instanceof TenantNotExistException || cause instanceof TooManyStatusEntriesException
+                || cause instanceof InvalidTargetAddressException) {
+            return true;
+        }
+
+        LOG.error("Found a message that has to be requeued. Processing with delay of {}ms: ", delay, cause);
+
+        try {
+            TimeUnit.MILLISECONDS.sleep(delay);
+        } catch (final InterruptedException e) {
+            LOG.error("Delay interrupted!", e);
+            Thread.currentThread().interrupt();
+        }
+
+        return false;
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/InvalidTargetAddressException.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/InvalidTargetAddressException.java
@@ -15,10 +15,6 @@ import org.eclipse.hawkbit.exception.SpServerError;
  * Exception which is thrown when trying to set an invalid target address.
  */
 public class InvalidTargetAddressException extends AbstractServerRtException {
-
-    /**
-     * 
-     */
     private static final long serialVersionUID = 1L;
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 
       <!-- Spring boot version overrides (should be reviewed with every boot upgrade) - START -->
       <!-- Newer versions needed than defined in Boot -->
-      <spring-amqp.version>1.6.3.RELEASE</spring-amqp.version>
+      <spring-amqp.version>1.6.5.RELEASE</spring-amqp.version>
       <spring-security.version>4.1.2.RELEASE</spring-security.version>
       <spring.version>4.3.3.RELEASE</spring.version>
       <spring-integration.version>4.3.2.RELEASE</spring-integration.version>


### PR DESCRIPTION
We have currently the problem that when we have to requeue a message we do this immediately. The result is that rabbit will push it back immediately again. This results in loop that consumes all available resources both on broker and server side.

The standard Rabbit recommendation to throttle this using dead letter in combination with a ttl is problematic as it does not allow to still have a real dead letter for later investigation.

In general we have to distinguish between three error cases:
* hawkBit runtime has a real problem (e.g. DB down). These message should be requed and processed later, i.e. when the problem is fixed. This is the default behaviour.
* hawkBit identifies the cause of the failure as a problem on the sender side (i.e. invalid data). This message goes into dead letter. These problems are defined by means of blacklisting the issue. This is done to ensure that we do not "loose" messages into dead letter in case of an unknown error. I call this "loose" as in practice it is really hard to find message in the haystack called dead letter.
* As a result the third category are Unknown errors which might be of either of the categories above.

No matter which cause is the reason to requeue it seems to me to be good compromise to continue the current behaviour but throttle message consumption down until the problem could be fixed on hawkBit side, i.e. either handling the message by means pushing to dead letter or fix the problem inside hawkBit that cause the issue.

I used a new custom exception handling strategy introduced with Spring AMQP 1.6.3 (and fixed in 1.6.5 😄 ) to get this done.

A new `hawkbit.dmf.rabbitmq.requeue-delay` can be configured (default: 0)

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>