### PR TITLE
The UI does not show "null" as a form value anymore.

### DIFF
--- a/examples/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetBuilder.java
+++ b/examples/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetBuilder.java
@@ -86,8 +86,6 @@ public class TargetBuilder {
      * 
      * @param count
      *            the amount of target bodies which should be created
-     * @param offset
-     *            for
      * @return a list of {@link MgmtSoftwareModuleTypeRequestBodyPost}
      */
     public List<MgmtTargetRequestBody> buildAsList(final int count) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModule.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModule.java
@@ -144,7 +144,7 @@ public class JpaSoftwareModule extends AbstractJpaNamedVersionedEntity implement
 
     /**
      * @param artifact
-     *            is removed from the assigned {@link LocalArtifact}s.
+     *            is removed from the assigned {@link Artifact}s.
      */
     public void removeArtifact(final Artifact artifact) {
         if (artifacts != null) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleAddUpdateWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleAddUpdateWindow.java
@@ -75,7 +75,7 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
     private FormLayout formLayout;
 
     /**
-     * Constructor for SoftwareModule
+     * Constructor for SoftwareModuleAddUpdateWindow
      * 
      * @param i18n
      *            I18N
@@ -276,19 +276,16 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
             return;
         }
         editSwModule = Boolean.TRUE;
-        final SoftwareModule swModle = softwareManagement.findSoftwareModuleById(baseSwModuleId);
-        nameTextField.setValue(swModle.getName());
-        versionTextField.setValue(swModle.getVersion());
+        final SoftwareModule swModule = softwareManagement.findSoftwareModuleById(baseSwModuleId);
+        nameTextField.setValue(swModule.getName());
+        versionTextField.setValue(swModule.getVersion());
+        vendorTextField.setValue(swModule.getVendor());
+        descTextArea.setValue(swModule.getDescription());
 
-        vendorTextField.setValue(swModle.getVendor() == null ? StringUtils.EMPTY
-                : HawkbitCommonUtil.trimAndNullIfEmpty(swModle.getVendor()));
-        descTextArea.setValue(swModle.getDescription() == null ? StringUtils.EMPTY
-                : HawkbitCommonUtil.trimAndNullIfEmpty(swModle.getDescription()));
-
-        if (swModle.getType().isDeleted()) {
-            typeComboBox.addItem(swModle.getType().getName());
+        if (swModule.getType().isDeleted()) {
+            typeComboBox.addItem(swModule.getType().getName());
         }
-        typeComboBox.setValue(swModle.getType().getName());
+        typeComboBox.setValue(swModule.getType().getName());
     }
 
     public FormLayout getFormLayout() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleAddUpdateWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleAddUpdateWindow.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ui.artifacts.smtable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
 import org.eclipse.hawkbit.repository.builder.SoftwareModuleCreate;
@@ -73,6 +74,20 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
 
     private FormLayout formLayout;
 
+    /**
+     * Constructor for SoftwareModule
+     * 
+     * @param i18n
+     *            I18N
+     * @param uiNotifcation
+     *            UINotification
+     * @param eventBus
+     *            UIEventBus
+     * @param softwareManagement
+     *            SoftwareManagement
+     * @param entityFactory
+     *            EntityFactory
+     */
     public SoftwareModuleAddUpdateWindow(final I18N i18n, final UINotification uiNotifcation, final UIEventBus eventBus,
             final SoftwareManagement softwareManagement, final EntityFactory entityFactory) {
         this.i18n = i18n;
@@ -137,10 +152,12 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
 
         vendorTextField = createTextField("textfield.vendor", UIComponentIdProvider.SOFT_MODULE_VENDOR);
         vendorTextField.setRequired(false);
+        vendorTextField.setNullRepresentation(StringUtils.EMPTY);
 
         descTextArea = new TextAreaBuilder().caption(i18n.get("textfield.description")).style("text-area-style")
                 .prompt(i18n.get("textfield.description")).id(UIComponentIdProvider.ADD_SW_MODULE_DESCRIPTION)
                 .buildTextComponent();
+        descTextArea.setNullRepresentation(StringUtils.EMPTY);
 
         typeComboBox = SPUIComponentProvider.getComboBox(i18n.get("upload.swmodule.type"), "", null, null, true, null,
                 i18n.get("upload.swmodule.type"));
@@ -262,9 +279,10 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
         final SoftwareModule swModle = softwareManagement.findSoftwareModuleById(baseSwModuleId);
         nameTextField.setValue(swModle.getName());
         versionTextField.setValue(swModle.getVersion());
-        vendorTextField.setValue(swModle.getVendor() == null ? HawkbitCommonUtil.SP_STRING_EMPTY
+
+        vendorTextField.setValue(swModle.getVendor() == null ? StringUtils.EMPTY
                 : HawkbitCommonUtil.trimAndNullIfEmpty(swModle.getVendor()));
-        descTextArea.setValue(swModle.getDescription() == null ? HawkbitCommonUtil.SP_STRING_EMPTY
+        descTextArea.setValue(swModle.getDescription() == null ? StringUtils.EMPTY
                 : HawkbitCommonUtil.trimAndNullIfEmpty(swModle.getDescription()));
 
         if (swModle.getType().isDeleted()) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleAddUpdateWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleAddUpdateWindow.java
@@ -279,8 +279,8 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
         final SoftwareModule swModule = softwareManagement.findSoftwareModuleById(baseSwModuleId);
         nameTextField.setValue(swModule.getName());
         versionTextField.setValue(swModule.getVersion());
-        vendorTextField.setValue(swModule.getVendor());
-        descTextArea.setValue(swModule.getDescription());
+        vendorTextField.setValue(HawkbitCommonUtil.trimAndNullIfEmpty(swModule.getVendor()));
+        descTextArea.setValue(HawkbitCommonUtil.trimAndNullIfEmpty(swModule.getDescription()));
 
         if (swModule.getType().isDeleted()) {
             typeComboBox.addItem(swModule.getType().getName());

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleDetails.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ui.artifacts.smtable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
 import org.eclipse.hawkbit.repository.model.MetaData;
@@ -107,7 +108,7 @@ public class SoftwareModuleDetails extends AbstractNamedVersionedEntityTableDeta
 
     @Override
     protected void populateDetailsWidget() {
-        String maxAssign = HawkbitCommonUtil.SP_STRING_EMPTY;
+        String maxAssign = StringUtils.EMPTY;
         if (getSelectedBaseEntity() != null) {
             if (getSelectedBaseEntity().getType().getMaxAssignments() == 1) {
                 maxAssign = getI18n().get("label.singleAssign.type");
@@ -117,8 +118,7 @@ public class SoftwareModuleDetails extends AbstractNamedVersionedEntityTableDeta
             updateSoftwareModuleDetailsLayout(getSelectedBaseEntity().getType().getName(),
                     getSelectedBaseEntity().getVendor(), maxAssign);
         } else {
-            updateSoftwareModuleDetailsLayout(HawkbitCommonUtil.SP_STRING_EMPTY, HawkbitCommonUtil.SP_STRING_EMPTY,
-                    maxAssign);
+            updateSoftwareModuleDetailsLayout(StringUtils.EMPTY, StringUtils.EMPTY, maxAssign);
         }
 
         populateMetadataDetails();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleDetails.java
@@ -108,8 +108,8 @@ public class SoftwareModuleDetails extends AbstractNamedVersionedEntityTableDeta
 
     @Override
     protected void populateDetailsWidget() {
-        String maxAssign = StringUtils.EMPTY;
         if (getSelectedBaseEntity() != null) {
+            String maxAssign;
             if (getSelectedBaseEntity().getType().getMaxAssignments() == 1) {
                 maxAssign = getI18n().get("label.singleAssign.type");
             } else {
@@ -118,9 +118,8 @@ public class SoftwareModuleDetails extends AbstractNamedVersionedEntityTableDeta
             updateSoftwareModuleDetailsLayout(getSelectedBaseEntity().getType().getName(),
                     getSelectedBaseEntity().getVendor(), maxAssign);
         } else {
-            updateSoftwareModuleDetailsLayout(StringUtils.EMPTY, StringUtils.EMPTY, maxAssign);
+            updateSoftwareModuleDetailsLayout(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY);
         }
-
         populateMetadataDetails();
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/CreateUpdateSoftwareTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/CreateUpdateSoftwareTypeLayout.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.ui.artifacts.smtype;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
 import org.eclipse.hawkbit.repository.TagManagement;
@@ -60,6 +61,24 @@ public class CreateUpdateSoftwareTypeLayout extends CreateUpdateTypeLayout<Softw
     private Label multiAssign;
     private OptionGroup assignOptiongroup;
 
+    /**
+     * Constructor for CreateUpdateSoftwareTypeLayout
+     * 
+     * @param i18n
+     *            I18N
+     * @param tagManagement
+     *            TagManagement
+     * @param entityFactory
+     *            EntityFactory
+     * @param eventBus
+     *            UIEventBus
+     * @param permChecker
+     *            SpPermissionChecker
+     * @param uiNotification
+     *            UINotification
+     * @param swTypeManagementService
+     *            SoftwareManagement
+     */
     public CreateUpdateSoftwareTypeLayout(final I18N i18n, final TagManagement tagManagement,
             final EntityFactory entityFactory, final UIEventBus eventBus, final SpPermissionChecker permChecker,
             final UINotification uiNotification, final SoftwareManagement swTypeManagementService) {
@@ -92,7 +111,7 @@ public class CreateUpdateSoftwareTypeLayout extends CreateUpdateTypeLayout<Softw
                 .styleName(ValoTheme.TEXTFIELD_TINY + " " + SPUIDefinitions.TYPE_DESC)
                 .prompt(i18n.get("textfield.description")).immediate(true).id(SPUIDefinitions.NEW_SOFTWARE_TYPE_DESC)
                 .buildTextComponent();
-        tagDesc.setNullRepresentation("");
+        tagDesc.setNullRepresentation(StringUtils.EMPTY);
 
         singleMultiOptionGroup();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/CreateUpdateSoftwareTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/CreateUpdateSoftwareTypeLayout.java
@@ -238,13 +238,13 @@ public class CreateUpdateSoftwareTypeLayout extends CreateUpdateTypeLayout<Softw
         final String typeKeyValue = HawkbitCommonUtil.trimAndNullIfEmpty(typeKey.getValue());
         final String typeDescValue = HawkbitCommonUtil.trimAndNullIfEmpty(tagDesc.getValue());
         final String assignValue = (String) assignOptiongroup.getValue();
-        if (null != assignValue && assignValue.equalsIgnoreCase(singleAssignStr)) {
+        if (assignValue != null && assignValue.equalsIgnoreCase(singleAssignStr)) {
             assignNumber = 1;
-        } else if (null != assignValue && assignValue.equalsIgnoreCase(multiAssignStr)) {
+        } else if (assignValue != null && assignValue.equalsIgnoreCase(multiAssignStr)) {
             assignNumber = Integer.MAX_VALUE;
         }
 
-        if (null != typeNameValue && null != typeKeyValue) {
+        if (typeNameValue != null && typeKeyValue != null) {
             final SoftwareModuleType newSWType = swTypeManagementService.createSoftwareModuleType(
                     entityFactory.softwareModuleType().create().key(typeKeyValue).name(typeNameValue)
                             .description(typeDescValue).colour(colorPicked).maxAssignments(assignNumber));

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/AbstractMetadataPopupLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/AbstractMetadataPopupLayout.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.ui.common;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.model.MetaData;
 import org.eclipse.hawkbit.repository.model.NamedVersionedEntity;
@@ -233,7 +234,7 @@ public abstract class AbstractMetadataPopupLayout<E extends NamedVersionedEntity
         final TextField keyField = new TextFieldBuilder().caption(i18n.get("textfield.key")).required(true)
                 .prompt(i18n.get("textfield.key")).immediate(true).id(UIComponentIdProvider.METADATA_KEY_FIELD_ID)
                 .maxLengthAllowed(128).buildTextComponent();
-        keyField.addTextChangeListener(event -> onKeyChange(event));
+        keyField.addTextChangeListener(this::onKeyChange);
         keyField.setTextChangeEventMode(TextChangeEventMode.EAGER);
         keyField.setWidth("100%");
         return keyField;
@@ -243,10 +244,10 @@ public abstract class AbstractMetadataPopupLayout<E extends NamedVersionedEntity
         valueTextArea = new TextAreaBuilder().caption(i18n.get("textfield.value")).required(true)
                 .prompt(i18n.get("textfield.value")).immediate(true).id(UIComponentIdProvider.METADATA_VALUE_ID)
                 .maxLengthAllowed(4000).buildTextComponent();
-        valueTextArea.setNullRepresentation("");
+        valueTextArea.setNullRepresentation(StringUtils.EMPTY);
         valueTextArea.setSizeFull();
         valueTextArea.setHeight(100, Unit.PERCENTAGE);
-        valueTextArea.addTextChangeListener(event -> onValueChange(event));
+        valueTextArea.addTextChangeListener(this::onValueChange);
         valueTextArea.setTextChangeEventMode(TextChangeEventMode.EAGER);
         return valueTextArea;
     }
@@ -264,9 +265,9 @@ public abstract class AbstractMetadataPopupLayout<E extends NamedVersionedEntity
         metadataGrid.getColumn(KEY).setHeaderCaption(i18n.get("header.key"));
         metadataGrid.getColumn(VALUE).setHeaderCaption(i18n.get("header.value"));
         metadataGrid.getColumn(VALUE).setHidden(true);
-        metadataGrid.addSelectionListener(event -> onRowClick(event));
+        metadataGrid.addSelectionListener(this::onRowClick);
         metadataGrid.getColumn(DELETE_BUTTON).setHeaderCaption("");
-        metadataGrid.getColumn(DELETE_BUTTON).setRenderer(new HtmlButtonRenderer(event -> onDelete(event)));
+        metadataGrid.getColumn(DELETE_BUTTON).setRenderer(new HtmlButtonRenderer(this::onDelete));
         metadataGrid.getColumn(DELETE_BUTTON).setWidth(50);
         metadataGrid.getColumn(KEY).setExpandRatio(1);
         return metadataGrid;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/builder/TextAreaBuilder.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/builder/TextAreaBuilder.java
@@ -24,7 +24,7 @@ public class TextAreaBuilder extends AbstractTextFieldBuilder<TextArea> {
      */
     public TextAreaBuilder() {
         maxLengthAllowed(TEXT_AREA_DEFAULT_MAX_LENGTH);
-        styleName(ValoTheme.TEXTAREA_TINY);
+        styleName(ValoTheme.TEXTAREA_SMALL);
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/SoftwareModuleDetailsTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/SoftwareModuleDetailsTable.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.ui.common.detailslayout;
 
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.exception.EntityReadOnlyException;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
@@ -89,6 +90,8 @@ public class SoftwareModuleDetailsTable extends Table {
      *            SessionEventBus
      * @param manageDistUIState
      *            ManageDistUIState
+     * @param uiNotification
+     *            UINotification for displaying error and success notifications
      */
     public SoftwareModuleDetailsTable(final I18N i18n, final boolean isUnassignSoftModAllowed,
             final SpPermissionChecker permissionChecker, final DistributionSetManagement distributionSetManagement,
@@ -111,7 +114,7 @@ public class SoftwareModuleDetailsTable extends Table {
         setContainerDataSource(getSwModuleContainer());
         setColumnHeaderMode(ColumnHeaderMode.EXPLICIT);
         addSWModuleTableHeader();
-        setSizeFull(); // check if this style is required
+        setSizeFull();
         addStyleName(SPUIStyleDefinitions.SW_MODULE_TABLE);
     }
 
@@ -216,7 +219,7 @@ public class SoftwareModuleDetailsTable extends Table {
             if (swModType.getKey().equals(sw.getType().getKey())) {
                 final HorizontalLayout horizontalLayout = new HorizontalLayout();
                 horizontalLayout.setSizeFull();
-                final Label softwareModule = HawkbitCommonUtil.getFormatedLabel(HawkbitCommonUtil.SP_STRING_EMPTY);
+                final Label softwareModule = HawkbitCommonUtil.getFormatedLabel(StringUtils.EMPTY);
                 final Button reassignSoftModule = SPUIComponentProvider.getButton(sw.getName(), "", "", "", true,
                         FontAwesome.TIMES, SPUIButtonStyleSmallNoBorder.class);
                 reassignSoftModule

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/CreateUpdateDistSetTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/CreateUpdateDistSetTypeLayout.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
@@ -81,6 +82,26 @@ public class CreateUpdateDistSetTypeLayout extends CreateUpdateTypeLayout<Distri
 
     private IndexedContainer originalSelectedTableContainer;
 
+    /**
+     * Constructor for CreateUpdateDistSetTypeLayout
+     * 
+     * @param i18n
+     *            I18N
+     * @param tagManagement
+     *            TagManagement
+     * @param entityFactory
+     *            EntityFactory
+     * @param eventBus
+     *            UIEventBus
+     * @param permChecker
+     *            SpPermissionChecker
+     * @param uiNotification
+     *            UINotification
+     * @param softwareManagement
+     *            SoftwareManagement
+     * @param distributionSetManagement
+     *            DistributionSetManagement
+     */
     public CreateUpdateDistSetTypeLayout(final I18N i18n, final TagManagement tagManagement,
             final EntityFactory entityFactory, final UIEventBus eventBus, final SpPermissionChecker permChecker,
             final UINotification uiNotification, final SoftwareManagement softwareManagement,
@@ -105,7 +126,7 @@ public class CreateUpdateDistSetTypeLayout extends CreateUpdateTypeLayout<Distri
                 .styleName(ValoTheme.TEXTFIELD_TINY + " " + SPUIDefinitions.DIST_SET_TYPE_DESC)
                 .prompt(i18n.get("textfield.description")).immediate(true)
                 .id(SPUIDefinitions.NEW_DISTRIBUTION_TYPE_DESC).buildTextComponent();
-        tagDesc.setNullRepresentation("");
+        tagDesc.setNullRepresentation(StringUtils.EMPTY);
     }
 
     private TextField createTextField(final String in18Key, final String styleName, final String id) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetDetails.java
@@ -311,7 +311,7 @@ public class DistributionSetDetails extends AbstractNamedVersionedEntityTableDet
     @Override
     protected void onEdit(final ClickEvent event) {
         final Window newDistWindow = distributionAddUpdateWindowLayout.getWindow(getSelectedBaseEntityId());
-        newDistWindow.setCaption(getI18n().get("caption.update.dist"));
+        newDistWindow.setCaption(getI18n().get(UIComponentIdProvider.DIST_UPDATE_CAPTION));
         UI.getCurrent().addWindow(newDistWindow);
         newDistWindow.setVisible(Boolean.TRUE);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetDetails.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
@@ -244,7 +245,7 @@ public class DistributionSetDetails extends AbstractNamedVersionedEntityTableDet
         final VerticalLayout verticalLayout = new VerticalLayout();
         final HorizontalLayout horizontalLayout = new HorizontalLayout();
         horizontalLayout.setSizeFull();
-        final Label softwareModule = HawkbitCommonUtil.getFormatedLabel(HawkbitCommonUtil.SP_STRING_EMPTY);
+        final Label softwareModule = HawkbitCommonUtil.getFormatedLabel(StringUtils.EMPTY);
         final Button reassignSoftModule = assignSoftModuleButton(softwareModuleName);
         softwareModule.setValue(softwareModuleName);
         softwareModule.setDescription(softwareModuleName);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
@@ -152,7 +152,7 @@ public class DistributionSetTableHeader extends AbstractTableHeader {
     @Override
     protected void addNewItem(final ClickEvent event) {
         final Window newDistWindow = addUpdateWindowLayout.getWindow(null);
-        newDistWindow.setCaption(i18n.get("caption.add.new.dist"));
+        newDistWindow.setCaption(i18n.get(UIComponentIdProvider.DIST_ADD_CAPTION));
         UI.getCurrent().addWindow(newDistWindow);
         newDistWindow.setVisible(Boolean.TRUE);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleDetails.java
@@ -145,8 +145,8 @@ public class SwModuleDetails extends AbstractNamedVersionedEntityTableDetailsLay
     }
 
     private void populateDetails() {
-        String maxAssign = StringUtils.EMPTY;
         if (getSelectedBaseEntity() != null) {
+            String maxAssign;
             if (getSelectedBaseEntity().getType().getMaxAssignments() == 1) {
                 maxAssign = getI18n().get("label.singleAssign.type");
             } else {
@@ -155,7 +155,7 @@ public class SwModuleDetails extends AbstractNamedVersionedEntityTableDetailsLay
             updateSwModuleDetailsLayout(getSelectedBaseEntity().getType().getName(),
                     getSelectedBaseEntity().getVendor(), maxAssign);
         } else {
-            updateSwModuleDetailsLayout(StringUtils.EMPTY, StringUtils.EMPTY, maxAssign);
+            updateSwModuleDetailsLayout(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY);
         }
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleDetails.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ui.distributions.smtable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SoftwareManagement;
 import org.eclipse.hawkbit.repository.model.MetaData;
@@ -144,7 +145,7 @@ public class SwModuleDetails extends AbstractNamedVersionedEntityTableDetailsLay
     }
 
     private void populateDetails() {
-        String maxAssign = HawkbitCommonUtil.SP_STRING_EMPTY;
+        String maxAssign = StringUtils.EMPTY;
         if (getSelectedBaseEntity() != null) {
             if (getSelectedBaseEntity().getType().getMaxAssignments() == 1) {
                 maxAssign = getI18n().get("label.singleAssign.type");
@@ -154,8 +155,7 @@ public class SwModuleDetails extends AbstractNamedVersionedEntityTableDetailsLay
             updateSwModuleDetailsLayout(getSelectedBaseEntity().getType().getName(),
                     getSelectedBaseEntity().getVendor(), maxAssign);
         } else {
-            updateSwModuleDetailsLayout(HawkbitCommonUtil.SP_STRING_EMPTY, HawkbitCommonUtil.SP_STRING_EMPTY,
-                    maxAssign);
+            updateSwModuleDetailsLayout(StringUtils.EMPTY, StringUtils.EMPTY, maxAssign);
         }
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTable.java
@@ -137,6 +137,7 @@ public class SwModuleTable extends AbstractNamedVersionTable<SoftwareModule, Lon
     @EventBusListenerMethod(scope = EventScope.UI)
     void onSoftwareModuleUpdateEvents(final SoftwareModuleUpdatedEventContainer eventContainer) {
 
+        @SuppressWarnings("unchecked")
         final List<Long> visibleItemIds = (List<Long>) getVisibleItemIds();
 
         handleSelectedAndUpdatedSoftwareModules(eventContainer.getEvents());
@@ -196,7 +197,7 @@ public class SwModuleTable extends AbstractNamedVersionTable<SoftwareModule, Lon
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_DESC, String.class, "", false, true);
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_VERSION, String.class, null, false, false);
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_NAME, String.class, null, false, true);
-        lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_VENDOR, String.class, null, false, true);
+        lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_VENDOR, String.class, "", false, true);
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_CREATED_BY, String.class, null, false, true);
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_LAST_MODIFIED_BY, String.class, null, false, true);
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_CREATED_DATE, String.class, null, false, true);
@@ -308,7 +309,7 @@ public class SwModuleTable extends AbstractNamedVersionTable<SoftwareModule, Lon
 
     }
 
-    private String getTableStyle(final Long typeId, final boolean isAssigned, final String color) {
+    private static String getTableStyle(final Long typeId, final boolean isAssigned, final String color) {
         if (isAssigned) {
             addTypeStyle(typeId, color);
             return "distribution-upload-type-" + typeId;
@@ -316,7 +317,7 @@ public class SwModuleTable extends AbstractNamedVersionTable<SoftwareModule, Lon
         return null;
     }
 
-    private void addTypeStyle(final Long tagId, final String color) {
+    private static void addTypeStyle(final Long tagId, final String color) {
         final JavaScript javaScript = UI.getCurrent().getPage().getJavaScript();
         UI.getCurrent()
                 .access(() -> javaScript.execute(

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTable.java
@@ -197,7 +197,7 @@ public class SwModuleTable extends AbstractNamedVersionTable<SoftwareModule, Lon
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_DESC, String.class, "", false, true);
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_VERSION, String.class, null, false, false);
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_NAME, String.class, null, false, true);
-        lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_VENDOR, String.class, "", false, true);
+        lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_VENDOR, String.class, null, false, true);
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_CREATED_BY, String.class, null, false, true);
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_LAST_MODIFIED_BY, String.class, null, false, true);
         lazyContainer.addContainerProperty(SPUILabelDefinitions.VAR_CREATED_DATE, String.class, null, false, true);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/AutoCompleteTextFieldComponent.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/AutoCompleteTextFieldComponent.java
@@ -195,7 +195,7 @@ public class AutoCompleteTextFieldComponent extends HorizontalLayout {
     }
 
     private TextField createSearchField() {
-        final TextField textField = new TextFieldBuilder().immediate(true).id("custom.query.text.Id")
+        final TextField textField = new TextFieldBuilder().immediate(true).id(UIComponentIdProvider.CUSTOM_FILTER_QUERY)
                 .maxLengthAllowed(SPUILabelDefinitions.TARGET_FILTER_QUERY_TEXT_FIELD_LENGTH).buildTextComponent();
         textField.addStyleName("target-filter-textfield");
         textField.setWidth(900.0F, Unit.PIXELS);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterHeader.java
@@ -31,8 +31,7 @@ import com.vaadin.ui.TextField;
 import com.vaadin.ui.VerticalLayout;
 
 /**
- *
- *
+ * Layout for Custom Filter view
  */
 public class TargetFilterHeader extends VerticalLayout {
 
@@ -52,6 +51,16 @@ public class TargetFilterHeader extends VerticalLayout {
 
     private SPUIButton searchResetIcon;
 
+    /**
+     * Constructor for TargetFilterHeader
+     * 
+     * @param eventBus
+     *            UIEventBus
+     * @param filterManagementUIState
+     *            FilterManagementUIState
+     * @param permissionChecker
+     *            SpPermissionChecker
+     */
     public TargetFilterHeader(final UIEventBus eventBus, final FilterManagementUIState filterManagementUIState,
             final SpPermissionChecker permissionChecker) {
         this.eventBus = eventBus;
@@ -69,7 +78,7 @@ public class TargetFilterHeader extends VerticalLayout {
         createfilterButton = createAddButton();
     }
 
-    private Label createHeaderCaption() {
+    private static Label createHeaderCaption() {
         return new LabelBuilder().name(SPUIDefinitions.TARGET_FILTER_LIST_HEADER_CAPTION).buildCaptionLabel();
     }
 
@@ -89,7 +98,7 @@ public class TargetFilterHeader extends VerticalLayout {
 
     }
 
-    private HorizontalLayout createHeaderFilterIconLayout() {
+    private static HorizontalLayout createHeaderFilterIconLayout() {
         final HorizontalLayout titleFilterIconsLayout = new HorizontalLayout();
         titleFilterIconsLayout.addStyleName(SPUIStyleDefinitions.WIDGET_TITLE);
         titleFilterIconsLayout.setSpacing(false);
@@ -125,8 +134,9 @@ public class TargetFilterHeader extends VerticalLayout {
     }
 
     private SPUIButton createSearchResetIcon() {
-        final SPUIButton button = (SPUIButton) SPUIComponentProvider.getButton(getSearchRestIconId(), "", "", null,
-                false, FontAwesome.SEARCH, SPUIButtonStyleSmallNoBorder.class);
+        final SPUIButton button = (SPUIButton) SPUIComponentProvider.getButton(
+                UIComponentIdProvider.TARGET_FILTER_TBL_SEARCH_RESET_ID, "", "", null, false, FontAwesome.SEARCH,
+                SPUIButtonStyleSmallNoBorder.class);
         button.addClickListener(event -> onSearchResetClick());
         return button;
     }
@@ -159,10 +169,6 @@ public class TargetFilterHeader extends VerticalLayout {
         searchResetIcon.setData(Boolean.FALSE);
         resetSearchText();
 
-    }
-
-    private String getSearchRestIconId() {
-        return UIComponentIdProvider.TARGET_FILTER_TBL_SEARCH_RESET_ID;
     }
 
     protected void resetSearchText() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/AbstractCreateUpdateTagLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/AbstractCreateUpdateTagLayout.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ui.layouts;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.builder.TagUpdate;
@@ -110,6 +111,22 @@ public abstract class AbstractCreateUpdateTagLayout<E extends NamedEntity> exten
     protected String tagNameValue;
     protected String tagDescValue;
 
+    /**
+     * Constructor for AbstractCreateUpdateTagLayout
+     * 
+     * @param i18n
+     *            I18N
+     * @param tagManagement
+     *            TagManagement
+     * @param entityFactory
+     *            EntityFactory
+     * @param eventBus
+     *            UIEventBus
+     * @param permChecker
+     *            SpPermissionChecker
+     * @param uiNotification
+     *            UINotification
+     */
     public AbstractCreateUpdateTagLayout(final I18N i18n, final TagManagement tagManagement,
             final EntityFactory entityFactory, final UIEventBus eventBus, final SpPermissionChecker permChecker,
             final UINotification uiNotification) {
@@ -192,7 +209,7 @@ public abstract class AbstractCreateUpdateTagLayout<E extends NamedEntity> exten
                 .prompt(i18n.get("textfield.description")).immediate(true).id(SPUIDefinitions.NEW_TARGET_TAG_DESC)
                 .buildTextComponent();
 
-        tagDesc.setNullRepresentation("");
+        tagDesc.setNullRepresentation(StringUtils.EMPTY);
 
         tagNameComboBox = SPUIComponentProvider.getComboBox(null, "", null, null, false, "",
                 i18n.get("label.combobox.tag"));

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
@@ -302,9 +302,9 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
         resetComponents();
         populateDistSetTypeNameCombo();
         populateValuesOfDistribution(editDistId);
-        return new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW).caption(i18n.get("caption.add.new.dist"))
-                .content(this).layout(formLayout).i18n(i18n).saveDialogCloseListener(new SaveOnCloseDialogListener())
-                .buildCommonDialogWindow();
+        return new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW)
+                .caption(i18n.get(UIComponentIdProvider.DIST_ADD_CAPTION)).content(this).layout(formLayout).i18n(i18n)
+                .saveDialogCloseListener(new SaveOnCloseDialogListener()).buildCommonDialogWindow();
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
@@ -76,6 +76,24 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
 
     private FormLayout formLayout;
 
+    /**
+     * Constructor for DistributionAddUpdateWindowLayout
+     * 
+     * @param i18n
+     *            I18N
+     * @param notificationMessage
+     *            UINotification
+     * @param eventBus
+     *            UIEventBus
+     * @param distributionSetManagement
+     *            DistributionSetManagement
+     * @param systemManagement
+     *            SystemManagement
+     * @param entityFactory
+     *            EntityFactory
+     * @param distributionSetTable
+     *            DistributionSetTable
+     */
     public DistributionAddUpdateWindowLayout(final I18N i18n, final UINotification notificationMessage,
             final UIEventBus eventBus, final DistributionSetManagement distributionSetManagement,
             final SystemManagement systemManagement, final EntityFactory entityFactory,
@@ -154,7 +172,7 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
     private TextField createTextField(final String in18Key, final String id) {
         final TextField buildTextField = new TextFieldBuilder().caption(i18n.get(in18Key)).required(true)
                 .prompt(i18n.get(in18Key)).immediate(true).id(id).buildTextComponent();
-        buildTextField.setNullRepresentation("");
+        buildTextField.setNullRepresentation(StringUtils.EMPTY);
         return buildTextField;
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.ui.management.dstable;
 
 import java.util.Collections;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SystemManagement;
@@ -142,7 +143,7 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
         descTextArea = new TextAreaBuilder().caption(i18n.get("textfield.description")).style("text-area-style")
                 .prompt(i18n.get("textfield.description")).immediate(true).id(UIComponentIdProvider.DIST_ADD_DESC)
                 .buildTextComponent();
-        descTextArea.setNullRepresentation("");
+        descTextArea.setNullRepresentation(StringUtils.EMPTY);
 
         reqMigStepCheckbox = SPUIComponentProvider.getCheckBox(i18n.get("checkbox.dist.required.migration.step"),
                 "dist-checkbox-style", null, false, "");
@@ -288,9 +289,7 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
         distsetTypeNameComboBox.setValue(distSet.getType().getId());
 
         reqMigStepCheckbox.setValue(distSet.isRequiredMigrationStep());
-        if (distSet.getDescription() != null) {
-            descTextArea.setValue(distSet.getDescription());
-        }
+        descTextArea.setValue(distSet.getDescription());
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionDetails.java
@@ -97,7 +97,7 @@ public class DistributionDetails extends AbstractNamedVersionedEntityTableDetail
     @Override
     protected void onEdit(final ClickEvent event) {
         final Window newDistWindow = distributionAddUpdateWindowLayout.getWindow(getSelectedBaseEntityId());
-        newDistWindow.setCaption(getI18n().get("caption.update.dist"));
+        newDistWindow.setCaption(getI18n().get(UIComponentIdProvider.DIST_UPDATE_CAPTION));
         UI.getCurrent().addWindow(newDistWindow);
         newDistWindow.setVisible(Boolean.TRUE);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
@@ -22,6 +22,7 @@ import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
 import org.eclipse.hawkbit.ui.components.RefreshableContainer;
 import org.eclipse.hawkbit.ui.layouts.AbstractCreateUpdateTagLayout;
 import org.eclipse.hawkbit.ui.management.event.DistributionSetTagTableEvent;
+import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
@@ -83,15 +84,17 @@ public class CreateUpdateDistributionTagLayoutWindow extends AbstractCreateUpdat
     @Override
     protected void createNewTag() {
         super.createNewTag();
-        if (isNotEmpty(getTagNameValue())) {
+        final String tagNameValueTrimmed = HawkbitCommonUtil.trimAndNullIfEmpty(tagNameValue);
+        final String tagDescriptionTrimmed = HawkbitCommonUtil.trimAndNullIfEmpty(tagDescValue);
+        if (isNotEmpty(tagNameValueTrimmed)) {
 
             String colour = ColorPickerConstants.START_COLOR.getCSS();
             if (isNotEmpty(getColorPicked())) {
                 colour = getColorPicked();
             }
 
-            final DistributionSetTag newDistTag = tagManagement.createDistributionSetTag(
-                    entityFactory.tag().create().name(tagNameValue).description(tagDescValue).colour(colour));
+            final DistributionSetTag newDistTag = tagManagement.createDistributionSetTag(entityFactory.tag().create()
+                    .name(tagNameValueTrimmed).description(tagDescriptionTrimmed).colour(colour));
             eventBus.publish(this, new DistributionSetTagTableEvent(BaseEntityEventType.ADD_ENTITY, newDistTag));
             displaySuccess(newDistTag.getName());
             resetDistTagValues();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/CountMessageLabel.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/footer/CountMessageLabel.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.ui.management.footer;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.eclipse.hawkbit.ui.management.event.ManagementUIEvent;
@@ -48,6 +49,20 @@ public class CountMessageLabel extends Label {
 
     private final TargetTable targetTable;
 
+    /**
+     * Constructor
+     * 
+     * @param eventBus
+     *            UIEventBus
+     * @param targetManagement
+     *            TargetManagement
+     * @param i18n
+     *            I18N
+     * @param managementUIState
+     *            ManagementUIState
+     * @param targetTable
+     *            TargetTable
+     */
     public CountMessageLabel(final UIEventBus eventBus, final TargetManagement targetManagement, final I18N i18n,
             final ManagementUIState managementUIState, final TargetTable targetTable) {
         this.targetManagement = targetManagement;
@@ -127,17 +142,14 @@ public class CountMessageLabel extends Label {
             final String dists = i18n.get("label.filter.dist");
             final String custom = i18n.get("label.filter.custom");
             final StringBuilder filterMesgBuf = new StringBuilder(i18n.get("label.filter"));
-            filterMesgBuf.append(HawkbitCommonUtil.SP_STRING_SPACE);
+            filterMesgBuf.append(StringUtils.SPACE);
             filterMesgBuf.append(getStatusMsg(targFilParams.getClickedStatusTargetTags(), status));
             filterMesgBuf.append(getOverdueStateMsg(targFilParams.isOverdueFilterEnabled(), overdue));
             filterMesgBuf
                     .append(getTagsMsg(targFilParams.isNoTagSelected(), targFilParams.getClickedTargetTags(), tags));
-            filterMesgBuf.append(
-                    targFilParams.getSearchText().map(search -> text).orElse(HawkbitCommonUtil.SP_STRING_SPACE));
-            filterMesgBuf.append(
-                    targFilParams.getDistributionSet().map(set -> dists).orElse(HawkbitCommonUtil.SP_STRING_SPACE));
-            filterMesgBuf.append(targFilParams.getTargetFilterQuery().map(query -> custom)
-                    .orElse(HawkbitCommonUtil.SP_STRING_SPACE));
+            filterMesgBuf.append(targFilParams.getSearchText().map(search -> text).orElse(StringUtils.SPACE));
+            filterMesgBuf.append(targFilParams.getDistributionSet().map(set -> dists).orElse(StringUtils.SPACE));
+            filterMesgBuf.append(targFilParams.getTargetFilterQuery().map(query -> custom).orElse(StringUtils.SPACE));
             final String filterMesageChk = filterMesgBuf.toString().trim();
             String filterMesage = filterMesageChk;
             if (filterMesage.endsWith(",")) {
@@ -199,7 +211,7 @@ public class CountMessageLabel extends Label {
      * @return String as msg.
      */
     private static String getStatusMsg(final List<TargetUpdateStatus> status, final String param) {
-        return status.isEmpty() ? HawkbitCommonUtil.SP_STRING_SPACE : param;
+        return status.isEmpty() ? StringUtils.SPACE : param;
     }
 
     /**
@@ -210,7 +222,7 @@ public class CountMessageLabel extends Label {
      * @return String as msg.
      */
     private static String getOverdueStateMsg(final boolean overdueState, final String param) {
-        return !overdueState ? HawkbitCommonUtil.SP_STRING_SPACE : param;
+        return !overdueState ? StringUtils.SPACE : param;
     }
 
     /**
@@ -223,6 +235,6 @@ public class CountMessageLabel extends Label {
      */
     private static String getTagsMsg(final Boolean noTargetTagSelected, final List<String> tags, final String param) {
         return tags.isEmpty() && (noTargetTagSelected == null || !noTargetTagSelected.booleanValue())
-                ? HawkbitCommonUtil.SP_STRING_SPACE : param;
+                ? StringUtils.SPACE : param;
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetAddUpdateWindowLayout.java
@@ -204,9 +204,8 @@ public class TargetAddUpdateWindowLayout extends CustomComponent {
         controllerIDTextField.setValue(target.getControllerId());
         controllerIDTextField.setEnabled(Boolean.FALSE);
         nameTextField.setValue(target.getName());
-        if (target.getDescription() != null) {
-            descTextArea.setValue(target.getDescription());
-        }
+        nameTextField.setRequired(true);
+        descTextArea.setValue(target.getDescription());
     }
 
     public FormLayout getFormLayout() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetAddUpdateWindowLayout.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ui.management.targettable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.Target;
@@ -100,7 +101,7 @@ public class TargetAddUpdateWindowLayout extends CustomComponent {
         descTextArea = new TextAreaBuilder().caption(i18n.get("textfield.description")).style("text-area-style")
                 .prompt(i18n.get("textfield.description")).immediate(true).id(UIComponentIdProvider.TARGET_ADD_DESC)
                 .buildTextComponent();
-        descTextArea.setNullRepresentation(HawkbitCommonUtil.SP_STRING_EMPTY);
+        descTextArea.setNullRepresentation(StringUtils.EMPTY);
     }
 
     private TextField createTextField(final String in18Key, final String id) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetAddUpdateWindowLayout.java
@@ -146,9 +146,9 @@ public class TargetAddUpdateWindowLayout extends CustomComponent {
     }
 
     public Window getWindow() {
-        window = new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW).caption(i18n.get("caption.add.new.target"))
-                .content(this).layout(formLayout).i18n(i18n).saveDialogCloseListener(new SaveOnDialogCloseListener())
-                .buildCommonDialogWindow();
+        window = new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW)
+                .caption(i18n.get(UIComponentIdProvider.TARGET_ADD_CAPTION)).content(this).layout(formLayout).i18n(i18n)
+                .saveDialogCloseListener(new SaveOnDialogCloseListener()).buildCommonDialogWindow();
 
         return window;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.DeploymentManagement;
 import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
@@ -26,7 +27,6 @@ import org.eclipse.hawkbit.ui.management.dstable.DistributionBeanQuery;
 import org.eclipse.hawkbit.ui.management.event.BulkUploadPopupEvent;
 import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.management.state.TargetBulkUpload;
-import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
@@ -139,7 +139,7 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
         closeButton = getCloseButton();
     }
 
-    private ProgressBar creatreProgressBar() {
+    private static ProgressBar creatreProgressBar() {
         final ProgressBar progressBarIndicator = new ProgressBar(0F);
         progressBarIndicator.addStyleName("bulk-upload-label");
         progressBarIndicator.setSizeFull();
@@ -171,7 +171,7 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
         return bulkUploadHandler;
     }
 
-    private Label getStatusCountLabel() {
+    private static Label getStatusCountLabel() {
         final Label countLabel = new Label();
         countLabel.setImmediate(true);
         countLabel.addStyleName("bulk-upload-label");
@@ -185,7 +185,7 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
         final TextArea description = new TextAreaBuilder().caption(i18n.get("textfield.description"))
                 .style("text-area-style").prompt(i18n.get("textfield.description")).immediate(true)
                 .id(UIComponentIdProvider.BULK_UPLOAD_DESC).buildTextComponent();
-        description.setNullRepresentation(HawkbitCommonUtil.SP_STRING_EMPTY);
+        description.setNullRepresentation(StringUtils.EMPTY);
         description.setWidth("100%");
         return description;
     }
@@ -244,12 +244,9 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
         final BeanQueryFactory<DistributionBeanQuery> distributionQF = new BeanQueryFactory<>(
                 DistributionBeanQuery.class);
         distributionQF.setQueryConfiguration(queryConfiguration);
-        final LazyQueryContainer distributionContainer = new LazyQueryContainer(
+        return new LazyQueryContainer(
                 new LazyQueryDefinition(true, SPUIDefinitions.PAGE_SIZE, SPUILabelDefinitions.VAR_DIST_ID_NAME),
                 distributionQF);
-
-        return distributionContainer;
-
     }
 
     private void buildLayout() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
@@ -116,7 +116,7 @@ public class TargetDetails extends AbstractTableDetailsLayout<Target> {
 
     private void openWindow() {
         final Window newDistWindow = targetAddUpdateWindowLayout.getWindow();
-        newDistWindow.setCaption(getI18n().get("caption.update.dist"));
+        newDistWindow.setCaption(getI18n().get(UIComponentIdProvider.TARGET_UPDATE_CAPTION));
         UI.getCurrent().addWindow(newDistWindow);
         newDistWindow.setVisible(Boolean.TRUE);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
@@ -271,7 +271,7 @@ public class TargetTableHeader extends AbstractTableHeader {
     protected void addNewItem(final ClickEvent event) {
         targetAddUpdateWindow.resetComponents();
         final Window addTargetWindow = targetAddUpdateWindow.getWindow();
-        addTargetWindow.setCaption(i18n.get("caption.add.new.target"));
+        addTargetWindow.setCaption(i18n.get(UIComponentIdProvider.TARGET_ADD_CAPTION));
         UI.getCurrent().addWindow(addTargetWindow);
         addTargetWindow.setVisible(Boolean.TRUE);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CreateUpdateTargetTagLayoutWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CreateUpdateTargetTagLayoutWindow.java
@@ -22,12 +22,12 @@ import org.eclipse.hawkbit.ui.common.table.BaseEntityEventType;
 import org.eclipse.hawkbit.ui.components.RefreshableContainer;
 import org.eclipse.hawkbit.ui.layouts.AbstractCreateUpdateTagLayout;
 import org.eclipse.hawkbit.ui.management.event.TargetTagTableEvent;
+import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.I18N;
 import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.vaadin.spring.events.EventBus.UIEventBus;
 
 /**
- *
  * Class for Create / Update Tag Layout of target
  */
 public class CreateUpdateTargetTagLayoutWindow extends AbstractCreateUpdateTagLayout<TargetTag>
@@ -35,6 +35,22 @@ public class CreateUpdateTargetTagLayoutWindow extends AbstractCreateUpdateTagLa
 
     private static final long serialVersionUID = 2446682350481560235L;
 
+    /**
+     * Constructor for CreateUpdateTargetTagLayoutWindow
+     * 
+     * @param i18n
+     *            I18N
+     * @param tagManagement
+     *            TagManagement
+     * @param entityFactory
+     *            EntityFactory
+     * @param eventBus
+     *            UIEventBus
+     * @param permChecker
+     *            SpPermissionChecker
+     * @param uiNotification
+     *            UINotification
+     */
     public CreateUpdateTargetTagLayoutWindow(final I18N i18n, final TagManagement tagManagement,
             final EntityFactory entityFactory, final UIEventBus eventBus, final SpPermissionChecker permChecker,
             final UINotification uiNotification) {
@@ -68,7 +84,7 @@ public class CreateUpdateTargetTagLayoutWindow extends AbstractCreateUpdateTagLa
     public void setTagDetails(final String targetTagSelected) {
         tagName.setValue(targetTagSelected);
         final TargetTag selectedTargetTag = tagManagement.findTargetTag(targetTagSelected);
-        if (null != selectedTargetTag) {
+        if (selectedTargetTag != null) {
             tagDesc.setValue(selectedTargetTag.getDescription());
             if (null == selectedTargetTag.getColour()) {
                 setTagColor(getColorPickerLayout().getDefaultColor(), ColorPickerConstants.DEFAULT_COLOR);
@@ -100,14 +116,16 @@ public class CreateUpdateTargetTagLayoutWindow extends AbstractCreateUpdateTagLa
     @Override
     protected void createNewTag() {
         super.createNewTag();
-        if (isNotEmpty(getTagNameValue())) {
+        final String tagNameTrimmed = HawkbitCommonUtil.trimAndNullIfEmpty(tagNameValue);
+        final String tagDescriptionTrimmed = HawkbitCommonUtil.trimAndNullIfEmpty(tagDescValue);
+        if (isNotEmpty(tagNameTrimmed)) {
             String colour = ColorPickerConstants.START_COLOR.getCSS();
             if (isNotEmpty(getColorPicked())) {
                 colour = getColorPicked();
             }
 
-            final TargetTag newTargetTag = tagManagement.createTargetTag(
-                    entityFactory.tag().create().name(getTagNameValue()).description(getTagDescValue()).colour(colour));
+            final TargetTag newTargetTag = tagManagement.createTargetTag(entityFactory.tag().create()
+                    .name(tagNameTrimmed).description(tagDescriptionTrimmed).colour(colour));
             eventBus.publish(this, new TargetTagTableEvent(BaseEntityEventType.ADD_ENTITY, newTargetTag));
             displaySuccess(newTargetTag.getName());
         } else {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
@@ -12,6 +12,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
@@ -334,7 +335,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
                 .maxLengthAllowed(SPUILabelDefinitions.TARGET_FILTER_QUERY_TEXT_FIELD_LENGTH).buildTextComponent();
 
         filterField.setId(UIComponentIdProvider.ROLLOUT_TARGET_FILTER_QUERY_FIELD);
-        filterField.setNullRepresentation(HawkbitCommonUtil.SP_STRING_EMPTY);
+        filterField.setNullRepresentation(StringUtils.EMPTY);
         filterField.setEnabled(false);
         filterField.setSizeUndefined();
         return filterField;
@@ -402,7 +403,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
         targetFilterQueryCombo.setContainerDataSource(container);
     }
 
-    private Container createTargetFilterComboContainer() {
+    private static Container createTargetFilterComboContainer() {
         final BeanQueryFactory<TargetFilterBeanQuery> targetFilterQF = new BeanQueryFactory<>(
                 TargetFilterBeanQuery.class);
         return new LazyQueryContainer(
@@ -504,7 +505,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
         final TextArea descriptionField = new TextAreaBuilder().style("text-area-style")
                 .prompt(i18n.get("textfield.description")).id(UIComponentIdProvider.ROLLOUT_DESCRIPTION_ID)
                 .buildTextComponent();
-        descriptionField.setNullRepresentation(HawkbitCommonUtil.SP_STRING_EMPTY);
+        descriptionField.setNullRepresentation(StringUtils.EMPTY);
         descriptionField.setSizeUndefined();
         return descriptionField;
     }
@@ -558,7 +559,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
         distributionSet.setContainerDataSource(container);
     }
 
-    private Container createDsComboContainer() {
+    private static Container createDsComboContainer() {
         final BeanQueryFactory<DistributionBeanQuery> distributionQF = new BeanQueryFactory<>(
                 DistributionBeanQuery.class);
         return new LazyQueryContainer(

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
@@ -286,7 +286,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
 
     private TextField createIntegerTextField(final String in18Key, final String id) {
         final TextField textField = createTextField(in18Key, id);
-        textField.setNullRepresentation("");
+        textField.setNullRepresentation(StringUtils.EMPTY);
         textField.setConverter(new StringToIntegerConverter());
         textField.setConversionError(i18n.get(MESSAGE_ENTER_NUMBER));
         textField.setSizeUndefined();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/HawkbitCommonUtil.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/HawkbitCommonUtil.java
@@ -14,6 +14,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.TimeZone;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.model.AssignmentResult;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.NamedEntity;
@@ -41,14 +42,6 @@ import com.vaadin.ui.Table;
  */
 public final class HawkbitCommonUtil {
     public static final String SP_STRING_PIPE = " | ";
-    /**
-     * Define spaced string.
-     */
-    public static final String SP_STRING_SPACE = " ";
-    /**
-     * Define empty string.
-     */
-    public static final String SP_STRING_EMPTY = "";
     /**
      * Html span.
      */
@@ -124,7 +117,7 @@ public final class HawkbitCommonUtil {
      *         null.
      */
     public static String concatStrings(final String delimiter, final String... texts) {
-        final String delim = delimiter == null ? SP_STRING_EMPTY : delimiter;
+        final String delim = delimiter == null ? StringUtils.EMPTY : delimiter;
         final StringBuilder conCatStrBldr = new StringBuilder();
         if (null != texts) {
             for (final String text : texts) {
@@ -159,7 +152,8 @@ public final class HawkbitCommonUtil {
      * Get Label for Artifact Details.
      *
      * @param name
-     * @return
+     *            artifact name
+     * @return ArtifactoryDetailsLabelId
      */
     public static String getArtifactoryDetailsLabelId(final String name) {
         return new StringBuilder()
@@ -174,7 +168,7 @@ public final class HawkbitCommonUtil {
      *            as caption of the details
      * @param name
      *            as name
-     * @return
+     * @return SoftwareModuleName
      */
     public static String getSoftwareModuleName(final String caption, final String name) {
         return new StringBuilder()
@@ -186,7 +180,7 @@ public final class HawkbitCommonUtil {
      * Get Label for Action History Details.
      *
      * @param name
-     * @return
+     * @return ActionHistoryLabelId
      */
     public static String getActionHistoryLabelId(final String name) {
         return new StringBuilder()
@@ -199,7 +193,7 @@ public final class HawkbitCommonUtil {
      *
      * @param pollStatus
      * @param i18N
-     * @return
+     * @return PollStatusToolTip
      */
     public static String getPollStatusToolTip(final PollStatus pollStatus, final I18N i18N) {
         if (pollStatus != null && pollStatus.getLastPollDate() != null && pollStatus.isOverdue()) {
@@ -312,7 +306,7 @@ public final class HawkbitCommonUtil {
     /**
      * @param distName
      * @param distVersion
-     * @return
+     * @return DistributionNameAndVersion
      */
     public static String getDistributionNameAndVersion(final String distName, final String distVersion) {
         return new StringBuilder(distName).append(':').append(distVersion).toString();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/HawkbitCommonUtil.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/HawkbitCommonUtil.java
@@ -95,11 +95,11 @@ public final class HawkbitCommonUtil {
      *         the text is not empty.
      */
     public static String trimAndNullIfEmpty(final String text) {
-        String emptyStr = null;
-        if (null != text && !text.trim().isEmpty()) {
-            emptyStr = text.trim();
+        String resultStr = null;
+        if (text != null && !text.trim().isEmpty()) {
+            resultStr = text.trim();
         }
-        return emptyStr;
+        return resultStr;
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UIComponentIdProvider.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UIComponentIdProvider.java
@@ -17,6 +17,14 @@ public final class UIComponentIdProvider {
      */
     public static final String TARGET_TABLE_ID = "target.tableId";
     /**
+     * caption for add target window
+     */
+    public static final String TARGET_ADD_CAPTION = "caption.add.new.target";
+    /**
+     * caption for update target window
+     */
+    public static final String TARGET_UPDATE_CAPTION = "caption.update.target";
+    /**
      * ID- Targ.Cont ID.
      */
     public static final String TARGET_ADD_CONTROLLER_ID = "target.add.ctrlId";
@@ -64,6 +72,11 @@ public final class UIComponentIdProvider {
      * ID-Dist.
      */
     public static final String DIST_TABLE_ID = "dist.tableId";
+
+    public static final String DIST_ADD_CAPTION = "caption.add.dist";
+
+    public static final String DIST_UPDATE_CAPTION = "caption.update.dist";
+
     /**
      * ID-Dist.Name.
      */


### PR DESCRIPTION
The vendor and description field in the form for creating and updating a software module was corrected to display an empty textfield/-area. 
The field name in the target update dialog is mandatory now.
Furthermore there were small code changes for a proper code quality.

Reviewer: @SirWayne @Jonkno 

Signed-off-by: Melanie Retter <melanie.retter@bosch-si.com>