### PR TITLE
Fix missing TargetUpdate events

### DIFF
--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageDispatcherServiceIntegrationTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageDispatcherServiceIntegrationTest.java
@@ -61,7 +61,7 @@ public class AmqpMessageDispatcherServiceIntegrationTest extends AmqpServiceInte
             @Expect(type = ActionCreatedEvent.class, count = 2), @Expect(type = ActionUpdatedEvent.class, count = 1),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 6),
             @Expect(type = DistributionSetCreatedEvent.class, count = 2),
-            @Expect(type = TargetUpdatedEvent.class, count = 1), @Expect(type = TargetPollEvent.class, count = 3) })
+            @Expect(type = TargetUpdatedEvent.class, count = 2), @Expect(type = TargetPollEvent.class, count = 3) })
     public void assignDistributionSetMultipleTimes() {
         final DistributionSetAssignmentResult assignmentResult = registerTargetAndAssignDistributionSet();
 
@@ -98,8 +98,8 @@ public class AmqpMessageDispatcherServiceIntegrationTest extends AmqpServiceInte
         waitUntil(() -> {
             final Optional<Target> findTargetByControllerID = targetManagement
                     .findTargetByControllerID(REGISTER_TARGET);
-            return findTargetByControllerID.isPresent() && TargetUpdateStatus.PENDING
-                    .equals(findTargetByControllerID.get().getUpdateStatus());
+            return findTargetByControllerID.isPresent()
+                    && TargetUpdateStatus.PENDING.equals(findTargetByControllerID.get().getUpdateStatus());
         });
     }
 

--- a/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
+++ b/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
@@ -886,7 +886,8 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
-                .andExpect(jsonPath("content.[0].messages", hasItem("manual cancelation requested")))
+                .andExpect(jsonPath("content.[0].messages",
+                        hasItem("Update Server: cancel obsolete action due to new update")))
                 .andExpect(jsonPath("content.[0].reportedAt", equalTo(actionStatus.get(0).getCreatedAt())))
                 .andExpect(jsonPath("content.[1].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("running")))
@@ -912,7 +913,8 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
-                .andExpect(jsonPath("content.[0].messages", hasItem("manual cancelation requested")))
+                .andExpect(jsonPath("content.[0].messages",
+                        hasItem("Update Server: cancel obsolete action due to new update")))
                 .andExpect(jsonPath("content.[0].reportedAt", equalTo(actionStatus.get(1).getCreatedAt())))
                 .andExpect(jsonPath("content.[1].id", equalTo(actionStatus.get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("running")))
@@ -929,7 +931,8 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(jsonPath("content.[1].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("canceling")))
-                .andExpect(jsonPath("content.[1].messages", hasItem("manual cancelation requested")))
+                .andExpect(jsonPath("content.[1].messages",
+                        hasItem("Update Server: cancel obsolete action due to new update")))
                 .andExpect(jsonPath("content.[1].reportedAt", equalTo(actionStatus.get(1).getCreatedAt())))
                 .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("running")))
@@ -956,7 +959,8 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
-                .andExpect(jsonPath("content.[0].messages", hasItem("manual cancelation requested")))
+                .andExpect(jsonPath("content.[0].messages",
+                        hasItem("Update Server: cancel obsolete action due to new update")))
                 .andExpect(jsonPath("content.[0].reportedAt", equalTo(actionStatus.get(1).getCreatedAt())))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(1)))

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -222,7 +222,7 @@ public class JpaDeploymentManagement implements DeploymentManagement {
 
         if (targets.isEmpty()) {
             // detaching as it is not necessary to persist the set itself
-            entityManager.detach(set);
+            entityManager.clear();
             // return with nothing as all targets had the DS already assigned
             return new DistributionSetAssignmentResult(Collections.emptyList(), 0, targetsWithActionType.size(),
                     Collections.emptyList(), targetManagement);
@@ -327,7 +327,7 @@ public class JpaDeploymentManagement implements DeploymentManagement {
      * @param targetsIds
      *            to override {@link Action}s
      */
-    private Set<Long> overrideObsoleteUpdateActions(final List<Long> targetsIds) {
+    private List<Long> overrideObsoleteUpdateActions(final Collection<Long> targetsIds) {
 
         // Figure out if there are potential target/action combinations that
         // need to be considered for cancellation
@@ -346,7 +346,7 @@ public class JpaDeploymentManagement implements DeploymentManagement {
             cancelAssignDistributionSetEvent(action.getTarget(), action.getId());
 
             return action.getTarget().getId();
-        }).collect(Collectors.toSet());
+        }).collect(Collectors.toList());
 
     }
 
@@ -479,7 +479,7 @@ public class JpaDeploymentManagement implements DeploymentManagement {
         }
 
         // check if we need to override running update actions
-        final Set<Long> overrideObsoleteUpdateActions = overrideObsoleteUpdateActions(
+        final List<Long> overrideObsoleteUpdateActions = overrideObsoleteUpdateActions(
                 Collections.singletonList(action.getTarget().getId()));
 
         action.setActive(true);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -276,17 +276,22 @@ public class JpaDeploymentManagement implements DeploymentManagement {
 
         LOG.debug("assignDistribution({}) finished {}", set, result);
 
-        sendDistributionSetAssignmentEvent(targets, targetIdsCancellList, targetIdsToActions);
+        sendAssignmentEvents(targets, targetIdsCancellList, targetIdsToActions);
 
         return result;
     }
 
-    private void sendDistributionSetAssignmentEvent(final List<JpaTarget> targets, final Set<Long> targetIdsCancellList,
+    private void sendAssignmentEvents(final List<JpaTarget> targets, final Set<Long> targetIdsCancellList,
             final Map<String, JpaAction> targetIdsToActions) {
-        targets.stream().filter(t -> !!!targetIdsCancellList.contains(t.getId()))
-                .forEach(t -> sendTargetAssignDistributionSetEvent(targetIdsToActions.get(t.getControllerId())));
 
-        targets.forEach(this::sendTargetUpdatedEvent);
+        targets.forEach(target -> {
+            sendTargetUpdatedEvent(target);
+            if (targetIdsCancellList.contains(target.getId())) {
+                return;
+            }
+
+            sendTargetAssignDistributionSetEvent(targetIdsToActions.get(target.getControllerId()));
+        });
     }
 
     private static JpaAction createTargetAction(final Map<String, TargetWithActionType> targetsWithActionMap,

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -11,7 +11,6 @@ package org.eclipse.hawkbit.repository.jpa;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -232,12 +231,8 @@ public class JpaDeploymentManagement implements DeploymentManagement {
         final List<List<Long>> targetIds = Lists.partition(
                 targets.stream().map(Target::getId).collect(Collectors.toList()), Constants.MAX_ENTRIES_IN_STATEMENT);
 
-        // override all active actions and set them into canceling state, we
-        // need to remember which one we have been switched to canceling state
-        // because for targets which we have changed to canceling we don't want
-        // to publish the new action update event.
-        final Set<Long> targetIdsCancellList = new HashSet<>();
-        targetIds.forEach(ids -> targetIdsCancellList.addAll(overrideObsoleteUpdateActions(ids)));
+        // override all active actions and set them into canceling state
+        targetIds.forEach(this::overrideObsoleteUpdateActions);
 
         // cancel all scheduled actions which are in-active, these actions were
         // not active before and the manual assignment which has been done
@@ -254,9 +249,8 @@ public class JpaDeploymentManagement implements DeploymentManagement {
 
         targetIds.forEach(tIds -> targetRepository.setAssignedDistributionSetAndUpdateStatus(TargetUpdateStatus.PENDING,
                 set, System.currentTimeMillis(), currentUser, tIds));
-        final Map<String, JpaAction> targetIdsToActions = targets.stream()
-                .map(t -> actionRepository
-                        .save(createTargetAction(targetsWithActionMap, t, set, rollout, rolloutGroup)))
+        final Map<String, JpaAction> targetIdsToActions = targets.stream().map(
+                t -> actionRepository.save(createTargetAction(targetsWithActionMap, t, set, rollout, rolloutGroup)))
                 .collect(Collectors.toMap(a -> a.getTarget().getControllerId(), Function.identity()));
 
         // create initial action status when action is created so we remember
@@ -267,6 +261,9 @@ public class JpaDeploymentManagement implements DeploymentManagement {
 
         // flush to get action IDs
         entityManager.flush();
+        // detaching as everything that needs to be stored is already flushed
+        entityManager.clear();
+
         // collect updated target and actions IDs in order to return them
         final DistributionSetAssignmentResult result = new DistributionSetAssignmentResult(
                 targets.stream().map(Target::getControllerId).collect(Collectors.toList()), targets.size(),
@@ -275,18 +272,14 @@ public class JpaDeploymentManagement implements DeploymentManagement {
 
         LOG.debug("assignDistribution({}) finished {}", set, result);
 
-        // detaching as it is not necessary to persist the set itself
-        entityManager.detach(set);
-
-        sendDistributionSetAssignmentEvent(targets, targetIdsCancellList, targetIdsToActions);
+        sendDistributionSetAssignmentEvent(targets, targetIdsToActions);
 
         return result;
     }
 
-    private void sendDistributionSetAssignmentEvent(final List<JpaTarget> targets, final Set<Long> targetIdsCancellList,
+    private void sendDistributionSetAssignmentEvent(final List<JpaTarget> targets,
             final Map<String, JpaAction> targetIdsToActions) {
-        targets.stream().filter(t -> !!!targetIdsCancellList.contains(t.getId()))
-                .forEach(t -> assignDistributionSetEvent(targetIdsToActions.get(t.getControllerId())));
+        targets.forEach(t -> assignDistributionSetEvent(targetIdsToActions.get(t.getControllerId())));
     }
 
     private static JpaAction createTargetAction(final Map<String, TargetWithActionType> targetsWithActionMap,
@@ -311,7 +304,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
         // through JQL
         final JpaTarget target = (JpaTarget) action.getTarget();
         target.setUpdateStatus(TargetUpdateStatus.PENDING);
-        entityManager.detach(target);
 
         afterCommit.afterCommit(
                 () -> eventPublisher.publishEvent(new TargetUpdatedEvent(target, applicationContext.getId())));
@@ -339,7 +331,7 @@ public class JpaDeploymentManagement implements DeploymentManagement {
             // document that the status has been retrieved
 
             actionStatusRepository.save(new JpaActionStatus(action, Status.CANCELING, System.currentTimeMillis(),
-                    "manual cancelation requested"));
+                    RepositoryConstants.SERVER_MESSAGE_PREFIX + "cancel obsolete action due to new update"));
             actionRepository.save(action);
 
             cancelAssignDistributionSetEvent(action.getTarget(), action.getId());
@@ -368,7 +360,7 @@ public class JpaDeploymentManagement implements DeploymentManagement {
 
             // document that the status has been retrieved
             actionStatusRepository.save(new JpaActionStatus(action, Status.CANCELING, System.currentTimeMillis(),
-                    "manual cancelation requested"));
+                    RepositoryConstants.SERVER_MESSAGE_PREFIX + "manual cancelation requested"));
             final Action saveAction = actionRepository.save(action);
             cancelAssignDistributionSetEvent(action.getTarget(), action.getId());
 
@@ -412,7 +404,7 @@ public class JpaDeploymentManagement implements DeploymentManagement {
 
         // document that the status has been retrieved
         actionStatusRepository.save(new JpaActionStatus(action, Status.CANCELED, System.currentTimeMillis(),
-                "A force quit has been performed."));
+                RepositoryConstants.SERVER_MESSAGE_PREFIX + "A force quit has been performed."));
 
         DeploymentHelper.successCancellation(action, actionRepository, targetRepository);
 
@@ -420,8 +412,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     }
 
     @Override
-    @Modifying
-    @Transactional(isolation = Isolation.READ_COMMITTED)
     public long startScheduledActionsByRolloutGroupParent(@NotNull final Long rolloutId,
             final Long rolloutGroupParentId) {
         long totalActionsCount = 0L;
@@ -438,7 +428,7 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     private long startScheduledActionsByRolloutGroupParentInNewTransaction(final Long rolloutId,
             final Long rolloutGroupParentId, final int limit) {
         final DefaultTransactionDefinition def = new DefaultTransactionDefinition();
-        def.setName("startScheduledActions");
+        def.setName("startScheduledActions-" + rolloutId);
         def.setReadOnly(false);
         def.setIsolationLevel(Isolation.READ_UNCOMMITTED.value());
         def.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetManagementTest.java
@@ -366,6 +366,43 @@ public class DistributionSetManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
+    @Description("Ensures that distribution sets can assigned and unassigned to a  distribution set tag.")
+    public void assignAndUnassignDistributionSetToTag() {
+        final List<Long> assignDS = Lists.newArrayListWithExpectedSize(4);
+        for (int i = 0; i < 4; i++) {
+            assignDS.add(testdataFactory.createDistributionSet("DS" + i, "1.0", Collections.emptyList()).getId());
+        }
+
+        final DistributionSetTag tag = tagManagement
+                .createDistributionSetTag(entityFactory.tag().create().name("Tag1"));
+
+        final List<DistributionSet> assignedDS = distributionSetManagement.assignTag(assignDS, tag.getId());
+        assertThat(assignedDS.size()).as("assigned ds has wrong size").isEqualTo(4);
+        assignedDS.forEach(ds -> assertThat(ds.getTags().size()).as("ds has wrong tag size").isEqualTo(1));
+
+        DistributionSetTag findDistributionSetTag = tagManagement.findDistributionSetTag("Tag1").get();
+        assertThat(assignedDS.size()).as("assigned ds has wrong size")
+                .isEqualTo(findDistributionSetTag.getAssignedToDistributionSet().size());
+
+        final DistributionSet unAssignDS = distributionSetManagement.unAssignTag(assignDS.get(0),
+                findDistributionSetTag.getId());
+        assertThat(unAssignDS.getId()).as("unassigned ds is wrong").isEqualTo(assignDS.get(0));
+        assertThat(unAssignDS.getTags().size()).as("unassigned ds has wrong tag size").isEqualTo(0);
+        findDistributionSetTag = tagManagement.findDistributionSetTag("Tag1").get();
+        assertThat(findDistributionSetTag.getAssignedToDistributionSet().size()).as("ds tag ds has wrong ds size")
+                .isEqualTo(3);
+
+        final List<DistributionSet> unAssignTargets = distributionSetManagement
+                .unAssignAllDistributionSetsByTag(findDistributionSetTag.getId());
+        findDistributionSetTag = tagManagement.findDistributionSetTag("Tag1").get();
+        assertThat(findDistributionSetTag.getAssignedToDistributionSet().size()).as("ds tag has wrong ds size")
+                .isEqualTo(0);
+        assertThat(unAssignTargets.size()).as("unassigned target has wrong size").isEqualTo(3);
+        unAssignTargets
+                .forEach(target -> assertThat(target.getTags().size()).as("target has wrong tag size").isEqualTo(0));
+    }
+
+    @Test
     @Description("Ensures that updates concerning the internal software structure of a DS are not possible if the DS is already assigned.")
     public void updateDistributionSetForbiddedWithIllegalUpdate() {
         // prepare data

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.hawkbit.repository.test.util.TestContextProvider;
 import org.junit.Assert;
@@ -27,7 +28,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.event.ApplicationEventMulticaster;
 
-import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ConcurrentHashMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
 import com.jayway.awaitility.Awaitility;
@@ -111,20 +112,20 @@ public class EventVerifier implements TestRule {
 
     private static class EventCaptor implements ApplicationListener<RemoteApplicationEvent> {
 
-        private final Multiset<Class<?>> capturedEvents = HashMultiset.create();
+        private final Multiset<Class<?>> capturedEvents = ConcurrentHashMultiset.create();
 
         @Override
-        public synchronized void onApplicationEvent(final RemoteApplicationEvent event) {
+        public void onApplicationEvent(final RemoteApplicationEvent event) {
             capturedEvents.add(event.getClass());
         }
 
-        public synchronized int getCountFor(final Class<?> expectedEvent) {
+        public int getCountFor(final Class<?> expectedEvent) {
             return capturedEvents.count(expectedEvent);
         }
 
-        public synchronized Set<Class<?>> diff(final Expect[] allEvents) {
+        public Set<Class<?>> diff(final Expect[] allEvents) {
             return Sets.difference(capturedEvents.elementSet(),
-                    java.util.stream.Stream.of(allEvents).map((e) -> e.type()).collect(Collectors.toSet()));
+                    Stream.of(allEvents).map(Expect::type).collect(Collectors.toSet()));
         }
 
     }


### PR DESCRIPTION
Assign DistributionSet does not send assignment events in case cancellations have to be handled first by DMF. However, the mechanism was applied as well to TargetUpdate events which is obviously wrong. The target was changed even in case of cancelations.

I applied as well a few optimisations and small fixes.
* Clear entiymanager after flush (instead of manual detachments)
* Applied standard scheme to action status created by update server.
* jave stream used for calculating cancellations.

Reviewers: @melanieretter @SirWayne 