### PR TITLE
Bug wrong count bulk upload dialog when runtime exception

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
@@ -269,7 +269,7 @@ public class BulkUploadHandler extends CustomComponent
             tempFile = null;
         }
 
-        private void readEachLine(final String line, final double innerCounter, final double totalNumberOfLines) {
+        private void readEachLine(final String line, final long innerCounter, final long totalNumberOfLines) {
             final String csvDelimiter = ",";
             final String[] targets = line.split(csvDelimiter);
             if (targets.length == 2) {
@@ -281,7 +281,7 @@ public class BulkUploadHandler extends CustomComponent
             }
             final float current = managementUIState.getTargetTableFilters().getBulkUpload()
                     .getProgressBarCurrentValue();
-            final float next = (float) (innerCounter / totalNumberOfLines);
+            final float next = innerCounter / totalNumberOfLines;
             if (Math.abs(next - 0.1) < 0.00001 || current - next >= 0 || next - current >= 0.05
                     || Math.abs(next - 1) < 0.00001) {
                 managementUIState.getTargetTableFilters().getBulkUpload().setProgressBarCurrentValue(next);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
@@ -269,7 +269,7 @@ public class BulkUploadHandler extends CustomComponent
             tempFile = null;
         }
 
-        private void readEachLine(final String line, final double innerCounter, final double totalFileSize) {
+        private void readEachLine(final String line, final double innerCounter, final double totalNumberOfLines) {
             final String csvDelimiter = ",";
             final String[] targets = line.split(csvDelimiter);
             if (targets.length == 2) {
@@ -281,7 +281,7 @@ public class BulkUploadHandler extends CustomComponent
             }
             final float current = managementUIState.getTargetTableFilters().getBulkUpload()
                     .getProgressBarCurrentValue();
-            final float next = (float) (innerCounter / totalFileSize);
+            final float next = (float) (innerCounter / totalNumberOfLines);
             if (Math.abs(next - 0.1) < 0.00001 || current - next >= 0 || next - current >= 0.05
                     || Math.abs(next - 1) < 0.00001) {
                 managementUIState.getTargetTableFilters().getBulkUpload().setProgressBarCurrentValue(next);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/BulkUploadHandler.java
@@ -233,6 +233,7 @@ public class BulkUploadHandler extends CustomComponent
                         .setSucessfulUploadCount(successfullTargetCount);
                 eventBus.publish(this, new TargetTableEvent(TargetComponentEvent.BULK_TARGET_CREATED));
                 managementUIState.getTargetTableFilters().getBulkUpload().setFailedUploadCount(syncedFailedTargetCount);
+                managementUIState.getTargetTableFilters().getBulkUpload().setProgressBarCurrentValue(1);
             }
         }
 


### PR DESCRIPTION
Fix for the bug by changing the way the syncCountAfterUpload method works. Now the method validates if something went wrong by comparing the successfullTargetCount/failedTargetCount with the total count. The process bar for the upload is also set to 100% if something went wrong.

Reviewer: @melanieretter and @schabdo 

Signed-off-by: Jonathan Philip Knoblauch <JonathanPhilip.Knoblauch@bosch-si.com>
