### PR TITLE
Grid inside RolloutView now has a horizontal scrollbar

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGridLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGridLayout.java
@@ -36,7 +36,7 @@ public abstract class AbstractGridLayout extends VerticalLayout {
     }
 
     protected void buildLayout() {
-        setSizeUndefined();
+        setSizeFull();
         setSpacing(true);
         setMargin(false);
         setStyleName("group");

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
@@ -83,9 +83,6 @@ import com.vaadin.ui.renderers.HtmlRenderer;
  */
 public class RolloutListGrid extends AbstractGrid {
 
-    // necessary for customizing the space to the right border of the table
-    private static final String PLACEHOLDER = "placeholder";
-
     private static final long serialVersionUID = 4060904914954370524L;
 
     private static final String UPDATE_OPTION = "Update";
@@ -163,8 +160,8 @@ public class RolloutListGrid extends AbstractGrid {
     /**
      * Handles the RolloutChangeEvent to refresh the item in the grid.
      *
-     * @param rolloutChangeEvent
-     *            the event which contains the rollout which has been changed
+     * @param eventContainer
+     *            container which holds the rollout change event
      */
     @SuppressWarnings("unchecked")
     @EventBusListenerMethod(scope = EventScope.UI)
@@ -233,8 +230,6 @@ public class RolloutListGrid extends AbstractGrid {
             rolloutGridContainer.addContainerProperty(UPDATE_OPTION, String.class, FontAwesome.EDIT.getHtml(), false,
                     false);
         }
-
-        rolloutGridContainer.addContainerProperty(PLACEHOLDER, String.class, "", false, false);
     }
 
     @Override
@@ -263,16 +258,12 @@ public class RolloutListGrid extends AbstractGrid {
 
         if (permissionChecker.hasRolloutUpdatePermission()) {
             getColumn(UPDATE_OPTION).setMinimumWidth(25);
-            getColumn(UPDATE_OPTION).setMaximumWidth(25);
+            getColumn(UPDATE_OPTION).setMaximumWidth(40);
+        } else {
+            getColumn(PAUSE_OPTION).setMaximumWidth(60);
         }
 
-        getColumn(PLACEHOLDER).setMinimumWidth(25);
-        getColumn(PLACEHOLDER).setMaximumWidth(25);
-
         getColumn(VAR_TOTAL_TARGETS_COUNT_STATUS).setMinimumWidth(280);
-        // getColumn(VAR_TOTAL_TARGETS_COUNT_STATUS).setMaximumWidth(1000);
-
-        setFrozenColumnCount(getColumns().size());
     }
 
     @Override
@@ -299,9 +290,12 @@ public class RolloutListGrid extends AbstractGrid {
             getColumn(UPDATE_OPTION).setHeaderCaption(i18n.get("header.action.update"));
         }
 
-        getColumn(PLACEHOLDER).setHeaderCaption(PLACEHOLDER);
-
-        final HeaderCell join = getDefaultHeaderRow().join(RUN_OPTION, PAUSE_OPTION, UPDATE_OPTION, PLACEHOLDER);
+        HeaderCell join;
+        if (permissionChecker.hasRolloutUpdatePermission()) {
+            join = getDefaultHeaderRow().join(RUN_OPTION, PAUSE_OPTION, UPDATE_OPTION);
+        } else {
+            join = getDefaultHeaderRow().join(RUN_OPTION, PAUSE_OPTION);
+        }
         join.setText(i18n.get("header.action"));
     }
 
@@ -329,8 +323,6 @@ public class RolloutListGrid extends AbstractGrid {
         if (permissionChecker.hasRolloutUpdatePermission()) {
             columnList.add(UPDATE_OPTION);
         }
-
-        columnList.add(PLACEHOLDER);
 
         columnList.add(VAR_CREATED_DATE);
         columnList.add(VAR_CREATED_USER);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
@@ -83,6 +83,9 @@ import com.vaadin.ui.renderers.HtmlRenderer;
  */
 public class RolloutListGrid extends AbstractGrid {
 
+    // necessary for customizing the space to the right border of the table
+    private static final String PLACEHOLDER = "placeholder";
+
     private static final long serialVersionUID = 4060904914954370524L;
 
     private static final String UPDATE_OPTION = "Update";
@@ -230,6 +233,8 @@ public class RolloutListGrid extends AbstractGrid {
             rolloutGridContainer.addContainerProperty(UPDATE_OPTION, String.class, FontAwesome.EDIT.getHtml(), false,
                     false);
         }
+
+        rolloutGridContainer.addContainerProperty(PLACEHOLDER, String.class, "", false, false);
     }
 
     @Override
@@ -261,7 +266,11 @@ public class RolloutListGrid extends AbstractGrid {
             getColumn(UPDATE_OPTION).setMaximumWidth(25);
         }
 
+        getColumn(PLACEHOLDER).setMinimumWidth(25);
+        getColumn(PLACEHOLDER).setMaximumWidth(25);
+
         getColumn(VAR_TOTAL_TARGETS_COUNT_STATUS).setMinimumWidth(280);
+        // getColumn(VAR_TOTAL_TARGETS_COUNT_STATUS).setMaximumWidth(1000);
 
         setFrozenColumnCount(getColumns().size());
     }
@@ -290,7 +299,9 @@ public class RolloutListGrid extends AbstractGrid {
             getColumn(UPDATE_OPTION).setHeaderCaption(i18n.get("header.action.update"));
         }
 
-        final HeaderCell join = getDefaultHeaderRow().join(RUN_OPTION, PAUSE_OPTION, UPDATE_OPTION);
+        getColumn(PLACEHOLDER).setHeaderCaption(PLACEHOLDER);
+
+        final HeaderCell join = getDefaultHeaderRow().join(RUN_OPTION, PAUSE_OPTION, UPDATE_OPTION, PLACEHOLDER);
         join.setText(i18n.get("header.action"));
     }
 
@@ -318,6 +329,8 @@ public class RolloutListGrid extends AbstractGrid {
         if (permissionChecker.hasRolloutUpdatePermission()) {
             columnList.add(UPDATE_OPTION);
         }
+
+        columnList.add(PLACEHOLDER);
 
         columnList.add(VAR_CREATED_DATE);
         columnList.add(VAR_CREATED_USER);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupListGrid.java
@@ -173,8 +173,6 @@ public class RolloutGroupListGrid extends AbstractGrid {
         getColumn(SPUILabelDefinitions.ROLLOUT_GROUP_THRESHOLD).setMaximumWidth(100);
 
         getColumn(SPUILabelDefinitions.VAR_TOTAL_TARGETS_COUNT_STATUS).setMinimumWidth(280);
-
-        setFrozenColumnCount(7);
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListGrid.java
@@ -133,9 +133,6 @@ public class RolloutGroupTargetsListGrid extends AbstractGrid {
 
         getColumn(SPUILabelDefinitions.VAR_LAST_MODIFIED_BY).setMaximumWidth(180);
         getColumn(SPUILabelDefinitions.VAR_LAST_MODIFIED_BY).setMinimumWidth(50);
-
-        setFrozenColumnCount(getColumns().size());
-
     }
 
     @Override


### PR DESCRIPTION
The three grids inside the RolloutView did not have a horizontal scrollbar. Enable that feature and made some small changes in column width for proper displaying of the action buttons.

Reviewer: @kaizimmerm @SirWayne 

Signed-off-by: Melanie Retter <melanie.retter@bosch-si.com>