### PR TITLE
Fix default isolation and auto commit

### DIFF
--- a/hawkbit-autoconfigure/src/main/resources/hawkbitdefaults.properties
+++ b/hawkbit-autoconfigure/src/main/resources/hawkbitdefaults.properties
@@ -32,6 +32,7 @@ endpoints.spring.cloud.bus.env.enabled=false
 spring.jpa.database=H2
 spring.jpa.show-sql=false
 spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.tomcat.defaultAutoCommit=false
 # Logging
 spring.datasource.eclipselink.logging.logger=JavaLogger
 spring.jpa.properties.eclipselink.logging.level=off

--- a/hawkbit-ddi-resource/src/test/resources/application-test.properties
+++ b/hawkbit-ddi-resource/src/test/resources/application-test.properties
@@ -26,6 +26,7 @@ hawkbit.server.security.dos.maxAttributeEntriesPerTarget=10
 spring.jpa.database=H2
 spring.datasource.url=jdbc:h2:mem:sp-db;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.tomcat.defaultAutoCommit=false
 spring.datasource.username=sa
 spring.datasource.password=sa
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
@@ -286,19 +286,6 @@ public interface RolloutManagement {
      */
     boolean exists(@NotNull Long rolloutId);
 
-    /***
-     * Get finished percentage details for a specified group which is in running
-     * state.
-     *
-     * @param rolloutId
-     *            the ID of the {@link Rollout}
-     * @param rolloutGroupId
-     *            the ID of the {@link RolloutGroup}
-     * @return percentage finished
-     */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
-    float getFinishedPercentForRunningGroup(@NotNull Long rolloutId, @NotNull Long rolloutGroupId);
-
     /**
      * Pauses a rollout which is currently running. The Rollout switches
      * {@link RolloutStatus#PAUSED}. {@link RolloutGroup}s which are currently

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/TotalTargetCountStatus.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/TotalTargetCountStatus.java
@@ -105,6 +105,13 @@ public class TotalTargetCountStatus {
     }
 
     /**
+     * @return finished percentage of targets
+     */
+    public float getFinishedPercent() {
+        return ((float) getTotalTargetCountByStatus(TotalTargetCountStatus.Status.FINISHED) / totalTargetCount) * 100;
+    }
+
+    /**
      * Populate all target status to a the given map
      *
      * @param statusTotalCountMap

--- a/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/AbstractRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/AbstractRolloutManagement.java
@@ -77,7 +77,7 @@ public abstract class AbstractRolloutManagement implements RolloutManagement {
         this.lockRegistry = lockRegistry;
     }
 
-    protected int runInNewTransaction(final String transactionName, final TransactionCallback<Integer> action) {
+    protected Long runInNewTransaction(final String transactionName, final TransactionCallback<Long> action) {
         final DefaultTransactionDefinition def = new DefaultTransactionDefinition();
         def.setName(transactionName);
         def.setReadOnly(false);

--- a/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/AbstractRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/AbstractRolloutManagement.java
@@ -28,7 +28,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -83,7 +82,6 @@ public abstract class AbstractRolloutManagement implements RolloutManagement {
         def.setName(transactionName);
         def.setReadOnly(false);
         def.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-        def.setIsolationLevel(Isolation.READ_UNCOMMITTED.value());
         return new TransactionTemplate(txManager, def).execute(action);
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -42,7 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link Action} repository.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>, JpaSpecificationExecutor<JpaAction> {
     /**
      * Retrieves an Action with all lazy attributes.
@@ -190,7 +190,7 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
      *            the current status of the actions which are affected
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Query("UPDATE JpaAction a SET a.status = :statusToSet WHERE a.target IN :targetsIds AND a.active = :active AND a.status = :currentStatus AND a.distributionSet.requiredMigrationStep = false")
     void switchStatus(@Param("statusToSet") Action.Status statusToSet, @Param("targetsIds") List<Long> targetIds,
             @Param("active") boolean active, @Param("currentStatus") Action.Status currentStatus);
@@ -424,7 +424,7 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
      *            the IDs of the actions to be deleted.
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     // Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477
     @Query("DELETE FROM JpaAction a WHERE a.id IN ?1")
     void deleteByIdIn(final Collection<Long> actionIDs);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -380,7 +380,7 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
      *            id of {@link Rollout}
      * @return list of objects with status and target count
      */
-    @Query("SELECT NEW org.eclipse.hawkbit.repository.model.TotalTargetCountActionStatus( a.rollout.id, a.status , COUNT(a.target)) FROM JpaAction a WHERE a.rollout.id IN ?1 GROUP BY a.rollout.id,a.status")
+    @Query("SELECT NEW org.eclipse.hawkbit.repository.model.TotalTargetCountActionStatus( a.rollout.id, a.status , COUNT(a.id)) FROM JpaAction a WHERE a.rollout.id IN ?1 GROUP BY a.rollout.id,a.status")
     List<TotalTargetCountActionStatus> getStatusCountByRolloutId(List<Long> rolloutId);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -35,7 +35,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusRepository.java
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusRepository.java
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link ActionStatus} repository.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface ActionStatusRepository
         extends BaseEntityRepository<JpaActionStatus, Long>, JpaSpecificationExecutor<JpaActionStatus> {
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/BaseEntityRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/BaseEntityRepository.java
@@ -17,7 +17,6 @@ import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/BaseEntityRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/BaseEntityRepository.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
  *            of the entity type
  */
 @NoRepositoryBean
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface BaseEntityRepository<T extends AbstractJpaTenantAwareBaseEntity, I extends Serializable>
         extends PagingAndSortingRepository<T, I> {
 
@@ -40,7 +40,7 @@ public interface BaseEntityRepository<T extends AbstractJpaTenantAwareBaseEntity
      *            to delete data from
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     void deleteByTenantIgnoreCase(String tenant);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetMetadataRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetMetadataRepository.java
@@ -13,7 +13,6 @@ import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSetMetadata;
 import org.eclipse.hawkbit.repository.model.DistributionSetMetadata;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetMetadataRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetMetadataRepository.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * {@link DistributionSetMetadata} repository.
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface DistributionSetMetadataRepository
         extends PagingAndSortingRepository<JpaDistributionSetMetadata, DsMetadataCompositeKey>,
         JpaSpecificationExecutor<JpaDistributionSetMetadata> {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetRepository.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link DistributionSet} repository.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface DistributionSetRepository
         extends BaseEntityRepository<JpaDistributionSet, Long>, JpaSpecificationExecutor<JpaDistributionSet> {
 
@@ -51,7 +51,7 @@ public interface DistributionSetRepository
      *            to be deleted
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Query("update JpaDistributionSet d set d.deleted = 1 where d.id in :ids")
     void deleteDistributionSet(@Param("ids") Long... ids);
 
@@ -63,7 +63,7 @@ public interface DistributionSetRepository
      * @return number of affected/deleted records
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     // Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477
     @Query("DELETE FROM JpaDistributionSet d WHERE d.id IN ?1")
     int deleteByIdIn(Collection<Long> ids);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetRepository.java
@@ -23,7 +23,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTagRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTagRepository.java
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link TargetTag} repository.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface DistributionSetTagRepository
         extends BaseEntityRepository<JpaDistributionSetTag, Long>, JpaSpecificationExecutor<JpaDistributionSetTag> {
     /**
@@ -35,7 +35,7 @@ public interface DistributionSetTagRepository
      * @return 1 if tag was deleted
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     Long deleteByName(final String tagName);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTagRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTagRepository.java
@@ -17,7 +17,6 @@ import org.eclipse.hawkbit.repository.model.DistributionSetTag;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTypeRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTypeRepository.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link PagingAndSortingRepository} for {@link DistributionSetType}.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface DistributionSetTypeRepository
         extends BaseEntityRepository<JpaDistributionSetType, Long>, JpaSpecificationExecutor<JpaDistributionSetType> {
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTypeRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTypeRepository.java
@@ -15,7 +15,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
@@ -32,8 +32,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
@@ -72,7 +70,7 @@ public class JpaArtifactManagement implements ArtifactManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public Artifact createArtifact(final InputStream stream, final Long moduleId, final String filename,
             final String providedMd5Sum, final String providedSha1Sum, final boolean overrideExisting,
@@ -103,7 +101,7 @@ public class JpaArtifactManagement implements ArtifactManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public boolean clearArtifactBinary(final String sha1Hash, final Long moduleId) {
 
@@ -122,7 +120,7 @@ public class JpaArtifactManagement implements ArtifactManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public void deleteArtifact(final Long id) {
         final JpaArtifact existing = (JpaArtifact) findArtifact(id)
@@ -190,7 +188,7 @@ public class JpaArtifactManagement implements ArtifactManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public Artifact createArtifact(final InputStream inputStream, final Long moduleId, final String filename,
             final boolean overrideExisting) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
@@ -185,7 +185,6 @@ public class JpaArtifactManagement implements ArtifactManagement {
     }
 
     @Override
-
     @Transactional
     public Artifact createArtifact(final InputStream inputStream, final Long moduleId, final String filename,
             final boolean overrideExisting) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
@@ -41,7 +41,7 @@ import org.springframework.validation.annotation.Validated;
  * JPA based {@link ArtifactManagement} implementation.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 @Validated
 public class JpaArtifactManagement implements ArtifactManagement {
 
@@ -73,7 +73,7 @@ public class JpaArtifactManagement implements ArtifactManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public Artifact createArtifact(final InputStream stream, final Long moduleId, final String filename,
             final String providedMd5Sum, final String providedSha1Sum, final boolean overrideExisting,
             final String contentType) {
@@ -104,7 +104,7 @@ public class JpaArtifactManagement implements ArtifactManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public boolean clearArtifactBinary(final String sha1Hash, final Long moduleId) {
 
         if (localArtifactRepository.existsWithSha1HashAndSoftwareModuleIdIsNot(sha1Hash, moduleId)) {
@@ -123,7 +123,7 @@ public class JpaArtifactManagement implements ArtifactManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteArtifact(final Long id) {
         final JpaArtifact existing = (JpaArtifact) findArtifact(id)
                 .orElseThrow(() -> new EntityNotFoundException(Artifact.class, id));
@@ -191,7 +191,7 @@ public class JpaArtifactManagement implements ArtifactManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public Artifact createArtifact(final InputStream inputStream, final Long moduleId, final String filename,
             final boolean overrideExisting) {
         return createArtifact(inputStream, moduleId, filename, null, null, overrideExisting, null);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
@@ -70,7 +70,6 @@ public class JpaArtifactManagement implements ArtifactManagement {
     }
 
     @Override
-
     @Transactional
     public Artifact createArtifact(final InputStream stream, final Long moduleId, final String filename,
             final String providedMd5Sum, final String providedSha1Sum, final boolean overrideExisting,
@@ -101,7 +100,6 @@ public class JpaArtifactManagement implements ArtifactManagement {
     }
 
     @Override
-
     @Transactional
     public boolean clearArtifactBinary(final String sha1Hash, final Long moduleId) {
 
@@ -120,7 +118,6 @@ public class JpaArtifactManagement implements ArtifactManagement {
     }
 
     @Override
-
     @Transactional
     public void deleteArtifact(final Long id) {
         final JpaArtifact existing = (JpaArtifact) findArtifact(id)

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -68,7 +68,7 @@ import org.springframework.validation.annotation.Validated;
  * JPA based {@link ControllerManagement} implementation.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 @Validated
 public class JpaControllerManagement implements ControllerManagement {
     private static final Logger LOG = LoggerFactory.getLogger(ControllerManagement.class);
@@ -127,7 +127,7 @@ public class JpaControllerManagement implements ControllerManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public Target updateLastTargetQuery(final String controllerId, final URI address) {
         final JpaTarget target = (JpaTarget) targetRepository.findByControllerId(controllerId)
                 .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
@@ -197,7 +197,7 @@ public class JpaControllerManagement implements ControllerManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public Target findOrRegisterTargetIfItDoesNotexist(final String controllerId, final URI address) {
         final Specification<JpaTarget> spec = (targetRoot, query, cb) -> cb
                 .equal(targetRoot.get(JpaTarget_.controllerId), controllerId);
@@ -387,7 +387,7 @@ public class JpaControllerManagement implements ControllerManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public Target updateControllerAttributes(final String controllerId, final Map<String, String> data) {
         final JpaTarget target = (JpaTarget) targetRepository.findByControllerId(controllerId)
                 .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
@@ -409,7 +409,7 @@ public class JpaControllerManagement implements ControllerManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public Action registerRetrieved(final Long actionId, final String message) {
         return handleRegisterRetrieved(actionId, message);
     }
@@ -469,7 +469,7 @@ public class JpaControllerManagement implements ControllerManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public ActionStatus addInformationalActionStatus(final ActionStatusCreate c) {
         final JpaActionStatusCreate create = (JpaActionStatusCreate) c;
         final JpaAction action = getActionAndThrowExceptionIfNotFound(create.getActionId());

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -125,7 +125,6 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-
     @Transactional
     public Target updateLastTargetQuery(final String controllerId, final URI address) {
         final JpaTarget target = (JpaTarget) targetRepository.findByControllerId(controllerId)
@@ -195,7 +194,6 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-
     @Transactional
     public Target findOrRegisterTargetIfItDoesNotexist(final String controllerId, final URI address) {
         final Specification<JpaTarget> spec = (targetRoot, query, cb) -> cb
@@ -241,7 +239,6 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public Action addCancelActionStatus(final ActionStatusCreate c) {
         final JpaActionStatusCreate create = (JpaActionStatusCreate) c;
@@ -285,7 +282,6 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public Action addUpdateActionStatus(final ActionStatusCreate c) {
         final JpaActionStatusCreate create = (JpaActionStatusCreate) c;
@@ -385,7 +381,6 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-
     @Transactional
     public Target updateControllerAttributes(final String controllerId, final Map<String, String> data) {
         final JpaTarget target = (JpaTarget) targetRepository.findByControllerId(controllerId)
@@ -407,7 +402,6 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-
     @Transactional
     public Action registerRetrieved(final Long actionId, final String message) {
         return handleRegisterRetrieved(actionId, message);
@@ -467,7 +461,6 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-
     @Transactional
     public ActionStatus addInformationalActionStatus(final ActionStatusCreate c) {
         final JpaActionStatusCreate create = (JpaActionStatusCreate) c;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -59,7 +59,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -126,7 +125,7 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public Target updateLastTargetQuery(final String controllerId, final URI address) {
         final JpaTarget target = (JpaTarget) targetRepository.findByControllerId(controllerId)
@@ -196,7 +195,7 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public Target findOrRegisterTargetIfItDoesNotexist(final String controllerId, final URI address) {
         final Specification<JpaTarget> spec = (targetRoot, query, cb) -> cb
@@ -242,7 +241,7 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public Action addCancelActionStatus(final ActionStatusCreate c) {
         final JpaActionStatusCreate create = (JpaActionStatusCreate) c;
@@ -286,7 +285,7 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public Action addUpdateActionStatus(final ActionStatusCreate c) {
         final JpaActionStatusCreate create = (JpaActionStatusCreate) c;
@@ -386,7 +385,7 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public Target updateControllerAttributes(final String controllerId, final Map<String, String> data) {
         final JpaTarget target = (JpaTarget) targetRepository.findByControllerId(controllerId)
@@ -408,7 +407,7 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public Action registerRetrieved(final Long actionId, final String message) {
         return handleRegisterRetrieved(actionId, message);
@@ -468,7 +467,7 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public ActionStatus addInformationalActionStatus(final ActionStatusCreate c) {
         final JpaActionStatusCreate create = (JpaActionStatusCreate) c;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -140,7 +140,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     private PlatformTransactionManager txManager;
 
     @Override
-
     @Transactional
     // Exception squid:S2095: see
     // https://jira.sonarsource.com/browse/SONARJAVA-1478

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -80,7 +80,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Isolation;
@@ -142,7 +141,7 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     private PlatformTransactionManager txManager;
 
     @Override
-    @Modifying
+
     @Transactional
     // Exception squid:S2095: see
     // https://jira.sonarsource.com/browse/SONARJAVA-1478
@@ -154,7 +153,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     }
 
     @Override
-    @Modifying
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public DistributionSetAssignmentResult assignDistributionSet(final Long dsID,
             final Collection<TargetWithActionType> targets) {
@@ -162,7 +160,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     }
 
     @Override
-    @Modifying
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public DistributionSetAssignmentResult assignDistributionSet(final Long dsID,
             final Collection<TargetWithActionType> targets, final String actionMessage) {
@@ -349,7 +346,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     }
 
     @Override
-    @Modifying
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public Action cancelAction(final Long actionId) {
         LOG.debug("cancelAction({})", actionId);
@@ -392,7 +388,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     }
 
     @Override
-    @Modifying
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public Action forceQuitAction(final Long actionId) {
         final JpaAction action = actionRepository.findById(actionId)
@@ -419,7 +414,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     }
 
     @Override
-    @Modifying
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public long startScheduledActionsByRolloutGroupParent(@NotNull final Long rolloutId,
             final Long rolloutGroupParentId) {
@@ -625,7 +619,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     }
 
     @Override
-    @Modifying
     @Transactional
     public Action forceTargetAction(final Long actionId) {
         final JpaAction action = actionRepository.findById(actionId)

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
@@ -69,7 +69,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.validation.annotation.Validated;
@@ -283,13 +282,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
             create.type(systemManagement.getTenantMetadata().getDefaultDsType().getKey());
         }
 
-        final JpaDistributionSet dSet = create.build();
-
-        if (distributionSetRepository.countByNameAndVersion(dSet.getName(), dSet.getVersion()) > 0) {
-            throw new EntityAlreadyExistsException("DistributionSet with that name and version already exists.");
-        }
-
-        return distributionSetRepository.save(dSet);
+        return distributionSetRepository.save(create.build());
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
@@ -353,7 +353,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public DistributionSetType assignMandatorySoftwareModuleTypes(final Long dsTypeId,
             final Collection<Long> softwareModulesTypeIds) {
@@ -374,7 +373,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public DistributionSetType assignOptionalSoftwareModuleTypes(final Long dsTypeId,
             final Collection<Long> softwareModulesTypeIds) {
@@ -403,7 +401,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public DistributionSetType unassignSoftwareModuleType(final Long dsTypeId, final Long softwareModuleTypeId) {
         final JpaDistributionSetType type = findDistributionSetTypeAndThrowExceptionIfNotFound(dsTypeId);
@@ -583,7 +580,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public DistributionSetType createDistributionSetType(final DistributionSetTypeCreate c) {
         final JpaDistributionSetTypeCreate create = (JpaDistributionSetTypeCreate) c;
@@ -592,7 +588,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public void deleteDistributionSetType(final Long typeId) {
 
@@ -609,7 +604,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Transactional
-
     public List<DistributionSetMetadata> createDistributionSetMetadata(final Long dsId, final Collection<MetaData> md) {
 
         md.forEach(meta -> checkAndThrowAlreadyIfDistributionSetMetadataExists(
@@ -625,7 +619,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Transactional
-
     public DistributionSetMetadata updateDistributionSetMetadata(final Long dsId, final MetaData md) {
 
         // check if exists otherwise throw entity not found exception
@@ -641,7 +634,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Transactional
-
     public void deleteDistributionSetMetadata(final Long distributionSetId, final String key) {
         final JpaDistributionSetMetadata metadata = (JpaDistributionSetMetadata) findDistributionSetMetadata(
                 distributionSetId, key).orElseThrow(
@@ -825,7 +817,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public List<DistributionSet> assignTag(final Collection<Long> dsIds, final Long dsTagId) {
         final List<JpaDistributionSet> allDs = findDistributionSetListWithDetails(dsIds);
@@ -845,7 +836,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public List<DistributionSet> unAssignAllDistributionSetsByTag(final Long dsTagId) {
 
@@ -860,7 +850,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public DistributionSet unAssignTag(final Long dsId, final Long dsTagId) {
         final List<JpaDistributionSet> allDs = findDistributionSetListWithDetails(Arrays.asList(dsId));
@@ -883,7 +872,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public List<DistributionSetType> createDistributionSetTypes(final Collection<DistributionSetTypeCreate> types) {
 
@@ -891,7 +879,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public void deleteDistributionSet(final Long setId) {
         throwExceptionIfDistributionSetDoesNotExist(setId);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
@@ -136,7 +136,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public DistributionSetTagAssignmentResult toggleTagAssignment(final Collection<Long> dsIds, final String tagName) {
         final List<JpaDistributionSet> sets = findDistributionSetListWithDetails(dsIds);
@@ -184,7 +183,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public DistributionSet updateDistributionSet(final DistributionSetUpdate u) {
         final GenericDistributionSetUpdate update = (GenericDistributionSetUpdate) u;
@@ -235,7 +233,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public void deleteDistributionSet(final Collection<Long> distributionSetIDs) {
         final List<DistributionSet> setsFound = findDistributionSetAllById(distributionSetIDs);
@@ -273,7 +270,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public DistributionSet createDistributionSet(final DistributionSetCreate c) {
         final JpaDistributionSetCreate create = (JpaDistributionSetCreate) c;
@@ -285,14 +281,12 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public List<DistributionSet> createDistributionSets(final Collection<DistributionSetCreate> creates) {
         return creates.stream().map(this::createDistributionSet).collect(Collectors.toList());
     }
 
     @Override
-
     @Transactional
     public DistributionSet assignSoftwareModules(final Long setId, final Collection<Long> moduleIds) {
 
@@ -312,7 +306,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public DistributionSet unassignSoftwareModule(final Long setId, final Long moduleId) {
         final JpaDistributionSet set = findDistributionSetAndThrowExceptionIfNotFound(setId);
@@ -326,7 +319,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-
     @Transactional
     public DistributionSetType updateDistributionSetType(final DistributionSetTypeUpdate u) {
         final GenericDistributionSetTypeUpdate update = (GenericDistributionSetTypeUpdate) u;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
@@ -81,7 +81,7 @@ import com.google.common.collect.Lists;
  * JPA implementation of {@link DistributionSetManagement}.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 @Validated
 public class JpaDistributionSetManagement implements DistributionSetManagement {
 
@@ -139,7 +139,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSetTagAssignmentResult toggleTagAssignment(final Collection<Long> dsIds, final String tagName) {
         final List<JpaDistributionSet> sets = findDistributionSetListWithDetails(dsIds);
 
@@ -187,7 +187,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSet updateDistributionSet(final DistributionSetUpdate u) {
         final GenericDistributionSetUpdate update = (GenericDistributionSetUpdate) u;
 
@@ -238,7 +238,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteDistributionSet(final Collection<Long> distributionSetIDs) {
         final List<DistributionSet> setsFound = findDistributionSetAllById(distributionSetIDs);
 
@@ -276,7 +276,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSet createDistributionSet(final DistributionSetCreate c) {
         final JpaDistributionSetCreate create = (JpaDistributionSetCreate) c;
         if (create.getType() == null) {
@@ -294,14 +294,14 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public List<DistributionSet> createDistributionSets(final Collection<DistributionSetCreate> creates) {
         return creates.stream().map(this::createDistributionSet).collect(Collectors.toList());
     }
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSet assignSoftwareModules(final Long setId, final Collection<Long> moduleIds) {
 
         final Collection<JpaSoftwareModule> modules = softwareModuleRepository.findByIdIn(moduleIds);
@@ -321,7 +321,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSet unassignSoftwareModule(final Long setId, final Long moduleId) {
         final JpaDistributionSet set = findDistributionSetAndThrowExceptionIfNotFound(setId);
         final JpaSoftwareModule module = findSoftwareModuleAndThrowExceptionIfNotFound(moduleId);
@@ -335,7 +335,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSetType updateDistributionSetType(final DistributionSetTypeUpdate u) {
         final GenericDistributionSetTypeUpdate update = (GenericDistributionSetTypeUpdate) u;
 
@@ -362,7 +362,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSetType assignMandatorySoftwareModuleTypes(final Long dsTypeId,
             final Collection<Long> softwareModulesTypeIds) {
         final Collection<JpaSoftwareModuleType> modules = softwareModuleTypeRepository
@@ -383,7 +383,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSetType assignOptionalSoftwareModuleTypes(final Long dsTypeId,
             final Collection<Long> softwareModulesTypeIds) {
 
@@ -412,7 +412,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSetType unassignSoftwareModuleType(final Long dsTypeId, final Long softwareModuleTypeId) {
         final JpaDistributionSetType type = findDistributionSetTypeAndThrowExceptionIfNotFound(dsTypeId);
 
@@ -592,7 +592,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSetType createDistributionSetType(final DistributionSetTypeCreate c) {
         final JpaDistributionSetTypeCreate create = (JpaDistributionSetTypeCreate) c;
 
@@ -601,7 +601,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteDistributionSetType(final Long typeId) {
 
         final JpaDistributionSetType toDelete = distributionSetTypeRepository.findById(typeId)
@@ -616,7 +616,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public List<DistributionSetMetadata> createDistributionSetMetadata(final Long dsId, final Collection<MetaData> md) {
 
@@ -632,7 +632,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public DistributionSetMetadata updateDistributionSetMetadata(final Long dsId, final MetaData md) {
 
@@ -648,7 +648,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public void deleteDistributionSetMetadata(final Long distributionSetId, final String key) {
         final JpaDistributionSetMetadata metadata = (JpaDistributionSetMetadata) findDistributionSetMetadata(
@@ -834,7 +834,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public List<DistributionSet> assignTag(final Collection<Long> dsIds, final Long dsTagId) {
         final List<JpaDistributionSet> allDs = findDistributionSetListWithDetails(dsIds);
 
@@ -854,7 +854,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public List<DistributionSet> unAssignAllDistributionSetsByTag(final Long dsTagId) {
 
         final DistributionSetTag distributionSetTag = tagManagement.findDistributionSetTagById(dsTagId)
@@ -869,7 +869,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSet unAssignTag(final Long dsId, final Long dsTagId) {
         final List<JpaDistributionSet> allDs = findDistributionSetListWithDetails(Arrays.asList(dsId));
 
@@ -892,7 +892,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public List<DistributionSetType> createDistributionSetTypes(final Collection<DistributionSetTypeCreate> types) {
 
         return types.stream().map(this::createDistributionSetType).collect(Collectors.toList());
@@ -900,7 +900,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteDistributionSet(final Long setId) {
         throwExceptionIfDistributionSetDoesNotExist(setId);
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
@@ -68,7 +68,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.validation.annotation.Validated;
@@ -137,7 +136,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSetTagAssignmentResult toggleTagAssignment(final Collection<Long> dsIds, final String tagName) {
         final List<JpaDistributionSet> sets = findDistributionSetListWithDetails(dsIds);
@@ -185,7 +184,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSet updateDistributionSet(final DistributionSetUpdate u) {
         final GenericDistributionSetUpdate update = (GenericDistributionSetUpdate) u;
@@ -236,7 +235,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public void deleteDistributionSet(final Collection<Long> distributionSetIDs) {
         final List<DistributionSet> setsFound = findDistributionSetAllById(distributionSetIDs);
@@ -274,7 +273,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSet createDistributionSet(final DistributionSetCreate c) {
         final JpaDistributionSetCreate create = (JpaDistributionSetCreate) c;
@@ -286,14 +285,14 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public List<DistributionSet> createDistributionSets(final Collection<DistributionSetCreate> creates) {
         return creates.stream().map(this::createDistributionSet).collect(Collectors.toList());
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSet assignSoftwareModules(final Long setId, final Collection<Long> moduleIds) {
 
@@ -313,7 +312,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSet unassignSoftwareModule(final Long setId, final Long moduleId) {
         final JpaDistributionSet set = findDistributionSetAndThrowExceptionIfNotFound(setId);
@@ -327,7 +326,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSetType updateDistributionSetType(final DistributionSetTypeUpdate u) {
         final GenericDistributionSetTypeUpdate update = (GenericDistributionSetTypeUpdate) u;
@@ -354,7 +353,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSetType assignMandatorySoftwareModuleTypes(final Long dsTypeId,
             final Collection<Long> softwareModulesTypeIds) {
@@ -375,7 +374,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSetType assignOptionalSoftwareModuleTypes(final Long dsTypeId,
             final Collection<Long> softwareModulesTypeIds) {
@@ -404,7 +403,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSetType unassignSoftwareModuleType(final Long dsTypeId, final Long softwareModuleTypeId) {
         final JpaDistributionSetType type = findDistributionSetTypeAndThrowExceptionIfNotFound(dsTypeId);
@@ -584,7 +583,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSetType createDistributionSetType(final DistributionSetTypeCreate c) {
         final JpaDistributionSetTypeCreate create = (JpaDistributionSetTypeCreate) c;
@@ -593,7 +592,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public void deleteDistributionSetType(final Long typeId) {
 
@@ -610,7 +609,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public List<DistributionSetMetadata> createDistributionSetMetadata(final Long dsId, final Collection<MetaData> md) {
 
         md.forEach(meta -> checkAndThrowAlreadyIfDistributionSetMetadataExists(
@@ -626,7 +625,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public DistributionSetMetadata updateDistributionSetMetadata(final Long dsId, final MetaData md) {
 
         // check if exists otherwise throw entity not found exception
@@ -642,7 +641,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public void deleteDistributionSetMetadata(final Long distributionSetId, final String key) {
         final JpaDistributionSetMetadata metadata = (JpaDistributionSetMetadata) findDistributionSetMetadata(
                 distributionSetId, key).orElseThrow(
@@ -826,7 +825,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public List<DistributionSet> assignTag(final Collection<Long> dsIds, final Long dsTagId) {
         final List<JpaDistributionSet> allDs = findDistributionSetListWithDetails(dsIds);
@@ -846,7 +845,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public List<DistributionSet> unAssignAllDistributionSetsByTag(final Long dsTagId) {
 
@@ -861,7 +860,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSet unAssignTag(final Long dsId, final Long dsTagId) {
         final List<JpaDistributionSet> allDs = findDistributionSetListWithDetails(Arrays.asList(dsId));
@@ -884,7 +883,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public List<DistributionSetType> createDistributionSetTypes(final Collection<DistributionSetTypeCreate> types) {
 
@@ -892,7 +891,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public void deleteDistributionSet(final Long setId) {
         throwExceptionIfDistributionSetDoesNotExist(setId);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaReportManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaReportManagement.java
@@ -41,7 +41,6 @@ import org.eclipse.hawkbit.repository.report.model.SeriesTime;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaReportManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaReportManagement.java
@@ -49,7 +49,7 @@ import org.springframework.validation.annotation.Validated;
  * JPA implementation of {@link ReportManagement}.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 @Validated
 public class JpaReportManagement implements ReportManagement {
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
@@ -59,7 +59,7 @@ import org.springframework.validation.annotation.Validated;
  * JPA implementation of {@link RolloutGroupManagement}.
  */
 @Validated
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public class JpaRolloutGroupManagement implements RolloutGroupManagement {
 
     @Autowired

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
@@ -51,7 +51,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -35,7 +35,6 @@ import org.eclipse.hawkbit.repository.builder.RolloutUpdate;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutGroupCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutUpdatedEvent;
 import org.eclipse.hawkbit.repository.exception.ConstraintViolationException;
-import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.EntityReadOnlyException;
 import org.eclipse.hawkbit.repository.exception.RolloutIllegalStateException;
@@ -190,10 +189,6 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     }
 
     private JpaRollout createRollout(final JpaRollout rollout) {
-        final Optional<Rollout> existingRollout = rolloutRepository.findByName(rollout.getName());
-        if (existingRollout.isPresent()) {
-            throw new EntityAlreadyExistsException(existingRollout.get().getName());
-        }
 
         final Long totalTargets = targetManagement.countTargetByTargetFilterQuery(rollout.getTargetFilterQuery());
         if (totalTargets == 0) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -96,7 +96,7 @@ import com.google.common.collect.Lists;
  * JPA implementation of {@link RolloutManagement}.
  */
 @Validated
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public class JpaRolloutManagement extends AbstractRolloutManagement {
     private static final Logger LOGGER = LoggerFactory.getLogger(JpaRolloutManagement.class);
 
@@ -171,7 +171,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public Rollout createRollout(final RolloutCreate rollout, final int amountGroup,
             final RolloutGroupConditions conditions) {
@@ -181,7 +181,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public Rollout createRollout(final RolloutCreate rollout, final List<RolloutGroupCreate> groups,
             final RolloutGroupConditions conditions) {
@@ -414,7 +414,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public Rollout startRollout(final Long rolloutId) {
         LOGGER.debug("startRollout called for rollout {}", rolloutId);
@@ -545,7 +545,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public void pauseRollout(final Long rolloutId) {
         final JpaRollout rollout = getRolloutAndThrowExceptionIfNotFound(rolloutId);
@@ -563,7 +563,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public void resumeRollout(final Long rolloutId) {
         final JpaRollout rollout = getRolloutAndThrowExceptionIfNotFound(rolloutId);
@@ -788,7 +788,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public void deleteRollout(final long rolloutId) {
         final JpaRollout jpaRollout = rolloutRepository.findOne(rolloutId);
@@ -893,7 +893,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public Rollout updateRollout(final RolloutUpdate u) {
         final GenericRolloutUpdate update = (GenericRolloutUpdate) u;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -77,7 +77,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.AsyncResult;
@@ -170,7 +169,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public Rollout createRollout(final RolloutCreate rollout, final int amountGroup,
             final RolloutGroupConditions conditions) {
         RolloutHelper.verifyRolloutGroupParameter(amountGroup);
@@ -180,7 +179,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public Rollout createRollout(final RolloutCreate rollout, final List<RolloutGroupCreate> groups,
             final RolloutGroupConditions conditions) {
         RolloutHelper.verifyRolloutGroupParameter(groups.size());
@@ -412,7 +411,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public Rollout startRollout(final Long rolloutId) {
         LOGGER.debug("startRollout called for rollout {}", rolloutId);
 
@@ -543,7 +542,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public void pauseRollout(final Long rolloutId) {
         final JpaRollout rollout = getRolloutAndThrowExceptionIfNotFound(rolloutId);
         if (!RolloutStatus.RUNNING.equals(rollout.getStatus())) {
@@ -561,7 +560,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public void resumeRollout(final Long rolloutId) {
         final JpaRollout rollout = getRolloutAndThrowExceptionIfNotFound(rolloutId);
         if (!(RolloutStatus.PAUSED.equals(rollout.getStatus()))) {
@@ -786,7 +785,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public void deleteRollout(final long rolloutId) {
         final JpaRollout jpaRollout = rolloutRepository.findOne(rolloutId);
 
@@ -891,7 +890,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public Rollout updateRollout(final RolloutUpdate u) {
         final GenericRolloutUpdate update = (GenericRolloutUpdate) u;
         final JpaRollout rollout = getRolloutAndThrowExceptionIfNotFound(update.getId());

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSoftwareManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSoftwareManagement.java
@@ -69,9 +69,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
@@ -118,7 +116,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     private VirtualPropertyReplacer virtualPropertyReplacer;
 
     @Override
-    @Modifying
+
     @Transactional
     public SoftwareModule updateSoftwareModule(final SoftwareModuleUpdate u) {
         final GenericSoftwareModuleUpdate update = (GenericSoftwareModuleUpdate) u;
@@ -133,7 +131,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public SoftwareModuleType updateSoftwareModuleType(final SoftwareModuleTypeUpdate u) {
         final GenericSoftwareModuleTypeUpdate update = (GenericSoftwareModuleTypeUpdate) u;
@@ -148,7 +146,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public SoftwareModule createSoftwareModule(final SoftwareModuleCreate c) {
         final JpaSoftwareModuleCreate create = (JpaSoftwareModuleCreate) c;
@@ -157,7 +155,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public List<SoftwareModule> createSoftwareModule(final Collection<SoftwareModuleCreate> swModules) {
         return swModules.stream().map(this::createSoftwareModule).collect(Collectors.toList());
@@ -230,7 +228,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public void deleteSoftwareModules(final Collection<Long> ids) {
         final List<JpaSoftwareModule> swModulesToDelete = softwareModuleRepository.findByIdIn(ids);
@@ -489,7 +487,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public SoftwareModuleType createSoftwareModuleType(final SoftwareModuleTypeCreate c) {
         final JpaSoftwareModuleTypeCreate create = (JpaSoftwareModuleTypeCreate) c;
@@ -498,7 +496,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public void deleteSoftwareModuleType(final Long typeId) {
         final JpaSoftwareModuleType toDelete = softwareModuleTypeRepository.findById(typeId)
@@ -524,7 +522,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public SoftwareModuleMetadata createSoftwareModuleMetadata(final Long moduleId, final MetaData md) {
 
         checkAndThrowAlreadyIfSoftwareModuleMetadataExists(moduleId, md);
@@ -541,7 +539,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public List<SoftwareModuleMetadata> createSoftwareModuleMetadata(final Long moduleId,
             final Collection<MetaData> md) {
         md.forEach(meta -> checkAndThrowAlreadyIfSoftwareModuleMetadataExists(moduleId, meta));
@@ -556,7 +554,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public SoftwareModuleMetadata updateSoftwareModuleMetadata(final Long moduleId, final MetaData md) {
 
         // check if exists otherwise throw entity not found exception
@@ -601,7 +599,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Transactional
-    @Modifying
+
     public void deleteSoftwareModuleMetadata(final Long moduleId, final String key) {
         final JpaSoftwareModuleMetadata metadata = (JpaSoftwareModuleMetadata) findSoftwareModuleMetadata(moduleId, key)
                 .orElseThrow(() -> new EntityNotFoundException(SoftwareModuleMetadata.class, moduleId, key));
@@ -665,14 +663,14 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public void deleteSoftwareModule(final Long moduleId) {
         deleteSoftwareModules(Sets.newHashSet(moduleId));
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public List<SoftwareModuleType> createSoftwareModuleType(final Collection<SoftwareModuleTypeCreate> creates) {
         return creates.stream().map(this::createSoftwareModuleType).collect(Collectors.toList());

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSoftwareManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSoftwareManagement.java
@@ -116,7 +116,6 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     private VirtualPropertyReplacer virtualPropertyReplacer;
 
     @Override
-
     @Transactional
     public SoftwareModule updateSoftwareModule(final SoftwareModuleUpdate u) {
         final GenericSoftwareModuleUpdate update = (GenericSoftwareModuleUpdate) u;
@@ -131,7 +130,6 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-
     @Transactional
     public SoftwareModuleType updateSoftwareModuleType(final SoftwareModuleTypeUpdate u) {
         final GenericSoftwareModuleTypeUpdate update = (GenericSoftwareModuleTypeUpdate) u;
@@ -146,7 +144,6 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-
     @Transactional
     public SoftwareModule createSoftwareModule(final SoftwareModuleCreate c) {
         final JpaSoftwareModuleCreate create = (JpaSoftwareModuleCreate) c;
@@ -155,7 +152,6 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-
     @Transactional
     public List<SoftwareModule> createSoftwareModule(final Collection<SoftwareModuleCreate> swModules) {
         return swModules.stream().map(this::createSoftwareModule).collect(Collectors.toList());
@@ -228,7 +224,6 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-
     @Transactional
     public void deleteSoftwareModules(final Collection<Long> ids) {
         final List<JpaSoftwareModule> swModulesToDelete = softwareModuleRepository.findByIdIn(ids);
@@ -487,7 +482,6 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-
     @Transactional
     public SoftwareModuleType createSoftwareModuleType(final SoftwareModuleTypeCreate c) {
         final JpaSoftwareModuleTypeCreate create = (JpaSoftwareModuleTypeCreate) c;
@@ -496,7 +490,6 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-
     @Transactional
     public void deleteSoftwareModuleType(final Long typeId) {
         final JpaSoftwareModuleType toDelete = softwareModuleTypeRepository.findById(typeId)
@@ -522,7 +515,6 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Transactional
-
     public SoftwareModuleMetadata createSoftwareModuleMetadata(final Long moduleId, final MetaData md) {
 
         checkAndThrowAlreadyIfSoftwareModuleMetadataExists(moduleId, md);
@@ -539,7 +531,6 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Transactional
-
     public List<SoftwareModuleMetadata> createSoftwareModuleMetadata(final Long moduleId,
             final Collection<MetaData> md) {
         md.forEach(meta -> checkAndThrowAlreadyIfSoftwareModuleMetadataExists(moduleId, meta));
@@ -554,7 +545,6 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Transactional
-
     public SoftwareModuleMetadata updateSoftwareModuleMetadata(final Long moduleId, final MetaData md) {
 
         // check if exists otherwise throw entity not found exception
@@ -599,7 +589,6 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Transactional
-
     public void deleteSoftwareModuleMetadata(final Long moduleId, final String key) {
         final JpaSoftwareModuleMetadata metadata = (JpaSoftwareModuleMetadata) findSoftwareModuleMetadata(moduleId, key)
                 .orElseThrow(() -> new EntityNotFoundException(SoftwareModuleMetadata.class, moduleId, key));
@@ -663,14 +652,12 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-
     @Transactional
     public void deleteSoftwareModule(final Long moduleId) {
         deleteSoftwareModules(Sets.newHashSet(moduleId));
     }
 
     @Override
-
     @Transactional
     public List<SoftwareModuleType> createSoftwareModuleType(final Collection<SoftwareModuleTypeCreate> creates) {
         return creates.stream().map(this::createSoftwareModuleType).collect(Collectors.toList());

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSoftwareManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSoftwareManagement.java
@@ -83,7 +83,7 @@ import com.google.common.collect.Sets;
  * JPA implementation of {@link SoftwareManagement}.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 @Validated
 public class JpaSoftwareManagement implements SoftwareManagement {
 
@@ -119,7 +119,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public SoftwareModule updateSoftwareModule(final SoftwareModuleUpdate u) {
         final GenericSoftwareModuleUpdate update = (GenericSoftwareModuleUpdate) u;
 
@@ -134,7 +134,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public SoftwareModuleType updateSoftwareModuleType(final SoftwareModuleTypeUpdate u) {
         final GenericSoftwareModuleTypeUpdate update = (GenericSoftwareModuleTypeUpdate) u;
 
@@ -149,7 +149,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public SoftwareModule createSoftwareModule(final SoftwareModuleCreate c) {
         final JpaSoftwareModuleCreate create = (JpaSoftwareModuleCreate) c;
 
@@ -158,7 +158,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public List<SoftwareModule> createSoftwareModule(final Collection<SoftwareModuleCreate> swModules) {
         return swModules.stream().map(this::createSoftwareModule).collect(Collectors.toList());
     }
@@ -231,7 +231,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteSoftwareModules(final Collection<Long> ids) {
         final List<JpaSoftwareModule> swModulesToDelete = softwareModuleRepository.findByIdIn(ids);
 
@@ -490,7 +490,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public SoftwareModuleType createSoftwareModuleType(final SoftwareModuleTypeCreate c) {
         final JpaSoftwareModuleTypeCreate create = (JpaSoftwareModuleTypeCreate) c;
 
@@ -499,7 +499,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteSoftwareModuleType(final Long typeId) {
         final JpaSoftwareModuleType toDelete = softwareModuleTypeRepository.findById(typeId)
                 .orElseThrow(() -> new EntityNotFoundException(SoftwareModuleType.class, typeId));
@@ -523,7 +523,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public SoftwareModuleMetadata createSoftwareModuleMetadata(final Long moduleId, final MetaData md) {
 
@@ -540,7 +540,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public List<SoftwareModuleMetadata> createSoftwareModuleMetadata(final Long moduleId,
             final Collection<MetaData> md) {
@@ -555,7 +555,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public SoftwareModuleMetadata updateSoftwareModuleMetadata(final Long moduleId, final MetaData md) {
 
@@ -600,7 +600,7 @@ public class JpaSoftwareManagement implements SoftwareManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public void deleteSoftwareModuleMetadata(final Long moduleId, final String key) {
         final JpaSoftwareModuleMetadata metadata = (JpaSoftwareModuleMetadata) findSoftwareModuleMetadata(moduleId, key)
@@ -666,14 +666,14 @@ public class JpaSoftwareManagement implements SoftwareManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteSoftwareModule(final Long moduleId) {
         deleteSoftwareModules(Sets.newHashSet(moduleId));
     }
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public List<SoftwareModuleType> createSoftwareModuleType(final Collection<SoftwareModuleTypeCreate> creates) {
         return creates.stream().map(this::createSoftwareModuleType).collect(Collectors.toList());
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
@@ -35,7 +35,6 @@ import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -46,7 +45,7 @@ import org.springframework.validation.annotation.Validated;
  * JPA implementation of {@link SystemManagement}.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 @Validated
 public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, SystemManagement {
     @Autowired
@@ -152,7 +151,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public TenantMetaData getTenantMetadata(final String tenant) {
         final TenantMetaData result = tenantMetaDataRepository.findByTenantIgnoreCase(tenant);
@@ -188,7 +187,6 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
         def.setName("initial-tenant-creation");
         def.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
         def.setReadOnly(false);
-        def.setIsolationLevel(Isolation.READ_UNCOMMITTED.value());
         return systemSecurityContext.runAsSystemAsTenant(
                 () -> new TransactionTemplate(txManager, def).execute(status -> tenantMetaDataRepository
                         .save(new JpaTenantMetaData(createStandardSoftwareDataSetup(), tenant))),
@@ -201,7 +199,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public void deleteTenant(final String tenant) {
         cacheManager.evictCaches(tenant);
@@ -223,7 +221,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public TenantMetaData getTenantMetadata() {
         if (tenantAware.getCurrentTenant() == null) {
@@ -245,7 +243,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     // suspend the transaction here to do a read-request against the medata
     // table, when the current
     // tenant is not cached anyway already.
-    @Transactional(propagation = Propagation.NOT_SUPPORTED, isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public String currentTenant() {
         final String initialTenantCreation = currentTenantCacheKeyGenerator.getCreateInitialTenant().get();
         if (initialTenantCreation == null) {
@@ -257,7 +255,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public TenantMetaData updateTenantMetadata(final Long defaultDsType) {
         final JpaTenantMetaData data = (JpaTenantMetaData) getTenantMetadata();

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
@@ -198,7 +198,6 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
 
     @Override
     @Transactional
-
     public void deleteTenant(final String tenant) {
         cacheManager.evictCaches(tenant);
         tenantAware.runAsTenant(tenant, () -> {
@@ -229,17 +228,6 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
 
     @Override
     @Cacheable(value = "currentTenant", keyGenerator = "currentTenantKeyGenerator", cacheManager = "directCacheManager", unless = "#result == null")
-    // set transaction to not supported, due we call this in
-    // BaseEntity#prePersist methods
-    // and it seems that JPA committing the transaction when executing this
-    // transactional method,
-    // which then leads that the BaseEntity#prePersist is called again to
-    // persist the un-persisted
-    // entity and we landing again in the #currentTenant() method
-    // suspend the transaction here to do a read-request against the medata
-    // table, when the current
-    // tenant is not cached anyway already.
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public String currentTenant() {
         final String initialTenantCreation = currentTenantCacheKeyGenerator.getCreateInitialTenant().get();
         if (initialTenantCreation == null) {
@@ -252,7 +240,6 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
 
     @Override
     @Transactional
-
     public TenantMetaData updateTenantMetadata(final Long defaultDsType) {
         final JpaTenantMetaData data = (JpaTenantMetaData) getTenantMetadata();
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
@@ -32,7 +32,6 @@ import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.interceptor.KeyGenerator;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Propagation;
@@ -199,7 +198,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
 
     @Override
     @Transactional
-    @Modifying
+
     public void deleteTenant(final String tenant) {
         cacheManager.evictCaches(tenant);
         tenantAware.runAsTenant(tenant, () -> {
@@ -253,7 +252,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
 
     @Override
     @Transactional
-    @Modifying
+
     public TenantMetaData updateTenantMetadata(final Long defaultDsType) {
         final JpaTenantMetaData data = (JpaTenantMetaData) getTenantMetadata();
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTagManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTagManagement.java
@@ -43,7 +43,7 @@ import org.springframework.validation.annotation.Validated;
  * JP>A implementation of {@link TagManagement}.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 @Validated
 public class JpaTagManagement implements TagManagement {
 
@@ -68,7 +68,7 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public TargetTag createTargetTag(final TagCreate c) {
         final JpaTagCreate create = (JpaTagCreate) c;
 
@@ -83,7 +83,7 @@ public class JpaTagManagement implements TagManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public List<TargetTag> createTargetTags(final Collection<TagCreate> tt) {
         @SuppressWarnings({ "unchecked", "rawtypes" })
         final Collection<JpaTagCreate> targetTags = (Collection) tt;
@@ -94,7 +94,7 @@ public class JpaTagManagement implements TagManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteTargetTag(final String targetTagName) {
         final TargetTag tag = targetTagRepository.findByNameEquals(targetTagName)
                 .orElseThrow(() -> new EntityNotFoundException(TargetTag.class, targetTagName));
@@ -132,7 +132,7 @@ public class JpaTagManagement implements TagManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public TargetTag updateTargetTag(final TagUpdate u) {
         final GenericTagUpdate update = (GenericTagUpdate) u;
 
@@ -148,7 +148,7 @@ public class JpaTagManagement implements TagManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSetTag updateDistributionSetTag(final TagUpdate u) {
         final GenericTagUpdate update = (GenericTagUpdate) u;
 
@@ -169,7 +169,7 @@ public class JpaTagManagement implements TagManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public DistributionSetTag createDistributionSetTag(final TagCreate c) {
         final JpaTagCreate create = (JpaTagCreate) c;
 
@@ -184,7 +184,7 @@ public class JpaTagManagement implements TagManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public List<DistributionSetTag> createDistributionSetTags(final Collection<TagCreate> dst) {
 
         @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -197,7 +197,7 @@ public class JpaTagManagement implements TagManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteDistributionSetTag(final String tagName) {
         final DistributionSetTag tag = distributionSetTagRepository.findByNameEquals(tagName)
                 .orElseThrow(() -> new EntityNotFoundException(DistributionSetTag.class, tagName));

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTagManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTagManagement.java
@@ -33,7 +33,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
@@ -74,7 +73,7 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public List<TargetTag> createTargetTags(final Collection<TagCreate> tt) {
         @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -85,7 +84,7 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public void deleteTargetTag(final String targetTagName) {
         final TargetTag tag = targetTagRepository.findByNameEquals(targetTagName)
@@ -123,7 +122,7 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public TargetTag updateTargetTag(final TagUpdate u) {
         final GenericTagUpdate update = (GenericTagUpdate) u;
@@ -139,7 +138,7 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSetTag updateDistributionSetTag(final TagUpdate u) {
         final GenericTagUpdate update = (GenericTagUpdate) u;
@@ -160,7 +159,7 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public DistributionSetTag createDistributionSetTag(final TagCreate c) {
         final JpaTagCreate create = (JpaTagCreate) c;
@@ -168,7 +167,7 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public List<DistributionSetTag> createDistributionSetTags(final Collection<TagCreate> dst) {
 
@@ -181,7 +180,7 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public void deleteDistributionSetTag(final String tagName) {
         final DistributionSetTag tag = distributionSetTagRepository.findByNameEquals(tagName)

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTagManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTagManagement.java
@@ -73,7 +73,6 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-
     @Transactional
     public List<TargetTag> createTargetTags(final Collection<TagCreate> tt) {
         @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -84,7 +83,6 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-
     @Transactional
     public void deleteTargetTag(final String targetTagName) {
         final TargetTag tag = targetTagRepository.findByNameEquals(targetTagName)
@@ -122,7 +120,6 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-
     @Transactional
     public TargetTag updateTargetTag(final TagUpdate u) {
         final GenericTagUpdate update = (GenericTagUpdate) u;
@@ -159,7 +156,6 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-
     @Transactional
     public DistributionSetTag createDistributionSetTag(final TagCreate c) {
         final JpaTagCreate create = (JpaTagCreate) c;
@@ -167,7 +163,6 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-
     @Transactional
     public List<DistributionSetTag> createDistributionSetTags(final Collection<TagCreate> dst) {
 
@@ -180,7 +175,6 @@ public class JpaTagManagement implements TagManagement {
     }
 
     @Override
-
     @Transactional
     public void deleteDistributionSetTag(final String tagName) {
         final DistributionSetTag tag = distributionSetTagRepository.findByNameEquals(tagName)

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTagManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTagManagement.java
@@ -19,7 +19,6 @@ import org.eclipse.hawkbit.repository.TagManagement;
 import org.eclipse.hawkbit.repository.builder.GenericTagUpdate;
 import org.eclipse.hawkbit.repository.builder.TagCreate;
 import org.eclipse.hawkbit.repository.builder.TagUpdate;
-import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.jpa.builder.JpaTagCreate;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSetTag;
@@ -35,7 +34,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
@@ -72,13 +70,7 @@ public class JpaTagManagement implements TagManagement {
     public TargetTag createTargetTag(final TagCreate c) {
         final JpaTagCreate create = (JpaTagCreate) c;
 
-        final JpaTargetTag targetTag = create.buildTargetTag();
-
-        if (findTargetTag(targetTag.getName()).isPresent()) {
-            throw new EntityAlreadyExistsException();
-        }
-
-        return targetTagRepository.save(targetTag);
+        return targetTagRepository.save(create.buildTargetTag());
     }
 
     @Override
@@ -172,14 +164,7 @@ public class JpaTagManagement implements TagManagement {
     @Transactional
     public DistributionSetTag createDistributionSetTag(final TagCreate c) {
         final JpaTagCreate create = (JpaTagCreate) c;
-
-        final JpaDistributionSetTag distributionSetTag = create.buildDistributionSetTag();
-
-        if (distributionSetTagRepository.findByNameEquals(distributionSetTag.getName()).isPresent()) {
-            throw new EntityAlreadyExistsException();
-        }
-
-        return distributionSetTagRepository.save(distributionSetTag);
+        return distributionSetTagRepository.save(create.buildDistributionSetTag());
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
@@ -49,7 +49,7 @@ import com.google.common.collect.Lists;
  * JPA implementation of {@link TargetFilterQueryManagement}.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 @Validated
 public class JpaTargetFilterQueryManagement implements TargetFilterQueryManagement {
 
@@ -69,7 +69,7 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     }
 
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Override
     public TargetFilterQuery createTargetFilterQuery(final TargetFilterQueryCreate c) {
         final JpaTargetFilterQueryCreate create = (JpaTargetFilterQueryCreate) c;
@@ -84,7 +84,7 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteTargetFilterQuery(final Long targetFilterQueryId) {
         findTargetFilterQueryById(targetFilterQueryId)
                 .orElseThrow(() -> new EntityNotFoundException(TargetFilterQuery.class, targetFilterQueryId));
@@ -179,7 +179,7 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public TargetFilterQuery updateTargetFilterQuery(final TargetFilterQueryUpdate u) {
         final GenericTargetFilterQueryUpdate update = (GenericTargetFilterQueryUpdate) u;
 
@@ -193,7 +193,7 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public TargetFilterQuery updateTargetFilterQueryAutoAssignDS(final Long queryId, final Long dsId) {
         final JpaTargetFilterQuery targetFilterQuery = findTargetFilterQueryOrThrowExceptionIfNotFound(queryId);
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
@@ -74,7 +74,6 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     }
 
     @Override
-
     @Transactional
     public void deleteTargetFilterQuery(final Long targetFilterQueryId) {
         findTargetFilterQueryById(targetFilterQueryId)
@@ -169,7 +168,6 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     }
 
     @Override
-
     @Transactional
     public TargetFilterQuery updateTargetFilterQuery(final TargetFilterQueryUpdate u) {
         final GenericTargetFilterQueryUpdate update = (GenericTargetFilterQueryUpdate) u;
@@ -183,7 +181,6 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     }
 
     @Override
-
     @Transactional
     public TargetFilterQuery updateTargetFilterQueryAutoAssignDS(final Long queryId, final Long dsId) {
         final JpaTargetFilterQuery targetFilterQuery = findTargetFilterQueryOrThrowExceptionIfNotFound(queryId);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
@@ -20,7 +20,6 @@ import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
 import org.eclipse.hawkbit.repository.builder.GenericTargetFilterQueryUpdate;
 import org.eclipse.hawkbit.repository.builder.TargetFilterQueryCreate;
 import org.eclipse.hawkbit.repository.builder.TargetFilterQueryUpdate;
-import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.jpa.builder.JpaTargetFilterQueryCreate;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet;
@@ -38,7 +37,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.Specifications;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
@@ -74,12 +72,7 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     public TargetFilterQuery createTargetFilterQuery(final TargetFilterQueryCreate c) {
         final JpaTargetFilterQueryCreate create = (JpaTargetFilterQueryCreate) c;
 
-        final JpaTargetFilterQuery query = create.build();
-
-        if (targetFilterQueryRepository.findByName(query.getName()).isPresent()) {
-            throw new EntityAlreadyExistsException(query.getName());
-        }
-        return targetFilterQueryRepository.save(query);
+        return targetFilterQueryRepository.save(create.build());
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
@@ -36,7 +36,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.Specifications;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
@@ -66,7 +65,6 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
         this.distributionSetManagement = distributionSetManagement;
     }
 
-    @Modifying
     @Transactional
     @Override
     public TargetFilterQuery createTargetFilterQuery(final TargetFilterQueryCreate c) {
@@ -76,7 +74,7 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public void deleteTargetFilterQuery(final Long targetFilterQueryId) {
         findTargetFilterQueryById(targetFilterQueryId)
@@ -171,7 +169,7 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public TargetFilterQuery updateTargetFilterQuery(final TargetFilterQueryUpdate u) {
         final GenericTargetFilterQueryUpdate update = (GenericTargetFilterQueryUpdate) u;
@@ -185,7 +183,7 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public TargetFilterQuery updateTargetFilterQueryAutoAssignDS(final Long queryId, final Long dsId) {
         final JpaTargetFilterQuery targetFilterQuery = findTargetFilterQueryOrThrowExceptionIfNotFound(queryId);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -179,7 +179,6 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-
     @Transactional
     public void deleteTarget(final String controllerID) {
         final Target target = targetRepository.findByControllerId(controllerID)
@@ -399,7 +398,6 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-
     @Transactional
     public Target unAssignTag(final String controllerID, final Long targetTagId) {
         final Target target = targetRepository.findByControllerId(controllerID)
@@ -545,7 +543,6 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-
     @Transactional
     public Target createTarget(final TargetCreate c) {
         final JpaTargetCreate create = (JpaTargetCreate) c;
@@ -553,7 +550,6 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-
     @Transactional
     public List<Target> createTargets(final Collection<TargetCreate> targets) {
         return targets.stream().map(this::createTarget).collect(Collectors.toList());

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -60,7 +60,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
@@ -148,7 +147,6 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-    @Modifying
     @Transactional
     public Target updateTarget(final TargetUpdate u) {
         final JpaTargetUpdate update = (JpaTargetUpdate) u;
@@ -165,7 +163,6 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-    @Modifying
     @Transactional
     public void deleteTargets(final Collection<Long> targetIDs) {
         final List<JpaTarget> targets = targetRepository.findAll(targetIDs);
@@ -182,7 +179,7 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public void deleteTarget(final String controllerID) {
         final Target target = targetRepository.findByControllerId(controllerID)
@@ -322,7 +319,6 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-    @Modifying
     @Transactional
     public TargetTagAssignmentResult toggleTagAssignment(final Collection<String> controllerIds, final String tagName) {
         final TargetTag tag = targetTagRepository.findByNameEquals(tagName)
@@ -360,7 +356,6 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-    @Modifying
     @Transactional
     public List<Target> assignTag(final Collection<String> controllerIds, final Long tagId) {
         final List<JpaTarget> allTargets = targetRepository
@@ -390,7 +385,6 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-    @Modifying
     @Transactional
     public List<Target> unAssignAllTargetsByTag(final Long targetTagId) {
 
@@ -405,7 +399,7 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public Target unAssignTag(final String controllerID, final Long targetTagId) {
         final Target target = targetRepository.findByControllerId(controllerID)
@@ -551,7 +545,7 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public Target createTarget(final TargetCreate c) {
         final JpaTargetCreate create = (JpaTargetCreate) c;
@@ -559,7 +553,7 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-    @Modifying
+
     @Transactional
     public List<Target> createTargets(final Collection<TargetCreate> targets) {
         return targets.stream().map(this::createTarget).collect(Collectors.toList());

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -72,7 +72,7 @@ import com.google.common.collect.Lists;
  * JPA implementation of {@link TargetManagement}.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 @Validated
 public class JpaTargetManagement implements TargetManagement {
 
@@ -151,7 +151,7 @@ public class JpaTargetManagement implements TargetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public Target updateTarget(final TargetUpdate u) {
         final JpaTargetUpdate update = (JpaTargetUpdate) u;
 
@@ -168,7 +168,7 @@ public class JpaTargetManagement implements TargetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteTargets(final Collection<Long> targetIDs) {
         final List<JpaTarget> targets = targetRepository.findAll(targetIDs);
 
@@ -185,7 +185,7 @@ public class JpaTargetManagement implements TargetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public void deleteTarget(final String controllerID) {
         final Target target = targetRepository.findByControllerId(controllerID)
                 .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerID));
@@ -325,7 +325,7 @@ public class JpaTargetManagement implements TargetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public TargetTagAssignmentResult toggleTagAssignment(final Collection<String> controllerIds, final String tagName) {
         final TargetTag tag = targetTagRepository.findByNameEquals(tagName)
                 .orElseThrow(() -> new EntityNotFoundException(TargetTag.class, tagName));
@@ -363,7 +363,7 @@ public class JpaTargetManagement implements TargetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public List<Target> assignTag(final Collection<String> controllerIds, final Long tagId) {
         final List<JpaTarget> allTargets = targetRepository
                 .findAll(TargetSpecifications.byControllerIdWithStatusAndTagsInJoin(controllerIds));
@@ -393,7 +393,7 @@ public class JpaTargetManagement implements TargetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public List<Target> unAssignAllTargetsByTag(final Long targetTagId) {
 
         final TargetTag tag = targetTagRepository.findById(targetTagId)
@@ -408,7 +408,7 @@ public class JpaTargetManagement implements TargetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public Target unAssignTag(final String controllerID, final Long targetTagId) {
         final Target target = targetRepository.findByControllerId(controllerID)
                 .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerID));
@@ -554,7 +554,7 @@ public class JpaTargetManagement implements TargetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public Target createTarget(final TargetCreate c) {
         final JpaTargetCreate create = (JpaTargetCreate) c;
 
@@ -569,7 +569,7 @@ public class JpaTargetManagement implements TargetManagement {
 
     @Override
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     public List<Target> createTargets(final Collection<TargetCreate> targets) {
         return targets.stream().map(this::createTarget).collect(Collectors.toList());
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantConfigurationManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantConfigurationManagement.java
@@ -31,7 +31,7 @@ import org.springframework.validation.annotation.Validated;
 /**
  * Central tenant configuration management operations of the SP server.
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 @Validated
 public class JpaTenantConfigurationManagement implements TenantConfigurationManagement {
 
@@ -123,7 +123,7 @@ public class JpaTenantConfigurationManagement implements TenantConfigurationMana
 
     @Override
     @CacheEvict(value = "tenantConfiguration", key = "#configurationKeyName")
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public <T extends Serializable> TenantConfigurationValue<T> addOrUpdateConfiguration(
             final String configurationKeyName, final T value) {
@@ -162,7 +162,7 @@ public class JpaTenantConfigurationManagement implements TenantConfigurationMana
 
     @Override
     @CacheEvict(value = "tenantConfiguration", key = "#configurationKeyName")
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Modifying
     public void deleteConfiguration(final String configurationKeyName) {
         tenantConfigurationRepository.deleteByKey(configurationKeyName);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantConfigurationManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantConfigurationManagement.java
@@ -122,7 +122,6 @@ public class JpaTenantConfigurationManagement implements TenantConfigurationMana
     @Override
     @CacheEvict(value = "tenantConfiguration", key = "#configurationKeyName")
     @Transactional
-
     public <T extends Serializable> TenantConfigurationValue<T> addOrUpdateConfiguration(
             final String configurationKeyName, final T value) {
 
@@ -161,7 +160,6 @@ public class JpaTenantConfigurationManagement implements TenantConfigurationMana
     @Override
     @CacheEvict(value = "tenantConfiguration", key = "#configurationKeyName")
     @Transactional
-
     public void deleteConfiguration(final String configurationKeyName) {
         tenantConfigurationRepository.deleteByKey(configurationKeyName);
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantConfigurationManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantConfigurationManagement.java
@@ -23,8 +23,6 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
@@ -124,7 +122,7 @@ public class JpaTenantConfigurationManagement implements TenantConfigurationMana
     @Override
     @CacheEvict(value = "tenantConfiguration", key = "#configurationKeyName")
     @Transactional
-    @Modifying
+
     public <T extends Serializable> TenantConfigurationValue<T> addOrUpdateConfiguration(
             final String configurationKeyName, final T value) {
 
@@ -163,7 +161,7 @@ public class JpaTenantConfigurationManagement implements TenantConfigurationMana
     @Override
     @CacheEvict(value = "tenantConfiguration", key = "#configurationKeyName")
     @Transactional
-    @Modifying
+
     public void deleteConfiguration(final String configurationKeyName) {
         tenantConfigurationRepository.deleteByKey(configurationKeyName);
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantStatsManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantStatsManagement.java
@@ -12,7 +12,6 @@ import org.eclipse.hawkbit.repository.TenantStatsManagement;
 import org.eclipse.hawkbit.repository.report.model.TenantUsage;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantStatsManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTenantStatsManagement.java
@@ -37,7 +37,7 @@ public class JpaTenantStatsManagement implements TenantStatsManagement {
     private TenantAware tenantAware;
 
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public TenantUsage getStatsOfTenant() {
         final String tenant = tenantAware.getCurrentTenant();
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/LocalArtifactRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/LocalArtifactRepository.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/LocalArtifactRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/LocalArtifactRepository.java
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link Artifact} repository.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface LocalArtifactRepository extends BaseEntityRepository<JpaArtifact, Long> {
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -276,7 +276,7 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
     @Override
     protected Map<String, Object> getVendorProperties() {
 
-        final Map<String, Object> properties = Maps.newHashMapWithExpectedSize(4);
+        final Map<String, Object> properties = Maps.newHashMapWithExpectedSize(5);
         // Turn off dynamic weaving to disable LTW lookup in static weaving mode
         properties.put("eclipselink.weaving", "false");
         // needed for reports
@@ -285,6 +285,8 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
         properties.put("eclipselink.ddl-generation", "none");
         // Embeed into hawkBit logging
         properties.put("eclipselink.logging.logger", "JavaLogger");
+        // Ensure that we flush only at the end of the transaction
+        properties.put("eclipselink.persistence-context.flush-mode", "COMMIT");
 
         return properties;
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -9,7 +9,6 @@
 package org.eclipse.hawkbit.repository.jpa;
 
 import java.util.Map;
-import java.util.concurrent.Executor;
 
 import javax.persistence.EntityManager;
 import javax.sql.DataSource;
@@ -70,7 +69,6 @@ import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration;
@@ -545,7 +543,7 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
      * @param autoAssignChecker
      *            to run a check as tenant
      * @param lockRegistry
-     *            to lock the tenant for auto assigment
+     *            to lock the tenant for auto assignment
      * @return a new {@link AutoAssignChecker}
      */
     @Bean
@@ -575,8 +573,6 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
      *            to run the rollout handler
      * @param systemSecurityContext
      *            to run as system
-     * @param threadPoolExecutor
-     *            to execute the handlers in parallel
      * @return a new {@link RolloutScheduler} bean.
      */
     @Bean
@@ -584,9 +580,7 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
     @Profile("!test")
     @ConditionalOnProperty(prefix = "hawkbit.rollout.scheduler", name = "enabled", matchIfMissing = true)
     RolloutScheduler rolloutScheduler(final TenantAware tenantAware, final SystemManagement systemManagement,
-            final RolloutManagement rolloutManagement, final SystemSecurityContext systemSecurityContext,
-            @Qualifier("asyncExecutor") final Executor threadPoolExecutor) {
-        return new RolloutScheduler(tenantAware, systemManagement, rolloutManagement, systemSecurityContext,
-                threadPoolExecutor);
+            final RolloutManagement rolloutManagement, final SystemSecurityContext systemSecurityContext) {
+        return new RolloutScheduler(tenantAware, systemManagement, rolloutManagement, systemSecurityContext);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutGroupRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutGroupRepository.java
@@ -21,7 +21,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutGroupRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutGroupRepository.java
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * The repository interface for the {@link RolloutGroup} model.
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface RolloutGroupRepository
         extends BaseEntityRepository<JpaRolloutGroup, Long>, JpaSpecificationExecutor<JpaRolloutGroup> {
 
@@ -119,7 +119,7 @@ public interface RolloutGroupRepository
      *            the status of the rolloutgroups
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Query("UPDATE JpaRolloutGroup g SET g.status = :status WHERE g.parent = :parent")
     void setStatusForCildren(@Param("status") RolloutGroupStatus status, @Param("parent") RolloutGroup parent);
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutRepository.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * The repository interface for the {@link Rollout} model.
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface RolloutRepository
         extends BaseEntityRepository<JpaRollout, Long>, JpaSpecificationExecutor<JpaRollout> {
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutRepository.java
@@ -17,7 +17,6 @@ import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.Rollout.RolloutStatus;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutTargetGroupRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutTargetGroupRepository.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Spring data repository for {@link RolloutTargetGroup}.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface RolloutTargetGroupRepository
         extends CrudRepository<RolloutTargetGroup, RolloutTargetGroupId>, JpaSpecificationExecutor<RolloutTargetGroup> {
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutTargetGroupRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutTargetGroupRepository.java
@@ -13,7 +13,6 @@ import org.eclipse.hawkbit.repository.jpa.model.RolloutTargetGroup;
 import org.eclipse.hawkbit.repository.jpa.model.RolloutTargetGroupId;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleMetadataRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleMetadataRepository.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link SoftwareModuleMetadata} repository.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface SoftwareModuleMetadataRepository
         extends PagingAndSortingRepository<JpaSoftwareModuleMetadata, SwMetadataCompositeKey>,
         JpaSpecificationExecutor<JpaSoftwareModuleMetadata> {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleMetadataRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleMetadataRepository.java
@@ -15,7 +15,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleRepository.java
@@ -23,7 +23,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleRepository.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link SoftwareModule} repository.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface SoftwareModuleRepository
         extends BaseEntityRepository<JpaSoftwareModule, Long>, JpaSpecificationExecutor<JpaSoftwareModule> {
 
@@ -70,7 +70,7 @@ public interface SoftwareModuleRepository
      *
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Query("UPDATE JpaSoftwareModule b SET b.deleted = 1, b.lastModifiedAt = :lastModifiedAt, b.lastModifiedBy = :lastModifiedBy WHERE b.id IN :ids")
     void deleteSoftwareModule(@Param("lastModifiedAt") Long modifiedAt, @Param("lastModifiedBy") String modifiedBy,
             @Param("ids") final Long... ids);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleTypeRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleTypeRepository.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleTypeRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleTypeRepository.java
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Repository for {@link SoftwareModuleType}.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface SoftwareModuleTypeRepository
         extends BaseEntityRepository<JpaSoftwareModuleType, Long>, JpaSpecificationExecutor<JpaSoftwareModuleType> {
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetFilterQueryRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetFilterQueryRepository.java
@@ -17,7 +17,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetFilterQueryRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetFilterQueryRepository.java
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Spring data repositories for {@link TargetFilterQuery}s.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface TargetFilterQueryRepository
         extends BaseEntityRepository<JpaTargetFilterQuery, Long>, JpaSpecificationExecutor<JpaTargetFilterQuery> {
 
@@ -49,7 +49,7 @@ public interface TargetFilterQueryRepository
      *            distribution set ids to be set to null
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Query("update JpaTargetFilterQuery d set d.autoAssignDistributionSet = NULL where d.autoAssignDistributionSet in :ids")
     void unsetAutoAssignDistributionSet(@Param("ids") Long... dsIds);
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
@@ -25,7 +25,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
@@ -32,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link Target} repository.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>, JpaSpecificationExecutor<JpaTarget> {
 
     /**
@@ -50,7 +50,7 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
      *            to update
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     @Query("UPDATE JpaTarget t  SET t.assignedDistributionSet = :set, t.lastModifiedAt = :lastModifiedAt, t.lastModifiedBy = :lastModifiedBy, t.updateStatus = :status WHERE t.id IN :targets")
     void setAssignedDistributionSetAndUpdateStatus(@Param("status") TargetUpdateStatus status,
             @Param("set") JpaDistributionSet set, @Param("lastModifiedAt") Long modifiedAt,
@@ -85,7 +85,7 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
      *            to be deleted
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     // Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=349477
     @Query("DELETE FROM JpaTarget t WHERE t.id IN ?1")
     void deleteByIdIn(final Collection<Long> targetIDs);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetTagRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetTagRepository.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link TargetTag} repository.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface TargetTagRepository
         extends BaseEntityRepository<JpaTargetTag, Long>, JpaSpecificationExecutor<JpaTargetTag> {
 
@@ -34,7 +34,7 @@ public interface TargetTagRepository
      * @return 1 if tag was deleted
      */
     @Modifying
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional
     Long deleteByName(String tagName);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetTagRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetTagRepository.java
@@ -15,7 +15,6 @@ import org.eclipse.hawkbit.repository.jpa.model.JpaTargetTag;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantConfigurationRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantConfigurationRepository.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
  * The spring-data repository for the entity {@link TenantConfiguration}.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface TenantConfigurationRepository extends BaseEntityRepository<JpaTenantConfiguration, Long> {
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantConfigurationRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantConfigurationRepository.java
@@ -10,7 +10,6 @@ package org.eclipse.hawkbit.repository.jpa;
 
 import org.eclipse.hawkbit.repository.jpa.model.JpaTenantConfiguration;
 import org.eclipse.hawkbit.repository.model.TenantConfiguration;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantMetaDataRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantMetaDataRepository.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
  * repository for operations on {@link TenantMetaData} entity.
  *
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public interface TenantMetaDataRepository extends PagingAndSortingRepository<JpaTenantMetaData, Long> {
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantMetaDataRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantMetaDataRepository.java
@@ -13,7 +13,6 @@ import java.util.List;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTenantMetaData;
 import org.eclipse.hawkbit.repository.model.TenantMetaData;
 import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantMetaDataRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantMetaDataRepository.java
@@ -12,7 +12,9 @@ import java.util.List;
 
 import org.eclipse.hawkbit.repository.jpa.model.JpaTenantMetaData;
 import org.eclipse.hawkbit.repository.model.TenantMetaData;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -29,6 +31,7 @@ public interface TenantMetaDataRepository extends PagingAndSortingRepository<Jpa
      *            to search for
      * @return found {@link TenantMetaData} or <code>null</code>
      */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     TenantMetaData findByTenantIgnoreCase(String tenant);
 
     @Override
@@ -37,6 +40,8 @@ public interface TenantMetaDataRepository extends PagingAndSortingRepository<Jpa
     /**
      * @param tenant
      */
+    @Transactional
+    @Modifying
     void deleteByTenantIgnoreCase(String tenant);
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignScheduler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignScheduler.java
@@ -84,20 +84,21 @@ public class AutoAssignScheduler {
         // each tenant separately.
         final List<String> tenants = systemManagement.findTenants();
         LOGGER.info("Checking target filter queries for tenants: {}", tenants.size());
-        for (final String tenant : tenants) {
 
-            final Lock lock = lockRegistry.obtain(tenant + "-autoassign");
-            if (!lock.tryLock()) {
-                return null;
-            }
-            try {
+        final Lock lock = lockRegistry.obtain("autoassign");
+        if (!lock.tryLock()) {
+            return null;
+        }
+
+        try {
+            for (final String tenant : tenants) {
                 tenantAware.runAsTenant(tenant, () -> {
                     autoAssignChecker.check();
                     return null;
                 });
-            } finally {
-                lock.unlock();
             }
+        } finally {
+            lock.unlock();
         }
         return null;
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/event/JpaEventEntityManager.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/event/JpaEventEntityManager.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
  * A TenantAwareEvent entity manager, which loads an entity by id and type for
  * remote events.
  */
-@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+@Transactional(readOnly = true)
 public class JpaEventEntityManager implements EventEntityManager {
 
     private final TenantAware tenantAware;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/RolloutScheduler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/RolloutScheduler.java
@@ -9,9 +9,6 @@
 package org.eclipse.hawkbit.repository.jpa.rollout;
 
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorCompletionService;
 
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.SystemManagement;
@@ -20,8 +17,6 @@ import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
-
-import com.google.common.base.Throwables;
 
 /**
  * Scheduler to schedule the {@link RolloutManagement#handleRollouts()}. The
@@ -42,8 +37,6 @@ public class RolloutScheduler {
 
     private final SystemSecurityContext systemSecurityContext;
 
-    private final ExecutorCompletionService<Void> completionService;
-
     /**
      * Constructor.
      * 
@@ -55,17 +48,13 @@ public class RolloutScheduler {
      *            to run the rollout handler
      * @param systemSecurityContext
      *            to run as system
-     * @param threadPoolExecutor
-     *            to execute the handlers in parallel
      */
     public RolloutScheduler(final TenantAware tenantAware, final SystemManagement systemManagement,
-            final RolloutManagement rolloutManagement, final SystemSecurityContext systemSecurityContext,
-            final Executor threadPoolExecutor) {
+            final RolloutManagement rolloutManagement, final SystemSecurityContext systemSecurityContext) {
         this.tenantAware = tenantAware;
         this.systemManagement = systemManagement;
         this.rolloutManagement = rolloutManagement;
         this.systemSecurityContext = systemSecurityContext;
-        completionService = new ExecutorCompletionService<>(threadPoolExecutor);
     }
 
     /**
@@ -80,7 +69,7 @@ public class RolloutScheduler {
 
         // run this code in system code privileged to have the necessary
         // permission to query and create entities.
-        final int tasks = systemSecurityContext.runAsSystem(() -> {
+        systemSecurityContext.runAsSystem(() -> {
             // workaround eclipselink that is currently not possible to
             // execute a query without multitenancy if MultiTenant
             // annotation is used.
@@ -90,25 +79,21 @@ public class RolloutScheduler {
             final List<String> tenants = systemManagement.findTenants();
             LOGGER.info("Checking rollouts for {} tenants", tenants.size());
             for (final String tenant : tenants) {
-                completionService.submit(() -> tenantAware.runAsTenant(tenant, () -> {
-                    rolloutManagement.handleRollouts();
+                tenantAware.runAsTenant(tenant, () -> {
+                    try {
+                        rolloutManagement.handleRollouts();
+                        // We catch all potential runtime exceptions here to
+                        // ensure that not all tenants are blocked if we have a
+                        // problem with a rollout.
+                    } catch (@SuppressWarnings("squid:S1166") final RuntimeException e) {
+                        LOGGER.error("Failed to handle rollouts for tenant {}. I will move on to next tenant.", tenant,
+                                e);
+                    }
                     return null;
-                }));
+                });
             }
-            return tenants.size();
+            return null;
         });
-
-        waitUntilHandlersAreComplete(tasks);
     }
 
-    private void waitUntilHandlersAreComplete(final int tasks) {
-        try {
-            for (int i = 0; i < tasks; i++) {
-                completionService.take().get();
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            Thread.currentThread().interrupt();
-            throw Throwables.propagate(e);
-        }
-    }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/RolloutSpecification.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/RolloutSpecification.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.hawkbit.repository.jpa.specifications;
 
+import javax.persistence.criteria.Predicate;
+
 import org.eclipse.hawkbit.repository.jpa.model.JpaRollout;
 import org.eclipse.hawkbit.repository.jpa.model.JpaRollout_;
 import org.eclipse.hawkbit.repository.model.Rollout;
@@ -25,15 +27,21 @@ public final class RolloutSpecification {
 
     /**
      * {@link Specification} for retrieving {@link Rollout}s by its DELETED
-     * attribute.
+     * attribute. Includes fetch for stuff that is required for {@link Rollout}
+     * queries.
      * 
      * @param isDeleted
      *            TRUE/FALSE are compared to the attribute DELETED. If NULL the
      *            attribute is ignored
      * @return the {@link Rollout} {@link Specification}
      */
-    public static Specification<JpaRollout> isDeleted(final Boolean isDeleted) {
-        return (root, query, cb) -> cb.equal(root.<Boolean> get(JpaRollout_.deleted), isDeleted);
+    public static Specification<JpaRollout> isDeletedWithDistributionSet(final Boolean isDeleted) {
+        return (root, query, cb) -> {
+
+            final Predicate predicate = cb.equal(root.<Boolean> get(JpaRollout_.deleted), isDeleted);
+            root.fetch(JpaRollout_.distributionSet);
+            return predicate;
+        };
 
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
@@ -50,15 +50,14 @@ public final class TargetSpecifications {
 
     /**
      * {@link Specification} for retrieving {@link Target}s including
-     * {@link TargetTag}s and {@link TargetStatus}.
+     * {@link TargetTag}s.
      *
      * @param controllerIDs
      *            to search for
      *
      * @return the {@link Target} {@link Specification}
      */
-    public static Specification<JpaTarget> byControllerIdWithStatusAndTagsInJoin(
-            final Collection<String> controllerIDs) {
+    public static Specification<JpaTarget> byControllerIdWithTagsInJoin(final Collection<String> controllerIDs) {
         return (targetRoot, query, cb) -> {
             final Predicate predicate = targetRoot.get(JpaTarget_.controllerId).in(controllerIDs);
             targetRoot.fetch(JpaTarget_.tags, JoinType.LEFT);
@@ -68,16 +67,15 @@ public final class TargetSpecifications {
     }
 
     /**
-     * {@link Specification} for retrieving {@link Target}s including {
-     * {@link TargetStatus}.
+     * {@link Specification} for retrieving {@link JpaTarget}s including
+     * {@link JpaTarget#getAssignedDistributionSet()}.
      *
      * @param controllerIDs
      *            to search for
      *
      * @return the {@link Target} {@link Specification}
      */
-    public static Specification<JpaTarget> byControllerIdWithStatusAndAssignedInJoin(
-            final Collection<String> controllerIDs) {
+    public static Specification<JpaTarget> byControllerIdWithAssignedDsInJoin(final Collection<String> controllerIDs) {
         return (targetRoot, query, cb) -> {
 
             final Predicate predicate = targetRoot.get(JpaTarget_.controllerId).in(controllerIDs);
@@ -92,9 +90,7 @@ public final class TargetSpecifications {
      *
      * @param updateStatus
      *            to be filtered on
-     * @param fetch
-     *            {@code true} to fetch the {@link TargetInfo} otherwise only
-     *            join it.
+     * 
      * @return the {@link Target} {@link Specification}
      */
     public static Specification<JpaTarget> hasTargetUpdateStatus(final Collection<TargetUpdateStatus> updateStatus) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_11_1__target_filter_query_UQ___H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_11_1__target_filter_query_UQ___H2.sql
@@ -1,0 +1,2 @@
+ alter table sp_target_filter_query 
+        add constraint uk_tenant_custom_filter_name  unique (name, tenant);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_11_1__target_filter_query_UQ___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_11_1__target_filter_query_UQ___MYSQL.sql
@@ -1,0 +1,2 @@
+ alter table sp_target_filter_query 
+        add constraint uk_tenant_custom_filter_name  unique (name, tenant);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/AbstractJpaIntegrationTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/AbstractJpaIntegrationTest.java
@@ -97,7 +97,7 @@ public abstract class AbstractJpaIntegrationTest extends AbstractIntegrationTest
     @Autowired
     protected TenantConfigurationProperties tenantConfigurationProperties;
 
-    @Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+    @Transactional(readOnly = true)
     protected List<Action> findActionsByRolloutAndStatus(final Rollout rollout, final Action.Status actionStatus) {
         return Lists.newArrayList(actionRepository.findByRolloutIdAndStatus(pageReq, rollout.getId(), actionStatus));
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetManagementTest.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
@@ -324,6 +325,17 @@ public class DistributionSetManagementTest extends AbstractJpaIntegrationTest {
 
         assertThat(set.getType()).as("Type should be equal to default type of tenant")
                 .isEqualTo(systemManagement.getTenantMetadata().getDefaultDsType());
+
+    }
+
+    @Test
+    @Description("Verifies that a DS is cannot be created if another DS with same name and version exists.")
+    public void createDistributionSetWithDuplicateNameAndVersionFails() {
+        distributionSetManagement
+                .createDistributionSet(entityFactory.distributionSet().create().name("newtypesoft").version("1"));
+
+        assertThatExceptionOfType(EntityAlreadyExistsException.class).isThrownBy(() -> distributionSetManagement
+                .createDistributionSet(entityFactory.distributionSet().create().name("newtypesoft").version("1")));
 
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -1488,7 +1488,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @ExpectEvents({ @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
-            @Expect(type = RolloutGroupUpdatedEvent.class, count = 11),
+            @Expect(type = RolloutGroupUpdatedEvent.class, count = 10),
             @Expect(type = RolloutUpdatedEvent.class, count = 6),
             @Expect(type = DistributionSetCreatedEvent.class, count = 1),
             @Expect(type = TargetCreatedEvent.class, count = 25), @Expect(type = TargetUpdatedEvent.class, count = 2),

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -143,12 +143,6 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
         verifyThrownExceptionBy(() -> rolloutManagement.deleteRollout(NOT_EXIST_IDL), "Rollout");
 
-        verifyThrownExceptionBy(() -> rolloutManagement.getFinishedPercentForRunningGroup(NOT_EXIST_IDL, NOT_EXIST_IDL),
-                "Rollout");
-        verifyThrownExceptionBy(
-                () -> rolloutManagement.getFinishedPercentForRunningGroup(createdRollout.getId(), NOT_EXIST_IDL),
-                "RolloutGroup");
-
         verifyThrownExceptionBy(() -> rolloutManagement.pauseRollout(NOT_EXIST_IDL), "Rollout");
         verifyThrownExceptionBy(() -> rolloutManagement.resumeRollout(NOT_EXIST_IDL), "Rollout");
         verifyThrownExceptionBy(() -> rolloutManagement.startRollout(NOT_EXIST_IDL), "Rollout");
@@ -1005,23 +999,24 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         rolloutManagement.handleRollouts();
         myRollout = rolloutManagement.findRolloutById(myRollout.getId()).get();
 
-        float percent = rolloutManagement.getFinishedPercentForRunningGroup(myRollout.getId(),
-                myRollout.getRolloutGroups().get(0).getId());
+        float percent = rolloutGroupManagement
+                .findRolloutGroupWithDetailedStatus(myRollout.getRolloutGroups().get(0).getId()).get()
+                .getTotalTargetCountStatus().getFinishedPercent();
         assertThat(percent).isEqualTo(40);
 
         changeStatusForRunningActions(myRollout, Status.FINISHED, 3);
         rolloutManagement.handleRollouts();
 
-        percent = rolloutManagement.getFinishedPercentForRunningGroup(myRollout.getId(),
-                myRollout.getRolloutGroups().get(0).getId());
+        percent = rolloutGroupManagement.findRolloutGroupWithDetailedStatus(myRollout.getRolloutGroups().get(0).getId())
+                .get().getTotalTargetCountStatus().getFinishedPercent();
         assertThat(percent).isEqualTo(100);
 
         changeStatusForRunningActions(myRollout, Status.FINISHED, 4);
         changeStatusForAllRunningActions(myRollout, Status.ERROR);
         rolloutManagement.handleRollouts();
 
-        percent = rolloutManagement.getFinishedPercentForRunningGroup(myRollout.getId(),
-                myRollout.getRolloutGroups().get(1).getId());
+        percent = rolloutGroupManagement.findRolloutGroupWithDetailedStatus(myRollout.getRolloutGroups().get(1).getId())
+                .get().getTotalTargetCountStatus().getFinishedPercent();
         assertThat(percent).isEqualTo(80);
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -133,7 +133,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
             + " by means of throwing EntityNotFoundException.")
     @ExpectEvents({ @Expect(type = RolloutDeletedEvent.class, count = 0),
             @Expect(type = RolloutGroupCreatedEvent.class, count = 10),
-            @Expect(type = RolloutGroupUpdatedEvent.class, count = 20),
+            @Expect(type = RolloutGroupUpdatedEvent.class, count = 10),
             @Expect(type = DistributionSetCreatedEvent.class, count = 1),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
             @Expect(type = RolloutUpdatedEvent.class, count = 1),
@@ -1465,7 +1465,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = TargetCreatedEvent.class, count = 25), @Expect(type = RolloutUpdatedEvent.class, count = 2),
             @Expect(type = RolloutGroupCreatedEvent.class, count = 5),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
-            @Expect(type = RolloutGroupUpdatedEvent.class, count = 10) })
+            @Expect(type = RolloutGroupUpdatedEvent.class, count = 5) })
     public void deleteRolloutWhichHasNeverStartedIsHardDeleted() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
@@ -1488,7 +1488,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @ExpectEvents({ @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
-            @Expect(type = RolloutGroupUpdatedEvent.class, count = 16),
+            @Expect(type = RolloutGroupUpdatedEvent.class, count = 11),
             @Expect(type = RolloutUpdatedEvent.class, count = 6),
             @Expect(type = DistributionSetCreatedEvent.class, count = 1),
             @Expect(type = TargetCreatedEvent.class, count = 25), @Expect(type = TargetUpdatedEvent.class, count = 2),

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -190,6 +191,16 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
         } catch (final ConstraintViolationException e) {
             // ok
         }
+    }
+
+    @Test
+    @Description("Verify that a target with same controller ID than another device cannot be created.")
+    @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1) })
+    public void createTargetThatViolatesUniqueConstraintFails() {
+        targetManagement.createTarget(entityFactory.target().create().controllerId("123"));
+
+        assertThatExceptionOfType(EntityAlreadyExistsException.class)
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId("123")));
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/resources/application-test.properties
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/resources/application-test.properties
@@ -9,6 +9,7 @@
 
 logging.level.=INFO
 logging.level.org.eclipse.persistence=ERROR
+logging.level.org.eclipse.hawkbit.repository.test.matcher.EventVerifier=ERROR
 
 spring.data.mongodb.uri=mongodb://localhost/spArtifactRepository${random.value}
 spring.data.mongodb.port=28017

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/resources/application-test.properties
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/resources/application-test.properties
@@ -9,7 +9,7 @@
 
 logging.level.=INFO
 logging.level.org.eclipse.persistence=ERROR
-logging.level.org.eclipse.hawkbit.repository.test.matcher.EventVerifier=ERROR
+logging.level.org.eclipse.hawkbit.repository.test.matcher.EventVerifier=DEBUG
 
 spring.data.mongodb.uri=mongodb://localhost/spArtifactRepository${random.value}
 spring.data.mongodb.port=28017
@@ -23,6 +23,7 @@ hawkbit.server.security.dos.maxAttributeEntriesPerTarget=10
 spring.jpa.database=H2
 spring.datasource.url=jdbc:h2:mem:sp-db;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.tomcat.default-auto-commit=false
 spring.datasource.username=sa
 spring.datasource.password=sa
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/resources/application-test.properties
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/resources/application-test.properties
@@ -9,7 +9,7 @@
 
 logging.level.=INFO
 logging.level.org.eclipse.persistence=ERROR
-logging.level.org.eclipse.hawkbit.repository.test.matcher.EventVerifier=DEBUG
+logging.level.org.eclipse.hawkbit.repository.test.matcher.EventVerifier=ERROR
 
 spring.data.mongodb.uri=mongodb://localhost/spArtifactRepository${random.value}
 spring.data.mongodb.port=28017

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
@@ -22,6 +22,8 @@ import org.junit.Assert;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.bus.event.RemoteApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -37,6 +39,7 @@ import com.jayway.awaitility.core.ConditionTimeoutException;
  * Test rule to setup and verify the event count for a method.
  */
 public class EventVerifier implements TestRule {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventVerifier.class);
 
     private EventCaptor eventCaptor;
 
@@ -115,6 +118,7 @@ public class EventVerifier implements TestRule {
 
         @Override
         public synchronized void onApplicationEvent(final RemoteApplicationEvent event) {
+            LOGGER.debug("Received event {}", event.getClass().getSimpleName());
             capturedEvents.add(event.getClass());
         }
 

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
@@ -270,7 +270,7 @@ public abstract class AbstractIntegrationTest implements EnvironmentAware {
     @Before
     public void before() throws Exception {
         mvc = createMvcWebAppContext().build();
-        final String description = "Updated description to have lastmodified available in tests";
+        final String description = "Updated description.";
 
         osType = securityRule
                 .runAsPrivileged(() -> testdataFactory.findOrCreateSoftwareModuleType(TestdataFactory.SM_TYPE_OS));

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/JpaTestRepositoryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/JpaTestRepositoryManagement.java
@@ -15,7 +15,6 @@ import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.transaction.annotation.Transactional;
 
 public class JpaTestRepositoryManagement implements TestRepositoryManagement {
 
@@ -45,13 +44,11 @@ public class JpaTestRepositoryManagement implements TestRepositoryManagement {
     }
 
     @Override
-    @Transactional
     public void clearTestRepository() {
         deleteAllRepos();
         cacheManager.getDirectCacheNames().forEach(name -> cacheManager.getDirectCache(name).clear());
     }
 
-    @Transactional
     public void deleteAllRepos() {
         final List<String> tenants = systemSecurityContext.runAsSystem(() -> systemManagement.findTenants());
         tenants.forEach(tenant -> {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/ProxyRollout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/ProxyRollout.java
@@ -8,11 +8,7 @@
  */
 package org.eclipse.hawkbit.ui.rollout.rollout;
 
-import java.util.Set;
-
-import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.Rollout.RolloutStatus;
-import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus;
 import org.eclipse.hawkbit.ui.customrenderers.client.renderers.RolloutRendererData;
 
@@ -30,98 +26,23 @@ public class ProxyRollout {
 
     private String modifiedDate;
 
-    private Integer numberOfGroups;
+    private int numberOfGroups;
 
     private Boolean isActionRecieved = Boolean.FALSE;
-
-    private Boolean isRequiredMigrationStep = Boolean.FALSE;
 
     private String totalTargetsCount;
 
     private RolloutRendererData rolloutRendererData;
 
-    private String discription;
-
-    private String type;
-
-    private Set<SoftwareModule> swModules;
-
     private Long id;
     private String name;
     private String version;
     private String description;
-    private DistributionSet distributionSet;
     private String createdBy;
     private String lastModifiedBy;
     private long forcedTime;
     private RolloutStatus status;
     private TotalTargetCountStatus totalTargetCountStatus;
-
-    /**
-     * @return the isRequiredMigrationStep
-     */
-
-    public Boolean getIsRequiredMigrationStep() {
-        return isRequiredMigrationStep;
-    }
-
-    /**
-     * @param isRequiredMigrationStep
-     *            the isRequiredMigrationStep to set
-     */
-
-    public void setIsRequiredMigrationStep(final Boolean isRequiredMigrationStep) {
-        this.isRequiredMigrationStep = isRequiredMigrationStep;
-    }
-
-    /**
-     * @return the discription
-     */
-
-    public String getDiscription() {
-        return discription;
-    }
-
-    /**
-     * @param discription
-     *            the discription to set
-     */
-
-    public void setDiscription(final String discription) {
-        this.discription = discription;
-    }
-
-    /**
-     * @return the type
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * @param type
-     *            the type to set
-     */
-
-    public void setType(final String type) {
-        this.type = type;
-    }
-
-    /**
-     * 
-     * @return the Set of Software modules
-     */
-    public Set<SoftwareModule> getSwModules() {
-        return swModules;
-    }
-
-    /**
-     * @param swModules
-     *            Set<SoftwareModule> to set
-     */
-    public void setSwModules(final Set<SoftwareModule> swModules) {
-        this.swModules = swModules;
-    }
 
     public RolloutRendererData getRolloutRendererData() {
         return rolloutRendererData;
@@ -149,7 +70,7 @@ public class ProxyRollout {
     /**
      * @return the numberOfGroups
      */
-    public Integer getNumberOfGroups() {
+    public int getNumberOfGroups() {
         return numberOfGroups;
     }
 
@@ -157,7 +78,7 @@ public class ProxyRollout {
      * @param numberOfGroups
      *            the numberOfGroups to set
      */
-    public void setNumberOfGroups(final Integer numberOfGroups) {
+    public void setNumberOfGroups(final int numberOfGroups) {
         this.numberOfGroups = numberOfGroups;
     }
 
@@ -255,14 +176,6 @@ public class ProxyRollout {
 
     public void setDescription(final String description) {
         this.description = description;
-    }
-
-    public DistributionSet getDistributionSet() {
-        return distributionSet;
-    }
-
-    public void setDistributionSet(final DistributionSet distributionSet) {
-        this.distributionSet = distributionSet;
     }
 
     public String getCreatedBy() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
@@ -10,9 +10,9 @@ package org.eclipse.hawkbit.ui.rollout.rollout;
 
 import static org.apache.commons.lang3.ArrayUtils.isEmpty;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
@@ -104,36 +104,30 @@ public class RolloutBeanQuery extends AbstractBeanQuery<ProxyRollout> {
     }
 
     private static List<ProxyRollout> getProxyRolloutList(final Slice<Rollout> rolloutBeans) {
-        final List<ProxyRollout> proxyRolloutList = new ArrayList<>();
-        for (final Rollout rollout : rolloutBeans) {
-            final ProxyRollout proxyRollout = new ProxyRollout();
-            proxyRollout.setName(rollout.getName());
-            proxyRollout.setDescription(rollout.getDescription());
-            final DistributionSet distributionSet = rollout.getDistributionSet();
-            proxyRollout.setDistributionSetNameVersion(
-                    HawkbitCommonUtil.getFormattedNameVersion(distributionSet.getName(), distributionSet.getVersion()));
-            proxyRollout.setDistributionSet(distributionSet);
-            proxyRollout.setNumberOfGroups(Integer.valueOf(rollout.getRolloutGroups().size()));
-            proxyRollout.setCreatedDate(SPDateTimeUtil.getFormattedDate(rollout.getCreatedAt()));
-            proxyRollout.setModifiedDate(SPDateTimeUtil.getFormattedDate(rollout.getLastModifiedAt()));
-            proxyRollout.setCreatedBy(UserDetailsFormatter.loadAndFormatCreatedBy(rollout));
-            proxyRollout.setLastModifiedBy(UserDetailsFormatter.loadAndFormatLastModifiedBy(rollout));
-            proxyRollout.setForcedTime(rollout.getForcedTime());
-            proxyRollout.setId(rollout.getId());
-            proxyRollout.setStatus(rollout.getStatus());
-            proxyRollout
-                    .setRolloutRendererData(new RolloutRendererData(rollout.getName(), rollout.getStatus().toString()));
+        return rolloutBeans.getContent().stream().map(RolloutBeanQuery::createProxy).collect(Collectors.toList());
+    }
 
-            final TotalTargetCountStatus totalTargetCountActionStatus = rollout.getTotalTargetCountStatus();
-            proxyRollout.setTotalTargetCountStatus(totalTargetCountActionStatus);
-            proxyRollout.setTotalTargetsCount(String.valueOf(rollout.getTotalTargets()));
-            proxyRollout.setType(distributionSet.getType().getName());
-            proxyRollout.setIsRequiredMigrationStep(distributionSet.isRequiredMigrationStep());
-            proxyRollout.setSwModules(distributionSet.getModules());
+    private static ProxyRollout createProxy(final Rollout rollout) {
+        final ProxyRollout proxyRollout = new ProxyRollout();
+        proxyRollout.setName(rollout.getName());
+        proxyRollout.setDescription(rollout.getDescription());
+        final DistributionSet distributionSet = rollout.getDistributionSet();
+        proxyRollout.setDistributionSetNameVersion(
+                HawkbitCommonUtil.getFormattedNameVersion(distributionSet.getName(), distributionSet.getVersion()));
+        proxyRollout.setNumberOfGroups(rollout.getRolloutGroupsCreated());
+        proxyRollout.setCreatedDate(SPDateTimeUtil.getFormattedDate(rollout.getCreatedAt()));
+        proxyRollout.setModifiedDate(SPDateTimeUtil.getFormattedDate(rollout.getLastModifiedAt()));
+        proxyRollout.setCreatedBy(UserDetailsFormatter.loadAndFormatCreatedBy(rollout));
+        proxyRollout.setLastModifiedBy(UserDetailsFormatter.loadAndFormatLastModifiedBy(rollout));
+        proxyRollout.setForcedTime(rollout.getForcedTime());
+        proxyRollout.setId(rollout.getId());
+        proxyRollout.setStatus(rollout.getStatus());
+        proxyRollout.setRolloutRendererData(new RolloutRendererData(rollout.getName(), rollout.getStatus().toString()));
 
-            proxyRolloutList.add(proxyRollout);
-        }
-        return proxyRolloutList;
+        final TotalTargetCountStatus totalTargetCountActionStatus = rollout.getTotalTargetCountStatus();
+        proxyRollout.setTotalTargetCountStatus(totalTargetCountActionStatus);
+        proxyRollout.setTotalTargetsCount(String.valueOf(rollout.getTotalTargets()));
+        return proxyRollout;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.hawkbit.repository.EntityFactory;
@@ -26,7 +25,6 @@ import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.Rollout.RolloutStatus;
-import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus;
 import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus.Status;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
@@ -83,10 +81,6 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
     private static final String RUN_OPTION = "Run";
 
     private static final String DELETE_OPTION = "Delete";
-
-    private static final String DS_TYPE = "type";
-
-    private static final String SW_MODULES = "swModules";
 
     private static final String IS_REQUIRED_MIGRATION_STEP = "isRequiredMigrationStep";
 
@@ -223,8 +217,6 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
     protected void addContainerProperties() {
         final LazyQueryContainer rolloutGridContainer = (LazyQueryContainer) getContainerDataSource();
         rolloutGridContainer.addContainerProperty(SPUILabelDefinitions.VAR_NAME, String.class, "", false, false);
-        rolloutGridContainer.addContainerProperty(DS_TYPE, String.class, null, false, false);
-        rolloutGridContainer.addContainerProperty(SW_MODULES, Set.class, null, false, false);
         rolloutGridContainer.addContainerProperty(ROLLOUT_RENDERER_DATA, RolloutRendererData.class, null, false, false);
         rolloutGridContainer.addContainerProperty(SPUILabelDefinitions.VAR_DESC, String.class, null, false, false);
         rolloutGridContainer.addContainerProperty(IS_REQUIRED_MIGRATION_STEP, boolean.class, null, false, false);
@@ -307,8 +299,6 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
     @Override
     protected void setColumnHeaderNames() {
         getColumn(ROLLOUT_RENDERER_DATA).setHeaderCaption(i18n.getMessage("header.name"));
-        getColumn(DS_TYPE).setHeaderCaption(i18n.getMessage("header.type"));
-        getColumn(SW_MODULES).setHeaderCaption(i18n.getMessage("header.swmodules"));
         getColumn(IS_REQUIRED_MIGRATION_STEP).setHeaderCaption(i18n.getMessage("header.migrations.step"));
         getColumn(SPUILabelDefinitions.VAR_DIST_NAME_VERSION)
                 .setHeaderCaption(i18n.getMessage("header.distributionset"));
@@ -362,8 +352,6 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
         final List<Object> columnList = new ArrayList<>();
         columnList.add(ROLLOUT_RENDERER_DATA);
         columnList.add(SPUILabelDefinitions.VAR_DIST_NAME_VERSION);
-        columnList.add(DS_TYPE);
-        columnList.add(SW_MODULES);
         columnList.add(IS_REQUIRED_MIGRATION_STEP);
         columnList.add(SPUILabelDefinitions.VAR_STATUS);
         columnList.add(SPUILabelDefinitions.VAR_TOTAL_TARGETS_COUNT_STATUS);
@@ -400,8 +388,6 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
         columnsToBeHidden.add(SPUILabelDefinitions.VAR_MODIFIED_BY);
         columnsToBeHidden.add(SPUILabelDefinitions.VAR_DESC);
         columnsToBeHidden.add(IS_REQUIRED_MIGRATION_STEP);
-        columnsToBeHidden.add(DS_TYPE);
-        columnsToBeHidden.add(SW_MODULES);
         for (final Object propertyId : columnsToBeHidden) {
             getColumn(propertyId).setHidden(true);
         }
@@ -561,49 +547,9 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
             description = ((RolloutRendererData) cell.getProperty().getValue()).getName();
         } else if (SPUILabelDefinitions.VAR_TOTAL_TARGETS_COUNT_STATUS.equals(cell.getPropertyId())) {
             description = getTooltip(((TotalTargetCountStatus) cell.getValue()).getStatusTotalCountMap());
-        } else if (SPUILabelDefinitions.VAR_DIST_NAME_VERSION.equals(cell.getPropertyId())) {
-            description = getDSDetails(cell.getItem());
         }
 
         return description;
-    }
-
-    private static String getDSDetails(final Item rolloutItem) {
-        final StringBuilder swModuleNames = new StringBuilder();
-        final StringBuilder swModuleVendors = new StringBuilder();
-        @SuppressWarnings("unchecked")
-        final Set<SoftwareModule> swModules = (Set<SoftwareModule>) rolloutItem.getItemProperty(SW_MODULES).getValue();
-        swModules.forEach(swModule -> {
-            swModuleNames.append(swModule.getName());
-            swModuleNames.append(" , ");
-            swModuleVendors.append(swModule.getVendor());
-            swModuleVendors.append(" , ");
-        });
-        final StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(HawkbitCommonUtil.HTML_UL_OPEN_TAG);
-        stringBuilder.append(HawkbitCommonUtil.HTML_LI_OPEN_TAG);
-        stringBuilder.append(" DistributionSet Description : ")
-                .append((String) rolloutItem.getItemProperty(SPUILabelDefinitions.VAR_DESC).getValue());
-        stringBuilder.append(HawkbitCommonUtil.HTML_LI_CLOSE_TAG);
-        stringBuilder.append(HawkbitCommonUtil.HTML_LI_OPEN_TAG);
-        stringBuilder.append(" DistributionSet Type : ")
-                .append((String) rolloutItem.getItemProperty(DS_TYPE).getValue());
-        stringBuilder.append(HawkbitCommonUtil.HTML_LI_CLOSE_TAG);
-        stringBuilder.append(HawkbitCommonUtil.HTML_LI_OPEN_TAG);
-        stringBuilder.append("Required Migration step : ")
-                .append((boolean) rolloutItem.getItemProperty(IS_REQUIRED_MIGRATION_STEP).getValue() ? "Yes" : "No");
-        stringBuilder.append(HawkbitCommonUtil.HTML_LI_CLOSE_TAG);
-
-        stringBuilder.append(HawkbitCommonUtil.HTML_LI_OPEN_TAG);
-        stringBuilder.append("SoftWare Modules : ").append(swModuleNames.toString());
-        stringBuilder.append(HawkbitCommonUtil.HTML_LI_CLOSE_TAG);
-
-        stringBuilder.append(HawkbitCommonUtil.HTML_LI_OPEN_TAG);
-        stringBuilder.append("Vendor(s) : ").append(swModuleVendors.toString());
-        stringBuilder.append(HawkbitCommonUtil.HTML_LI_CLOSE_TAG);
-
-        stringBuilder.append(HawkbitCommonUtil.HTML_UL_CLOSE_TAG);
-        return stringBuilder.toString();
     }
 
     private static class RollouStatusCellStyleGenerator implements CellStyleGenerator {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupBeanQuery.java
@@ -15,6 +15,7 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.RolloutManagement;
@@ -113,38 +114,34 @@ public class RolloutGroupBeanQuery extends AbstractBeanQuery<ProxyRolloutGroup> 
     }
 
     private List<ProxyRolloutGroup> getProxyRolloutGroupList(final List<RolloutGroup> rolloutGroupBeans) {
-        final List<ProxyRolloutGroup> proxyRolloutGroupsList = new ArrayList<>();
-        for (final RolloutGroup rolloutGroup : rolloutGroupBeans) {
-            final ProxyRolloutGroup proxyRolloutGroup = new ProxyRolloutGroup();
-            proxyRolloutGroup.setName(rolloutGroup.getName());
-            proxyRolloutGroup.setDescription(rolloutGroup.getDescription());
-            proxyRolloutGroup.setCreatedDate(SPDateTimeUtil.getFormattedDate(rolloutGroup.getCreatedAt()));
-            proxyRolloutGroup.setModifiedDate(SPDateTimeUtil.getFormattedDate(rolloutGroup.getLastModifiedAt()));
-            proxyRolloutGroup.setCreatedBy(UserDetailsFormatter.loadAndFormatCreatedBy(rolloutGroup));
-            proxyRolloutGroup.setLastModifiedBy(UserDetailsFormatter.loadAndFormatLastModifiedBy(rolloutGroup));
-            proxyRolloutGroup.setId(rolloutGroup.getId());
-            proxyRolloutGroup.setStatus(rolloutGroup.getStatus());
-            proxyRolloutGroup.setErrorAction(rolloutGroup.getErrorAction());
-            proxyRolloutGroup.setErrorActionExp(rolloutGroup.getErrorActionExp());
-            proxyRolloutGroup.setErrorCondition(rolloutGroup.getErrorCondition());
-            proxyRolloutGroup.setErrorConditionExp(rolloutGroup.getErrorConditionExp());
-            proxyRolloutGroup.setSuccessCondition(rolloutGroup.getSuccessCondition());
-            proxyRolloutGroup.setSuccessConditionExp(rolloutGroup.getSuccessConditionExp());
-            proxyRolloutGroup.setFinishedPercentage(calculateFinishedPercentage(rolloutGroup));
-
-            proxyRolloutGroup.setRolloutRendererData(new RolloutRendererData(rolloutGroup.getName(), null));
-
-            proxyRolloutGroup.setTotalTargetsCount(String.valueOf(rolloutGroup.getTotalTargets()));
-            proxyRolloutGroup.setTotalTargetCountStatus(rolloutGroup.getTotalTargetCountStatus());
-
-            proxyRolloutGroupsList.add(proxyRolloutGroup);
-        }
-        return proxyRolloutGroupsList;
+        return rolloutGroupBeans.stream().map(RolloutGroupBeanQuery::createProxy).collect(Collectors.toList());
     }
 
-    private String calculateFinishedPercentage(final RolloutGroup rolloutGroup) {
-        return HawkbitCommonUtil.formattingFinishedPercentage(rolloutGroup, getRolloutManagement()
-                .getFinishedPercentForRunningGroup(rolloutGroup.getRollout().getId(), rolloutGroup.getId()));
+    private static ProxyRolloutGroup createProxy(final RolloutGroup rolloutGroup) {
+        final ProxyRolloutGroup proxyRolloutGroup = new ProxyRolloutGroup();
+        proxyRolloutGroup.setName(rolloutGroup.getName());
+        proxyRolloutGroup.setDescription(rolloutGroup.getDescription());
+        proxyRolloutGroup.setCreatedDate(SPDateTimeUtil.getFormattedDate(rolloutGroup.getCreatedAt()));
+        proxyRolloutGroup.setModifiedDate(SPDateTimeUtil.getFormattedDate(rolloutGroup.getLastModifiedAt()));
+        proxyRolloutGroup.setCreatedBy(UserDetailsFormatter.loadAndFormatCreatedBy(rolloutGroup));
+        proxyRolloutGroup.setLastModifiedBy(UserDetailsFormatter.loadAndFormatLastModifiedBy(rolloutGroup));
+        proxyRolloutGroup.setId(rolloutGroup.getId());
+        proxyRolloutGroup.setStatus(rolloutGroup.getStatus());
+        proxyRolloutGroup.setErrorAction(rolloutGroup.getErrorAction());
+        proxyRolloutGroup.setErrorActionExp(rolloutGroup.getErrorActionExp());
+        proxyRolloutGroup.setErrorCondition(rolloutGroup.getErrorCondition());
+        proxyRolloutGroup.setErrorConditionExp(rolloutGroup.getErrorConditionExp());
+        proxyRolloutGroup.setSuccessCondition(rolloutGroup.getSuccessCondition());
+        proxyRolloutGroup.setSuccessConditionExp(rolloutGroup.getSuccessConditionExp());
+        proxyRolloutGroup.setFinishedPercentage(HawkbitCommonUtil.formattingFinishedPercentage(rolloutGroup,
+                rolloutGroup.getTotalTargetCountStatus().getFinishedPercent()));
+
+        proxyRolloutGroup.setRolloutRendererData(new RolloutRendererData(rolloutGroup.getName(), null));
+
+        proxyRolloutGroup.setTotalTargetsCount(String.valueOf(rolloutGroup.getTotalTargets()));
+        proxyRolloutGroup.setTotalTargetCountStatus(rolloutGroup.getTotalTargetCountStatus());
+
+        return proxyRolloutGroup;
     }
 
     @Override


### PR DESCRIPTION
Currently hawkBit is not very flexible concerning the transaction isolation level as these are defined hardcoded for all transactions and cannot be changed. However, depending on the underlying DB infrastructure it might be feasible to leverage a default isolation of the DB or set one for the application (i.e. on driver level).

The following topics where addressed to give hawkBit users the flexibility they (or their DBAs) need:

* Removed the static isolation default definition from the transaction annotations. From now on a transaction defines an isolation only if it has defined needs (e.g. needs READ_COMMITED). Otherwise DB or driver/connection default is used.
  * Fixed several bugs where the repository was actually relying on READ_UNCOMMITED which is risky as not every DB might behave the way we implicitly expect here (i.e. read uncommitted results from other transactions).
* Set EclipseLink flush-mode to COMMIT. Again to ensure that transactions are not relying on an implicit mechanism in this case by means of how the EntityManager flushes inside the transaction.
  * Fixed bugs where in fact transactions worked only due to EclipseLinks default flush behaviour. Execute manual flushes in these cases.


Two smaller issues where addressed as well:

* Disabled auto commit as hawkBit by definition does everything in a transaction (something else would be a bug). We do not need it and this way the transaction manager is not forced to disable/enable it during transaction runtime.
* Removed springs `@Mofifying` annotation from our own transactions. This is actually a leftover back from the day as where the repository was deeply integrated with Spring Data.

Reviewers: @schabdo @michahirsch 