### PR TITLE
DDI API: Extend API response to report previous update execution status.

### DIFF
--- a/docs/src/main/resources/documentation/interfaces/ddi-api.md
+++ b/docs/src/main/resources/documentation/interfaces/ddi-api.md
@@ -97,7 +97,14 @@ _Example Response_
             }
         ]
     },
-    "id": "1"
+    "id": "1",
+    "actionHistory": {
+        "status": "RETRIEVED",
+        "messages": [
+            "Installing update",
+            "Downloading artifacts"
+            ]
+    }
 }
 ```
 

--- a/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistory.java
+++ b/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistory.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Siemens AG, 2017
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.ddi.json.model;
+
+import java.util.List;
+
+import org.eclipse.hawkbit.ddi.rest.api.DdiRootControllerRestApi;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * Provide action history information to the controller as part of response to
+ * {@link DdiRootControllerRestApi#getControllerBasedeploymentAction}: 1.
+ * Current action status at the server; 2. List of messages from action history
+ * that were sent to server earlier by the controller using
+ * {@link DdiActionFeedback}.
+ */
+
+@JsonPropertyOrder({ "status", "messages" })
+public class DdiActionHistory {
+
+    @JsonProperty("status")
+    private final String actionStatus;
+
+    @JsonProperty("messages")
+    private final List<String> messages;
+
+    /**
+     * Parameterized constructor for creating {@link DdiActionHistory}.
+     *
+     * @param actionStatus
+     *            is the current action status at the server
+     * @param messages
+     *            is a list of messages retrieved from action history.
+     */
+    @JsonCreator
+    public DdiActionHistory(@JsonProperty("status") final String actionStatus,
+            @JsonProperty("messages") List<String> messages) {
+        this.actionStatus = actionStatus;
+        this.messages = messages;
+    }
+
+    @Override
+    public String toString() {
+        return "Action history [" + "status=" + actionStatus + ", messages={" + messages.toString() + "}]";
+    }
+}

--- a/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBase.java
+++ b/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBase.java
@@ -13,19 +13,31 @@ import javax.validation.constraints.NotNull;
 import org.springframework.hateoas.ResourceSupport;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * Update action resource.
  */
+@JsonPropertyOrder({ "id", "deployment", "actionHistory" })
 public class DdiDeploymentBase extends ResourceSupport {
 
     @JsonProperty("id")
     @NotNull
     private final String deplyomentId;
 
+    @JsonProperty("deployment")
     @NotNull
     private final DdiDeployment deployment;
+
+    /**
+     * Action history containing current action status and a list of feedback
+     * messages received earlier from the controller.
+     */
+    @JsonProperty("actionHistory")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final DdiActionHistory actionHistory;
 
     /**
      * Constructor.
@@ -33,22 +45,38 @@ public class DdiDeploymentBase extends ResourceSupport {
      * @param id
      *            of the update action
      * @param deployment
-     *            details.
+     *            details
+     * @param actionHistory
+     *            containing current action status and a list of feedback
+     *            messages received earlier from the controller.
      */
     @JsonCreator
     public DdiDeploymentBase(@JsonProperty("id") final String id,
-            @JsonProperty("deplyomentId") final DdiDeployment deployment) {
+            @JsonProperty("deplyomentId") final DdiDeployment deployment,
+            @JsonProperty("actionHistory") final DdiActionHistory actionHistory) {
         this.deplyomentId = id;
         this.deployment = deployment;
+        this.actionHistory = actionHistory;
     }
 
     public DdiDeployment getDeployment() {
         return deployment;
     }
 
+    /**
+     * Returns the action history containing current action status and a list of
+     * feedback messages received earlier from the controller.
+     *
+     * @return {@link DdiActionHistory}
+     */
+    public DdiActionHistory getActionHistory() {
+        return actionHistory;
+    }
+
     @Override
     public String toString() {
-        return "DeploymentBase [id=" + deplyomentId + ", deployment=" + deployment + "]";
+        return "DeploymentBase [id=" + deplyomentId + ", deployment=" + deployment + " actionHistory="
+                + actionHistory.toString() + "]";
     }
 
 }

--- a/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiStatus.java
+++ b/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiStatus.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,6 +32,7 @@ public class DdiStatus {
     @Valid
     private final DdiResult result;
 
+    @Size(min = 0, max = 50)
     private final List<String> details;
 
     /**

--- a/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/rest/api/DdiRestConstants.java
+++ b/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/rest/api/DdiRestConstants.java
@@ -43,6 +43,13 @@ public final class DdiRestConstants {
      */
     public static final String CONFIG_DATA_ACTION = "configData";
 
+    /**
+     * Default value specifying that no action history to be sent as part of
+     * response to deploymentBase
+     * {@link DdiRootControllerRestApi#getControllerBasedeploymentAction}.
+     */
+    public static final String NO_ACTION_HISTORY = "0";
+
     private DdiRestConstants() {
         // constant class, private constructor.
     }

--- a/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/rest/api/DdiRootControllerRestApi.java
+++ b/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/rest/api/DdiRootControllerRestApi.java
@@ -136,6 +136,17 @@ public interface DdiRootControllerRestApi {
      *            an hashcode of the resource which indicates if the action has
      *            been changed, e.g. from 'soft' to 'force' and the eTag needs
      *            to be re-generated
+     * @param actionHistoryMessageCount
+     *            specifies the number of messages to be returned from action
+     *            history. Regardless of the passed value, in order to restrict
+     *            resource utilization by controllers, maximum number of
+     *            messages that are retrieved from database is limited by
+     *            {@link RepositoryConstants#MAX_ACTION_HISTORY_MSG_COUNT}.
+     *            actionHistoryMessageCount < 0, retrieves the maximum allowed
+     *            number of action status messages from history;
+     *            actionHistoryMessageCount = 0, does not retrieve any message;
+     *            and actionHistoryMessageCount > 0, retrieves the specified
+     *            number of messages, limited by maximum allowed number.
      * @param request
      *            the HTTP request injected by spring
      * @return the response
@@ -146,7 +157,8 @@ public interface DdiRootControllerRestApi {
     ResponseEntity<DdiDeploymentBase> getControllerBasedeploymentAction(@PathVariable("tenant") final String tenant,
             @PathVariable("controllerId") @NotEmpty final String controllerId,
             @PathVariable("actionId") @NotEmpty final Long actionId,
-            @RequestParam(value = "c", required = false, defaultValue = "-1") final int resource);
+            @RequestParam(value = "c", required = false, defaultValue = "-1") final int resource,
+            @RequestParam(value = "actionHistory", defaultValue = DdiRestConstants.NO_ACTION_HISTORY) final Integer actionHistoryMessageCount);
 
     /**
      * This is the feedback channel for the {@link DdiDeploymentBase} action.

--- a/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DataConversionHelper.java
+++ b/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DataConversionHelper.java
@@ -118,7 +118,7 @@ public final class DataConversionHelper {
                 result.add(ControllerLinkBuilder
                         .linkTo(ControllerLinkBuilder.methodOn(DdiRootController.class, tenantAware.getCurrentTenant())
                                 .getControllerBasedeploymentAction(tenantAware.getCurrentTenant(),
-                                        target.getControllerId(), action.getId(), calculateEtag(action)))
+                                        target.getControllerId(), action.getId(), calculateEtag(action), null))
                         .withRel(DdiRestConstants.DEPLOYMENT_BASE_ACTION));
             }
         }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.repository;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -317,4 +318,30 @@ public interface ControllerManagement {
             + SpringEvalExpressions.IS_SYSTEM_CODE)
     Optional<Target> findByTargetId(@NotNull Long targetId);
 
+    /**
+     * Retrieves the specified number of messages from action history of the
+     * given {@link Action} based on messageCount. Regardless of the value of
+     * messageCount, in order to restrict resource utilization by controllers,
+     * maximum number of messages that are retrieved from database is limited by
+     * {@link RepositoryConstants#MAX_ACTION_HISTORY_MSG_COUNT}. messageCount <
+     * 0, retrieves the maximum allowed number of action status messages from
+     * history; messageCount = 0, does not retrieve any message; and
+     * messageCount > 0, retrieves the specified number of messages, limited by
+     * maximum allowed number. A controller sends the feedback for an
+     * {@link ActionStatus} as a list of messages; while returning the messages,
+     * even though the messages from multiple {@link ActionStatus} are retrieved
+     * in descending order by the reported time
+     * ({@link ActionStatus#getOccurredAt()}), i.e. latest ActionStatus first,
+     * the sub-ordering of messages from within single {@link ActionStatus} is
+     * unspecified.
+     *
+     * @param actionId
+     *            to be filtered on
+     * @param messageCount
+     *            is the number of messages to return from history
+     *
+     * @return action history.
+     */
+    @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
+    List<String> getActionHistoryMessages(@NotNull Long actionId, final int messageCount);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RepositoryConstants.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RepositoryConstants.java
@@ -30,6 +30,12 @@ public final class RepositoryConstants {
      */
     public static final int DEFAULT_DS_TYPES_IN_TENANT = 2;
 
+    /**
+     * Maximum number of messages that can be retrieved by a controller for an
+     * {@link Action}.
+     */
+    public static final int MAX_ACTION_HISTORY_MSG_COUNT = 100;
+
     private RepositoryConstants() {
         // Utility class.
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionStatusRepository.java
@@ -17,6 +17,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -63,4 +65,21 @@ public interface ActionStatusRepository
      */
     @EntityGraph(value = "ActionStatus.withMessages", type = EntityGraphType.LOAD)
     Page<ActionStatus> getByActionId(Pageable pageReq, Long actionId);
+
+    /**
+     * Finds a filtered list of status messages for an action.
+     *
+     * @param pageable
+     *            for page configuration
+     * @param actionId
+     *            for which to get the status messages
+     * @param filter
+     *            is the SQL like pattern to use for filtering out or excluding
+     *            the messages
+     *
+     * @return Page with found status messages.
+     */
+    @Query("SELECT message FROM JpaActionStatus actionstatus JOIN actionstatus.messages message WHERE actionstatus.action.id = :actionId AND message NOT LIKE :filter")
+    Page<String> findMessagesByActionIdAndMessageNotLike(final Pageable pageable, @Param("actionId") Long actionId,
+            @Param("filter") String filter);
 }


### PR DESCRIPTION
Resolves #381

The mechanism is useful for example, when the client software running on
the device loses this information prior to reporting a final execution
status such as 'closed' to hawkBit. This may happen, e.g., due to a
power cycle or simply a crash. Upon the client software restarting, it
installs the same payload again as advertised by hawkBit (as the device
has not sent a final update execution status). Instead, if the last
feedback sent to hawkBit would be reported back to the device, the
client may resume installation.

Feedback messages sent as part of POST
    /{tenant}/controller/v1/{targetid}/deploymentBase/{actionId}/feedback,
are sent back to controller as part of response to GET
    /{tenant}/controller/v1/{targetid}/deploymentBase/{actionId}.

Following example illustrates the API changes:

1. After retrieving the action from server, controller sends:
curl
'http://127.0.0.1:8080/default/controller/v1/1/deploymentBase/1/feedback'
-i -X POST -H 'Content-Type: application/json;charset=UTF-8' -H 'Accept:
application/hal+json' -d '{
  "id" : "1",
  "time" : "20170406T121500",
  "status" : {
    "result" : {
      "progress" : {
        "of" : 1,
        "cnt" : 0
      },
      "finished" : "none"
    },
    "execution" : "proceeding",
    "details" : [ "proceeding with download" ]
  }
}'

2. Once finished downloading the artifact, controller sends
curl
'http://127.0.0.1:8080/default/controller/v1/1/deploymentBase/1/feedback'
-i -X POST -H 'Content-Type: application/json;charset=UTF-8' -H 'Accept:
application/hal+json' -d '{
{
  "id" : "1",
  "time" : "20170406T123000",
  "status" : {
    "result" : {
      "progress" : {
        "of" : 1,
        "cnt" : 0
      },
      "finished" : "none"
    },
    "execution" : "proceeding",
    "details" : [ "downloaded artifacts for update" ]
  }
}'

3. If there is a power outage now, the controller can retrieve the
action again when it restarts.
curl
'http://127.0.0.1:8080/default/controller/v1/1/deploymentBase/1?c=411599879'
-i -H 'Accept: application/hal+json'

Response will be like below
{
  "id": "1",
  "deployment": {
    "download": "forced",
    "update": "forced",
    "chunks": [
      {
      "part": "os",
      "version": "1",
      "name": "1",
      "artifacts": [....],
      }
    ],
  },
  "previousfeedback": {
    "status": "RETRIEVED",
    "type": "FORCED",
    "forcetime": 0,
    "messages": [
      "Update Server: Target retrieved update action and should start
now the download.",
      "Update Server: Target reported PROCEEDING at 20170406T121500",
      "proceeding with download",
      "Update Server: Target retrieved update action and should start
now the download.",
      "Update Server: Target reported PROCEEDING at 20170406T123000",
      "downloaded artifacts for update"
    ],
  }
}

4. Based on the feedback messages, controller may be able to skip the
download and resume with installation and send additional feedback
curl
'http://127.0.0.1:8080/default/controller/v1/1/deploymentBase/1/feedback'
-i -X POST -H 'Content-Type: application/json;charset=UTF-8' -H 'Accept:
application/hal+json' -d '{
  "id" : "1",
  "time" : "20170406T121314",
  "status" : {
    "result" : {
      "progress" : {
        "of" : 1,
        "cnt" : 0
      },
      "finished" : "none"
    },
    "execution" : "resumed",
    "details" : [ "resuming installation based on previous feedback,
download skipped" ]
  }
}'

Signed-off-by: Christian Storm <christian.storm@siemens.com>
Signed-off-by: Himanshu Kumar Singh <himanshu.singh@siemens.com>
Signed-off-by: Raju HS <raju.hs@siemens.com>