### PR TITLE
Remove nested cascade delete between rollout groups.

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_11_2__rollout_group_fix_cascade___H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_11_2__rollout_group_fix_cascade___H2.sql
@@ -1,0 +1,5 @@
+alter table sp_rolloutgroup drop constraint fk_rolloutgroup_rolloutgroup;
+alter table sp_rolloutgroup 
+        add constraint fk_rolloutgroup_rolloutgroup 
+        foreign key (parent_id) 
+        references sp_rolloutgroup (id);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_11_2__rollout_group_fix_cascade___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_11_2__rollout_group_fix_cascade___MYSQL.sql
@@ -1,0 +1,5 @@
+alter table sp_rolloutgroup drop FOREIGN KEY fk_rolloutgroup_rolloutgroup;
+alter table sp_rolloutgroup 
+        add constraint fk_rolloutgroup_rolloutgroup 
+        foreign key (parent_id) 
+        references sp_rolloutgroup (id);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -1457,14 +1457,14 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     @Test
     @ExpectEvents({ @Expect(type = RolloutDeletedEvent.class, count = 1),
             @Expect(type = DistributionSetCreatedEvent.class, count = 1),
-            @Expect(type = TargetCreatedEvent.class, count = 25), @Expect(type = RolloutUpdatedEvent.class, count = 2),
-            @Expect(type = RolloutGroupCreatedEvent.class, count = 5),
+            @Expect(type = TargetCreatedEvent.class, count = 115), @Expect(type = RolloutUpdatedEvent.class, count = 2),
+            @Expect(type = RolloutGroupCreatedEvent.class, count = 50),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
-            @Expect(type = RolloutGroupUpdatedEvent.class, count = 5) })
+            @Expect(type = RolloutGroupUpdatedEvent.class, count = 50) })
     public void deleteRolloutWhichHasNeverStartedIsHardDeleted() {
-        final int amountTargetsForRollout = 10;
+        final int amountTargetsForRollout = 100;
         final int amountOtherTargets = 15;
-        final int amountGroups = 5;
+        final int amountGroups = 50;
         final String successCondition = "50";
         final String errorCondition = "80";
         final Rollout createdRollout = createSimpleTestRolloutWithTargetsAndDistributionSet(amountTargetsForRollout,


### PR DESCRIPTION
Removed cascade delete from inter rollout group relationship. This does not help with the delete as the cascade comes already from the rollout itself. 

While unnecessary it does causes problems on certain DB engines (e.g. InnoDB)

See https://dev.mysql.com/doc/refman/5.7/en/innodb-foreign-key-constraints.html which sais:
"Cascading operations may not be nested more than 15 levels deep"

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>