### PR TITLE
remove license:check from sonar-build due multiple copyrights problem

### DIFF
--- a/sonarCircleCi.sh
+++ b/sonarCircleCi.sh
@@ -15,7 +15,7 @@ if [ "$CIRCLE_BRANCH" = "master" ]; then
 # preview in case of pull request - disabled as circle does not fill those with pull reuqests from different directories
 else
   #if [ -n "$CI_PULL_REQUEST" ]; then
-  #  mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify license:check sonar:sonar -B -e -V \
+  #  mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B -e -V \
   #    -Dclirr=true \
   #    -Dsonar.analysis.mode=issues \
   #    -Dsonar.github.pullRequest=`echo $CI_PULL_REQUEST| awk -F'/' '{print $7}'` \
@@ -24,7 +24,7 @@ else
   #    -Dsonar.login=$SONAR_SERVER_USER \
   #    -Dsonar.password=$SONAR_SERVER_PASSWD
   #else
-    mvn verify license:check
+    mvn verify
   #fi
 fi
-# but noting in case of other branches
+# but nothing in case of other branches


### PR DESCRIPTION
Removing the `license:check` goal from the sonar-build due problems of multiple copyrights e.g. from pull-requests from other organizations.

Related #506.

There is no easy way to support a template with the mycila license-plugin to allow different copyrights.
See https://github.com/mycila/license-maven-plugin/issues/119

The eclipse-che project are also looking for a solution
https://github.com/eclipse/che/issues/3281

Signed-off-by: Michael Hirsch <michael.hirsch@bosch-si.com>