### PR TITLE
add cache condition to prevent null cache value of tenant

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
@@ -244,7 +244,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     }
 
     @Override
-    @Cacheable(value = "currentTenant", keyGenerator = "currentTenantKeyGenerator", cacheManager = "directCacheManager")
+    @Cacheable(value = "currentTenant", keyGenerator = "currentTenantKeyGenerator", cacheManager = "directCacheManager", unless = "#result == null")
     // set transaction to not supported, due we call this in
     // BaseEntity#prePersist methods
     // and it seems that JPA committing the transaction when executing this


### PR DESCRIPTION
Prevent `null` values to be cached as `currentTenant()` in the `JpaSystemManagement` because once the cache is filled with the `null` value it is never be evicted. 

This happens e.g. you are using the DMF- or DDI-API to create targets even though the tenant does not exists. Then the cache is filled with the `null` value and you cannot login on the UI anymore because the tenant is not created lazy. 

So just introduce an cache-condition to prevent to cache the `null` tenant.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>