### PR TITLE
Optimised locking on large scale tenant scenarios.

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -716,31 +716,31 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     // No transaction, will be created per handled rollout
     @Transactional(propagation = Propagation.NEVER)
     public void handleRollouts() {
-        rolloutRepository
-                .findByStatusIn(Lists.newArrayList(RolloutStatus.CREATING, RolloutStatus.DELETING,
-                        RolloutStatus.STARTING, RolloutStatus.READY, RolloutStatus.RUNNING))
-                .forEach(this::handleRollout);
-    }
+        final List<Long> rollouts = rolloutRepository.findByStatusIn(Lists.newArrayList(RolloutStatus.CREATING,
+                RolloutStatus.DELETING, RolloutStatus.STARTING, RolloutStatus.READY, RolloutStatus.RUNNING));
 
-    private void handleRollout(final Long rolloutId) {
-        LOGGER.debug("handleRollout called for rollout {}", rolloutId);
+        if (rollouts.isEmpty()) {
+            return;
+        }
 
         final String tenant = tenantAware.getCurrentTenant();
 
-        final String handlerId = tenant + "-rollout-" + rolloutId;
+        final String handlerId = tenant + "-rollout";
         final Lock lock = lockRegistry.obtain(handlerId);
         if (!lock.tryLock()) {
             return;
         }
 
         try {
-            runInNewTransaction(handlerId, status -> executeFittingHandler(rolloutId));
+            rollouts.forEach(rolloutId -> runInNewTransaction(handlerId + "-" + rolloutId,
+                    status -> executeFittingHandler(rolloutId)));
         } finally {
             lock.unlock();
         }
     }
 
     private int executeFittingHandler(final Long rolloutId) {
+        LOGGER.debug("handle rollout {}", rolloutId);
         final JpaRollout rollout = rolloutRepository.findOne(rolloutId);
 
         switch (rollout.getStatus()) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.repository.jpa;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -108,6 +109,9 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
      * Maximum amount of actions that are deleted in one transaction.
      */
     private static final int TRANSACTION_ACTIONS = 5_000;
+
+    private static final List<RolloutStatus> ACTIVE_ROLLOUTS = Arrays.asList(RolloutStatus.CREATING,
+            RolloutStatus.DELETING, RolloutStatus.STARTING, RolloutStatus.READY, RolloutStatus.RUNNING);
 
     @Autowired
     private RolloutRepository rolloutRepository;
@@ -716,8 +720,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     // No transaction, will be created per handled rollout
     @Transactional(propagation = Propagation.NEVER)
     public void handleRollouts() {
-        final List<Long> rollouts = rolloutRepository.findByStatusIn(Lists.newArrayList(RolloutStatus.CREATING,
-                RolloutStatus.DELETING, RolloutStatus.STARTING, RolloutStatus.READY, RolloutStatus.RUNNING));
+        final List<Long> rollouts = rolloutRepository.findByStatusIn(ACTIVE_ROLLOUTS);
 
         if (rollouts.isEmpty()) {
             return;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -9,7 +9,6 @@
 package org.eclipse.hawkbit.repository.jpa;
 
 import java.util.Map;
-import java.util.concurrent.Executor;
 
 import javax.persistence.EntityManager;
 import javax.sql.DataSource;
@@ -70,7 +69,6 @@ import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration;
@@ -545,7 +543,7 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
      * @param autoAssignChecker
      *            to run a check as tenant
      * @param lockRegistry
-     *            to lock the tenant for auto assigment
+     *            to lock the tenant for auto assignment
      * @return a new {@link AutoAssignChecker}
      */
     @Bean
@@ -575,8 +573,6 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
      *            to run the rollout handler
      * @param systemSecurityContext
      *            to run as system
-     * @param threadPoolExecutor
-     *            to execute the handlers in parallel
      * @return a new {@link RolloutScheduler} bean.
      */
     @Bean
@@ -584,9 +580,7 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
     @Profile("!test")
     @ConditionalOnProperty(prefix = "hawkbit.rollout.scheduler", name = "enabled", matchIfMissing = true)
     RolloutScheduler rolloutScheduler(final TenantAware tenantAware, final SystemManagement systemManagement,
-            final RolloutManagement rolloutManagement, final SystemSecurityContext systemSecurityContext,
-            @Qualifier("asyncExecutor") final Executor threadPoolExecutor) {
-        return new RolloutScheduler(tenantAware, systemManagement, rolloutManagement, systemSecurityContext,
-                threadPoolExecutor);
+            final RolloutManagement rolloutManagement, final SystemSecurityContext systemSecurityContext) {
+        return new RolloutScheduler(tenantAware, systemManagement, rolloutManagement, systemSecurityContext);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignScheduler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignScheduler.java
@@ -84,20 +84,21 @@ public class AutoAssignScheduler {
         // each tenant separately.
         final List<String> tenants = systemManagement.findTenants();
         LOGGER.info("Checking target filter queries for tenants: {}", tenants.size());
-        for (final String tenant : tenants) {
 
-            final Lock lock = lockRegistry.obtain(tenant + "-autoassign");
-            if (!lock.tryLock()) {
-                return null;
-            }
-            try {
+        final Lock lock = lockRegistry.obtain("autoassign");
+        if (!lock.tryLock()) {
+            return null;
+        }
+
+        try {
+            for (final String tenant : tenants) {
                 tenantAware.runAsTenant(tenant, () -> {
                     autoAssignChecker.check();
                     return null;
                 });
-            } finally {
-                lock.unlock();
             }
+        } finally {
+            lock.unlock();
         }
         return null;
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/RolloutScheduler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/RolloutScheduler.java
@@ -80,7 +80,15 @@ public class RolloutScheduler {
             LOGGER.info("Checking rollouts for {} tenants", tenants.size());
             for (final String tenant : tenants) {
                 tenantAware.runAsTenant(tenant, () -> {
-                    rolloutManagement.handleRollouts();
+                    try {
+                        rolloutManagement.handleRollouts();
+                        // We catch all potential runtime exceptions here to
+                        // ensure that not all tenants are blocked if we have a
+                        // problem with a rollout.
+                    } catch (@SuppressWarnings("squid:S1166") final RuntimeException e) {
+                        LOGGER.error("Failed to handle rollouts for tenant {}. I will move on to next tenant.", tenant,
+                                e);
+                    }
                     return null;
                 });
             }


### PR DESCRIPTION
The current setup for locking the tenant by the schedulers puts pretty high load on the server. Turned out during load testing. This is especially true for installations that use a cluster wide lock implementation (e.g. DB based).

This is refactored by means of lesser locks and less parallel processing for the rollouts.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>