### PR TITLE
Add target filter query feign client resource

### DIFF
--- a/examples/hawkbit-example-ddi-feign-client/src/main/java/org/eclipse/hawkbit/ddi/client/resource/DdiDlArtifactStoreControllerResourceClient.java
+++ b/examples/hawkbit-example-ddi-feign-client/src/main/java/org/eclipse/hawkbit/ddi/client/resource/DdiDlArtifactStoreControllerResourceClient.java
@@ -8,28 +8,13 @@
  */
 package org.eclipse.hawkbit.ddi.client.resource;
 
-import java.io.InputStream;
-
 import org.eclipse.hawkbit.ddi.dl.rest.api.DdiDlArtifactStoreControllerRestApi;
-import org.eclipse.hawkbit.ddi.dl.rest.api.DdiDlRestConstants;
 import org.springframework.cloud.netflix.feign.FeignClient;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * Client binding for the artifact store controller resource of the DDI-DL API.
  */
 @FeignClient(name = "DdiDlArtifactStoreControllerClient", url = "${hawkbit.url:localhost:8080}")
 public interface DdiDlArtifactStoreControllerResourceClient extends DdiDlArtifactStoreControllerRestApi {
-
-    @Override
-    @RequestMapping(method = RequestMethod.GET, value = DdiDlRestConstants.ARTIFACT_DOWNLOAD_BY_FILENAME
-            + "/{fileName}")
-    ResponseEntity<InputStream> downloadArtifactByFilename(@PathVariable("tenant") final String tenant,
-            @PathVariable("fileName") final String fileName,
-            @RequestParam(value = "principal", required = false) final Object principal);
 
 }

--- a/examples/hawkbit-example-ddi-feign-client/src/main/java/org/eclipse/hawkbit/ddi/client/resource/DdiDlArtifactStoreControllerResourceClient.java
+++ b/examples/hawkbit-example-ddi-feign-client/src/main/java/org/eclipse/hawkbit/ddi/client/resource/DdiDlArtifactStoreControllerResourceClient.java
@@ -8,13 +8,28 @@
  */
 package org.eclipse.hawkbit.ddi.client.resource;
 
+import java.io.InputStream;
+
 import org.eclipse.hawkbit.ddi.dl.rest.api.DdiDlArtifactStoreControllerRestApi;
+import org.eclipse.hawkbit.ddi.dl.rest.api.DdiDlRestConstants;
 import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * Client binding for the artifact store controller resource of the DDI-DL API.
  */
 @FeignClient(name = "DdiDlArtifactStoreControllerClient", url = "${hawkbit.url:localhost:8080}")
 public interface DdiDlArtifactStoreControllerResourceClient extends DdiDlArtifactStoreControllerRestApi {
+
+    @Override
+    @RequestMapping(method = RequestMethod.GET, value = DdiDlRestConstants.ARTIFACT_DOWNLOAD_BY_FILENAME
+            + "/{fileName}")
+    ResponseEntity<InputStream> downloadArtifactByFilename(@PathVariable("tenant") final String tenant,
+            @PathVariable("fileName") final String fileName,
+            @RequestParam(value = "principal", required = false) final Object principal);
 
 }

--- a/examples/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/MgmtTargetFilterQueryClientResource.java
+++ b/examples/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/MgmtTargetFilterQueryClientResource.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.client.resource;
+
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtTargetFilterQueryRestApi;
+import org.springframework.cloud.netflix.feign.FeignClient;
+
+/**
+ * Client binding for the Target filter query resource of the management API.
+ */
+@FeignClient(name = "MgmtTargetFilterQueryClient", url = "${hawkbit.url:localhost:8080}")
+public interface MgmtTargetFilterQueryClientResource extends MgmtTargetFilterQueryRestApi {
+}

--- a/examples/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetFilterQueryBuilder.java
+++ b/examples/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetFilterQueryBuilder.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.client.resource.builder;
+
+import org.eclipse.hawkbit.mgmt.json.model.targetfilter.MgmtTargetFilterQueryRequestBody;
+
+/**
+ * Builder pattern for building {@link MgmtTargetFilterQueryRequestBody}.
+ */
+// Exception squid:S1701 - builder pattern
+@SuppressWarnings({ "squid:S1701" })
+public class TargetFilterQueryBuilder {
+
+    private String name;
+    private String query;
+
+    /**
+     * @param name
+     *            the name of the filter
+     * @return the builder itself
+     */
+    public TargetFilterQueryBuilder name(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * @param query
+     *            the query filter
+     * @return the builder itself
+     */
+    public TargetFilterQueryBuilder query(final String query) {
+        this.query = query;
+        return this;
+    }
+
+    /**
+     * Builds a single entry of {@link MgmtTargetFilterQueryRequestBody} which
+     * can directly be used to post on the RESTful-API.
+     * 
+     * @return a single entry of {@link MgmtTargetFilterQueryRequestBody}
+     */
+    public MgmtTargetFilterQueryRequestBody build() {
+        return doBuild("");
+    }
+
+    private MgmtTargetFilterQueryRequestBody doBuild(final String suffix) {
+        final MgmtTargetFilterQueryRequestBody body = new MgmtTargetFilterQueryRequestBody();
+        body.setName(suffix + name);
+        body.setQuery(query);
+        return body;
+    }
+
+}

--- a/examples/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetFilterQueryBuilder.java
+++ b/examples/hawkbit-example-mgmt-feign-client/src/main/java/org/eclipse/hawkbit/mgmt/client/resource/builder/TargetFilterQueryBuilder.java
@@ -47,14 +47,9 @@ public class TargetFilterQueryBuilder {
      * @return a single entry of {@link MgmtTargetFilterQueryRequestBody}
      */
     public MgmtTargetFilterQueryRequestBody build() {
-        return doBuild("");
-    }
-
-    private MgmtTargetFilterQueryRequestBody doBuild(final String suffix) {
         final MgmtTargetFilterQueryRequestBody body = new MgmtTargetFilterQueryRequestBody();
-        body.setName(suffix + name);
+        body.setName(name);
         body.setQuery(query);
         return body;
     }
-
 }

--- a/hawkbit-ddi-dl-api/src/main/java/org/eclipse/hawkbit/ddi/dl/rest/api/DdiDlArtifactStoreControllerRestApi.java
+++ b/hawkbit-ddi-dl-api/src/main/java/org/eclipse/hawkbit/ddi/dl/rest/api/DdiDlArtifactStoreControllerRestApi.java
@@ -12,7 +12,6 @@ import java.io.InputStream;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -43,7 +42,7 @@ public interface DdiDlArtifactStoreControllerRestApi {
             + "/{fileName}")
     @ResponseBody
     ResponseEntity<InputStream> downloadArtifactByFilename(@PathVariable("tenant") final String tenant,
-            @PathVariable("fileName") final String fileName, @AuthenticationPrincipal final Object principal);
+            @PathVariable("fileName") final String fileName);
 
     /**
      * Handles GET MD5 checksum file download request.

--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactStoreController.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactStoreController.java
@@ -36,7 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
@@ -71,7 +71,8 @@ public class DdiArtifactStoreController implements DdiDlArtifactStoreControllerR
 
     @Override
     public ResponseEntity<InputStream> downloadArtifactByFilename(@PathVariable("tenant") final String tenant,
-            @PathVariable("fileName") final String fileName, @AuthenticationPrincipal final Object principal) {
+            @PathVariable("fileName") final String fileName) {
+        final Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         final List<Artifact> foundArtifacts = artifactManagement.findArtifactByFilename(fileName);
 
         if (foundArtifacts.isEmpty()) {


### PR DESCRIPTION
Added a feign client resource for MgmtTargetFilterQueryRestApi. Addionalt added a builder for the target filter request body.

Also fixed the DdiDlArtifactStoreControllerResourceClient. Feign cannot handle the `@AuthenticationPrincipal`. I have overwritten the method and declare the `@AuthenticationPrincipal` as not required.

Reviewers: @Jonkno @melanieretter 