### PR TITLE
Correct the sql query for filtering distribution sets by tags

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/DistributionSetSpecification.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/DistributionSetSpecification.java
@@ -27,6 +27,7 @@ import org.eclipse.hawkbit.repository.jpa.model.JpaTarget_;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Specifications class for {@link DistributionSet}s. The class provides Spring
@@ -145,7 +146,7 @@ public final class DistributionSetSpecification {
         tags.get(JpaDistributionSetTag_.name);
         final Path<String> exp = tags.get(JpaDistributionSetTag_.name);
         if (selectDSWithNoTag != null && selectDSWithNoTag) {
-            if (tagNames != null) {
+            if (!CollectionUtils.isEmpty(tagNames)) {
                 return cb.or(exp.isNull(), exp.in(tagNames));
             } else {
                 return exp.isNull();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtons.java
@@ -27,6 +27,7 @@ import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
+import org.springframework.util.StringUtils;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
 import org.vaadin.spring.events.EventBus.UIEventBus;
@@ -94,7 +95,7 @@ public class DistributionTagButtons extends AbstractFilterButtons implements Ref
 
     @Override
     protected String createButtonId(final String name) {
-        return name;
+        return StringUtils.trimAllWhitespace(name);
     }
 
     @Override


### PR DESCRIPTION
While filtering distribution sets by tag on the Deployment View, the sql query to get the result of the database consists of multiple parameters. One parameter contains other tag names which can be selected at the same time. It is necessary to check if the collection containing the other tag names is empty. A null check is not enough.
Furthermore the ids of entity tags should not contain whitespaces.

Signed-off-by: Melanie Retter <melanie.retter@bosch-si.com>