### PR TITLE
ignore IOException on cleanup

### DIFF
--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
@@ -291,8 +291,12 @@ public abstract class AbstractIntegrationTest implements EnvironmentAware {
     }
 
     @After
-    public void cleanCurrentCollection() throws IOException {
-        FileUtils.deleteDirectory(new File(artifactFilesystemProperties.getPath()));
+    public void cleanUp() {
+        try {
+            FileUtils.deleteDirectory(new File(artifactFilesystemProperties.getPath()));
+        } catch (final IOException e) {
+            LOG.warn("Cannot cleanup file-directory", e);
+        }
     }
 
     protected DefaultMockMvcBuilder createMvcWebAppContext() {


### PR DESCRIPTION
Ignore IOException on clean-up because e.g. on parallel test-execution the folder does not exists anymore and the test crashes e.g. because the folder does not exists to delete.

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>