### PR TITLE
Fix DMF update cancel message

### DIFF
--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
@@ -156,6 +156,10 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
 
     void sendCancelMessageToTarget(final String tenant, final String controllerId, final Long actionId,
             final URI address) {
+        if (!IpUtil.isAmqpUri(address)) {
+            return;
+        }
+
         final Message message = getMessageConverter().toMessage(actionId,
                 createConnectorMessageProperties(tenant, controllerId, EventTopic.CANCEL_DOWNLOAD));
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -409,9 +409,13 @@ public class JpaDeploymentManagement implements DeploymentManagement {
      *            the action id of the assignment
      */
     private void cancelAssignDistributionSetEvent(final Target target, final Long actionId) {
-        target.getTargetInfo();
+        loadLazyTargetInfo(target);
         afterCommit.afterCommit(() -> eventPublisher
                 .publishEvent(new CancelTargetAssignmentEvent(target, actionId, applicationContext.getId())));
+    }
+
+    private static void loadLazyTargetInfo(final Target target) {
+        target.getTargetInfo();
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -409,6 +409,7 @@ public class JpaDeploymentManagement implements DeploymentManagement {
      *            the action id of the assignment
      */
     private void cancelAssignDistributionSetEvent(final Target target, final Long actionId) {
+        target.getTargetInfo();
         afterCommit.afterCommit(() -> eventPublisher
                 .publishEvent(new CancelTargetAssignmentEvent(target, actionId, applicationContext.getId())));
     }


### PR DESCRIPTION
wo bugs actually:

- DMF tries to send cancelation even for DDI targets
- DMF send cancelation actually fails as target info is needed but not part of the event.
