### PR TITLE
ArtifactRepository tenant aware.

### DIFF
--- a/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatorStartup.java
+++ b/examples/hawkbit-device-simulator/src/main/java/org/eclipse/hawkbit/simulator/SimulatorStartup.java
@@ -16,8 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
 
 /**
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @ConditionalOnProperty(prefix = "hawkbit.device.simulator", name = "autostart", matchIfMissing = true)
-public class SimulatorStartup implements ApplicationListener<ContextRefreshedEvent> {
+public class SimulatorStartup implements ApplicationListener<ApplicationReadyEvent> {
     private static final Logger LOGGER = LoggerFactory.getLogger(SimulatorStartup.class);
 
     @Autowired
@@ -42,7 +42,7 @@ public class SimulatorStartup implements ApplicationListener<ContextRefreshedEve
     private AmqpProperties amqpProperties;
 
     @Override
-    public void onApplicationEvent(final ContextRefreshedEvent event) {
+    public void onApplicationEvent(final ApplicationReadyEvent event) {
         simulationProperties.getAutostarts().forEach(autostart -> {
             for (int i = 0; i < autostart.getAmount(); i++) {
                 final String deviceId = autostart.getName() + i;

--- a/extensions/hawkbit-extension-artifact-repository-mongo/pom.xml
+++ b/extensions/hawkbit-extension-artifact-repository-mongo/pom.xml
@@ -54,6 +54,11 @@
          <artifactId>allure-junit-adaptor</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter-logging</artifactId>
+         <scope>test</scope>
+      </dependency>
       <!-- MongoDB -->
       <dependency>
          <groupId>de.flapdoodle.embed</groupId>

--- a/extensions/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStore.java
+++ b/extensions/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStore.java
@@ -76,7 +76,7 @@ public class MongoDBArtifactStore implements ArtifactRepository {
 
     private final GridFsOperations gridFs;
 
-    protected MongoDBArtifactStore(final GridFsOperations gridFs) {
+    MongoDBArtifactStore(final GridFsOperations gridFs) {
         this.gridFs = gridFs;
     }
 

--- a/extensions/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStore.java
+++ b/extensions/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStore.java
@@ -253,7 +253,7 @@ public class MongoDBArtifactStore implements ArtifactRepository {
     }
 
     @Override
-    public void deleteTenant(final String tenant) {
+    public void deleteByTenant(final String tenant) {
         try {
             gridFs.delete(new Query().addCriteria(Criteria.where(TENANT_QUERY).is(sanitizeTenant(tenant))));
         } catch (final MongoClientException e) {

--- a/extensions/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStore.java
+++ b/extensions/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStore.java
@@ -24,13 +24,13 @@ import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
+import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.gridfs.GridFsOperations;
+import org.springframework.validation.annotation.Validated;
 
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteStreams;
@@ -44,6 +44,7 @@ import com.mongodb.gridfs.GridFSFile;
  * The file management which looks up all the file in the file tore.
  *
  */
+@Validated
 public class MongoDBArtifactStore implements ArtifactRepository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDBArtifactStore.class);
@@ -56,9 +57,14 @@ public class MongoDBArtifactStore implements ArtifactRepository {
     private static final String FILENAME = "filename";
 
     /**
-     * The mongoDB field which automatically calculated by the mongoDB.
+     * The mongoDB field which holds the tenant of the file to download.
      */
-    private static final String MD5 = "md5";
+    private static final String TENANT = "tenant";
+
+    /**
+     * Query by {@link TenantAware} field.
+     */
+    private static final String TENANT_QUERY = "metadata." + TENANT;
 
     /**
      * The mongoDB field which holds the SHA1 hash, stored in the meta data
@@ -68,10 +74,11 @@ public class MongoDBArtifactStore implements ArtifactRepository {
 
     private static final String ID = "_id";
 
-    @Autowired
-    private GridFsOperations gridFs;
+    private final GridFsOperations gridFs;
 
-    MongoTemplate mongoTemplate;
+    protected MongoDBArtifactStore(final GridFsOperations gridFs) {
+        this.gridFs = gridFs;
+    }
 
     /**
      * Retrieves a {@link GridFSDBFile} from the store by it's SHA1 hash.
@@ -82,36 +89,28 @@ public class MongoDBArtifactStore implements ArtifactRepository {
      * @return The DbArtifact object or {@code null} if no file exists.
      */
     @Override
-    public DbArtifact getArtifactBySha1(final String sha1Hash) {
-        return map(gridFs.findOne(new Query().addCriteria(Criteria.where(FILENAME).is(sha1Hash))));
-    }
+    public DbArtifact getArtifactBySha1(final String tenant, final String sha1Hash) {
 
-    /**
-     * Retrieves a {@link GridFSDBFile} from the store by it's MD5 hash.
-     * 
-     * @param md5Hash
-     *            the md5-hash of the file to lookup.
-     * @return The gridfs file object or {@code null} if no file exists.
-     */
-    public DbArtifact getArtifactByMd5(final String md5Hash) {
-        return map(gridFs.findOne(new Query().addCriteria(Criteria.where(MD5).is(md5Hash))));
+        return map(gridFs.findOne(new Query()
+                .addCriteria(Criteria.where(FILENAME).is(sha1Hash).and(TENANT_QUERY).is(tenant.toUpperCase()))));
     }
 
     @Override
-    public DbArtifact store(final InputStream content, final String filename, final String contentType) {
-        return store(content, filename, contentType, null);
+    public DbArtifact store(final String tenant, final InputStream content, final String filename,
+            final String contentType) {
+        return store(tenant, content, filename, contentType, null);
     }
 
     @Override
-    public DbArtifact store(final InputStream content, final String filename, final String contentType,
-            final DbArtifactHash hash) {
+    public DbArtifact store(final String tenant, final InputStream content, final String filename,
+            final String contentType, final DbArtifactHash hash) {
         File tempFile = null;
         try {
             LOGGER.debug("storing file {} of content {}", filename, contentType);
             tempFile = File.createTempFile("uploadFile", null);
             try (final BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(tempFile))) {
                 try (BufferedInputStream bis = new BufferedInputStream(content)) {
-                    return store(bis, contentType, bos, tempFile, hash);
+                    return store(tenant, bis, contentType, bos, tempFile, hash);
                 }
             }
         } catch (final IOException | MongoException e1) {
@@ -124,9 +123,10 @@ public class MongoDBArtifactStore implements ArtifactRepository {
     }
 
     @Override
-    public void deleteBySha1(final String sha1Hash) {
+    public void deleteBySha1(final String tenant, final String sha1Hash) {
         try {
-            deleteArtifact(gridFs.findOne(new Query().addCriteria(Criteria.where(FILENAME).is(sha1Hash))));
+            deleteArtifact(gridFs.findOne(new Query()
+                    .addCriteria(Criteria.where(FILENAME).is(sha1Hash).and(TENANT_QUERY).is(tenant.toUpperCase()))));
         } catch (final MongoException e) {
             throw new ArtifactStoreException(e.getMessage(), e);
         }
@@ -143,18 +143,20 @@ public class MongoDBArtifactStore implements ArtifactRepository {
 
     }
 
-    private DbArtifact store(final InputStream content, final String contentType, final OutputStream os,
-            final File tempFile, final DbArtifactHash hash) {
+    private DbArtifact store(final String tenant, final InputStream content, final String contentType,
+            final OutputStream os, final File tempFile, final DbArtifactHash hash) {
         final GridFsArtifact storedArtifact;
         try {
             final String sha1Hash = computeSHA1Hash(content, os, hash != null ? hash.getSha1() : null);
             // upload if it does not exist already, check if file exists, not
             // tenant specific.
-            final GridFSDBFile result = gridFs.findOne(new Query().addCriteria(Criteria.where(FILENAME).is(sha1Hash)));
+            final GridFSDBFile result = gridFs.findOne(new Query()
+                    .addCriteria(Criteria.where(FILENAME).is(sha1Hash).and(TENANT_QUERY).is(tenant.toUpperCase())));
             if (null == result) {
                 try (FileInputStream inputStream = new FileInputStream(tempFile)) {
                     final BasicDBObject metadata = new BasicDBObject();
                     metadata.put(SHA1, sha1Hash);
+                    metadata.put(TENANT, tenant.toUpperCase());
                     storedArtifact = map(gridFs.store(inputStream, sha1Hash, contentType, metadata));
                 }
             } else {
@@ -243,5 +245,14 @@ public class MongoDBArtifactStore implements ArtifactRepository {
         artifact.setContentType(fsFile.getContentType());
         artifact.setHashes(new DbArtifactHash(fsFile.getFilename(), fsFile.getMD5()));
         return artifact;
+    }
+
+    @Override
+    public void deleteTenant(final String tenant) {
+        try {
+            gridFs.delete(new Query().addCriteria(Criteria.where(TENANT_QUERY).is(tenant.toUpperCase())));
+        } catch (final MongoClientException e) {
+            throw new ArtifactStoreException(e.getMessage(), e);
+        }
     }
 }

--- a/extensions/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreAutoConfiguration.java
+++ b/extensions/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreAutoConfiguration.java
@@ -8,7 +8,6 @@
  */
 package org.eclipse.hawkbit.artifact.repository;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,7 +26,6 @@ public class MongoDBArtifactStoreAutoConfiguration {
      * @return Default {@link ArtifactRepository} implementation.
      */
     @Bean
-    @ConditionalOnMissingBean
     ArtifactRepository artifactRepository(final GridFsOperations gridFs) {
         return new MongoDBArtifactStore(gridFs);
     }

--- a/extensions/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreAutoConfiguration.java
+++ b/extensions/hawkbit-extension-artifact-repository-mongo/src/main/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreAutoConfiguration.java
@@ -8,10 +8,12 @@
  */
 package org.eclipse.hawkbit.artifact.repository;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.mongodb.gridfs.GridFsOperations;
 
 /**
  * Auto configuration for the {@link MongoDBArtifactStore}.
@@ -25,7 +27,8 @@ public class MongoDBArtifactStoreAutoConfiguration {
      * @return Default {@link ArtifactRepository} implementation.
      */
     @Bean
-    public ArtifactRepository artifactRepository() {
-        return new MongoDBArtifactStore();
+    @ConditionalOnMissingBean
+    ArtifactRepository artifactRepository(final GridFsOperations gridFs) {
+        return new MongoDBArtifactStore(gridFs);
     }
 }

--- a/extensions/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
+++ b/extensions/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
@@ -64,7 +64,7 @@ public class MongoDBArtifactStoreTest {
     }
 
     @Test
-    @Description("Deltes file from repoeitory identified ny SHA1 hash as filename.")
+    @Description("Deletes file from repository identified by SHA1 hash as filename.")
     public void deleteArtifactBySHA1Hash() throws NoSuchAlgorithmException {
         final int filelengthBytes = 128;
         final String filename = "testfile.json";
@@ -77,7 +77,7 @@ public class MongoDBArtifactStoreTest {
     }
 
     @Test
-    @Description("Verfies that all data of a tenant is erased if repositoty is asked to do so. "
+    @Description("Verfies that all data of a tenant is erased if repository is asked to do so. "
             + "Data of other tenants is not affected.")
     public void deleteTenant() throws NoSuchAlgorithmException {
         final int filelengthBytes = 128;
@@ -87,7 +87,8 @@ public class MongoDBArtifactStoreTest {
         final String shaDeleted = storeAndVerify(TENANT, filelengthBytes, filename, contentType);
         final String shaUndeleted = storeAndVerify("another_tenant", filelengthBytes, filename, contentType);
 
-        artifactStoreUnderTest.deleteTenant(TENANT);
+        artifactStoreUnderTest.deleteByTenant("tenant_that_does_not_exist");
+        artifactStoreUnderTest.deleteByTenant(TENANT);
         assertThat(artifactStoreUnderTest.getArtifactBySha1(TENANT, shaDeleted)).isNull();
         assertThat(artifactStoreUnderTest.getArtifactBySha1("another_tenant", shaUndeleted)).isNotNull();
     }

--- a/extensions/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
+++ b/extensions/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
@@ -20,29 +20,28 @@ import org.eclipse.hawkbit.artifact.TestConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.data.mongodb.gridfs.GridFsOperations;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.google.common.io.BaseEncoding;
 
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Step;
 import ru.yandex.qatools.allure.annotations.Stories;
 
 @Features("Component Tests - Repository")
 @Stories("Artifact Store MongoDB")
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = { MongoDBArtifactStoreAutoConfiguration.class, TestConfiguration.class })
-@TestPropertySource(properties = { "spring.data.mongodb.port=0", "spring.mongodb.embedded.version=3.2.7" })
+@SpringBootTest(classes = { MongoDBArtifactStoreAutoConfiguration.class, TestConfiguration.class }, properties = {
+        "spring.data.mongodb.port=0", "spring.mongodb.embedded.version=3.4.4",
+        "logging.level.org.springframework.data.mongodb=DEBUG" }, webEnvironment = WebEnvironment.NONE)
 public class MongoDBArtifactStoreTest {
+    private static final String TENANT = "test_tenant";
 
     @Autowired
     private MongoDBArtifactStore artifactStoreUnderTest;
-
-    @Autowired
-    private GridFsOperations gridFs;
 
     @Test
     @Description("Ensures that search by SHA1 hash (which is used by hawkBit as artifact ID) finds the expected results.")
@@ -51,23 +50,48 @@ public class MongoDBArtifactStoreTest {
         final String filename = "testfile.json";
         final String contentType = "application/json";
 
+        storeAndVerify(TENANT, filelengthBytes, filename, contentType);
+    }
+
+    @Step
+    private String storeAndVerify(final String tenant, final int filelengthBytes, final String filename,
+            final String contentType) throws NoSuchAlgorithmException {
+
         final DigestInputStream digestInputStream = digestInputStream(generateInputStream(filelengthBytes), "SHA-1");
-        artifactStoreUnderTest.store(digestInputStream, filename, contentType);
-        assertThat(artifactStoreUnderTest.getArtifactBySha1(
-                BaseEncoding.base16().lowerCase().encode(digestInputStream.getMessageDigest().digest()))).isNotNull();
+        artifactStoreUnderTest.store(tenant, digestInputStream, filename, contentType);
+
+        final String sha1 = BaseEncoding.base16().lowerCase().encode(digestInputStream.getMessageDigest().digest());
+        assertThat(artifactStoreUnderTest.getArtifactBySha1(tenant, sha1)).isNotNull();
+        return sha1;
     }
 
     @Test
-    @Description("Ensures that search by MD5 hash finds the expected results.")
-    public void findArtifactByMD5Hash() throws NoSuchAlgorithmException {
+    @Description("Deltes file from repoeitory identified ny SHA1 hash as filename.")
+    public void deleteArtifactBySHA1Hash() throws NoSuchAlgorithmException {
         final int filelengthBytes = 128;
         final String filename = "testfile.json";
         final String contentType = "application/json";
 
-        final DigestInputStream digestInputStream = digestInputStream(generateInputStream(filelengthBytes), "MD5");
-        artifactStoreUnderTest.store(digestInputStream, filename, contentType);
-        assertThat(artifactStoreUnderTest.getArtifactByMd5(
-                BaseEncoding.base16().lowerCase().encode(digestInputStream.getMessageDigest().digest()))).isNotNull();
+        final String sha1 = storeAndVerify(TENANT, filelengthBytes, filename, contentType);
+
+        artifactStoreUnderTest.deleteBySha1(TENANT, sha1);
+        assertThat(artifactStoreUnderTest.getArtifactBySha1(TENANT, sha1)).isNull();
+    }
+
+    @Test
+    @Description("Verfies that all data of a tenant is erased if repositoty is asked to do so. "
+            + "Data of other tenants is not affected.")
+    public void deleteTenant() throws NoSuchAlgorithmException {
+        final int filelengthBytes = 128;
+        final String filename = "testfile.json";
+        final String contentType = "application/json";
+
+        final String shaDeleted = storeAndVerify(TENANT, filelengthBytes, filename, contentType);
+        final String shaUndeleted = storeAndVerify("another_tenant", filelengthBytes, filename, contentType);
+
+        artifactStoreUnderTest.deleteTenant(TENANT);
+        assertThat(artifactStoreUnderTest.getArtifactBySha1(TENANT, shaDeleted)).isNull();
+        assertThat(artifactStoreUnderTest.getArtifactBySha1("another_tenant", shaUndeleted)).isNotNull();
     }
 
     private static ByteArrayInputStream generateInputStream(final int length) {

--- a/extensions/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
+++ b/extensions/hawkbit-extension-artifact-repository-mongo/src/test/java/org/eclipse/hawkbit/artifact/repository/MongoDBArtifactStoreTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.google.common.io.BaseEncoding;
@@ -35,8 +34,7 @@ import ru.yandex.qatools.allure.annotations.Stories;
 @Stories("Artifact Store MongoDB")
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = { MongoDBArtifactStoreAutoConfiguration.class, TestConfiguration.class }, properties = {
-        "spring.data.mongodb.port=0", "spring.mongodb.embedded.version=3.4.4",
-        "logging.level.org.springframework.data.mongodb=DEBUG" }, webEnvironment = WebEnvironment.NONE)
+        "spring.data.mongodb.port=0", "spring.mongodb.embedded.version=3.4.4" })
 public class MongoDBArtifactStoreTest {
     private static final String TENANT = "test_tenant";
 

--- a/extensions/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Artifact.java
+++ b/extensions/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Artifact.java
@@ -22,22 +22,22 @@ public class S3Artifact extends DbArtifact {
 
     private final AmazonS3 amazonS3;
     private final S3RepositoryProperties s3Properties;
-    private final String sha1;
+    private final String key;
 
-    S3Artifact(final AmazonS3 amazonS3, final S3RepositoryProperties s3Properties, final String sha1) {
+    S3Artifact(final AmazonS3 amazonS3, final S3RepositoryProperties s3Properties, final String key) {
         this.amazonS3 = amazonS3;
         this.s3Properties = s3Properties;
-        this.sha1 = sha1;
+        this.key = key;
     }
 
     @Override
     public InputStream getFileInputStream() {
-        return amazonS3.getObject(s3Properties.getBucketName(), sha1).getObjectContent();
+        return amazonS3.getObject(s3Properties.getBucketName(), key).getObjectContent();
     }
 
     @Override
     public String toString() {
-        return "S3Artifact [sha1=" + sha1 + ", getArtifactId()=" + getArtifactId() + ", getHashes()=" + getHashes()
+        return "S3Artifact [key=" + key + ", getArtifactId()=" + getArtifactId() + ", getHashes()=" + getHashes()
                 + ", getSize()=" + getSize() + ", getContentType()=" + getContentType() + "]";
     }
 }

--- a/extensions/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
+++ b/extensions/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
@@ -119,11 +119,12 @@ public class S3Repository implements ArtifactRepository {
             final String contentType, final File file, final DbArtifactHash hash) {
         final S3Artifact s3Artifact = createS3Artifact(tenant, sha1Hash16, mdMD5Hash16, contentType, file);
         checkHashes(s3Artifact, hash);
+        final String key = objectKey(tenant, sha1Hash16);
 
         LOG.info("Storing file {} with length {} to AWS S3 bucket {} as SHA1 {}", file.getName(), file.length(),
-                s3Properties.getBucketName(), sha1Hash16);
+                s3Properties.getBucketName(), key);
 
-        if (exists(sha1Hash16)) {
+        if (exists(key)) {
             LOG.debug("Artifact {} already exists on S3 bucket {}, don't need to upload twice", sha1Hash16,
                     s3Properties.getBucketName());
             return s3Artifact;
@@ -132,7 +133,7 @@ public class S3Repository implements ArtifactRepository {
         try (final InputStream inputStream = new BufferedInputStream(new FileInputStream(file),
                 RequestClientOptions.DEFAULT_STREAM_BUFFER_SIZE)) {
             final ObjectMetadata objectMetadata = createObjectMetadata(mdMD5Hash16, contentType, file);
-            amazonS3.putObject(s3Properties.getBucketName(), sha1Hash16, inputStream, objectMetadata);
+            amazonS3.putObject(s3Properties.getBucketName(), key, inputStream, objectMetadata);
 
             return s3Artifact;
         } catch (final IOException | AmazonClientException e) {

--- a/extensions/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
+++ b/extensions/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
@@ -24,6 +24,7 @@ import org.eclipse.hawkbit.artifact.repository.model.DbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.validation.annotation.Validated;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.RequestClientOptions;
@@ -50,6 +51,7 @@ import com.google.common.io.ByteStreams;
  * across several buckets.
  * </p>
  */
+@Validated
 public class S3Repository implements ArtifactRepository {
 
     private static final Logger LOG = LoggerFactory.getLogger(S3Repository.class);
@@ -175,7 +177,7 @@ public class S3Repository implements ArtifactRepository {
     }
 
     private static String objectKey(final String tenant, final String sha1Hash) {
-        return tenant.toUpperCase() + "/" + sha1Hash;
+        return tenant.trim().toUpperCase() + "/" + sha1Hash;
     }
 
     @Override
@@ -235,7 +237,7 @@ public class S3Repository implements ArtifactRepository {
     }
 
     @Override
-    public void deleteTenant(final String tenant) {
+    public void deleteByTenant(final String tenant) {
         final String folder = tenant.toUpperCase();
 
         LOG.info("Deleting S3 object folder (tenant) from bucket {} and key {}", s3Properties.getBucketName(), folder);

--- a/extensions/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
+++ b/extensions/hawkbit-extension-artifact-repository-s3/src/main/java/org/eclipse/hawkbit/artifact/repository/S3Repository.java
@@ -177,7 +177,7 @@ public class S3Repository implements ArtifactRepository {
     }
 
     private static String objectKey(final String tenant, final String sha1Hash) {
-        return tenant.trim().toUpperCase() + "/" + sha1Hash;
+        return sanitizeTenant(tenant) + "/" + sha1Hash;
     }
 
     @Override
@@ -238,7 +238,7 @@ public class S3Repository implements ArtifactRepository {
 
     @Override
     public void deleteByTenant(final String tenant) {
-        final String folder = tenant.toUpperCase();
+        final String folder = sanitizeTenant(tenant);
 
         LOG.info("Deleting S3 object folder (tenant) from bucket {} and key {}", s3Properties.getBucketName(), folder);
 
@@ -251,5 +251,9 @@ public class S3Repository implements ArtifactRepository {
             objects = amazonS3.listNextBatchOfObjects(objects);
         } while (objects.isTruncated());
 
+    }
+
+    private static String sanitizeTenant(final String tenant) {
+        return tenant.trim().toUpperCase();
     }
 }

--- a/extensions/hawkbit-extension-artifact-repository-s3/src/test/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryTest.java
+++ b/extensions/hawkbit-extension-artifact-repository-s3/src/test/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryTest.java
@@ -54,6 +54,7 @@ import ru.yandex.qatools.allure.annotations.Stories;
 @Features("Unit Tests - S3 Repository")
 @Stories("S3 Artifact Repository")
 public class S3RepositoryTest {
+    private static final String TENANT = "test_tenant";
 
     @Mock
     private AmazonS3 amazonS3Mock;
@@ -115,7 +116,7 @@ public class S3RepositoryTest {
         when(s3ObjectMetadataMock.getContentType()).thenReturn(knownContentType);
 
         // test
-        final DbArtifact artifactBySha1 = s3RepositoryUnderTest.getArtifactBySha1(knownSHA1Hash);
+        final DbArtifact artifactBySha1 = s3RepositoryUnderTest.getArtifactBySha1(TENANT, knownSHA1Hash);
 
         // verify
         assertThat(artifactBySha1.getArtifactId()).isEqualTo(knownSHA1Hash);
@@ -150,7 +151,7 @@ public class S3RepositoryTest {
         when(amazonS3Mock.getObject(s3Properties.getBucketName(), knownSHA1Hash)).thenReturn(null);
 
         // test
-        final DbArtifact artifactBySha1NotExists = s3RepositoryUnderTest.getArtifactBySha1(knownSHA1Hash);
+        final DbArtifact artifactBySha1NotExists = s3RepositoryUnderTest.getArtifactBySha1(TENANT, knownSHA1Hash);
 
         // verify
         assertThat(artifactBySha1NotExists).isNull();
@@ -201,7 +202,7 @@ public class S3RepositoryTest {
             throws IOException {
         final String knownFileName = "randomBytes";
         try (InputStream content = new BufferedInputStream(new ByteArrayInputStream(rndBytes))) {
-            s3RepositoryUnderTest.store(content, knownFileName, contentType, hashes);
+            s3RepositoryUnderTest.store(TENANT, content, knownFileName, contentType, hashes);
         }
     }
 

--- a/extensions/hawkbit-extension-artifact-repository-s3/src/test/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryTest.java
+++ b/extensions/hawkbit-extension-artifact-repository-s3/src/test/java/org/eclipse/hawkbit/artifact/repository/S3RepositoryTest.java
@@ -90,8 +90,9 @@ public class S3RepositoryTest {
         storeRandomBytes(rndBytes, knownContentType);
 
         // verify
-        Mockito.verify(amazonS3Mock).putObject(eq(s3Properties.getBucketName()), eq(knownSHA1),
-                inputStreamCaptor.capture(), objectMetaDataCaptor.capture());
+        Mockito.verify(amazonS3Mock).putObject(eq(s3Properties.getBucketName()),
+                eq(TENANT.toUpperCase() + "/" + knownSHA1), inputStreamCaptor.capture(),
+                objectMetaDataCaptor.capture());
 
         final ObjectMetadata recordedObjectMetadata = objectMetaDataCaptor.getValue();
         assertThat(recordedObjectMetadata.getContentType()).isEqualTo(knownContentType);

--- a/hawkbit-artifact-repository-filesystem/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemRepository.java
+++ b/hawkbit-artifact-repository-filesystem/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemRepository.java
@@ -26,6 +26,7 @@ import org.eclipse.hawkbit.artifact.repository.model.DbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.validation.annotation.Validated;
 
 import com.google.common.base.Splitter;
 import com.google.common.io.BaseEncoding;
@@ -44,6 +45,7 @@ import com.google.common.io.Files;
  * are stored in different sub-directories based on the last four digits of the
  * SHA1-hash {@code (/basepath/[two digit sha1]/[two digit sha1])}.
  */
+@Validated
 public class ArtifactFilesystemRepository implements ArtifactRepository {
 
     private static final Logger LOG = LoggerFactory.getLogger(ArtifactFilesystemRepository.class);
@@ -191,7 +193,7 @@ public class ArtifactFilesystemRepository implements ArtifactRepository {
         final List<String> folders = Splitter.fixedLength(2).splitToList(sha1.substring(length - 4, length));
         final String folder1 = folders.get(0);
         final String folder2 = folders.get(1);
-        return Paths.get(artifactResourceProperties.getPath(), tenant.toUpperCase(), folder1, folder2);
+        return Paths.get(artifactResourceProperties.getPath(), sanitizeTenant(tenant), folder1, folder2);
     }
 
     private DigestOutputStream openFileOutputStream(final File file, final MessageDigest mdSHA1,
@@ -201,7 +203,11 @@ public class ArtifactFilesystemRepository implements ArtifactRepository {
     }
 
     @Override
-    public void deleteTenant(final String tenant) {
-        FileUtils.deleteQuietly(Paths.get(artifactResourceProperties.getPath(), tenant.toUpperCase()).toFile());
+    public void deleteByTenant(final String tenant) {
+        FileUtils.deleteQuietly(Paths.get(artifactResourceProperties.getPath(), sanitizeTenant(tenant)).toFile());
+    }
+
+    private static String sanitizeTenant(final String tenant) {
+        return tenant.trim().toUpperCase();
     }
 }

--- a/hawkbit-artifact-repository-filesystem/src/test/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemRepositoryTest.java
+++ b/hawkbit-artifact-repository-filesystem/src/test/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemRepositoryTest.java
@@ -26,6 +26,7 @@ import ru.yandex.qatools.allure.annotations.Stories;
 @Features("Unit Tests - Artifact File System Repository")
 @Stories("Test storing artifact binaries in the file-system")
 public class ArtifactFilesystemRepositoryTest {
+    private static final String TENANT = "test_tenant";
 
     private final ArtifactFilesystemProperties artifactResourceProperties = new ArtifactFilesystemProperties();
 
@@ -51,8 +52,8 @@ public class ArtifactFilesystemRepositoryTest {
         final byte[] fileContent = randomBytes();
         final ArtifactFilesystem artifact = storeRandomArtifact(fileContent);
 
-        final DbArtifact artifactBySha1 = artifactFilesystemRepository
-                .getArtifactBySha1(artifact.getHashes().getSha1());
+        final DbArtifact artifactBySha1 = artifactFilesystemRepository.getArtifactBySha1(TENANT,
+                artifact.getHashes().getSha1());
         assertThat(artifactBySha1).isNotNull();
     }
 
@@ -61,16 +62,26 @@ public class ArtifactFilesystemRepositoryTest {
     public void deleteStoredArtifactBySHA1Hash() {
         final ArtifactFilesystem artifact = storeRandomArtifact(randomBytes());
 
-        artifactFilesystemRepository.deleteBySha1(artifact.getHashes().getSha1());
+        artifactFilesystemRepository.deleteBySha1(TENANT, artifact.getHashes().getSha1());
 
-        assertThat(artifactFilesystemRepository.getArtifactBySha1(artifact.getHashes().getSha1())).isNull();
+        assertThat(artifactFilesystemRepository.getArtifactBySha1(TENANT, artifact.getHashes().getSha1())).isNull();
+    }
+
+    @Test
+    @Description("Verfies that all artifacts of a tenant can be deleted in the file-system repository")
+    public void deleteStoredArtifactOftenant() {
+        final ArtifactFilesystem artifact = storeRandomArtifact(randomBytes());
+
+        artifactFilesystemRepository.deleteTenant(TENANT);
+
+        assertThat(artifactFilesystemRepository.getArtifactBySha1(TENANT, artifact.getHashes().getSha1())).isNull();
     }
 
     @Test
     @Description("Verfies that an artifact which does not exists is deleted quietly in the file-system repository")
     public void deleteArtifactWhichDoesNotExistsBySHA1HashWithoutException() {
         try {
-            artifactFilesystemRepository.deleteBySha1("sha1HashWhichDoesNotExists");
+            artifactFilesystemRepository.deleteBySha1(TENANT, "sha1HashWhichDoesNotExists");
         } catch (final Exception e) {
             Assertions.fail("did not expect an exception while deleting a file which does not exists");
         }
@@ -79,7 +90,8 @@ public class ArtifactFilesystemRepositoryTest {
     private ArtifactFilesystem storeRandomArtifact(final byte[] fileContent) {
         final String fileName = "filename.tmp";
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(fileContent);
-        final ArtifactFilesystem store = artifactFilesystemRepository.store(inputStream, fileName, "application/txt");
+        final ArtifactFilesystem store = artifactFilesystemRepository.store(TENANT, inputStream, fileName,
+                "application/txt");
         return store;
     }
 

--- a/hawkbit-artifact-repository-filesystem/src/test/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemRepositoryTest.java
+++ b/hawkbit-artifact-repository-filesystem/src/test/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemRepositoryTest.java
@@ -72,7 +72,7 @@ public class ArtifactFilesystemRepositoryTest {
     public void deleteStoredArtifactOftenant() {
         final ArtifactFilesystem artifact = storeRandomArtifact(randomBytes());
 
-        artifactFilesystemRepository.deleteTenant(TENANT);
+        artifactFilesystemRepository.deleteByTenant(TENANT);
 
         assertThat(artifactFilesystemRepository.getArtifactBySha1(TENANT, artifact.getHashes().getSha1())).isNull();
     }

--- a/hawkbit-artifact-repository-filesystem/src/test/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemRepositoryTest.java
+++ b/hawkbit-artifact-repository-filesystem/src/test/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemRepositoryTest.java
@@ -69,7 +69,7 @@ public class ArtifactFilesystemRepositoryTest {
 
     @Test
     @Description("Verfies that all artifacts of a tenant can be deleted in the file-system repository")
-    public void deleteStoredArtifactOftenant() {
+    public void deleteStoredArtifactOfTenant() {
         final ArtifactFilesystem artifact = storeRandomArtifact(randomBytes());
 
         artifactFilesystemRepository.deleteByTenant(TENANT);
@@ -82,6 +82,13 @@ public class ArtifactFilesystemRepositoryTest {
     public void deleteArtifactWhichDoesNotExistsBySHA1HashWithoutException() {
         try {
             artifactFilesystemRepository.deleteBySha1(TENANT, "sha1HashWhichDoesNotExists");
+        } catch (final Exception e) {
+            Assertions.fail("did not expect an exception while deleting a file which does not exists");
+        }
+
+        final ArtifactFilesystem artifact = storeRandomArtifact(randomBytes());
+        try {
+            artifactFilesystemRepository.deleteBySha1("tenantWhichDoesNotExist", artifact.getHashes().getSha1());
         } catch (final Exception e) {
             Assertions.fail("did not expect an exception while deleting a file which does not exists");
         }

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
@@ -313,7 +313,8 @@ public class SecurityManagedConfiguration {
 
             http.regexMatcher(HttpDownloadAuthenticationFilter.REQUEST_ID_REGEX_PATTERN)
                     .addFilterBefore(downloadIdAuthenticationFilter, FilterSecurityInterceptor.class);
-            http.authorizeRequests().anyRequest().authenticated();
+            http.authorizeRequests().anyRequest().authenticated().and().sessionManagement()
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
         }
 
         @Override
@@ -401,6 +402,7 @@ public class SecurityManagedConfiguration {
 
             httpSec.httpBasic().and().exceptionHandling().authenticationEntryPoint(basicAuthEntryPoint);
             httpSec.anonymous().disable();
+            httpSec.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
         }
     }
 

--- a/hawkbit-core/pom.xml
+++ b/hawkbit-core/pom.xml
@@ -28,6 +28,14 @@
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
       </dependency>
+      <dependency>
+         <groupId>javax.validation</groupId>
+         <artifactId>validation-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.hibernate</groupId>
+         <artifactId>hibernate-validator</artifactId>
+      </dependency>
     
       <!-- Test -->
       <dependency>

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactRepository.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactRepository.java
@@ -75,7 +75,8 @@ public interface ArtifactRepository {
     /**
      * Deletes an artifact by its SHA1 hash.
      * 
-     * 
+     * @param tenant
+     *            the tenant to store the artifact
      * @param sha1Hash
      *            the sha1-hash of the artifact to delete
      * 
@@ -87,6 +88,8 @@ public interface ArtifactRepository {
     /**
      * Retrieves a {@link DbArtifact} from the store by it's SHA1 hash.
      * 
+     * @param tenant
+     *            the tenant to store the artifact
      * @param sha1Hash
      *            the sha1-hash of the file to lookup.
      * @return The artifact file object or {@code null} if no file exists.
@@ -96,5 +99,11 @@ public interface ArtifactRepository {
      */
     DbArtifact getArtifactBySha1(@NotEmpty String tenant, @NotEmpty String sha1Hash);
 
-    void deleteTenant(@NotEmpty String tenant);
+    /**
+     * Deletes all artifacts of given tenant.
+     * 
+     * @param tenant
+     *            to erase
+     */
+    void deleteByTenant(@NotEmpty String tenant);
 }

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactRepository.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/ArtifactRepository.java
@@ -10,8 +10,11 @@ package org.eclipse.hawkbit.artifact.repository;
 
 import java.io.InputStream;
 
+import javax.validation.constraints.NotNull;
+
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifact;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
+import org.hibernate.validator.constraints.NotEmpty;
 
 /**
  * ArtifactRepository service interface.
@@ -39,11 +42,14 @@ public interface ArtifactRepository {
      * @throws ArtifactStoreException
      *             in case storing of the artifact was not successful
      */
-    DbArtifact store(final InputStream content, final String filename, final String contentType);
+    DbArtifact store(@NotEmpty String tenant, @NotNull InputStream content, @NotEmpty String filename,
+            String contentType);
 
     /**
      * Stores an artifact into the repository.
      * 
+     * @param tenant
+     *            the tenant to store the artifact
      * @param content
      *            the content to store
      * @param filename
@@ -63,7 +69,8 @@ public interface ArtifactRepository {
      *             in case {@code hash} is provided and not matching to the
      *             calculated hashes during storing
      */
-    DbArtifact store(final InputStream content, final String filename, final String contentType, DbArtifactHash hash);
+    DbArtifact store(@NotEmpty String tenant, @NotNull InputStream content, @NotEmpty String filename,
+            String contentType, DbArtifactHash hash);
 
     /**
      * Deletes an artifact by its SHA1 hash.
@@ -75,7 +82,7 @@ public interface ArtifactRepository {
      * @throws MethodNotSupportedException
      *             if implementation does not support the operation
      */
-    void deleteBySha1(final String sha1Hash);
+    void deleteBySha1(@NotEmpty String tenant, @NotEmpty String sha1Hash);
 
     /**
      * Retrieves a {@link DbArtifact} from the store by it's SHA1 hash.
@@ -87,5 +94,7 @@ public interface ArtifactRepository {
      * @throws MethodNotSupportedException
      *             if implementation does not support the operation
      */
-    DbArtifact getArtifactBySha1(String sha1Hash);
+    DbArtifact getArtifactBySha1(@NotEmpty String tenant, @NotEmpty String sha1Hash);
+
+    void deleteTenant(@NotEmpty String tenant);
 }

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDownloadResource.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDownloadResource.java
@@ -20,6 +20,7 @@ import org.eclipse.hawkbit.cache.DownloadIdCache;
 import org.eclipse.hawkbit.cache.DownloadType;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtDownloadRestApi;
 import org.eclipse.hawkbit.rest.util.RequestResponseContextHolder;
+import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,9 +38,6 @@ import com.google.common.net.HttpHeaders;
 
 /**
  * A resource for download artifacts.
- * 
- *
- *
  */
 @RestController
 @Scope(value = WebApplicationContext.SCOPE_REQUEST)
@@ -55,6 +53,9 @@ public class MgmtDownloadResource implements MgmtDownloadRestApi {
 
     @Autowired
     private RequestResponseContextHolder requestResponseContextHolder;
+
+    @Autowired
+    private TenantAware tenantAware;
 
     /**
      * Handles the GET request for downloading an artifact.
@@ -77,7 +78,7 @@ public class MgmtDownloadResource implements MgmtDownloadRestApi {
             DbArtifact artifact = null;
 
             if (DownloadType.BY_SHA1.equals(artifactCache.getDownloadType())) {
-                artifact = artifactRepository.getArtifactBySha1(artifactCache.getId());
+                artifact = artifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), artifactCache.getId());
             } else {
                 LOGGER.warn("Download Type {} not supported", artifactCache.getDownloadType());
             }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -23,11 +23,11 @@ import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.QuotaExceededException;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
-import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
+import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -118,13 +118,15 @@ public interface ControllerManagement {
     /**
      * Retrieves oldest {@link Action} that is active and assigned to a
      * {@link Target}.
+     * 
+     * For performance reasons this method does not throw
+     * {@link EntityNotFoundException} in case target with given controlelrId
+     * does not exist butt will return an {@link Optional#empty()} instead.
      *
      * @param controllerId
      *            identifies the target to retrieve the actions from
      * @return a list of actions assigned to given target which are active
      * 
-     * @throws EntityNotFoundException
-     *             if target with given ID does not exist
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
     Optional<Action> findOldestActiveActionByTarget(@NotNull String controllerId);

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -121,7 +121,7 @@ public interface ControllerManagement {
      * 
      * For performance reasons this method does not throw
      * {@link EntityNotFoundException} in case target with given controlelrId
-     * does not exist butt will return an {@link Optional#empty()} instead.
+     * does not exist but will return an {@link Optional#empty()} instead.
      *
      * @param controllerId
      *            identifies the target to retrieve the actions from

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -117,7 +117,7 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
     Optional<Action> findFirstByTargetControllerIdAndActive(final Sort sort, final String controllerId, boolean active);
 
     /**
-     * Checks if an active action exist for given
+     * Checks if an active action exists for given
      * {@link Target#getControllerId()}.
      * 
      * @param controllerId

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -117,6 +117,17 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
     Optional<Action> findFirstByTargetControllerIdAndActive(final Sort sort, final String controllerId, boolean active);
 
     /**
+     * Checks if an active action exist for given
+     * {@link Target#getControllerId()}.
+     * 
+     * @param controllerId
+     *            of target to check
+     * @return <code>true</code> if an active action for the target exists.
+     */
+    @Query("SELECT CASE WHEN COUNT(a)>0 THEN 'true' ELSE 'false' END FROM JpaAction a JOIN a.target t WHERE t.controllerId=:controllerId AND a.active=1")
+    boolean activeActionExistsForControllerId(@Param("controllerId") String controllerId);
+
+    /**
      * Retrieves latest {@link Action} for given target and
      * {@link SoftwareModule}.
      *

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -188,7 +188,9 @@ public class JpaControllerManagement implements ControllerManagement {
 
     @Override
     public Optional<Action> findOldestActiveActionByTarget(final String controllerId) {
-        throwExceptionIfTargetDoesNotExist(controllerId);
+        if (!actionRepository.activeActionExistsForControllerId(controllerId)) {
+            return Optional.empty();
+        }
 
         // used in favorite to findFirstByTargetAndActiveOrderByIdAsc due to
         // DATAJPA-841 issue.

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSoftwareModuleManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSoftwareModuleManagement.java
@@ -73,7 +73,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * JPA implementation of {@link SoftwareModuleManagement}.
@@ -591,7 +590,7 @@ public class JpaSoftwareModuleManagement implements SoftwareModuleManagement {
     @Retryable(include = {
             ConcurrencyFailureException.class }, maxAttempts = Constants.TX_RT_MAX, backoff = @Backoff(delay = Constants.TX_RT_DELAY))
     public void deleteSoftwareModule(final Long moduleId) {
-        deleteSoftwareModules(Sets.newHashSet(moduleId));
+        deleteSoftwareModules(Arrays.asList(moduleId));
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
 
+import org.eclipse.hawkbit.artifact.repository.ArtifactRepository;
 import org.eclipse.hawkbit.cache.TenancyCacheManager;
 import org.eclipse.hawkbit.repository.RolloutStatusCache;
 import org.eclipse.hawkbit.repository.SystemManagement;
@@ -115,6 +116,9 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
 
     @Autowired
     private RolloutStatusCache rolloutStatusCache;
+
+    @Autowired
+    private ArtifactRepository artifactRepository;
 
     @Override
     public SystemUsageReport getSystemUsageStatistics() {
@@ -236,6 +240,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
             distributionSetRepository.deleteByTenant(tenant);
             distributionSetTypeRepository.deleteByTenant(tenant);
             softwareModuleRepository.deleteByTenant(tenant);
+            artifactRepository.deleteTenant(tenant);
             softwareModuleTypeRepository.deleteByTenant(tenant);
             return null;
         });

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
@@ -240,7 +240,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
             distributionSetRepository.deleteByTenant(tenant);
             distributionSetTypeRepository.deleteByTenant(tenant);
             softwareModuleRepository.deleteByTenant(tenant);
-            artifactRepository.deleteTenant(tenant);
+            artifactRepository.deleteByTenant(tenant);
             softwareModuleTypeRepository.deleteByTenant(tenant);
             return null;
         });

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import javax.persistence.EntityManager;
 import javax.sql.DataSource;
 
+import org.eclipse.hawkbit.artifact.repository.ArtifactRepository;
 import org.eclipse.hawkbit.repository.ArtifactManagement;
 import org.eclipse.hawkbit.repository.ControllerManagement;
 import org.eclipse.hawkbit.repository.DeploymentManagement;
@@ -502,16 +503,13 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
         return new JpaControllerManagement();
     }
 
-    /**
-     * {@link JpaArtifactManagement} bean.
-     *
-     * @return a new {@link ArtifactManagement}
-     */
-
     @Bean
     @ConditionalOnMissingBean
-    ArtifactManagement artifactManagement() {
-        return new JpaArtifactManagement();
+    ArtifactManagement artifactManagement(final LocalArtifactRepository localArtifactRepository,
+            final SoftwareModuleRepository softwareModuleRepository, final ArtifactRepository artifactRepository,
+            final TenantAware tenantAware) {
+        return new JpaArtifactManagement(localArtifactRepository, softwareModuleRepository, artifactRepository,
+                tenantAware);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ArtifactManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ArtifactManagementTest.java
@@ -175,16 +175,21 @@ public class ArtifactManagementTest extends AbstractJpaIntegrationTest {
         assertThat(result2.getId()).isNotNull();
         assertThat(((JpaArtifact) result).getSha1Hash()).isNotEqualTo(((JpaArtifact) result2).getSha1Hash());
 
-        assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result).getSha1Hash())).isNotNull();
-        assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result2).getSha1Hash())).isNotNull();
+        assertThat(binaryArtifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), result.getSha1Hash()))
+                .isNotNull();
+        assertThat(binaryArtifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), result2.getSha1Hash()))
+                .isNotNull();
 
         artifactManagement.deleteArtifact(result.getId());
 
-        assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result).getSha1Hash())).isNull();
-        assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result2).getSha1Hash())).isNotNull();
+        assertThat(binaryArtifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), result.getSha1Hash()))
+                .isNull();
+        assertThat(binaryArtifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), result2.getSha1Hash()))
+                .isNotNull();
 
         artifactManagement.deleteArtifact(result2.getId());
-        assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result2).getSha1Hash())).isNull();
+        assertThat(binaryArtifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), result2.getSha1Hash()))
+                .isNull();
 
         assertThat(artifactRepository.findAll()).hasSize(0);
     }
@@ -211,12 +216,15 @@ public class ArtifactManagementTest extends AbstractJpaIntegrationTest {
         assertThat(result2.getId()).isNotNull();
         assertThat(((JpaArtifact) result).getSha1Hash()).isEqualTo(((JpaArtifact) result2).getSha1Hash());
 
-        assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result).getSha1Hash())).isNotNull();
+        assertThat(binaryArtifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), result.getSha1Hash()))
+                .isNotNull();
         artifactManagement.deleteArtifact(result.getId());
-        assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result).getSha1Hash())).isNotNull();
+        assertThat(binaryArtifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), result.getSha1Hash()))
+                .isNotNull();
 
         artifactManagement.deleteArtifact(result2.getId());
-        assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result).getSha1Hash())).isNull();
+        assertThat(binaryArtifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), result.getSha1Hash()))
+                .isNull();
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
@@ -78,6 +78,8 @@ public class ControllerManagementTest extends AbstractJpaIntegrationTest {
         assertThat(controllerManagement.getActionForDownloadByTargetAndSoftwareModule(target.getControllerId(),
                 module.getId())).isNotPresent();
 
+        assertThat(controllerManagement.findOldestActiveActionByTarget(NOT_EXIST_ID)).isNotPresent();
+
         assertThat(controllerManagement.hasTargetArtifactAssigned(target.getControllerId(), "XXX")).isFalse();
         assertThat(controllerManagement.hasTargetArtifactAssigned(target.getId(), "XXX")).isFalse();
     }
@@ -99,8 +101,6 @@ public class ControllerManagementTest extends AbstractJpaIntegrationTest {
 
         verifyThrownExceptionBy(() -> controllerManagement.addUpdateActionStatus(
                 entityFactory.actionStatus().create(NOT_EXIST_IDL).status(Action.Status.FINISHED)), "Action");
-
-        verifyThrownExceptionBy(() -> controllerManagement.findOldestActiveActionByTarget(NOT_EXIST_ID), "Target");
 
         verifyThrownExceptionBy(() -> controllerManagement
                 .getActionForDownloadByTargetAndSoftwareModule(target.getControllerId(), NOT_EXIST_IDL),

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleManagementTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.commons.lang3.RandomUtils;
 import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleCreatedEvent;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
-import org.eclipse.hawkbit.repository.jpa.model.JpaArtifact;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet;
 import org.eclipse.hawkbit.repository.jpa.model.JpaSoftwareModuleMetadata;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTarget;
@@ -490,13 +489,15 @@ public class SoftwareModuleManagementTest extends AbstractJpaIntegrationTest {
         assertThat(artifactRepository.findAll()).hasSize(results.length);
         for (final Artifact result : results) {
             assertThat(result.getId()).isNotNull();
-            assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result).getSha1Hash())).isNotNull();
+            assertThat(binaryArtifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), result.getSha1Hash()))
+                    .isNotNull();
         }
     }
 
     private void assertArtfiactNull(final Artifact... results) {
         for (final Artifact result : results) {
-            assertThat(binaryArtifactRepository.getArtifactBySha1(((JpaArtifact) result).getSha1Hash())).isNull();
+            assertThat(binaryArtifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), result.getSha1Hash()))
+                    .isNull();
         }
     }
 

--- a/hawkbit-repository/hawkbit-repository-test/src/main/resources/hawkbit-test-defaults.properties
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/resources/hawkbit-test-defaults.properties
@@ -10,8 +10,9 @@
 # Test utility properties for easier fault investigation - START
 ## Logging - START
 logging.level.=INFO
-logging.level.org.eclipse.persistence=ERROR
 logging.level.org.eclipse.hawkbit.repository.test.matcher.EventVerifier=ERROR
+logging.level.org.eclipse.persistence=ERROR
+spring.datasource.eclipselink.logging.logger=JavaLogger
 spring.jpa.properties.eclipselink.logging.level=FINE
 spring.jpa.properties.eclipselink.logging.level.sql=FINE
 spring.jpa.properties.eclipselink.logging.parameters=true

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/DosFilter.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/DosFilter.java
@@ -48,10 +48,10 @@ public class DosFilter extends OncePerRequestFilter {
     private final Pattern ipAdressBlacklist;
 
     private final Cache<String, AtomicInteger> readCountCache = Caffeine.newBuilder()
-            .expireAfterAccess(1, TimeUnit.SECONDS).build();
+            .expireAfterWrite(1, TimeUnit.SECONDS).build();
 
     private final Cache<String, AtomicInteger> writeCountCache = Caffeine.newBuilder()
-            .expireAfterAccess(1, TimeUnit.SECONDS).build();
+            .expireAfterWrite(1, TimeUnit.SECONDS).build();
 
     private final int maxRead;
     private final int maxWrite;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
@@ -52,6 +52,10 @@ public class CreateUpdateDistributionTagLayoutWindow extends AbstractCreateUpdat
 
     @Override
     protected void populateTagNameCombo() {
+        if (tagNameComboBox == null) {
+            return;
+        }
+
         tagNameComboBox.removeAllItems();
         final List<DistributionSetTag> distTagNameList = tagManagement
                 .findAllDistributionSetTags(new PageRequest(0, MAX_TAGS)).getContent();


### PR DESCRIPTION
Kind of design flaw. ArtifactRepository is not multi-tenancy ready not in API as well as the three implementations.

Added tenant to the API and to the three implementations:
* file + S3 -> tenant is a root folder
* MongoDb GridFS -> tenant is a metadata field

Reviewers: @michahirsch @schabdo 

Fixes as well a computation bug in the DosFilter

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>