### PR TITLE
Fix to many request filter URL configuration

### DIFF
--- a/hawkbit-autoconfigure/src/main/resources/hawkbitdefaults.properties
+++ b/hawkbit-autoconfigure/src/main/resources/hawkbitdefaults.properties
@@ -15,6 +15,9 @@ security.basic.realm=HawkBit
 security.user.name=admin
 security.user.password=admin
 
+# Ensure that DosFilter runs before Spring Security
+security.filter-order=5
+
 # Spring cloud bus and stream
 spring.cloud.bus.enabled=false
 # Disable Cloud Bus default events 

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/DosFilter.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/DosFilter.java
@@ -48,8 +48,8 @@ public class DosFilter extends OncePerRequestFilter {
     private final Cache<String, AtomicInteger> writeCountCache = CacheBuilder.newBuilder()
             .expireAfterAccess(1, TimeUnit.SECONDS).build();
 
-    private final Integer maxRead;
-    private final Integer maxWrite;
+    private final int maxRead;
+    private final int maxWrite;
 
     private final Pattern whitelist;
 
@@ -73,7 +73,7 @@ public class DosFilter extends OncePerRequestFilter {
      *            the header containing the forwarded IP address e.g.
      *            {@code x-forwarded-for}
      */
-    public DosFilter(final Integer maxRead, final Integer maxWrite, final String ipDosWhiteListPattern,
+    public DosFilter(final int maxRead, final int maxWrite, final String ipDosWhiteListPattern,
             final String ipBlackListPattern, final String forwardHeader) {
 
         this.maxRead = maxRead;

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/HawkbitSecurityProperties.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/HawkbitSecurityProperties.java
@@ -40,8 +40,7 @@ public class HawkbitSecurityProperties {
         private String blacklist = "";
 
         /**
-         * Name of the http header from which the remote ip is extracted for DDI
-         * connected clients.
+         * Name of the http header from which the remote ip is extracted.
          */
         private String remoteIpHeader = "X-Forwarded-For";
 
@@ -98,6 +97,11 @@ public class HawkbitSecurityProperties {
         private int maxRolloutGroupsPerRollout = 500;
 
         private final Filter filter = new Filter();
+        private final Filter uiFilter = new Filter();
+
+        public Filter getUiFilter() {
+            return uiFilter;
+        }
 
         public Filter getFilter() {
             return filter;


### PR DESCRIPTION
The filter configuration was broken due to wrong URL regex configured.

While this filter can only be the last line of defence in case of a real attack (when the attacker is in the servlet filter it is actually to late imho.) it does help to protect against unintended misuse.

Set order before spring security and added a config for the UI

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>