### PR TITLE
Reduce entity changes as part of DDI/DMF update feedback

### DIFF
--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactStoreController.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactStoreController.java
@@ -22,6 +22,7 @@ import org.eclipse.hawkbit.repository.ControllerManagement;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.RepositoryConstants;
 import org.eclipse.hawkbit.repository.exception.ArtifactBinaryNotFoundException;
+import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.SoftwareModuleNotAssignedToTargetException;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
@@ -31,7 +32,6 @@ import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.rest.util.RequestResponseContextHolder;
 import org.eclipse.hawkbit.rest.util.RestResourceConversionHelper;
 import org.eclipse.hawkbit.security.HawkbitSecurityProperties;
-import org.eclipse.hawkbit.util.IpUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -134,10 +134,10 @@ public class DdiArtifactStoreController implements DdiDlArtifactStoreControllerR
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    private ActionStatus checkAndReportDownloadByTarget(final HttpServletRequest request, final String targetid,
+    private ActionStatus checkAndReportDownloadByTarget(final HttpServletRequest request, final String controllerId,
             final Artifact artifact) {
-        final Target target = controllerManagement.updateLastTargetQuery(targetid,
-                IpUtil.getClientIpFromRequest(request, securityProperties));
+        final Target target = controllerManagement.findByControllerId(controllerId)
+                .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
 
         final Action action = controllerManagement
                 .getActionForDownloadByTargetAndSoftwareModule(target.getControllerId(),

--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactStoreController.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactStoreController.java
@@ -31,7 +31,6 @@ import org.eclipse.hawkbit.repository.model.Artifact;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.rest.util.RequestResponseContextHolder;
 import org.eclipse.hawkbit.rest.util.RestResourceConversionHelper;
-import org.eclipse.hawkbit.security.HawkbitSecurityProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,9 +60,6 @@ public class DdiArtifactStoreController implements DdiDlArtifactStoreControllerR
 
     @Autowired
     private ControllerManagement controllerManagement;
-
-    @Autowired
-    private HawkbitSecurityProperties securityProperties;
 
     @Autowired
     private RequestResponseContextHolder requestResponseContextHolder;

--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -111,8 +111,8 @@ public class DdiRootController implements DdiRootControllerRestApi {
             @PathVariable("softwareModuleId") final Long softwareModuleId) {
         LOG.debug("getSoftwareModulesArtifacts({})", controllerId);
 
-        final Target target = controllerManagement.updateLastTargetQuery(controllerId, IpUtil
-                .getClientIpFromRequest(requestResponseContextHolder.getHttpServletRequest(), securityProperties));
+        final Target target = controllerManagement.findByControllerId(controllerId)
+                .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
 
         final SoftwareModule softwareModule = softwareManagement.findSoftwareModuleById(softwareModuleId)
                 .orElseThrow(() -> new EntityNotFoundException(SoftwareModule.class, softwareModuleId));
@@ -142,8 +142,8 @@ public class DdiRootController implements DdiRootControllerRestApi {
             @PathVariable("fileName") final String fileName) {
         ResponseEntity<InputStream> result;
 
-        final Target target = controllerManagement.updateLastTargetQuery(controllerId, IpUtil
-                .getClientIpFromRequest(requestResponseContextHolder.getHttpServletRequest(), securityProperties));
+        final Target target = controllerManagement.findByControllerId(controllerId)
+                .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
         final SoftwareModule module = softwareManagement.findSoftwareModuleById(softwareModuleId)
                 .orElseThrow(() -> new EntityNotFoundException(SoftwareModule.class, softwareModuleId));
 
@@ -205,8 +205,8 @@ public class DdiRootController implements DdiRootControllerRestApi {
             @PathVariable("controllerId") final String controllerId,
             @PathVariable("softwareModuleId") final Long softwareModuleId,
             @PathVariable("fileName") final String fileName) {
-        controllerManagement.updateLastTargetQuery(controllerId, IpUtil
-                .getClientIpFromRequest(requestResponseContextHolder.getHttpServletRequest(), securityProperties));
+        controllerManagement.findByControllerId(controllerId)
+                .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
 
         final SoftwareModule module = softwareManagement.findSoftwareModuleById(softwareModuleId)
                 .orElseThrow(() -> new EntityNotFoundException(SoftwareModule.class, softwareModuleId));
@@ -234,8 +234,8 @@ public class DdiRootController implements DdiRootControllerRestApi {
             @RequestParam(value = "c", required = false, defaultValue = "-1") final int resource) {
         LOG.debug("getControllerBasedeploymentAction({},{})", controllerId, resource);
 
-        final Target target = controllerManagement.updateLastTargetQuery(controllerId, IpUtil
-                .getClientIpFromRequest(requestResponseContextHolder.getHttpServletRequest(), securityProperties));
+        final Target target = controllerManagement.findByControllerId(controllerId)
+                .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
 
         final Action action = findActionWithExceptionIfNotFound(actionId);
         if (!action.getTarget().getId().equals(target.getId())) {
@@ -271,8 +271,8 @@ public class DdiRootController implements DdiRootControllerRestApi {
             @PathVariable("actionId") @NotEmpty final Long actionId) {
         LOG.debug("provideBasedeploymentActionFeedback for target [{},{}]: {}", controllerId, actionId, feedback);
 
-        final Target target = controllerManagement.updateLastTargetQuery(controllerId, IpUtil
-                .getClientIpFromRequest(requestResponseContextHolder.getHttpServletRequest(), securityProperties));
+        final Target target = controllerManagement.findByControllerId(controllerId)
+                .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
 
         if (!actionId.equals(feedback.getId())) {
             LOG.warn(
@@ -361,9 +361,6 @@ public class DdiRootController implements DdiRootControllerRestApi {
     @Override
     public ResponseEntity<Void> putConfigData(@Valid @RequestBody final DdiConfigData configData,
             @PathVariable("tenant") final String tenant, @PathVariable("controllerId") final String controllerId) {
-        controllerManagement.updateLastTargetQuery(controllerId, IpUtil
-                .getClientIpFromRequest(requestResponseContextHolder.getHttpServletRequest(), securityProperties));
-
         controllerManagement.updateControllerAttributes(controllerId, configData.getData());
 
         return new ResponseEntity<>(HttpStatus.OK);
@@ -375,8 +372,8 @@ public class DdiRootController implements DdiRootControllerRestApi {
             @PathVariable("actionId") @NotEmpty final Long actionId) {
         LOG.debug("getControllerCancelAction({})", controllerId);
 
-        final Target target = controllerManagement.updateLastTargetQuery(controllerId, IpUtil
-                .getClientIpFromRequest(requestResponseContextHolder.getHttpServletRequest(), securityProperties));
+        final Target target = controllerManagement.findByControllerId(controllerId)
+                .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
 
         final Action action = findActionWithExceptionIfNotFound(actionId);
         if (!action.getTarget().getId().equals(target.getId())) {
@@ -406,8 +403,8 @@ public class DdiRootController implements DdiRootControllerRestApi {
             @PathVariable("actionId") @NotEmpty final Long actionId) {
         LOG.debug("provideCancelActionFeedback for target [{}]: {}", controllerId, feedback);
 
-        final Target target = controllerManagement.updateLastTargetQuery(controllerId, IpUtil
-                .getClientIpFromRequest(requestResponseContextHolder.getHttpServletRequest(), securityProperties));
+        final Target target = controllerManagement.findByControllerId(controllerId)
+                .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
 
         if (!actionId.equals(feedback.getId())) {
             LOG.warn(

--- a/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiCancelActionTest.java
+++ b/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiCancelActionTest.java
@@ -166,8 +166,6 @@ public class DdiCancelActionTest extends AbstractDDiApiIntegrationTest {
                 .andExpect(jsonPath("$.cancelAction.stopId", equalTo(String.valueOf(updateAction.getId()))));
         assertThat(targetManagement.findTargetByControllerID(TestdataFactory.DEFAULT_CONTROLLER_ID).get()
                 .getLastTargetQuery()).isLessThanOrEqualTo(System.currentTimeMillis());
-        assertThat(targetManagement.findTargetByControllerID(TestdataFactory.DEFAULT_CONTROLLER_ID).get()
-                .getLastTargetQuery()).isGreaterThanOrEqualTo(current);
 
         // controller confirmed cancelled action, should not be active anymore
         mvc.perform(post("/{tenant}/controller/v1/" + TestdataFactory.DEFAULT_CONTROLLER_ID + "/cancelAction/"
@@ -244,50 +242,38 @@ public class DdiCancelActionTest extends AbstractDDiApiIntegrationTest {
         assertThat(deploymentManagement.countActionStatusAll()).isEqualTo(2);
 
         assertThat(deploymentManagement.findActiveActionsByTarget(savedTarget.getControllerId())).hasSize(1);
-        long current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/" + TestdataFactory.DEFAULT_CONTROLLER_ID + "/cancelAction/"
                 + cancelAction.getId() + "/feedback", tenantAware.getCurrentTenant())
                         .content(JsonBuilder.cancelActionFeedback(cancelAction.getId().toString(), "proceeding"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
-        assertThat(targetManagement.findTargetByControllerID(TestdataFactory.DEFAULT_CONTROLLER_ID).get()
-                .getLastTargetQuery()).isGreaterThanOrEqualTo(current);
 
         assertThat(deploymentManagement.findActiveActionsByTarget(savedTarget.getControllerId())).hasSize(1);
         assertThat(deploymentManagement.countActionStatusAll()).isEqualTo(3);
 
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/" + TestdataFactory.DEFAULT_CONTROLLER_ID + "/cancelAction/"
                 + cancelAction.getId() + "/feedback", tenantAware.getCurrentTenant())
                         .content(JsonBuilder.cancelActionFeedback(cancelAction.getId().toString(), "resumed"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
-        assertThat(targetManagement.findTargetByControllerID(TestdataFactory.DEFAULT_CONTROLLER_ID).get()
-                .getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(deploymentManagement.findActiveActionsByTarget(savedTarget.getControllerId())).hasSize(1);
         assertThat(deploymentManagement.countActionStatusAll()).isEqualTo(4);
 
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/" + TestdataFactory.DEFAULT_CONTROLLER_ID + "/cancelAction/"
                 + cancelAction.getId() + "/feedback", tenantAware.getCurrentTenant())
                         .content(JsonBuilder.cancelActionFeedback(cancelAction.getId().toString(), "scheduled"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
-        assertThat(targetManagement.findTargetByControllerID(TestdataFactory.DEFAULT_CONTROLLER_ID).get()
-                .getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(deploymentManagement.countActionStatusAll()).isEqualTo(5);
         assertThat(deploymentManagement.findActiveActionsByTarget(savedTarget.getControllerId())).hasSize(1);
 
         // cancellation canceled -> should remove the action from active
         assertThat(deploymentManagement.findActiveActionsByTarget(savedTarget.getControllerId())).hasSize(1);
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/" + TestdataFactory.DEFAULT_CONTROLLER_ID + "/cancelAction/"
                 + cancelAction.getId() + "/feedback", tenantAware.getCurrentTenant())
                         .content(JsonBuilder.cancelActionFeedback(cancelAction.getId().toString(), "canceled"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
-        assertThat(targetManagement.findTargetByControllerID(TestdataFactory.DEFAULT_CONTROLLER_ID).get()
-                .getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(deploymentManagement.countActionStatusAll()).isEqualTo(6);
         assertThat(deploymentManagement.findActiveActionsByTarget(savedTarget.getControllerId())).hasSize(1);
 
@@ -296,26 +282,20 @@ public class DdiCancelActionTest extends AbstractDDiApiIntegrationTest {
         // with finished or
         // error
         assertThat(deploymentManagement.findActiveActionsByTarget(savedTarget.getControllerId())).hasSize(1);
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/" + TestdataFactory.DEFAULT_CONTROLLER_ID + "/cancelAction/"
                 + cancelAction.getId() + "/feedback", tenantAware.getCurrentTenant())
                         .content(JsonBuilder.cancelActionFeedback(cancelAction.getId().toString(), "rejected"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
-        assertThat(targetManagement.findTargetByControllerID(TestdataFactory.DEFAULT_CONTROLLER_ID).get()
-                .getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(deploymentManagement.countActionStatusAll()).isEqualTo(7);
         assertThat(deploymentManagement.findActiveActionsByTarget(savedTarget.getControllerId())).hasSize(1);
 
         // update closed -> should remove the action from active
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/" + TestdataFactory.DEFAULT_CONTROLLER_ID + "/deploymentBase/"
                 + cancelAction.getId() + "/feedback", tenantAware.getCurrentTenant())
                         .content(JsonBuilder.cancelActionFeedback(cancelAction.getId().toString(), "closed"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
-        assertThat(targetManagement.findTargetByControllerID(TestdataFactory.DEFAULT_CONTROLLER_ID).get()
-                .getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(deploymentManagement.countActionStatusAll()).isEqualTo(8);
         assertThat(deploymentManagement.findActiveActionsByTarget(savedTarget.getControllerId())).hasSize(0);
     }

--- a/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfigDataTest.java
+++ b/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfigDataTest.java
@@ -93,32 +93,16 @@ public class DdiConfigDataTest extends AbstractDDiApiIntegrationTest {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("dsafsdf", "sdsds");
 
-        long current = System.currentTimeMillis();
         mvc.perform(put("/{tenant}/controller/v1/4717/configData", tenantAware.getCurrentTenant())
                 .content(JsonBuilder.configData("", attributes, "closed")).contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
-        Thread.sleep(1); // is required: otherwise processing the next line is
-                         // often too fast and
-                         // the following assert will fail
-        assertThat(targetManagement.findTargetByControllerID("4717").get().getLastTargetQuery())
-                .isLessThanOrEqualTo(System.currentTimeMillis());
-        assertThat(targetManagement.findTargetByControllerID("4717").get().getLastTargetQuery())
-                .isGreaterThanOrEqualTo(current);
         assertThat(targetManagement.getControllerAttributes("4717")).isEqualTo(attributes);
 
         // update
         attributes.put("sdsds", "123412");
-        current = System.currentTimeMillis();
         mvc.perform(put("/{tenant}/controller/v1/4717/configData", tenantAware.getCurrentTenant())
                 .content(JsonBuilder.configData("", attributes, "closed")).contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
-        Thread.sleep(1); // is required: otherwise processing the next line is
-                         // often too fast and
-                         // the following assert will fail
-        assertThat(targetManagement.findTargetByControllerID("4717").get().getLastTargetQuery())
-                .isLessThanOrEqualTo(System.currentTimeMillis());
-        assertThat(targetManagement.findTargetByControllerID("4717").get().getLastTargetQuery())
-                .isGreaterThanOrEqualTo(current);
         assertThat(targetManagement.getControllerAttributes("4717")).isEqualTo(attributes);
     }
 

--- a/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiDeploymentBaseTest.java
+++ b/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiDeploymentBaseTest.java
@@ -213,8 +213,6 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
                         contains(ds.findFirstModuleByType(appType).get().getVersion())))
                 .andExpect(jsonPath("$.deployment.chunks[?(@.part==bApp)].name",
                         contains(ds.findFirstModuleByType(appType).get().getName())));
-        assertThat(targetManagement.findTargetByControllerID("4712").get().getLastTargetQuery())
-                .isGreaterThanOrEqualTo(current);
 
         // Retrieved is reported
         final Iterable<ActionStatus> actionStatusMessages = deploymentManagement
@@ -301,7 +299,7 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
 
         // Run test
 
-        long current = System.currentTimeMillis();
+        final long current = System.currentTimeMillis();
         mvc.perform(get("/{tenant}/controller/v1/4712", tenantAware.getCurrentTenant()))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(content().contentType(APPLICATION_JSON_HAL_UTF))
@@ -313,8 +311,6 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         assertThat(targetManagement.findTargetByControllerID("4712").get().getLastTargetQuery())
                 .isLessThanOrEqualTo(System.currentTimeMillis());
         assertThat(deploymentManagement.countActionStatusAll()).isEqualTo(2);
-
-        current = System.currentTimeMillis();
 
         final DistributionSet findDistributionSetByAction = distributionSetManagement
                 .findDistributionSetByAction(action.getId()).get();
@@ -371,8 +367,6 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
                         contains(ds.findFirstModuleByType(appType).get().getVersion())))
                 .andExpect(jsonPath("$.deployment.chunks[?(@.part==bApp)].name",
                         contains(ds.findFirstModuleByType(appType).get().getName())));
-        assertThat(targetManagement.findTargetByControllerID("4712").get().getLastTargetQuery())
-                .isGreaterThanOrEqualTo(current);
 
         // Retrieved is reported
         final List<ActionStatus> actionStatusMessages = deploymentManagement
@@ -488,8 +482,6 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
                         contains(ds.findFirstModuleByType(appType).get().getVersion())))
                 .andExpect(jsonPath("$.deployment.chunks[?(@.part==bApp)].name",
                         contains(ds.findFirstModuleByType(appType).get().getName())));
-        assertThat(targetManagement.findTargetByControllerID("4712").get().getLastTargetQuery())
-                .isGreaterThanOrEqualTo(current);
 
         // Retrieved is reported
         final Iterable<ActionStatus> actionStatusMessages = deploymentManagement
@@ -595,15 +587,12 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
 
         // action1 done
 
-        long current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/4712/deploymentBase/" + action1.getId() + "/feedback",
                 tenantAware.getCurrentTenant())
                         .content(JsonBuilder.deploymentActionFeedback(action1.getId().toString(), "closed"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
         myT = targetManagement.findTargetByControllerID("4712").get();
-        assertThat(myT.getLastTargetQuery()).isLessThanOrEqualTo(System.currentTimeMillis());
-        assertThat(myT.getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(myT.getUpdateStatus()).isEqualTo(TargetUpdateStatus.PENDING);
         assertThat(deploymentManagement.findActiveActionsByTarget(myT.getControllerId())).hasSize(2);
         assertThat(deploymentManagement.getAssignedDistributionSet(myT.getControllerId()).get()).isEqualTo(ds3);
@@ -615,15 +604,12 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         assertThat(actionStatusMessages.iterator().next().getStatus()).isEqualTo(Status.FINISHED);
 
         // action2 done
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/4712/deploymentBase/" + action2.getId() + "/feedback",
                 tenantAware.getCurrentTenant())
                         .content(JsonBuilder.deploymentActionFeedback(action2.getId().toString(), "closed"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
         myT = targetManagement.findTargetByControllerID("4712").get();
-        assertThat(myT.getLastTargetQuery()).isLessThanOrEqualTo(System.currentTimeMillis());
-        assertThat(myT.getLastTargetQuery()).isGreaterThanOrEqualTo(current);
 
         assertThat(myT.getUpdateStatus()).isEqualTo(TargetUpdateStatus.PENDING);
         assertThat(deploymentManagement.findActiveActionsByTarget(myT.getControllerId())).hasSize(1);
@@ -635,15 +621,12 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         assertThat(actionStatusMessages).haveAtLeast(1, new ActionStatusCondition(Status.FINISHED));
 
         // action3 done
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/4712/deploymentBase/" + action3.getId() + "/feedback",
                 tenantAware.getCurrentTenant())
                         .content(JsonBuilder.deploymentActionFeedback(action3.getId().toString(), "closed"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
         myT = targetManagement.findTargetByControllerID("4712").get();
-        assertThat(myT.getLastTargetQuery()).isLessThanOrEqualTo(System.currentTimeMillis());
-        assertThat(myT.getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(myT.getUpdateStatus()).isEqualTo(TargetUpdateStatus.IN_SYNC);
         assertThat(deploymentManagement.findActiveActionsByTarget(myT.getControllerId())).hasSize(0);
         assertThat(deploymentManagement.getAssignedDistributionSet(myT.getControllerId()).get()).isEqualTo(ds3);
@@ -670,7 +653,6 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         final Action action = deploymentManagement.findActionsByDistributionSet(pageReq, ds.getId()).getContent()
                 .get(0);
 
-        long current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/4712/deploymentBase/" + action.getId() + "/feedback",
                 tenantAware.getCurrentTenant())
                         .content(JsonBuilder.deploymentActionFeedback(action.getId().toString(), "closed", "failure",
@@ -678,8 +660,6 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
         Target myT = targetManagement.findTargetByControllerID("4712").get();
-        assertThat(myT.getLastTargetQuery()).isLessThanOrEqualTo(System.currentTimeMillis());
-        assertThat(myT.getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(targetManagement.findTargetByControllerID("4712").get().getUpdateStatus())
                 .isEqualTo(TargetUpdateStatus.ERROR);
         assertThat(targetManagement.findTargetByUpdateStatus(new PageRequest(0, 10), TargetUpdateStatus.PENDING))
@@ -699,7 +679,6 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         ds = distributionSetManagement.findDistributionSetByIdWithDetails(ds.getId()).get();
         assignDistributionSet(ds, Lists.newArrayList(targetManagement.findTargetByControllerID("4712").get()));
         final Action action2 = deploymentManagement.findActiveActionsByTarget(myT.getControllerId()).get(0);
-        current = System.currentTimeMillis();
 
         mvc.perform(post("/{tenant}/controller/v1/4712/deploymentBase/" + action2.getId() + "/feedback",
                 tenantAware.getCurrentTenant())
@@ -708,8 +687,6 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
 
         myT = targetManagement.findTargetByControllerID("4712").get();
-        assertThat(myT.getLastTargetQuery()).isLessThanOrEqualTo(System.currentTimeMillis());
-        assertThat(myT.getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(myT.getUpdateStatus()).isEqualTo(TargetUpdateStatus.IN_SYNC);
         assertThat(targetManagement.findTargetByUpdateStatus(new PageRequest(0, 10), TargetUpdateStatus.PENDING))
                 .hasSize(0);
@@ -748,9 +725,6 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         assertThat(targetManagement.findTargetByAssignedDistributionSet(ds.getId(), pageReq)).hasSize(1);
 
         // Now valid Feedback
-
-        long current = System.currentTimeMillis();
-
         for (int i = 0; i < 4; i++) {
             mvc.perform(post("/{tenant}/controller/v1/4712/deploymentBase/" + action.getId() + "/feedback",
                     tenantAware.getCurrentTenant())
@@ -760,7 +734,6 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         }
 
         myT = targetManagement.findTargetByControllerID("4712").get();
-        assertThat(myT.getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(myT.getUpdateStatus()).isEqualTo(TargetUpdateStatus.PENDING);
         assertThat(targetManagement.findTargetByUpdateStatus(new PageRequest(0, 10), TargetUpdateStatus.PENDING))
                 .hasSize(1);
@@ -773,14 +746,12 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         assertThat(deploymentManagement.findActionStatusAll(pageReq).getContent()).haveAtLeast(5,
                 new ActionStatusCondition(Status.RUNNING));
 
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/4712/deploymentBase/" + action.getId() + "/feedback",
                 tenantAware.getCurrentTenant())
                         .content(JsonBuilder.deploymentActionFeedback(action.getId().toString(), "scheduled"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
         myT = targetManagement.findTargetByControllerID("4712").get();
-        assertThat(myT.getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(myT.getUpdateStatus()).isEqualTo(TargetUpdateStatus.PENDING);
         assertThat(targetManagement.findTargetByUpdateStatus(new PageRequest(0, 10), TargetUpdateStatus.PENDING))
                 .hasSize(1);
@@ -793,14 +764,12 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         assertThat(deploymentManagement.findActionStatusAll(pageReq).getContent()).haveAtLeast(5,
                 new ActionStatusCondition(Status.RUNNING));
 
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/4712/deploymentBase/" + action.getId() + "/feedback",
                 tenantAware.getCurrentTenant())
                         .content(JsonBuilder.deploymentActionFeedback(action.getId().toString(), "resumed"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
         myT = targetManagement.findTargetByControllerID("4712").get();
-        assertThat(myT.getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(myT.getUpdateStatus()).isEqualTo(TargetUpdateStatus.PENDING);
         assertThat(targetManagement.findTargetByUpdateStatus(new PageRequest(0, 10), TargetUpdateStatus.PENDING))
                 .hasSize(1);
@@ -813,14 +782,12 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         assertThat(deploymentManagement.findActionStatusAll(pageReq).getContent()).haveAtLeast(6,
                 new ActionStatusCondition(Status.RUNNING));
 
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/4712/deploymentBase/" + action.getId() + "/feedback",
                 tenantAware.getCurrentTenant())
                         .content(JsonBuilder.deploymentActionFeedback(action.getId().toString(), "canceled"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
         myT = targetManagement.findTargetByControllerID("4712").get();
-        assertThat(myT.getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(myT.getUpdateStatus()).isEqualTo(TargetUpdateStatus.PENDING);
         assertThat(deploymentManagement.findActiveActionsByTarget(myT.getControllerId())).hasSize(1);
         assertThat(targetManagement.findTargetByUpdateStatus(new PageRequest(0, 10), TargetUpdateStatus.PENDING))
@@ -836,14 +803,12 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         assertThat(deploymentManagement.findActionStatusAll(pageReq).getContent()).haveAtLeast(1,
                 new ActionStatusCondition(Status.CANCELED));
 
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/4712/deploymentBase/" + action.getId() + "/feedback",
                 tenantAware.getCurrentTenant())
                         .content(JsonBuilder.deploymentActionFeedback(action.getId().toString(), "rejected"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
         myT = targetManagement.findTargetByControllerID("4712").get();
-        assertThat(myT.getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(myT.getUpdateStatus()).isEqualTo(TargetUpdateStatus.PENDING);
         assertThat(deploymentManagement.findActiveActionsByTarget(myT.getControllerId())).hasSize(1);
         assertThat(deploymentManagement.countActionStatusAll()).isEqualTo(9);
@@ -854,14 +819,12 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         assertThat(deploymentManagement.findActionStatusAll(pageReq).getContent()).haveAtLeast(1,
                 new ActionStatusCondition(Status.CANCELED));
 
-        current = System.currentTimeMillis();
         mvc.perform(post("/{tenant}/controller/v1/4712/deploymentBase/" + action.getId() + "/feedback",
                 tenantAware.getCurrentTenant())
                         .content(JsonBuilder.deploymentActionFeedback(action.getId().toString(), "closed"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk());
         myT = targetManagement.findTargetByControllerID("4712").get();
-        assertThat(myT.getLastTargetQuery()).isGreaterThanOrEqualTo(current);
         assertThat(myT.getUpdateStatus()).isEqualTo(TargetUpdateStatus.IN_SYNC);
         assertThat(deploymentManagement.findActiveActionsByTarget(myT.getControllerId())).hasSize(0);
         assertThat(targetManagement.findTargetByUpdateStatus(new PageRequest(0, 10), TargetUpdateStatus.ERROR))

--- a/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootControllerTest.java
+++ b/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootControllerTest.java
@@ -178,7 +178,7 @@ public class DdiRootControllerTest extends AbstractDDiApiIntegrationTest {
     @Test
     @Description("Ensures that etag check results in not modified response if provided etag by client is identical to entity in repository.")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1),
-            @Expect(type = TargetPollEvent.class, count = 7),
+            @Expect(type = TargetPollEvent.class, count = 6),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 2),
             @Expect(type = TargetUpdatedEvent.class, count = 3), @Expect(type = ActionUpdatedEvent.class, count = 1),
             @Expect(type = DistributionSetCreatedEvent.class, count = 2),
@@ -323,7 +323,7 @@ public class DdiRootControllerTest extends AbstractDDiApiIntegrationTest {
             @Expect(type = DistributionSetCreatedEvent.class, count = 1),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 1),
             @Expect(type = ActionCreatedEvent.class, count = 1), @Expect(type = ActionUpdatedEvent.class, count = 1),
-            @Expect(type = TargetUpdatedEvent.class, count = 2), @Expect(type = TargetPollEvent.class, count = 3),
+            @Expect(type = TargetUpdatedEvent.class, count = 2),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3) })
     public void tryToFinishAnUpdateProcessAfterItHasBeenFinished() throws Exception {
         final DistributionSet ds = testdataFactory.createDistributionSet("");

--- a/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -245,8 +245,6 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
                     + convertCorrelationId(message));
         }
 
-        updateLastPollTime(action.getTarget());
-
         final Status status = mapStatus(message, actionUpdateStatus, action);
         final ActionStatusCreate actionStatus = entityFactory.actionStatus().create(action.getId()).status(status)
                 .messages(messages);
@@ -300,10 +298,6 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
                 "Cancel rejected message is not allowed, if action is on state: " + action.getStatus());
         return null;
 
-    }
-
-    private void updateLastPollTime(final Target target) {
-        controllerManagement.updateLastTargetQuery(target.getControllerId(), null);
     }
 
     private static String convertCorrelationId(final Message message) {

--- a/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
+++ b/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerServiceTest.java
@@ -58,7 +58,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
@@ -417,9 +416,6 @@ public class AmqpMessageHandlerServiceTest {
 
         // test
         amqpMessageHandlerService.onMessage(message, MessageType.EVENT.name(), TENANT, "vHost");
-
-        // verify
-        verify(controllerManagementMock).updateLastTargetQuery(any(String.class), Matchers.isNull(URI.class));
 
         final ArgumentCaptor<String> tenantCaptor = ArgumentCaptor.forClass(String.class);
         final ArgumentCaptor<Target> targetCaptor = ArgumentCaptor.forClass(Target.class);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -401,7 +401,6 @@ public class JpaControllerManagement implements ControllerManagement {
                     String.valueOf(securityProperties.getDos().getMaxAttributeEntriesPerTarget()));
         }
 
-        target.setLastTargetQuery(System.currentTimeMillis());
         target.setRequestControllerAttributes(false);
 
         return targetRepository.save(target);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
@@ -49,12 +49,14 @@ public class RSQLTargetFieldTest extends AbstractJpaIntegrationTest {
                 .name("targetName123").description("targetDesc123"));
         attributes.put("revision", "1.1");
         target = controllerManagement.updateControllerAttributes(target.getControllerId(), attributes);
+        target = controllerManagement.updateLastTargetQuery(target.getControllerId(), null);
 
         target2 = targetManagement
                 .createTarget(entityFactory.target().create().controllerId("targetId1234").description("targetId1234"));
         attributes.put("revision", "1.2");
         Thread.sleep(1);
         target2 = controllerManagement.updateControllerAttributes(target2.getControllerId(), attributes);
+        target2 = controllerManagement.updateLastTargetQuery(target2.getControllerId(), null);
 
         testdataFactory.createTarget("targetId1235");
         testdataFactory.createTarget("targetId1236");


### PR DESCRIPTION
DDI and DMF report if a targets has polled the API. The repository updates in this case the last query and address fields and sends a TargetPoll event.

However, it does this as feed for all the other calls (e.g. update feedback or artefact download). That puts unnecessary pressure of the repository and raised the probability of concurrent modification errors the device provides lots of feedback in parallel (seen over here as well by other users #467).

Use case wise its also wrong. The event is called TargetPoll for a reason. I reduced these updates accordingly so that they are only done in case of DDI poll and DMF THING_CREATE.

Reviewers: @schabdo 