### PR TITLE
remove dirty context annotation

### DIFF
--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
@@ -75,11 +75,16 @@ public class EventVerifier implements TestRule {
             verifyRightCountOfEvents(expectedEvents);
             verifyAllEventsCounted(expectedEvents);
         } finally {
-            final ApplicationEventMulticaster aem = TestContextProvider.getContext().getBean(
+            final ConfigurableApplicationContext context = TestContextProvider.getContext();
+            if (context instanceof AbstractApplicationContext) {
+                ((AbstractApplicationContext) context).getApplicationListeners().remove(eventCaptor);
+            }
+            final ApplicationEventMulticaster aem = context.getBean(
                     AbstractApplicationContext.APPLICATION_EVENT_MULTICASTER_BEAN_NAME,
                     ApplicationEventMulticaster.class);
             aem.removeApplicationListener(eventCaptor);
         }
+        eventCaptor = null;
     }
 
     private void verifyRightCountOfEvents(final Expect[] expectedEvents) {

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
@@ -27,6 +27,7 @@ import org.springframework.cloud.bus.event.RemoteApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.support.AbstractApplicationContext;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
@@ -70,8 +71,15 @@ public class EventVerifier implements TestRule {
     }
 
     private void afterTest(final Expect[] expectedEvents) {
-        verifyRightCountOfEvents(expectedEvents);
-        verifyAllEventsCounted(expectedEvents);
+        try {
+            verifyRightCountOfEvents(expectedEvents);
+            verifyAllEventsCounted(expectedEvents);
+        } finally {
+            final ApplicationEventMulticaster aem = TestContextProvider.getContext().getBean(
+                    AbstractApplicationContext.APPLICATION_EVENT_MULTICASTER_BEAN_NAME,
+                    ApplicationEventMulticaster.class);
+            aem.removeApplicationListener(eventCaptor);
+        }
     }
 
     private void verifyRightCountOfEvents(final Expect[] expectedEvents) {

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
@@ -79,8 +79,6 @@ import org.springframework.data.auditing.AuditingHandler;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.MediaTypes;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -96,11 +94,6 @@ import com.google.common.collect.Lists;
 @ActiveProfiles({ "test" })
 @WithUser(principal = "bumlux", allSpPermissions = true, authorities = { CONTROLLER_ROLE, SYSTEM_ROLE })
 @SpringApplicationConfiguration(classes = { TestConfiguration.class, TestSupportBinderAutoConfiguration.class })
-// destroy the context after each test class because otherwise we get problem
-// when context is
-// refreshed we e.g. get two instances of CacheManager which leads to very
-// strange test failures.
-@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public abstract class AbstractIntegrationTest implements EnvironmentAware {
     private final static Logger LOG = LoggerFactory.getLogger(AbstractIntegrationTest.class);
 


### PR DESCRIPTION
We should remove the `@DirtyContext` annotation from the `AbstractIntegrationTest` to improve test-execution time. This was introduced long time ago, I guess because of caching-problems but this should work without `@DirtyContext` again.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>