### PR TITLE
Set isolation level. Remove manual artifact cleanup at tenant delete

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
@@ -59,9 +59,6 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     private TargetFilterQueryRepository targetFilterQueryRepository;
 
     @Autowired
-    private ActionRepository actionRepository;
-
-    @Autowired
     private DistributionSetRepository distributionSetRepository;
 
     @Autowired
@@ -83,16 +80,10 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     private DistributionSetTagRepository distributionSetTagRepository;
 
     @Autowired
-    private LocalArtifactRepository artifactRepository;
-
-    @Autowired
     private TenantConfigurationRepository tenantConfigurationRepository;
 
     @Autowired
     private RolloutRepository rolloutRepository;
-
-    @Autowired
-    private RolloutGroupRepository rolloutGroupRepository;
 
     @Autowired
     private TenantAware tenantAware;
@@ -196,6 +187,8 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
         final DefaultTransactionDefinition def = new DefaultTransactionDefinition();
         def.setName("initial-tenant-creation");
         def.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        def.setReadOnly(false);
+        def.setIsolationLevel(Isolation.READ_UNCOMMITTED.value());
         return systemSecurityContext.runAsSystemAsTenant(
                 () -> new TransactionTemplate(txManager, def).execute(status -> tenantMetaDataRepository
                         .save(new JpaTenantMetaData(createStandardSoftwareDataSetup(), tenant))),
@@ -219,7 +212,6 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
             targetRepository.deleteByTenantIgnoreCase(tenant);
             targetFilterQueryRepository.deleteByTenantIgnoreCase(tenant);
             rolloutRepository.deleteByTenantIgnoreCase(tenant);
-            artifactRepository.deleteByTenantIgnoreCase(tenant);
             targetTagRepository.deleteByTenantIgnoreCase(tenant);
             distributionSetTagRepository.deleteByTenantIgnoreCase(tenant);
             distributionSetRepository.deleteByTenantIgnoreCase(tenant);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignChecker.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignChecker.java
@@ -29,6 +29,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -87,6 +88,8 @@ public class AutoAssignChecker {
         final DefaultTransactionDefinition def = new DefaultTransactionDefinition();
         def.setName("autoAssignDSToTargets");
         def.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        def.setReadOnly(false);
+        def.setIsolationLevel(Isolation.READ_UNCOMMITTED.value());
         transactionTemplate = new TransactionTemplate(transactionManager, def);
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignChecker.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignChecker.java
@@ -89,7 +89,7 @@ public class AutoAssignChecker {
         def.setName("autoAssignDSToTargets");
         def.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
         def.setReadOnly(false);
-        def.setIsolationLevel(Isolation.READ_UNCOMMITTED.value());
+        def.setIsolationLevel(Isolation.READ_COMMITTED.value());
         transactionTemplate = new TransactionTemplate(transactionManager, def);
     }
 


### PR DESCRIPTION
* Set missing isolation levels for manual transaction setup in order to avoid using (undefined) DB default.
* Remove manual artefact erase at tenant deletion as we have a cascade for this with module delete.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>