### PR TITLE
call getEntity only on visible item

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
@@ -170,9 +170,9 @@ public class TargetTable extends AbstractTable<Target, TargetIdName> {
         if (isFilterEnabled()) {
             refreshTargets();
         } else {
-            eventContainer.getEvents().stream().map(event -> event.getEntity())
-                    .filter(target -> visibleItemIds.contains(target.getTargetIdName()))
-                    .forEach(target -> updateVisibleItemOnEvent(target.getTargetInfo()));
+            eventContainer.getEvents().stream()
+                    .filter(event -> visibleItemIds.contains(new TargetIdName(event.getEntityId(), null, null)))
+                    .forEach(event -> updateVisibleItemOnEvent(event.getEntity().getTargetInfo()));
             targetContainer.commit();
         }
 


### PR DESCRIPTION
We should not call `getEntity()` on each `TargetUpdatedEvent` because it could be that this event is fired from another node and this would lead into a select statement to lazy query the `Target` entity on each event even though it's not necessary.

There is an easy workaround to do it, because the `TargetIdName` is implementing the `hashCode` only based on the `targetId'  which is already in the event.

This mechanism to build a `TargetIdName` only based on the `targetId` is also already done when deleting a Target, due the ID in the Vaadin table is the class `TargetIdName` but the comparison is based on the `hashCode` which then will work because the `hashCode` is only the `long targetId`.

This is a very easy and quick workaround to prevent these many select statements when events are from a different node and will cause an extra select statement on the UI even though the item is currently not visible and don't need to be updated on the view.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>