### PR TITLE
Substitute the layout container of HawkbitUI

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/HawkbitUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/HawkbitUI.java
@@ -46,6 +46,7 @@ import com.vaadin.ui.CssLayout;
 import com.vaadin.ui.CustomLayout;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
+import com.vaadin.ui.Panel;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
@@ -144,10 +145,10 @@ public class HawkbitUI extends DefaultHawkbitUI implements DetachListener {
         viewHeadercontent.addComponent(notificationUnreadButton);
         viewHeadercontent.setComponentAlignment(notificationUnreadButton, Alignment.MIDDLE_RIGHT);
 
-        final HorizontalLayout content = new HorizontalLayout();
-        contentVerticalLayout.addComponent(content);
-        content.setStyleName("view-content");
+        final Panel content = new Panel();
         content.setSizeFull();
+        content.setStyleName("view-content");
+        contentVerticalLayout.addComponent(content);
 
         rootLayout.setExpandRatio(contentVerticalLayout, 1.0F);
         contentVerticalLayout.setStyleName("main-content");

--- a/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/common.scss
+++ b/hawkbit-ui/src/main/resources/VAADIN/themes/hawkbit/customstyles/common.scss
@@ -52,6 +52,9 @@
       padding-left: 20px;
       min-width: 1000px;
       min-height: 400px;
+	  border: 0px;   
+	  background-color: transparent;   
+	  box-shadow: none;
     }
 
     //View background styles


### PR DESCRIPTION
The HawkbitUI now uses a Panel as component container instead of a HorizontalLayout

Reviewer: @SirWayne @schabdo 

Signed-off-by: Melanie Retter <melanie.retter@bosch-si.com>