### PR TITLE
Fix Rollout UI performance.

### DIFF
--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
@@ -294,7 +294,7 @@ public abstract class AbstractIntegrationTest implements EnvironmentAware {
     public void cleanUp() {
         try {
             FileUtils.deleteDirectory(new File(artifactFilesystemProperties.getPath()));
-        } catch (final IOException e) {
+        } catch (final IOException | IllegalArgumentException e) {
             LOG.warn("Cannot cleanup file-directory", e);
         }
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
@@ -113,6 +113,11 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
         statusIconMap.put(RolloutStatus.DELETING, new StatusFontIcon(null, SPUIStyleDefinitions.STATUS_SPINNER_RED));
     }
 
+    private static final List<Object> HIDDEN_COLUMNS = Arrays.asList(SPUILabelDefinitions.VAR_NAME,
+            SPUILabelDefinitions.VAR_CREATED_DATE, SPUILabelDefinitions.VAR_CREATED_USER,
+            SPUILabelDefinitions.VAR_MODIFIED_DATE, SPUILabelDefinitions.VAR_MODIFIED_BY,
+            SPUILabelDefinitions.VAR_DESC);
+
     RolloutListGrid(final VaadinMessageSource i18n, final UIEventBus eventBus,
             final RolloutManagement rolloutManagement, final UINotification uiNotification,
             final RolloutUIState rolloutUIState, final SpPermissionChecker permissionChecker,
@@ -375,14 +380,7 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
 
     @Override
     protected void setHiddenColumns() {
-        final List<Object> columnsToBeHidden = new ArrayList<>();
-        columnsToBeHidden.add(SPUILabelDefinitions.VAR_NAME);
-        columnsToBeHidden.add(SPUILabelDefinitions.VAR_CREATED_DATE);
-        columnsToBeHidden.add(SPUILabelDefinitions.VAR_CREATED_USER);
-        columnsToBeHidden.add(SPUILabelDefinitions.VAR_MODIFIED_DATE);
-        columnsToBeHidden.add(SPUILabelDefinitions.VAR_MODIFIED_BY);
-        columnsToBeHidden.add(SPUILabelDefinitions.VAR_DESC);
-        for (final Object propertyId : columnsToBeHidden) {
+        for (final Object propertyId : HIDDEN_COLUMNS) {
             getColumn(propertyId).setHidden(true);
         }
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
@@ -82,8 +82,6 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
 
     private static final String DELETE_OPTION = "Delete";
 
-    private static final String IS_REQUIRED_MIGRATION_STEP = "isRequiredMigrationStep";
-
     private static final String ROLLOUT_RENDERER_DATA = "rolloutRendererData";
 
     private final transient RolloutManagement rolloutManagement;
@@ -219,7 +217,6 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
         rolloutGridContainer.addContainerProperty(SPUILabelDefinitions.VAR_NAME, String.class, "", false, false);
         rolloutGridContainer.addContainerProperty(ROLLOUT_RENDERER_DATA, RolloutRendererData.class, null, false, false);
         rolloutGridContainer.addContainerProperty(SPUILabelDefinitions.VAR_DESC, String.class, null, false, false);
-        rolloutGridContainer.addContainerProperty(IS_REQUIRED_MIGRATION_STEP, boolean.class, null, false, false);
         rolloutGridContainer.addContainerProperty(SPUILabelDefinitions.VAR_STATUS, RolloutStatus.class, null, false,
                 false);
         rolloutGridContainer.addContainerProperty(SPUILabelDefinitions.VAR_DIST_NAME_VERSION, String.class, null, false,
@@ -299,7 +296,6 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
     @Override
     protected void setColumnHeaderNames() {
         getColumn(ROLLOUT_RENDERER_DATA).setHeaderCaption(i18n.getMessage("header.name"));
-        getColumn(IS_REQUIRED_MIGRATION_STEP).setHeaderCaption(i18n.getMessage("header.migrations.step"));
         getColumn(SPUILabelDefinitions.VAR_DIST_NAME_VERSION)
                 .setHeaderCaption(i18n.getMessage("header.distributionset"));
         getColumn(SPUILabelDefinitions.VAR_NUMBER_OF_GROUPS).setHeaderCaption(i18n.getMessage("header.numberofgroups"));
@@ -352,7 +348,6 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
         final List<Object> columnList = new ArrayList<>();
         columnList.add(ROLLOUT_RENDERER_DATA);
         columnList.add(SPUILabelDefinitions.VAR_DIST_NAME_VERSION);
-        columnList.add(IS_REQUIRED_MIGRATION_STEP);
         columnList.add(SPUILabelDefinitions.VAR_STATUS);
         columnList.add(SPUILabelDefinitions.VAR_TOTAL_TARGETS_COUNT_STATUS);
         columnList.add(SPUILabelDefinitions.VAR_NUMBER_OF_GROUPS);
@@ -387,7 +382,6 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
         columnsToBeHidden.add(SPUILabelDefinitions.VAR_MODIFIED_DATE);
         columnsToBeHidden.add(SPUILabelDefinitions.VAR_MODIFIED_BY);
         columnsToBeHidden.add(SPUILabelDefinitions.VAR_DESC);
-        columnsToBeHidden.add(IS_REQUIRED_MIGRATION_STEP);
         for (final Object propertyId : columnsToBeHidden) {
             getColumn(propertyId).setHidden(true);
         }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
@@ -262,19 +262,19 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
     protected void setColumnExpandRatio() {
 
         getColumn(ROLLOUT_RENDERER_DATA).setMinimumWidth(40);
-        getColumn(ROLLOUT_RENDERER_DATA).setMaximumWidth(150);
+        getColumn(ROLLOUT_RENDERER_DATA).setMaximumWidth(300);
 
         getColumn(SPUILabelDefinitions.VAR_DIST_NAME_VERSION).setMinimumWidth(40);
-        getColumn(SPUILabelDefinitions.VAR_DIST_NAME_VERSION).setMaximumWidth(150);
+        getColumn(SPUILabelDefinitions.VAR_DIST_NAME_VERSION).setMaximumWidth(300);
 
-        getColumn(SPUILabelDefinitions.VAR_STATUS).setMinimumWidth(75);
-        getColumn(SPUILabelDefinitions.VAR_STATUS).setMaximumWidth(75);
+        getColumn(SPUILabelDefinitions.VAR_STATUS).setMinimumWidth(40);
+        getColumn(SPUILabelDefinitions.VAR_STATUS).setMaximumWidth(60);
 
         getColumn(SPUILabelDefinitions.VAR_TOTAL_TARGETS).setMinimumWidth(40);
-        getColumn(SPUILabelDefinitions.VAR_TOTAL_TARGETS).setMaximumWidth(100);
+        getColumn(SPUILabelDefinitions.VAR_TOTAL_TARGETS).setMaximumWidth(60);
 
         getColumn(SPUILabelDefinitions.VAR_NUMBER_OF_GROUPS).setMinimumWidth(40);
-        getColumn(SPUILabelDefinitions.VAR_NUMBER_OF_GROUPS).setMaximumWidth(100);
+        getColumn(SPUILabelDefinitions.VAR_NUMBER_OF_GROUPS).setMaximumWidth(60);
 
         getColumn(RUN_OPTION).setMinimumWidth(25);
         getColumn(RUN_OPTION).setMaximumWidth(25);

--- a/hawkbit-ui/src/main/resources/messages.properties
+++ b/hawkbit-ui/src/main/resources/messages.properties
@@ -483,7 +483,7 @@ header.assigned.ds = Assigned DS
 header.installed.ds = Installed DS
 header.target.status = Status
 header.target.tags = Tags
-header.total.targets = Total targets 
+header.total.targets = Targets 
 header.key = Key
 header.value = Value
 header.auto.assignment.ds = Auto assignment
@@ -505,7 +505,7 @@ label.no = No
 
 #rollout - start
 header.distributionset = Distribution set
-header.numberofgroups = No. of groups
+header.numberofgroups = Groups
 header.detail.status = Detail status
 
 header.rolloutgroup.installed.percentage = % Finished


### PR DESCRIPTION
Optimised DB calls on Rollouts Management UI:

* Optimised DB call for rollout status count to reduce cost (still a very expensive dude, we have to think about caching here imho).
* Removed lazy query N+1 calls in rollout view (DS fetched, everything else removed). removed broken DS tooltip as part of this.
* Removed N+1 calls for group complete percentage computation.

As always a bit more stream usage as well :)

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>