### PR TITLE
Fix etag and headers for download id resource

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
@@ -291,7 +291,7 @@ public class SecurityManagedConfiguration {
         // in memory!
         filterRegBean.setFilter(new ExcludePathAwareShallowETagFilter(
                 "/rest/v1/softwaremodules/{smId}/artifacts/{artId}/download", "/{tenant}/controller/artifacts/**",
-                "/{targetid}/softwaremodules/{softwareModuleId}/artifacts/**"));
+                "/{targetid}/softwaremodules/{softwareModuleId}/artifacts/**", "/api/v1/downloadserver/**"));
 
         return filterRegBean;
     }


### PR DESCRIPTION
Quick fix for OOMs as result of usage of that resource. However, while looking at this I think all Download APIs need some refactoring and harmonisation .

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>