### PR TITLE
Removed deprecated GridFS column from repository

### DIFF
--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactStoreController.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactStoreController.java
@@ -89,7 +89,7 @@ public class DdiArtifactStoreController implements DdiDlArtifactStoreControllerR
         if (ifMatch != null && !RestResourceConversionHelper.matchesHttpHeader(ifMatch, artifact.getSha1Hash())) {
             result = new ResponseEntity<>(HttpStatus.PRECONDITION_FAILED);
         } else {
-            final DbArtifact file = artifactManagement.loadArtifactBinary(artifact.getId());
+            final DbArtifact file = artifactManagement.loadArtifactBinary(artifact.getSha1Hash());
 
             // we set a download status only if we are aware of the
             // targetid, i.e. authenticated and not anonymous

--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -157,7 +157,7 @@ public class DdiRootController implements DdiRootControllerRestApi {
             @SuppressWarnings("squid:S3655")
             final Artifact artifact = module.getArtifactByFilename(fileName).get();
 
-            final DbArtifact file = artifactManagement.loadArtifactBinary(artifact.getId());
+            final DbArtifact file = artifactManagement.loadArtifactBinary(artifact.getSha1Hash());
 
             final String ifMatch = requestResponseContextHolder.getHttpServletRequest().getHeader("If-Match");
             if (ifMatch != null && !RestResourceConversionHelper.matchesHttpHeader(ifMatch, artifact.getSha1Hash())) {

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpControllerAuthenticationTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpControllerAuthenticationTest.java
@@ -152,7 +152,7 @@ public class AmqpControllerAuthenticationTest {
 
         authenticationManager.postConstruct();
 
-        final JpaArtifact testArtifact = new JpaArtifact("afilename", "afilename", new JpaSoftwareModule(
+        final JpaArtifact testArtifact = new JpaArtifact(SHA1, "afilename", new JpaSoftwareModule(
                 new JpaSoftwareModuleType("a key", "a name", null, 1), "a name", null, null, null));
         testArtifact.setId(1L);
 
@@ -161,8 +161,8 @@ public class AmqpControllerAuthenticationTest {
 
         final DbArtifact artifact = new DbArtifact();
         artifact.setSize(ARTIFACT_SIZE);
-        artifact.setHashes(new DbArtifactHash("sha1 test", "md5 test"));
-        when(artifactManagementMock.loadArtifactBinary(1L)).thenReturn(artifact);
+        artifact.setHashes(new DbArtifactHash(SHA1, "md5 test"));
+        when(artifactManagementMock.loadArtifactBinary(SHA1)).thenReturn(artifact);
 
         amqpMessageHandlerService = new AmqpMessageHandlerService(rabbitTemplate,
                 mock(AmqpMessageDispatcherService.class), controllerManagementMock, new JpaEntityFactory());
@@ -173,8 +173,8 @@ public class AmqpControllerAuthenticationTest {
 
         when(hostnameResolverMock.resolveHostname()).thenReturn(new URL("http://localhost"));
 
-        when(controllerManagementMock.hasTargetArtifactAssigned(TARGET_ID, 1L)).thenReturn(true);
-        when(controllerManagementMock.hasTargetArtifactAssigned(CONTROLLER_ID, 1L)).thenReturn(true);
+        when(controllerManagementMock.hasTargetArtifactAssigned(TARGET_ID, SHA1)).thenReturn(true);
+        when(controllerManagementMock.hasTargetArtifactAssigned(CONTROLLER_ID, SHA1)).thenReturn(true);
     }
 
     @Test

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -10,7 +10,6 @@ package org.eclipse.hawkbit.amqp;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -76,9 +75,10 @@ import ru.yandex.qatools.allure.annotations.Stories;
 @Stories("AmqpMessage Handler Service Test")
 public class AmqpMessageHandlerServiceTest {
 
+    private static final String SHA1 = "12345";
     private static final String TENANT = "DEFAULT";
     private static final Long TENANT_ID = 123L;
-    private static String CONTROLLLER_ID = "123";
+    private static final String CONTROLLLER_ID = "123";
     private static final Long TARGET_ID = 123L;
 
     private AmqpMessageHandlerService amqpMessageHandlerService;
@@ -327,17 +327,16 @@ public class AmqpMessageHandlerServiceTest {
 
         // mock
         final Artifact localArtifactMock = mock(Artifact.class);
-        final Long mockedArtifactId = 1L;
-        when(localArtifactMock.getId()).thenReturn(mockedArtifactId);
+        when(localArtifactMock.getSha1Hash()).thenReturn(SHA1);
 
         final DbArtifact dbArtifactMock = mock(DbArtifact.class);
-        when(artifactManagementMock.findFirstArtifactBySHA1(anyString())).thenReturn(localArtifactMock);
-        when(controllerManagementMock.hasTargetArtifactAssigned(securityToken.getControllerId(), mockedArtifactId))
+        when(artifactManagementMock.findFirstArtifactBySHA1(SHA1)).thenReturn(localArtifactMock);
+        when(controllerManagementMock.hasTargetArtifactAssigned(securityToken.getControllerId(), SHA1))
                 .thenReturn(true);
-        when(artifactManagementMock.loadArtifactBinary(anyLong())).thenReturn(dbArtifactMock);
+        when(artifactManagementMock.loadArtifactBinary(anyString())).thenReturn(dbArtifactMock);
         when(dbArtifactMock.getArtifactId()).thenReturn("artifactId");
         when(dbArtifactMock.getSize()).thenReturn(1L);
-        when(dbArtifactMock.getHashes()).thenReturn(new DbArtifactHash("sha1", "md5"));
+        when(dbArtifactMock.getHashes()).thenReturn(new DbArtifactHash(SHA1, "md5"));
         when(hostnameResolverMock.resolveHostname()).thenReturn(new URL("http://localhost"));
 
         // test
@@ -349,7 +348,7 @@ public class AmqpMessageHandlerServiceTest {
         assertThat(downloadResponse.getResponseCode()).as("Message body response code is wrong")
                 .isEqualTo(HttpStatus.OK.value());
         assertThat(downloadResponse.getArtifact().getSize()).as("Wrong artifact size in message body").isEqualTo(1L);
-        assertThat(downloadResponse.getArtifact().getHashes().getSha1()).as("Wrong sha1 hash").isEqualTo("sha1");
+        assertThat(downloadResponse.getArtifact().getHashes().getSha1()).as("Wrong sha1 hash").isEqualTo(SHA1);
         assertThat(downloadResponse.getArtifact().getHashes().getMd5()).as("Wrong md5 hash").isEqualTo("md5");
         assertThat(downloadResponse.getDownloadUrl()).as("download url is wrong")
                 .startsWith("http://localhost/api/v1/downloadserver/downloadId/");

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDownloadArtifactResource.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDownloadArtifactResource.java
@@ -67,7 +67,7 @@ public class MgmtDownloadArtifactResource implements MgmtDownloadArtifactRestApi
         }
 
         final Artifact artifact = module.getArtifact(artifactId).get();
-        final DbArtifact file = artifactManagement.loadArtifactBinary(artifact.getId());
+        final DbArtifact file = artifactManagement.loadArtifactBinary(artifact.getSha1Hash());
         final HttpServletRequest request = requestResponseContextHolder.getHttpServletRequest();
         final String ifMatch = request.getHeader("If-Match");
         if (ifMatch != null && !RestResourceConversionHelper.matchesHttpHeader(ifMatch, artifact.getSha1Hash())) {

--- a/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
+++ b/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
@@ -163,7 +163,8 @@ public class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegra
 
         // binary
         try (InputStream fileInputStream = artifactManagement
-                .loadArtifactBinary(softwareManagement.findSoftwareModuleById(sm.getId()).getArtifacts().get(0).getId())
+                .loadArtifactBinary(
+                        softwareManagement.findSoftwareModuleById(sm.getId()).getArtifacts().get(0).getSha1Hash())
                 .getFileInputStream()) {
             assertTrue("Wrong artifact content",
                     IOUtils.contentEquals(new ByteArrayInputStream(random), fileInputStream));

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ArtifactManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ArtifactManagement.java
@@ -19,7 +19,7 @@ import org.eclipse.hawkbit.repository.exception.ArtifactDeleteFailedException;
 import org.eclipse.hawkbit.repository.exception.ArtifactUploadFailedException;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
-import org.eclipse.hawkbit.repository.exception.GridFSDBFileNotFoundException;
+import org.eclipse.hawkbit.repository.exception.ArtifactBinaryNotFoundException;
 import org.eclipse.hawkbit.repository.exception.InvalidMD5HashException;
 import org.eclipse.hawkbit.repository.exception.InvalidSHA1HashException;
 import org.eclipse.hawkbit.repository.model.Artifact;
@@ -190,11 +190,8 @@ public interface ArtifactManagement {
      *            to search for
      * @return loaded {@link DbArtifact}
      *
-     * @throws GridFSDBFileNotFoundException
+     * @throws ArtifactBinaryNotFoundException
      *             if file could not be found in store
-     * 
-     * @throws EntityNotFoundException
-     *             is artifact with given ID does not exist
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_DOWNLOAD_ARTIFACT + SpringEvalExpressions.HAS_AUTH_OR
             + SpringEvalExpressions.HAS_CONTROLLER_DOWNLOAD)

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ArtifactManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ArtifactManagement.java
@@ -186,7 +186,7 @@ public interface ArtifactManagement {
     /**
      * Loads {@link DbArtifact} from store for given {@link Artifact}.
      *
-     * @param artifactId
+     * @param sha1Hash
      *            to search for
      * @return loaded {@link DbArtifact}
      *
@@ -198,6 +198,6 @@ public interface ArtifactManagement {
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_DOWNLOAD_ARTIFACT + SpringEvalExpressions.HAS_AUTH_OR
             + SpringEvalExpressions.HAS_CONTROLLER_DOWNLOAD)
-    DbArtifact loadArtifactBinary(@NotNull Long artifactId);
+    DbArtifact loadArtifactBinary(@NotEmpty String sha1Hash);
 
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -178,15 +178,15 @@ public interface ControllerManagement {
      * 
      * @param controllerId
      *            the ID of the target to check
-     * @param artifactId
-     *            the artifact to verify if the given target had even been
+     * @param sha1Hash
+     *            of the artifact to verify if the given target had even been
      *            assigned to
      * @return {@code true} if the given target has currently or had ever a
      *         relation to the given artifact through the action history,
      *         otherwise {@code false}
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    boolean hasTargetArtifactAssigned(@NotNull String controllerId, @NotNull Long artifactId);
+    boolean hasTargetArtifactAssigned(@NotEmpty String controllerId, @NotEmpty String sha1Hash);
 
     /**
      * Checks if a given target has currently or has even been assigned to the
@@ -197,15 +197,15 @@ public interface ControllerManagement {
      * 
      * @param targetId
      *            the ID of the target to check
-     * @param artifactId
-     *            the artifact to verify if the given target had even been
+     * @param sha1Hash
+     *            of the artifact to verify if the given target had even been
      *            assigned to
      * @return {@code true} if the given target has currently or had ever a
      *         relation to the given artifact through the action history,
      *         otherwise {@code false}
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    boolean hasTargetArtifactAssigned(@NotNull Long targetId, @NotNull Long artifactId);
+    boolean hasTargetArtifactAssigned(@NotNull Long targetId, @NotEmpty String sha1Hash);
 
     /**
      * Registers retrieved status for given {@link Target} and {@link Action} if

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/ArtifactBinaryNotFoundException.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/ArtifactBinaryNotFoundException.java
@@ -16,7 +16,7 @@ import org.eclipse.hawkbit.exception.SpServerError;
  *
  *
  */
-public final class GridFSDBFileNotFoundException extends AbstractServerRtException {
+public final class ArtifactBinaryNotFoundException extends AbstractServerRtException {
 
     /**
     *
@@ -27,7 +27,7 @@ public final class GridFSDBFileNotFoundException extends AbstractServerRtExcepti
      * Creates a new FileUploadFailedException with
      * {@link SpServerError#SP_REST_BODY_NOT_READABLE} error.
      */
-    public GridFSDBFileNotFoundException() {
+    public ArtifactBinaryNotFoundException() {
         super(SpServerError.SP_ARTIFACT_LOAD_FAILED);
     }
 
@@ -35,7 +35,7 @@ public final class GridFSDBFileNotFoundException extends AbstractServerRtExcepti
      * @param cause
      *            for the exception
      */
-    public GridFSDBFileNotFoundException(final Throwable cause) {
+    public ArtifactBinaryNotFoundException(final Throwable cause) {
         super(SpServerError.SP_ARTIFACT_LOAD_FAILED, cause);
     }
 
@@ -43,7 +43,7 @@ public final class GridFSDBFileNotFoundException extends AbstractServerRtExcepti
      * @param message
      *            of the error
      */
-    public GridFSDBFileNotFoundException(final String message) {
+    public ArtifactBinaryNotFoundException(final String message) {
         super(message, SpServerError.SP_ARTIFACT_LOAD_FAILED);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Artifact.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Artifact.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.hawkbit.repository.model;
 
+import org.eclipse.hawkbit.artifact.repository.model.DbArtifact;
+
 import com.google.common.io.BaseEncoding;
 
 /**
@@ -34,7 +36,7 @@ public interface Artifact extends TenantAwareBaseEntity {
 
     /**
      * @return SHA-1 hash of the artifact in {@link BaseEncoding#base16()}
-     *         format.
+     *         format that identifies the {@link DbArtifact} in the system.
      */
     String getSha1Hash();
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
@@ -18,11 +18,11 @@ import org.eclipse.hawkbit.artifact.repository.HashNotMatchException;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
 import org.eclipse.hawkbit.repository.ArtifactManagement;
+import org.eclipse.hawkbit.repository.exception.ArtifactBinaryNotFoundException;
 import org.eclipse.hawkbit.repository.exception.ArtifactDeleteFailedException;
 import org.eclipse.hawkbit.repository.exception.ArtifactUploadFailedException;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
-import org.eclipse.hawkbit.repository.exception.GridFSDBFileNotFoundException;
 import org.eclipse.hawkbit.repository.exception.InvalidMD5HashException;
 import org.eclipse.hawkbit.repository.exception.InvalidSHA1HashException;
 import org.eclipse.hawkbit.repository.jpa.model.JpaArtifact;
@@ -172,12 +172,8 @@ public class JpaArtifactManagement implements ArtifactManagement {
 
     @Override
     public DbArtifact loadArtifactBinary(final String sha1Hash) {
-        final DbArtifact result = artifactRepository.getArtifactBySha1(sha1Hash);
-        if (result == null) {
-            throw new GridFSDBFileNotFoundException(sha1Hash);
-        }
-
-        return result;
+        return Optional.ofNullable(artifactRepository.getArtifactBySha1(sha1Hash))
+                .orElseThrow(() -> new ArtifactBinaryNotFoundException(sha1Hash));
     }
 
     private Artifact storeArtifactMetadata(final SoftwareModule softwareModule, final String providedFilename,

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
@@ -112,7 +112,7 @@ public class JpaArtifactManagement implements ArtifactManagement {
 
     private boolean clearArtifactBinary(final JpaArtifact existing) {
 
-        for (final Artifact lArtifact : localArtifactRepository.findByGridFsFileName(existing.getGridFsFileName())) {
+        for (final Artifact lArtifact : localArtifactRepository.findBySha1Hash(existing.getSha1Hash())) {
             if (!lArtifact.getSoftwareModule().isDeleted()
                     && Long.compare(lArtifact.getSoftwareModule().getId(), existing.getSoftwareModule().getId()) != 0) {
                 return false;
@@ -120,8 +120,8 @@ public class JpaArtifactManagement implements ArtifactManagement {
         }
 
         try {
-            LOG.debug("deleting artifact from repository {}", existing.getGridFsFileName());
-            artifactRepository.deleteBySha1(existing.getGridFsFileName());
+            LOG.debug("deleting artifact from repository {}", existing.getSha1Hash());
+            artifactRepository.deleteBySha1(existing.getSha1Hash());
             return true;
         } catch (final ArtifactStoreException e) {
             throw new ArtifactDeleteFailedException(e);
@@ -156,8 +156,8 @@ public class JpaArtifactManagement implements ArtifactManagement {
     }
 
     @Override
-    public Artifact findFirstArtifactBySHA1(final String sha1) {
-        return localArtifactRepository.findFirstByGridFsFileName(sha1);
+    public Artifact findFirstArtifactBySHA1(final String sha1Hash) {
+        return localArtifactRepository.findFirstBySha1Hash(sha1Hash);
     }
 
     @Override
@@ -171,13 +171,10 @@ public class JpaArtifactManagement implements ArtifactManagement {
     }
 
     @Override
-    public DbArtifact loadArtifactBinary(final Long artifactId) {
-        final JpaArtifact artifact = Optional.ofNullable(localArtifactRepository.findOne(artifactId))
-                .orElseThrow(() -> new EntityNotFoundException("Artifact with given id " + artifactId + " not found."));
-
-        final DbArtifact result = artifactRepository.getArtifactBySha1(artifact.getGridFsFileName());
+    public DbArtifact loadArtifactBinary(final String sha1Hash) {
+        final DbArtifact result = artifactRepository.getArtifactBySha1(sha1Hash);
         if (result == null) {
-            throw new GridFSDBFileNotFoundException(artifact.getGridFsFileName());
+            throw new GridFSDBFileNotFoundException(sha1Hash);
         }
 
         return result;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -156,21 +156,21 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    public boolean hasTargetArtifactAssigned(final String controllerId, final Long localArtifact) {
+    public boolean hasTargetArtifactAssigned(final String controllerId, final String sha1Hash) {
         final Target target = targetRepository.findByControllerId(controllerId);
         if (target == null) {
             return false;
         }
-        return actionRepository.count(ActionSpecifications.hasTargetAssignedArtifact(target, localArtifact)) > 0;
+        return actionRepository.count(ActionSpecifications.hasTargetAssignedArtifact(target, sha1Hash)) > 0;
     }
 
     @Override
-    public boolean hasTargetArtifactAssigned(final Long targetId, final Long localArtifact) {
+    public boolean hasTargetArtifactAssigned(final Long targetId, final String sha1Hash) {
         final Target target = targetRepository.findOne(targetId);
         if (target == null) {
             return false;
         }
-        return actionRepository.count(ActionSpecifications.hasTargetAssignedArtifact(target, localArtifact)) > 0;
+        return actionRepository.count(ActionSpecifications.hasTargetAssignedArtifact(target, sha1Hash)) > 0;
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/LocalArtifactRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/LocalArtifactRepository.java
@@ -48,20 +48,20 @@ public interface LocalArtifactRepository extends BaseEntityRepository<JpaArtifac
     /**
      * Searches for a {@link Artifact} based on given gridFsFileName.
      *
-     * @param gridFsFileName
+     * @param sha1Hash
      *            to search
      * @return list of {@link Artifact}s.
      */
-    List<Artifact> findByGridFsFileName(String gridFsFileName);
+    List<Artifact> findBySha1Hash(String sha1Hash);
 
     /**
      * Searches for a {@link Artifact} based on given gridFsFileName.
      *
-     * @param gridFsFileName
+     * @param sha1Hash
      *            to search
      * @return {@link Artifact} the first in the result list
      */
-    JpaArtifact findFirstByGridFsFileName(String gridFsFileName);
+    JpaArtifact findFirstBySha1Hash(String sha1Hash);
 
     /**
      * Searches for a {@link Artifact} based user provided filename at upload.

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaArtifact.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaArtifact.java
@@ -30,6 +30,7 @@ import org.hibernate.validator.constraints.NotEmpty;
  *
  */
 @Table(name = "sp_artifact", indexes = { @Index(name = "sp_idx_artifact_01", columnList = "tenant,software_module"),
+        @Index(name = "sp_idx_artifact_02", columnList = "tenant,sha1_hash"),
         @Index(name = "sp_idx_artifact_prim", columnList = "tenant,id") })
 @Entity
 // exception squid:S2160 - BaseEntity equals/hashcode is handling correctly for
@@ -38,10 +39,10 @@ import org.hibernate.validator.constraints.NotEmpty;
 public class JpaArtifact extends AbstractJpaTenantAwareBaseEntity implements Artifact {
     private static final long serialVersionUID = 1L;
 
-    @Column(name = "gridfs_file_name", length = 40)
+    @Column(name = "sha1_hash", length = 40, nullable = false, updatable = false)
     @Size(max = 40)
     @NotEmpty
-    private String gridFsFileName;
+    private String sha1Hash;
 
     @Column(name = "provided_file_name", length = 256)
     @Size(max = 256)
@@ -51,9 +52,6 @@ public class JpaArtifact extends AbstractJpaTenantAwareBaseEntity implements Art
     @ManyToOne(optional = false, cascade = { CascadeType.PERSIST })
     @JoinColumn(name = "software_module", nullable = false, updatable = false, foreignKey = @ForeignKey(value = ConstraintMode.CONSTRAINT, name = "fk_assigned_sm"))
     private JpaSoftwareModule softwareModule;
-
-    @Column(name = "sha1_hash", length = 40, nullable = true)
-    private String sha1Hash;
 
     @Column(name = "md5_hash", length = 32, nullable = true)
     private String md5Hash;
@@ -71,17 +69,17 @@ public class JpaArtifact extends AbstractJpaTenantAwareBaseEntity implements Art
     /**
      * Constructs artifact.
      *
-     * @param gridFsFileName
+     * @param sha1Hash
      *            that is the link to the {@link DbArtifact} entity.
      * @param filename
      *            that is used by {@link DbArtifact} store.
      * @param softwareModule
      *            of this artifact
      */
-    public JpaArtifact(@NotNull final String gridFsFileName, @NotNull final String filename,
+    public JpaArtifact(@NotEmpty final String sha1Hash, @NotNull final String filename,
             final SoftwareModule softwareModule) {
         setSoftwareModule(softwareModule);
-        this.gridFsFileName = gridFsFileName;
+        this.sha1Hash = sha1Hash;
         this.filename = filename;
     }
 
@@ -120,10 +118,6 @@ public class JpaArtifact extends AbstractJpaTenantAwareBaseEntity implements Art
     public final void setSoftwareModule(final SoftwareModule softwareModule) {
         this.softwareModule = (JpaSoftwareModule) softwareModule;
         this.softwareModule.addArtifact(this);
-    }
-
-    public String getGridFsFileName() {
-        return gridFsFileName;
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/ActionSpecifications.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/ActionSpecifications.java
@@ -43,18 +43,18 @@ public final class ActionSpecifications {
      * @param target
      *            the target to verfiy if the given artifact is currently
      *            assigned or had been assigned
-     * @param localArtifact
-     *            the local artifact to check wherever the target had ever been
-     *            assigned
+     * @param sha1Hash
+     *            of the local artifact to check wherever the target had ever
+     *            been assigned
      * @return a specification to use with spring JPA
      */
-    public static Specification<JpaAction> hasTargetAssignedArtifact(final Target target, final Long localArtifact) {
+    public static Specification<JpaAction> hasTargetAssignedArtifact(final Target target, final String sha1Hash) {
         return (actionRoot, query, criteriaBuilder) -> {
             final Join<JpaAction, JpaDistributionSet> dsJoin = actionRoot.join(JpaAction_.distributionSet);
             final SetJoin<JpaDistributionSet, JpaSoftwareModule> modulesJoin = dsJoin.join(JpaDistributionSet_.modules);
             final ListJoin<JpaSoftwareModule, JpaArtifact> artifactsJoin = modulesJoin
                     .join(JpaSoftwareModule_.artifacts);
-            return criteriaBuilder.and(criteriaBuilder.equal(artifactsJoin.get(JpaArtifact_.id), localArtifact),
+            return criteriaBuilder.and(criteriaBuilder.equal(artifactsJoin.get(JpaArtifact_.sha1Hash), sha1Hash),
                     criteriaBuilder.equal(actionRoot.get(JpaAction_.target), target));
         };
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_10_1__consolidate_artifact_sha1__H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_10_1__consolidate_artifact_sha1__H2.sql
@@ -1,0 +1,3 @@
+ALTER TABLE sp_artifact DROP COLUMN sha1_hash;
+ALTER TABLE sp_artifact CHANGE gridfs_file_name sha1_hash varchar(40) not null;
+CREATE INDEX sp_idx_artifact_02 ON sp_artifact (tenant, sha1_hash);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_10_1__consolidate_artifact_sha1__MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_10_1__consolidate_artifact_sha1__MYSQL.sql
@@ -1,0 +1,3 @@
+ALTER TABLE sp_artifact DROP COLUMN sha1_hash;
+ALTER TABLE sp_artifact CHANGE gridfs_file_name sha1_hash varchar(40) not null;
+CREATE INDEX sp_idx_artifact_02 ON sp_artifact (tenant, sha1_hash);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
@@ -11,18 +11,23 @@ package org.eclipse.hawkbit.repository.jpa;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayInputStream;
+
 import javax.validation.ConstraintViolationException;
 
+import org.apache.commons.lang3.RandomUtils;
 import org.eclipse.hawkbit.repository.RepositoryProperties;
 import org.eclipse.hawkbit.repository.event.remote.TargetAssignDistributionSetEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.ActionCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.ActionUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetUpdatedEvent;
 import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
 import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.Artifact;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
@@ -78,6 +83,41 @@ public class ControllerManagementTest extends AbstractJpaIntegrationTest {
         assertThat(actionStatusRepository.findAll(pageReq).getNumberOfElements()).isEqualTo(3);
         assertThat(deploymentManagement.findActionStatusByAction(pageReq, savedAction.getId()).getNumberOfElements())
                 .isEqualTo(3);
+    }
+
+    @Test
+    @Description(".")
+    @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1),
+            @Expect(type = DistributionSetCreatedEvent.class, count = 2),
+            @Expect(type = ActionCreatedEvent.class, count = 1), @Expect(type = TargetUpdatedEvent.class, count = 1),
+            @Expect(type = TargetAssignDistributionSetEvent.class, count = 1),
+            @Expect(type = SoftwareModuleCreatedEvent.class, count = 6),
+            @Expect(type = SoftwareModuleUpdatedEvent.class, count = 2) })
+    public void hasTargetArtifactAssignedIsTrueWithMultipleArtifacts() {
+        final byte[] random = RandomUtils.nextBytes(5 * 1024);
+
+        final DistributionSet ds = testdataFactory.createDistributionSet("");
+        final DistributionSet ds2 = testdataFactory.createDistributionSet("2");
+        Target savedTarget = testdataFactory.createTarget();
+
+        // create two artifacts with identical SHA1 hash
+        final Artifact artifact = artifactManagement.createArtifact(new ByteArrayInputStream(random),
+                ds.findFirstModuleByType(osType).getId(), "file1", false);
+        final Artifact artifact2 = artifactManagement.createArtifact(new ByteArrayInputStream(random),
+                ds2.findFirstModuleByType(osType).getId(), "file1", false);
+        assertThat(artifact.getSha1Hash()).isEqualTo(artifact2.getSha1Hash());
+
+        assertThat(
+                controllerManagament.hasTargetArtifactAssigned(savedTarget.getControllerId(), artifact.getSha1Hash()))
+                        .isFalse();
+        savedTarget = assignDistributionSet(ds.getId(), savedTarget.getControllerId()).getAssignedEntity().iterator()
+                .next();
+        assertThat(
+                controllerManagament.hasTargetArtifactAssigned(savedTarget.getControllerId(), artifact.getSha1Hash()))
+                        .isTrue();
+        assertThat(
+                controllerManagament.hasTargetArtifactAssigned(savedTarget.getControllerId(), artifact2.getSha1Hash()))
+                        .isTrue();
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
@@ -86,7 +86,7 @@ public class ControllerManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description("Verifies that assignement verfication works based on SHA1 hash. By design it is not important which artifact "
+    @Description("Verifies that assignement verification works based on SHA1 hash. By design it is not important which artifact "
             + "is actually used for the check as long as they have an identical binary, i.e. same SHA1 hash. ")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1),
             @Expect(type = DistributionSetCreatedEvent.class, count = 2),

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
@@ -86,7 +86,8 @@ public class ControllerManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description(".")
+    @Description("Verifies that assignement verfication works based on SHA1 hash. By design it is not important which artifact "
+            + "is actually used for the check as long as they have an identical binary, i.e. same SHA1 hash. ")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1),
             @Expect(type = DistributionSetCreatedEvent.class, count = 2),
             @Expect(type = ActionCreatedEvent.class, count = 1), @Expect(type = TargetUpdatedEvent.class, count = 1),

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SoftwareManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SoftwareManagementTest.java
@@ -501,14 +501,13 @@ public class SoftwareManagementTest extends AbstractJpaIntegrationTest {
         assertThat(artifactRepository.findAll()).hasSize(results.length);
         for (final Artifact result : results) {
             assertThat(result.getId()).isNotNull();
-            assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result).getGridFsFileName()))
-                    .isNotNull();
+            assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result).getSha1Hash())).isNotNull();
         }
     }
 
     private void assertArtfiactNull(final Artifact... results) {
         for (final Artifact result : results) {
-            assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result).getGridFsFileName())).isNull();
+            assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result).getSha1Hash())).isNull();
         }
     }
 


### PR DESCRIPTION
Refactored repository ArtifactManagement by means of removing the grids column. This is something that was used in the past when MongoDb GridFS artifact binary repository was hardcoded into the system.

I refactored as well the wild mix of identifying the DbBArtifact by artfact ID or SHA1 (especially DMF got this mixed). Its now always SHA1. That is the way to identify the artifact.

Reviewers: @Jonkno @melanieretter 