### PR TITLE
DMF API supports target attributes update

### DIFF
--- a/docs/src/main/resources/documentation/interfaces/dmf-api.md
+++ b/docs/src/main/resources/documentation/interfaces/dmf-api.md
@@ -57,6 +57,38 @@ All messages have to be sent to the exchange **dmf.exchange**.
 | type=THING\_CREATED <br /> tenant=tenant123 <br /> thingId=abc  <br /> sender=Lwm2m   | content\_type=application/json <br /> reply_to (optional) =sp.connector.replyTo  
 
 
+### Message to update target attributes
+
+| Message Header                      | Description                      | Type                                | Mandatory                                                    
+|-----------------------------|----------------------------------|-------------------------------------|----------------
+| type          | Type of the message              | Fixed string "EVENT"       | true
+| topic         | Topic to handle events different | Fixed string "UPDATE_ATTRIBUTES" | true
+| thingId       | The ID of the registered thing   | String                              | true
+| tenant        | The tenant this thing belongs to | String                              | false
+
+
+| Message Properties                      | Description                      | Type                                | Mandatory                                                    
+|-----------------------------|----------------------------------|-------------------------------------|----------------
+| content_type                 | The content type of the payload  | String                              | true
+
+
+**Example Header and Payload**
+
+| Headers                               | MessageProperties               |                                                              
+|---------------------------------------|---------------------------------|
+| type=EVENT <br /> tenant=tenant123 <br /> thingId=abc  <br /> topic=UPDATE\_ATTRIBUTES | content\_type=application/json <br /> 
+
+Payload Template
+
+```json
+{
+	"attributes": {
+		"exampleKey1" : "exampleValue1",
+		"exampleKey2" : "exampleValue2"
+	}
+}
+```
+
 ### Message to send an action status event to _hawkBit_
 
 The Java representation is ActionUpdateStatus:

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulator.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/DeviceSimulator.java
@@ -8,7 +8,10 @@
  */
 package org.eclipse.hawkbit.simulator;
 
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -36,6 +39,14 @@ public class DeviceSimulator {
     @Bean
     public EventBus eventBus() {
         return new AsyncEventBus(Executors.newFixedThreadPool(4));
+    }
+
+    /**
+     * @return central ScheduledExecutorService
+     */
+    @Bean
+    public ScheduledExecutorService threadPool() {
+        return newScheduledThreadPool(8);
     }
 
     /**

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatedDeviceFactory.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatedDeviceFactory.java
@@ -9,6 +9,8 @@
 package org.eclipse.hawkbit.simulator;
 
 import java.net.URL;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hawkbit.simulator.AbstractSimulatedDevice.Protocol;
 import org.eclipse.hawkbit.simulator.amqp.SpSenderService;
@@ -31,6 +33,9 @@ public class SimulatedDeviceFactory {
 
     @Autowired
     private SpSenderService spSenderService;
+
+    @Autowired
+    private ScheduledExecutorService threadPool;
 
     /**
      * Creating a simulated device.
@@ -84,6 +89,9 @@ public class SimulatedDeviceFactory {
         if (pollImmediatly) {
             spSenderService.createOrUpdateThing(tenant, id);
         }
+
+        threadPool.schedule(() -> spSenderService.updateAttributesOfThing(tenant, id), 2_000, TimeUnit.MILLISECONDS);
+
         return device;
     }
 

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationProperties.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationProperties.java
@@ -49,6 +49,10 @@ public class SimulationProperties {
         return this.autostarts;
     }
 
+    /**
+     * Properties for target attributes set as part of simulation.
+     *
+     */
     public static class Attribute {
         private String key;
         private String value;

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationProperties.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationProperties.java
@@ -27,6 +27,8 @@ import com.google.common.base.Splitter;
  */
 @Component
 @ConfigurationProperties("hawkbit.device.simulator")
+// Exception for squid:S2245 : not security relevant random number generation
+@SuppressWarnings("squid:S2245")
 public class SimulationProperties {
     private static final Splitter SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
     private static final Random RANDOM = new Random();

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationProperties.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulationProperties.java
@@ -10,12 +10,16 @@ package org.eclipse.hawkbit.simulator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hawkbit.simulator.AbstractSimulatedDevice.Protocol;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+
+import com.google.common.base.Splitter;
 
 /**
  * General simulator service properties.
@@ -24,6 +28,8 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties("hawkbit.device.simulator")
 public class SimulationProperties {
+    private static final Splitter SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
+    private static final Random RANDOM = new Random();
 
     /**
      * List of tenants where the simulator should auto start simulations after
@@ -31,8 +37,49 @@ public class SimulationProperties {
      */
     private final List<Autostart> autostarts = new ArrayList<>();
 
+    private final List<Attribute> attributes = new ArrayList<>();
+
+    public List<Attribute> getAttributes() {
+        return attributes;
+    }
+
     public List<Autostart> getAutostarts() {
         return this.autostarts;
+    }
+
+    public static class Attribute {
+        private String key;
+        private String value;
+        private String random;
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getValue() {
+            return Optional.ofNullable(value).orElseGet(this::getRandomElement);
+        }
+
+        public void setKey(final String key) {
+            this.key = key;
+        }
+
+        public void setValue(final String value) {
+            this.value = value;
+        }
+
+        public void setRandom(final String random) {
+            this.random = random;
+        }
+
+        public String getRandom() {
+            return random;
+        }
+
+        private String getRandomElement() {
+            final List<String> options = SPLITTER.splitToList(random);
+            return options.get(RANDOM.nextInt(options.size()));
+        }
     }
 
     /**

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/SpSenderService.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/SpSenderService.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.simulator.amqp;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.dmf.amqp.api.AmqpSettings;
 import org.eclipse.hawkbit.dmf.amqp.api.EventTopic;
@@ -18,6 +19,7 @@ import org.eclipse.hawkbit.dmf.amqp.api.MessageType;
 import org.eclipse.hawkbit.dmf.json.model.ActionStatus;
 import org.eclipse.hawkbit.dmf.json.model.ActionUpdateStatus;
 import org.eclipse.hawkbit.dmf.json.model.AttributeUpdate;
+import org.eclipse.hawkbit.simulator.SimulationProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.core.Message;
@@ -36,17 +38,23 @@ public class SpSenderService extends SenderService {
 
     private final String spExchange;
 
+    private final SimulationProperties simulationProperties;
+
     /**
      *
      * @param rabbitTemplate
      *            the rabbit template
      * @param amqpProperties
      *            the amqp properties
+     * @param simulationProperties
+     *            for attributes update class
      */
     @Autowired
-    public SpSenderService(final RabbitTemplate rabbitTemplate, final AmqpProperties amqpProperties) {
+    public SpSenderService(final RabbitTemplate rabbitTemplate, final AmqpProperties amqpProperties,
+            final SimulationProperties simulationProperties) {
         super(rabbitTemplate, amqpProperties);
         this.spExchange = AmqpSettings.DMF_EXCHANGE;
+        this.simulationProperties = simulationProperties;
     }
 
     /**
@@ -173,8 +181,8 @@ public class SpSenderService extends SenderService {
         messagePropertiesForSP.setReplyTo(amqpProperties.getSenderForSpExchange());
         final AttributeUpdate attributeUpdate = new AttributeUpdate();
 
-        // FIXME take from configuration
-        attributeUpdate.getAttributes().put("isoCode", "DE");
+        attributeUpdate.getAttributes().putAll(simulationProperties.getAttributes().stream().collect(
+                Collectors.toMap(SimulationProperties.Attribute::getKey, SimulationProperties.Attribute::getValue)));
 
         return convertMessage(attributeUpdate, messagePropertiesForSP);
     }

--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/SpSenderService.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/amqp/SpSenderService.java
@@ -76,8 +76,8 @@ public class SpSenderService extends SenderService {
      *
      * @param update
      *            the simulated update object
-     * @param messageDescription
-     *            a description according the update process
+     * @param updateResultMessages
+     *            list of messages for error
      */
     public void finishUpdateProcessWithError(final SimulatedUpdate update, final List<String> updateResultMessages) {
         sendErrorgMessage(update, updateResultMessages);
@@ -147,7 +147,7 @@ public class SpSenderService extends SenderService {
     }
 
     /**
-     * Create new attribute update message and send to udpate server.
+     * Create new attribute update message and send to update server.
      *
      * @param tenant
      *            the tenant to create the target
@@ -157,7 +157,7 @@ public class SpSenderService extends SenderService {
     public void updateAttributesOfThing(final String tenant, final String targetId) {
         sendMessage(spExchange, attributeUpdateMessage(tenant, targetId));
 
-        LOGGER.debug("Send update attributes message and send to update server for Thing \"{}\"", targetId);
+        LOGGER.debug("Create update attributes message and send to update server for Thing \"{}\"", targetId);
     }
 
     private Message thingCreatedMessage(final String tenant, final String targetId) {

--- a/examples/hawkbit-device-simulator/src/main/resources/application.properties
+++ b/examples/hawkbit-device-simulator/src/main/resources/application.properties
@@ -17,6 +17,12 @@ hawkbit.device.simulator.amqp.senderForSpExchange=simulator.replyTo
 ## Configuration for simulations
 hawkbit.device.simulator.autostarts.[0].tenant=DEFAULT
 
+hawkbit.device.simulator.attributes[0].key=isoCode
+hawkbit.device.simulator.attributes[0].random=DE,US,AU,FR,DK,CA
+hawkbit.device.simulator.attributes[1].key=hwRevision
+hawkbit.device.simulator.attributes[1].value=1.1
+hawkbit.device.simulator.attributes[2].key=serial
+hawkbit.device.simulator.attributes[2].value=${random.value}
 
 ## Configuration for local RabbitMQ integration
 spring.rabbitmq.username=guest

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -21,6 +21,7 @@ import org.eclipse.hawkbit.dmf.amqp.api.EventTopic;
 import org.eclipse.hawkbit.dmf.amqp.api.MessageHeaderKey;
 import org.eclipse.hawkbit.dmf.amqp.api.MessageType;
 import org.eclipse.hawkbit.dmf.json.model.ActionUpdateStatus;
+import org.eclipse.hawkbit.dmf.json.model.AttributeUpdate;
 import org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions;
 import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
 import org.eclipse.hawkbit.repository.ControllerManagement;
@@ -205,11 +206,26 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
      *            the topic of the event.
      */
     private void handleIncomingEvent(final Message message, final EventTopic topic) {
-        if (EventTopic.UPDATE_ACTION_STATUS.equals(topic)) {
+
+        switch (topic) {
+        case UPDATE_ACTION_STATUS:
             updateActionStatus(message);
-            return;
+            break;
+        case UPDATE_ATTRIBUTES:
+            updateAttributes(message);
+            break;
+        default:
+            logAndThrowMessageError(message, "Got event without appropriate topic.");
+            break;
         }
-        logAndThrowMessageError(message, "Got event without appropriate topic.");
+
+    }
+
+    private void updateAttributes(final Message message) {
+        final AttributeUpdate attributeUpdate = convertMessage(message, AttributeUpdate.class);
+        final String thingId = getStringHeaderKey(message, MessageHeaderKey.THING_ID, "ThingId is null");
+
+        controllerManagement.updateControllerAttributes(thingId, attributeUpdate.getAttributes());
     }
 
     /**

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -58,6 +58,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -114,6 +115,12 @@ public class AmqpMessageHandlerServiceTest {
 
     @Mock
     private RabbitTemplate rabbitTemplate;
+
+    @Captor
+    private ArgumentCaptor<Map<String, String>> attributesCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> targetIdCaptor;
 
     @Before
     public void before() throws Exception {
@@ -177,9 +184,6 @@ public class AmqpMessageHandlerServiceTest {
 
         final Message message = amqpMessageHandlerService.getMessageConverter().toMessage(attributeUpdate,
                 messageProperties);
-
-        final ArgumentCaptor<String> targetIdCaptor = ArgumentCaptor.forClass(String.class);
-        final ArgumentCaptor<Map> attributesCaptor = ArgumentCaptor.forClass(Map.class);
 
         when(controllerManagementMock.updateControllerAttributes(targetIdCaptor.capture(), attributesCaptor.capture()))
                 .thenReturn(null);

--- a/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/amqp/api/EventTopic.java
+++ b/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/amqp/api/EventTopic.java
@@ -10,9 +10,6 @@ package org.eclipse.hawkbit.dmf.amqp.api;
 
 /**
  * The event topics for the message headers.
- * 
- *
- *
  */
 public enum EventTopic {
 
@@ -27,6 +24,10 @@ public enum EventTopic {
     /**
      * Topic when sending and receiving a cancel download task.
      */
-    CANCEL_DOWNLOAD;
+    CANCEL_DOWNLOAD,
+    /**
+     * Topic when updating device attributes.
+     */
+    UPDATE_ATTRIBUTES;
 
 }

--- a/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/AttributeUpdate.java
+++ b/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/AttributeUpdate.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.dmf.json.model;
+
+import java.lang.annotation.Target;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Map of {@link Target} atrributes.
+ *
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AttributeUpdate {
+    @JsonProperty
+    private final Map<String, String> attributes = new HashMap<>();
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+}

--- a/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/AttributeUpdate.java
+++ b/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/AttributeUpdate.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Map of {@link Target} atrributes.
+ * Map of {@link Target} attributes.
  *
  */
 @JsonInclude(Include.NON_NULL)


### PR DESCRIPTION
Long missing feature. DMF now supports attributes the same way as DDI. However, compared to DDI the target is not asked to provide that feedback. Its completely optional.

Pull request contains the feature itself plus DeviceSimlator support for pushing attribute update whenever a new device gets simulated.

Review: @Jonkno @schabdo 