### PR TITLE
Fix rollout management cancel running action

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -254,8 +254,9 @@ public class JpaDeploymentManagement implements DeploymentManagement {
 
         targetIds.forEach(tIds -> targetRepository.setAssignedDistributionSetAndUpdateStatus(TargetUpdateStatus.PENDING,
                 set, System.currentTimeMillis(), currentUser, tIds));
-        final Map<String, JpaAction> targetIdsToActions = targets.stream().map(
-                t -> actionRepository.save(createTargetAction(targetsWithActionMap, t, set, rollout, rolloutGroup)))
+        final Map<String, JpaAction> targetIdsToActions = targets.stream()
+                .map(t -> actionRepository
+                        .save(createTargetAction(targetsWithActionMap, t, set, rollout, rolloutGroup)))
                 .collect(Collectors.toMap(a -> a.getTarget().getControllerId(), Function.identity()));
 
         // create initial action status when action is created so we remember
@@ -465,10 +466,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     }
 
     private void startScheduledAction(final JpaAction action) {
-        // check if we need to override running update actions
-        final Set<Long> overrideObsoleteUpdateActions = overrideObsoleteUpdateActions(
-                Collections.singletonList(action.getTarget().getId()));
-
         JpaTarget target = (JpaTarget) action.getTarget();
 
         if (target.getAssignedDistributionSet() != null
@@ -481,6 +478,10 @@ public class JpaDeploymentManagement implements DeploymentManagement {
             actionRepository.save(action);
             return;
         }
+
+        // check if we need to override running update actions
+        final Set<Long> overrideObsoleteUpdateActions = overrideObsoleteUpdateActions(
+                Collections.singletonList(action.getTarget().getId()));
 
         action.setActive(true);
         action.setStatus(Status.RUNNING);
@@ -669,7 +670,7 @@ public class JpaDeploymentManagement implements DeploymentManagement {
         final Long totalCount = entityManager.createQuery(countMsgQuery).getSingleResult();
 
         final CriteriaQuery<String> msgQuery = cb.createQuery(String.class);
-        final Root<JpaActionStatus>as = msgQuery.from(JpaActionStatus.class);
+        final Root<JpaActionStatus> as = msgQuery.from(JpaActionStatus.class);
         final ListJoin<JpaActionStatus, String> join = as.joinList("messages", JoinType.LEFT);
         final CriteriaQuery<String> selMsgQuery = msgQuery.select(join);
         selMsgQuery.where(cb.equal(as.get(JpaActionStatus_.id), actionStatusId));


### PR DESCRIPTION
**Scenario**
1. Assign distribution-set (version 1) to a target - keep it pending (running action)
2. Create a rollout using the same distribution-set (version 1) and create and start the rollout

**Behavior:** 
The rollout-management finishes the scheduled-action immediately because it recognized it is the same distribution set already assigned to the target as the rollout-management action. But it also cancels the running action which has been assigned manually before the check!

**Expected Behavior:**
The rollout-management keeps the manual assignment action running and just finishes the action created by the rollout itself, because the rollout-management does not need to start a schedule action if there is already the same running update with the same distribution-set