### PR TITLE
Correct method call for getting the installed distribution sets

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadConfirmationWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadConfirmationWindow.java
@@ -29,11 +29,11 @@ import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleSmallNoBorder;
 import org.eclipse.hawkbit.ui.decorators.SPUIButtonStyleTiny;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
-import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
+import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.vaadin.spring.events.EventBus.UIEventBus;
@@ -423,12 +423,12 @@ public class UploadConfirmationWindow implements Button.ClickListener {
                     errorLabel = icon;
                     errorLabelCount++;
                 }
-
             }
         }
         hideErrorIcon(warningLabel, errorLabelCount, duplicateCount, errorLabel, oldFileName, currentSwId);
     }
 
+    @SuppressWarnings("squid:S2259")
     private void hideErrorIcon(final Label warningLabel, final int errorLabelCount, final int duplicateCount,
             final Label errorLabel, final String oldFileName, final Long currentSwId) {
         if (warningLabel == null && (errorLabelCount > 1 || (duplicateCount == 1 && errorLabelCount == 1))) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadConfirmationWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/UploadConfirmationWindow.java
@@ -428,13 +428,15 @@ public class UploadConfirmationWindow implements Button.ClickListener {
         hideErrorIcon(warningLabel, errorLabelCount, duplicateCount, errorLabel, oldFileName, currentSwId);
     }
 
-    @SuppressWarnings("squid:S2259")
     private void hideErrorIcon(final Label warningLabel, final int errorLabelCount, final int duplicateCount,
             final Label errorLabel, final String oldFileName, final Long currentSwId) {
         if (warningLabel == null && (errorLabelCount > 1 || (duplicateCount == 1 && errorLabelCount == 1))) {
 
             final Optional<Artifact> artifactList = artifactManagement.findByFilenameAndSoftwareModule(oldFileName,
                     currentSwId);
+            if (errorLabel == null) {
+                return;
+            }
             errorLabel.removeStyleName(SPUIStyleDefinitions.ERROR_LABEL);
             errorLabel.setDescription(i18n.getMessage(ALREADY_EXISTS_MSG));
             if (!artifactList.isPresent()) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/AbstractNotificationView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/AbstractNotificationView.java
@@ -77,6 +77,7 @@ public abstract class AbstractNotificationView extends VerticalLayout implements
         getDashboardMenuItem().setNotificationUnreadValue(viewUnreadNotifcations);
     }
 
+    @SuppressWarnings("squid:UnusedPrivateMethod")
     private boolean noEventMatch(final TenantAwareEvent tenantAwareEvent) {
         return !skipUiEventsCache.asMap().keySet().stream()
                 .anyMatch(uiEvent -> uiEvent.matchRemoteEvent(tenantAwareEvent));

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTable.java
@@ -43,13 +43,13 @@ import org.eclipse.hawkbit.ui.management.state.ManagementUIState;
 import org.eclipse.hawkbit.ui.management.targettable.TargetTable;
 import org.eclipse.hawkbit.ui.push.DistributionSetUpdatedEventContainer;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
-import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.TableColumn;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
+import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
@@ -89,8 +89,9 @@ public class DistributionTable extends AbstractNamedVersionTable<DistributionSet
     private boolean isDistPinned;
     private Button distributinPinnedBtn;
 
-    DistributionTable(final UIEventBus eventBus, final VaadinMessageSource i18n, final SpPermissionChecker permissionChecker,
-            final UINotification notification, final ManagementUIState managementUIState,
+    DistributionTable(final UIEventBus eventBus, final VaadinMessageSource i18n,
+            final SpPermissionChecker permissionChecker, final UINotification notification,
+            final ManagementUIState managementUIState,
             final ManagementViewClientCriterion managementViewClientCriterion, final TargetManagement targetManagement,
             final DsMetadataPopupLayout dsMetadataPopupLayout,
             final DistributionSetManagement distributionSetManagement,
@@ -399,7 +400,8 @@ public class DistributionTable extends AbstractNamedVersionTable<DistributionSet
         if (!assignedTargets.isEmpty()) {
             assignTargetToDs(getItem(distItemId), assignedTargets);
         } else {
-            notification.displaySuccess(i18n.getMessage("message.no.targets.assiged.fortag", new Object[] { targetTagName }));
+            notification.displaySuccess(
+                    i18n.getMessage("message.no.targets.assiged.fortag", new Object[] { targetTagName }));
         }
     }
 
@@ -460,8 +462,8 @@ public class DistributionTable extends AbstractNamedVersionTable<DistributionSet
 
     private Boolean isNoTagButton(final String tagData, final String targetNoTagData) {
         if (tagData.equals(targetNoTagData)) {
-            notification.displayValidationError(
-                    i18n.getMessage("message.tag.cannot.be.assigned", new Object[] { i18n.getMessage("label.no.tag.assigned") }));
+            notification.displayValidationError(i18n.getMessage("message.tag.cannot.be.assigned",
+                    new Object[] { i18n.getMessage("label.no.tag.assigned") }));
             return true;
         }
         return false;
@@ -489,7 +491,8 @@ public class DistributionTable extends AbstractNamedVersionTable<DistributionSet
             final String distNameVersion) {
         String pendActionMsg = i18n.getMessage("message.target.assigned.pending");
         if (null == message) {
-            pendActionMsg = i18n.getMessage("message.dist.pending.action", new Object[] { controllerId, distNameVersion });
+            pendActionMsg = i18n.getMessage("message.dist.pending.action",
+                    new Object[] { controllerId, distNameVersion });
         }
         return pendActionMsg;
     }
@@ -528,7 +531,7 @@ public class DistributionTable extends AbstractNamedVersionTable<DistributionSet
         managementUIState.getDistributionTableFilters().getPinnedTarget().map(TargetIdName::getControllerId)
                 .ifPresent(controllerId -> {
 
-                    final Long installedDistId = deploymentManagement.getAssignedDistributionSet(controllerId)
+                    final Long installedDistId = deploymentManagement.getInstalledDistributionSet(controllerId)
                             .map(DistributionSet::getId).orElse(null);
                     final Long assignedDistId = deploymentManagement.getAssignedDistributionSet(controllerId)
                             .map(DistributionSet::getId).orElse(null);


### PR DESCRIPTION
There was an incorrect method call for getting the distribution sets which are installed. As a result the row highlighting of the distribution set table was not working correctly.

Signed-off-by: Melanie Retter <melanie.retter@bosch-si.com>