### PR TITLE
Fix exception handling on repository

### DIFF
--- a/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
+++ b/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
@@ -209,6 +209,11 @@ public final class MgmtRestConstants {
     public static final String SOFTWAREMODULE_V1_ARTIFACT = "artifacts";
 
     /**
+     * The target URL mapping, href link for software module access.
+     */
+    public static final String DISTRIBUTIONSET_V1_MODULE = "modules";
+
+    /**
      * The target URL mapping, href link for type information.
      */
     public static final String SOFTWAREMODULE_V1_TYPE = "type";

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetMapper.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetMapper.java
@@ -117,13 +117,17 @@ public final class MgmtDistributionSetMapper {
         response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getDistributionSet(response.getDsId()))
                 .withSelfRel());
 
+        response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getAssignedSoftwareModules(response.getDsId(),
+                MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
+                MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null))
+                        .withRel(MgmtRestConstants.DISTRIBUTIONSET_V1_MODULE));
+
         response.add(linkTo(methodOn(MgmtDistributionSetTypeRestApi.class)
                 .getDistributionSetType(distributionSet.getType().getId())).withRel("type"));
 
         response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getMetadata(response.getDsId(),
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
-                MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null))
-                        .withRel("metadata"));
+                MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null)).withRel("metadata"));
 
         return response;
     }

--- a/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
+++ b/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
@@ -356,7 +356,7 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
     @Description("Ensures that target update request fails is updated value fails against a constraint.")
     public void updateTargetDescriptionFailsIfInvalidLength() throws Exception {
         final String knownControllerId = "123";
-        final String knownNewDescription = RandomStringUtils.randomAlphabetic(520);
+        final String knownNewDescription = RandomStringUtils.randomAlphabetic(513);
         final String knownNameNotModiy = "nameNotModiy";
         final String body = new JSONObject().put("description", knownNewDescription).toString();
 

--- a/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
+++ b/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
@@ -353,6 +353,26 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
     }
 
     @Test
+    @Description("Ensures that target update request fails is updated value fails against a constraint.")
+    public void updateTargetDescriptionFailsIfInvalidLength() throws Exception {
+        final String knownControllerId = "123";
+        final String knownNewDescription = RandomStringUtils.randomAlphabetic(520);
+        final String knownNameNotModiy = "nameNotModiy";
+        final String body = new JSONObject().put("description", knownNewDescription).toString();
+
+        // prepare
+        targetManagement.createTarget(entityFactory.target().create().controllerId(knownControllerId)
+                .name(knownNameNotModiy).description("old description"));
+
+        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body)
+                .contentType(MediaType.APPLICATION_JSON)).andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isBadRequest());
+
+        final Target findTargetByControllerID = targetManagement.findTargetByControllerID(knownControllerId).get();
+        assertThat(findTargetByControllerID.getDescription()).isEqualTo("old description");
+    }
+
+    @Test
     @Description("Ensures that target update request is reflected by repository.")
     public void updateTargetSecurityToken() throws Exception {
         final String knownControllerId = "123";

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.validation.ConstraintViolationException;
 import javax.validation.constraints.NotNull;
 
 import org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions;
@@ -158,6 +159,12 @@ public interface TargetManagement {
      * @param create
      *            to be created
      * @return the created {@link Target}
+     * 
+     * @throws EntityAlreadyExistsException
+     *             given target already exists.
+     * @throws ConstraintViolationException
+     *             if fields are not filled as specified. Check
+     *             {@link TargetCreate} for field constraints.
      *
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_CREATE_TARGET + SpringEvalExpressions.HAS_AUTH_OR
@@ -176,6 +183,9 @@ public interface TargetManagement {
      *
      * @throws EntityAlreadyExistsException
      *             of one of the given targets already exist.
+     * @throws ConstraintViolationException
+     *             if fields are not filled as specified. Check
+     *             {@link TargetCreate} for field constraints.
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_CREATE_TARGET)
     List<Target> createTargets(@NotNull Collection<TargetCreate> creates);
@@ -612,6 +622,9 @@ public interface TargetManagement {
      * 
      * @throws EntityNotFoundException
      *             if given target does not exist
+     * @throws ConstraintViolationException
+     *             if fields are not filled as specified. Check
+     *             {@link TargetUpdate} for field constraints.
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_TARGET + SpringEvalExpressions.HAS_AUTH_OR
             + SpringEvalExpressions.IS_CONTROLLER)

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/ActionStatusCreate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/ActionStatusCreate.java
@@ -10,6 +10,8 @@ package org.eclipse.hawkbit.repository.builder;
 
 import java.util.Collection;
 
+import javax.validation.constraints.NotNull;
+
 import org.eclipse.hawkbit.repository.model.Action.Status;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.repository.model.BaseEntity;
@@ -26,7 +28,7 @@ public interface ActionStatusCreate {
      *            {@link ActionStatus#getStatus()}
      * @return updated {@link ActionStatusCreate} object
      */
-    ActionStatusCreate status(Status status);
+    ActionStatusCreate status(@NotNull Status status);
 
     /**
      * @param occurredAt

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/TargetCreate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/TargetCreate.java
@@ -8,10 +8,13 @@
  */
 package org.eclipse.hawkbit.repository.builder;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 import org.eclipse.hawkbit.repository.model.BaseEntity;
+import org.eclipse.hawkbit.repository.model.NamedEntity;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
-import org.hibernate.validator.constraints.NotEmpty;
 
 /**
  * Builder to create a new {@link Target} entry. Defines all fields that can be
@@ -26,28 +29,30 @@ public interface TargetCreate {
      *            for {@link Target#getControllerId()}
      * @return updated builder instance
      */
-    TargetCreate controllerId(@NotEmpty String controllerId);
+    TargetCreate controllerId(@Size(min = 1, max = Target.CONTROLLER_ID_MAX_SIZE) @NotNull String controllerId);
 
     /**
      * @param name
-     *            for {@link Target#getName()}
+     *            for {@link Target#getName()} filled with
+     *            {@link #controllerId(String)} as default if not set explicitly
      * @return updated builder instance
      */
-    TargetCreate name(@NotEmpty String name);
+    TargetCreate name(@Size(min = 1, max = NamedEntity.NAME_MAX_SIZE) @NotNull String name);
 
     /**
      * @param description
      *            for {@link Target#getDescription()}
      * @return updated builder instance
      */
-    TargetCreate description(String description);
+    TargetCreate description(@Size(max = NamedEntity.DESCRIPTION_MAX_SIZE) String description);
 
     /**
      * @param securityToken
-     *            for {@link Target#getSecurityToken()}
+     *            for {@link Target#getSecurityToken()} is generated with a
+     *            random sequence as default if not set explicitly
      * @return updated builder instance
      */
-    TargetCreate securityToken(String securityToken);
+    TargetCreate securityToken(@Size(min = 1, max = Target.SECURITY_TOKEN_MAX_SIZE) @NotNull String securityToken);
 
     /**
      * @param address
@@ -58,7 +63,7 @@ public interface TargetCreate {
      * 
      * @return updated builder instance
      */
-    TargetCreate address(String address);
+    TargetCreate address(@Size(max = Target.ADDRESS_MAX_SIZE) String address);
 
     /**
      * @param lastTargetQuery
@@ -69,10 +74,12 @@ public interface TargetCreate {
 
     /**
      * @param status
-     *            for {@link Target#getUpdateStatus()}
+     *            for {@link Target#getUpdateStatus()} is
+     *            {@link TargetUpdateStatus#UNKNOWN} as default if not set
+     *            explicitly
      * @return updated builder instance
      */
-    TargetCreate status(TargetUpdateStatus status);
+    TargetCreate status(@NotNull TargetUpdateStatus status);
 
     /**
      * @return peek on current state of {@link Target} in the builder

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/TargetUpdate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/TargetUpdate.java
@@ -8,9 +8,12 @@
  */
 package org.eclipse.hawkbit.repository.builder;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.eclipse.hawkbit.repository.model.NamedEntity;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
-import org.hibernate.validator.constraints.NotEmpty;
 
 /**
  * Builder to update an existing {@link Target} entry. Defines all fields that
@@ -24,21 +27,21 @@ public interface TargetUpdate {
      *            for {@link Target#getName()}
      * @return updated builder instance
      */
-    TargetUpdate name(@NotEmpty String name);
+    TargetUpdate name(@Size(min = 1, max = NamedEntity.NAME_MAX_SIZE) @NotNull String name);
 
     /**
      * @param description
      *            for {@link Target#getDescription()}
      * @return updated builder instance
      */
-    TargetUpdate description(String description);
+    TargetUpdate description(@Size(max = NamedEntity.DESCRIPTION_MAX_SIZE) String description);
 
     /**
      * @param securityToken
      *            for {@link Target#getSecurityToken()}
      * @return updated builder instance
      */
-    TargetUpdate securityToken(@NotEmpty String securityToken);
+    TargetUpdate securityToken(@Size(min = 1, max = Target.SECURITY_TOKEN_MAX_SIZE) @NotNull String securityToken);
 
     /**
      * @param address
@@ -49,7 +52,7 @@ public interface TargetUpdate {
      * 
      * @return updated builder instance
      */
-    TargetUpdate address(String address);
+    TargetUpdate address(@Size(max = Target.ADDRESS_MAX_SIZE) String address);
 
     /**
      * @param lastTargetQuery
@@ -63,5 +66,5 @@ public interface TargetUpdate {
      *            for {@link Target#getUpdateStatus()}
      * @return updated builder instance
      */
-    TargetUpdate status(TargetUpdateStatus status);
+    TargetUpdate status(@NotNull TargetUpdateStatus status);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/ConstraintViolationException.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/ConstraintViolationException.java
@@ -26,11 +26,12 @@ public class ConstraintViolationException extends AbstractServerRtException {
     /**
      * Constructor for {@link ConstraintViolationException}
      * 
-     * @param cause
-     *            of the exception
+     * @param ex
+     *            the javax.validation.ConstraintViolationException which is
+     *            thrown
      */
-    public ConstraintViolationException(final Throwable cause) {
-        this(getExceptionMessage(cause));
+    public ConstraintViolationException(final javax.validation.ConstraintViolationException ex) {
+        this(getExceptionMessage(ex));
     }
 
     /**
@@ -53,15 +54,11 @@ public class ConstraintViolationException extends AbstractServerRtException {
      *            javax.validation.ConstraintViolationException which is thrown
      * @return message String with proper error information
      */
-    public static String getExceptionMessage(final Throwable ex) {
-        if (ex instanceof javax.validation.ConstraintViolationException) {
-            return ((javax.validation.ConstraintViolationException) ex)
-                    .getConstraintViolations().stream().map(violation -> violation.getPropertyPath()
-                            + MESSAGE_FORMATTER_SEPARATOR + violation.getMessage() + ".")
-                    .collect(Collectors.joining(MESSAGE_FORMATTER_SEPARATOR));
-        }
-
-        return ex.getMessage();
+    public static String getExceptionMessage(final javax.validation.ConstraintViolationException ex) {
+        return ex
+                .getConstraintViolations().stream().map(violation -> violation.getPropertyPath()
+                        + MESSAGE_FORMATTER_SEPARATOR + violation.getMessage() + ".")
+                .collect(Collectors.joining(MESSAGE_FORMATTER_SEPARATOR));
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/ConstraintViolationException.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/ConstraintViolationException.java
@@ -26,12 +26,11 @@ public class ConstraintViolationException extends AbstractServerRtException {
     /**
      * Constructor for {@link ConstraintViolationException}
      * 
-     * @param ex
-     *            the javax.validation.ConstraintViolationException which is
-     *            thrown
+     * @param cause
+     *            of the exception
      */
-    public ConstraintViolationException(final javax.validation.ConstraintViolationException ex) {
-        this(getExceptionMessage(ex));
+    public ConstraintViolationException(final Throwable cause) {
+        this(getExceptionMessage(cause));
     }
 
     /**
@@ -54,11 +53,15 @@ public class ConstraintViolationException extends AbstractServerRtException {
      *            javax.validation.ConstraintViolationException which is thrown
      * @return message String with proper error information
      */
-    public static String getExceptionMessage(final javax.validation.ConstraintViolationException ex) {
-        return ex
-                .getConstraintViolations().stream().map(violation -> violation.getPropertyPath()
-                        + MESSAGE_FORMATTER_SEPARATOR + violation.getMessage() + ".")
-                .collect(Collectors.joining(MESSAGE_FORMATTER_SEPARATOR));
+    public static String getExceptionMessage(final Throwable ex) {
+        if (ex instanceof javax.validation.ConstraintViolationException) {
+            return ((javax.validation.ConstraintViolationException) ex)
+                    .getConstraintViolations().stream().map(violation -> violation.getPropertyPath()
+                            + MESSAGE_FORMATTER_SEPARATOR + violation.getMessage() + ".")
+                    .collect(Collectors.joining(MESSAGE_FORMATTER_SEPARATOR));
+        }
+
+        return ex.getMessage();
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetAssignmentResult.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetAssignmentResult.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.model;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.springframework.util.CollectionUtils;
@@ -23,7 +24,7 @@ import org.springframework.util.CollectionUtils;
 public class DistributionSetAssignmentResult extends AssignmentResult<Target> {
 
     private final List<String> assignedTargets;
-    private final List<Long> actions;
+    private final List<Action> actions;
 
     private final TargetManagement targetManagement;
 
@@ -45,7 +46,7 @@ public class DistributionSetAssignmentResult extends AssignmentResult<Target> {
      *
      */
     public DistributionSetAssignmentResult(final List<String> assignedTargets, final int assigned,
-            final int alreadyAssigned, final List<Long> actions, final TargetManagement targetManagement) {
+            final int alreadyAssigned, final List<Action> actions, final TargetManagement targetManagement) {
         super(assigned, alreadyAssigned, 0, Collections.emptyList(), Collections.emptyList());
         this.assignedTargets = assignedTargets;
         this.actions = actions;
@@ -60,7 +61,7 @@ public class DistributionSetAssignmentResult extends AssignmentResult<Target> {
             return Collections.emptyList();
         }
 
-        return Collections.unmodifiableList(actions);
+        return actions.stream().map(Action::getId).collect(Collectors.toList());
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/NamedEntity.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/NamedEntity.java
@@ -8,19 +8,34 @@
  */
 package org.eclipse.hawkbit.repository.model;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 /**
  * Entities that have a name and description.
  *
  */
 public interface NamedEntity extends TenantAwareBaseEntity {
+    /**
+     * Maximum length of name.
+     */
+    public static final int NAME_MAX_SIZE = 64;
+
+    /**
+     * Maximum length of description.
+     */
+    public static final int DESCRIPTION_MAX_SIZE = 512;
 
     /**
      * @return the description of the entity.
      */
+    @Size(max = DESCRIPTION_MAX_SIZE)
     String getDescription();
 
     /**
      * @return the name of the entity.
      */
+    @Size(min = 1, max = NAME_MAX_SIZE)
+    @NotNull
     String getName();
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
@@ -20,6 +20,20 @@ import java.util.concurrent.TimeUnit;
  * </p>
  */
 public interface Target extends NamedEntity {
+    /**
+     * Maximum length of controllerId.
+     */
+    public static final int CONTROLLER_ID_MAX_SIZE = 64;
+
+    /**
+     * Maximum length of securityToken.
+     */
+    public static final int SECURITY_TOKEN_MAX_SIZE = 128;
+
+    /**
+     * Maximum length of address.
+     */
+    public static final int ADDRESS_MAX_SIZE = 512;
 
     /**
      * @return business identifier of the {@link Target}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialect.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialect.java
@@ -42,7 +42,12 @@ public class HawkBitEclipseLinkJpaDialect extends EclipseLinkJpaDialect {
             return accessException;
         }
 
-        return searchAndTranslateSqlException(accessException);
+        final DataAccessException sql = searchAndTranslateSqlException(accessException);
+        if (sql != null) {
+            return sql;
+        }
+
+        return accessException;
     }
 
     private static DataAccessException searchAndTranslateSqlException(final RuntimeException ex) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialect.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialect.java
@@ -20,6 +20,7 @@ import org.springframework.orm.jpa.vendor.EclipseLinkJpaDialect;
  * mechanisms.
  *
  */
+// TODO try to document the most prominient use cases
 public class HawkBitEclipseLinkJpaDialect extends EclipseLinkJpaDialect {
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialect.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialect.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa;
+
+import java.sql.SQLException;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.support.SQLStateSQLExceptionTranslator;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.orm.jpa.vendor.EclipseLinkJpaDialect;
+
+/**
+ * {@link EclipseLinkJpaDialect} with additional exception translation
+ * mechanisms.
+ *
+ */
+public class HawkBitEclipseLinkJpaDialect extends EclipseLinkJpaDialect {
+    private static final long serialVersionUID = 1L;
+
+    private static final SQLStateSQLExceptionTranslator SQLSTATE_EXCEPTION_TRANSLATOR = new SQLStateSQLExceptionTranslator();
+
+    @Override
+    public DataAccessException translateExceptionIfPossible(final RuntimeException ex) {
+        final DataAccessException dataAccessException = super.translateExceptionIfPossible(ex);
+
+        if (dataAccessException != null) {
+            return translateJpaSystemExceptionIfPossible(dataAccessException);
+        }
+
+        return searchAndTranslateSqlException(ex);
+    }
+
+    private static DataAccessException translateJpaSystemExceptionIfPossible(
+            final DataAccessException accessException) {
+        if (!(accessException instanceof JpaSystemException)) {
+            return accessException;
+        }
+
+        return searchAndTranslateSqlException(accessException);
+    }
+
+    private static DataAccessException searchAndTranslateSqlException(final RuntimeException ex) {
+        final SQLException sqlException = findSqlException(ex);
+
+        if (sqlException == null) {
+            return null;
+        }
+
+        return SQLSTATE_EXCEPTION_TRANSLATOR.translate(null, null, sqlException);
+    }
+
+    private static SQLException findSqlException(final RuntimeException jpaSystemException) {
+        Throwable exception = jpaSystemException;
+        do {
+            final Throwable cause = exception.getCause();
+            if (cause instanceof SQLException) {
+                return (SQLException) cause;
+            }
+            exception = cause;
+        } while (exception != null);
+
+        return null;
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.repository.jpa;
 
 import java.net.URI;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -24,7 +24,6 @@ import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.QuotaManagement;
 import org.eclipse.hawkbit.repository.RepositoryConstants;
 import org.eclipse.hawkbit.repository.RepositoryProperties;
-import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.repository.builder.ActionStatusCreate;
 import org.eclipse.hawkbit.repository.event.remote.DownloadProgressEvent;
@@ -90,9 +89,6 @@ public class JpaControllerManagement implements ControllerManagement {
 
     @Autowired
     private SoftwareModuleRepository softwareModuleRepository;
-
-    @Autowired
-    private TargetManagement targetManagement;
 
     @Autowired
     private ActionStatusRepository actionStatusRepository;
@@ -212,10 +208,10 @@ public class JpaControllerManagement implements ControllerManagement {
         final JpaTarget target = targetRepository.findOne(spec);
 
         if (target == null) {
-            final Target result = targetManagement.createTarget(entityFactory.target().create()
+            final Target result = targetRepository.save((JpaTarget) entityFactory.target().create()
                     .controllerId(controllerId).description("Plug and Play target: " + controllerId).name(controllerId)
                     .status(TargetUpdateStatus.REGISTERED).lastTargetQuery(System.currentTimeMillis())
-                    .address(Optional.ofNullable(address).map(URI::toString).orElse(null)));
+                    .address(Optional.ofNullable(address).map(URI::toString).orElse(null)).build());
 
             afterCommit.afterCommit(
                     () -> eventPublisher.publishEvent(new TargetPollEvent(result, applicationContext.getId())));
@@ -533,7 +529,7 @@ public class JpaControllerManagement implements ControllerManagement {
     public List<String> getActionHistoryMessages(final Long actionId, final int messageCount) {
         // Just return empty list in case messageCount is zero.
         if (messageCount == 0) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         // For negative and large value of messageCount, limit the number of

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -135,8 +135,6 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     @Autowired
     private PlatformTransactionManager txManager;
 
-    // Note: OptimisticLockException added due to usage of flush whch means that
-    // springs transaction based exception mapping will not happen
     @Override
     @Transactional(isolation = Isolation.READ_COMMITTED)
     @Retryable(include = {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -19,7 +19,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
-import javax.persistence.OptimisticLockException;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.JoinType;
@@ -140,7 +139,8 @@ public class JpaDeploymentManagement implements DeploymentManagement {
     // springs transaction based exception mapping will not happen
     @Override
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    @Retryable(include = { ConcurrencyFailureException.class}, maxAttempts = Constants.TX_RT_MAX, backoff = @Backoff(delay = Constants.TX_RT_DELAY))
+    @Retryable(include = {
+            ConcurrencyFailureException.class }, maxAttempts = Constants.TX_RT_MAX, backoff = @Backoff(delay = Constants.TX_RT_DELAY))
     public DistributionSetAssignmentResult assignDistributionSet(final Long dsID, final ActionType actionType,
             final long forcedTimestamp, final Collection<String> targetIDs) {
 
@@ -151,7 +151,8 @@ public class JpaDeploymentManagement implements DeploymentManagement {
 
     @Override
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    @Retryable(include = { ConcurrencyFailureException.class}, maxAttempts = Constants.TX_RT_MAX, backoff = @Backoff(delay = Constants.TX_RT_DELAY))
+    @Retryable(include = {
+            ConcurrencyFailureException.class }, maxAttempts = Constants.TX_RT_MAX, backoff = @Backoff(delay = Constants.TX_RT_DELAY))
     public DistributionSetAssignmentResult assignDistributionSet(final Long dsID,
             final Collection<TargetWithActionType> targets) {
 
@@ -160,7 +161,8 @@ public class JpaDeploymentManagement implements DeploymentManagement {
 
     @Override
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    @Retryable(include = { ConcurrencyFailureException.class }, maxAttempts = Constants.TX_RT_MAX, backoff = @Backoff(delay = Constants.TX_RT_DELAY))
+    @Retryable(include = {
+            ConcurrencyFailureException.class }, maxAttempts = Constants.TX_RT_MAX, backoff = @Backoff(delay = Constants.TX_RT_DELAY))
     public DistributionSetAssignmentResult assignDistributionSet(final Long dsID,
             final Collection<TargetWithActionType> targets, final String actionMessage) {
 
@@ -257,12 +259,9 @@ public class JpaDeploymentManagement implements DeploymentManagement {
         // action history.
         targetIdsToActions.values().forEach(action -> setRunningActionStatus(action, actionMessage));
 
-        // flush to get action IDs
-        // entityManager.flush();
-
         // detaching as it is not necessary to persist the set itself
         entityManager.detach(set);
-        // detaching as the entity has been changed by the JPQL query above
+        // detaching as the entity has been updated by the JPQL query above
         targets.forEach(entityManager::detach);
 
         sendAssignmentEvents(targets, targetIdsCancellList, targetIdsToActions);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -290,7 +290,7 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
     @Override
     protected AbstractJpaVendorAdapter createJpaVendorAdapter() {
         return new EclipseLinkJpaVendorAdapter() {
-            HawkBitEclipseLinkJpaDialect jpaDialect = new HawkBitEclipseLinkJpaDialect();
+            private final HawkBitEclipseLinkJpaDialect jpaDialect = new HawkBitEclipseLinkJpaDialect();
 
             @Override
             public EclipseLinkJpaDialect getJpaDialect() {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -90,6 +90,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.orm.jpa.vendor.AbstractJpaVendorAdapter;
+import org.springframework.orm.jpa.vendor.EclipseLinkJpaDialect;
 import org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -287,7 +288,14 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
 
     @Override
     protected AbstractJpaVendorAdapter createJpaVendorAdapter() {
-        return new EclipseLinkJpaVendorAdapter();
+        return new EclipseLinkJpaVendorAdapter() {
+            HawkBitEclipseLinkJpaDialect jpaDialect = new HawkBitEclipseLinkJpaDialect();
+
+            @Override
+            public EclipseLinkJpaDialect getJpaDialect() {
+                return jpaDialect;
+            }
+        };
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
@@ -53,7 +53,7 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
      */
     @Modifying
     @Transactional
-    @Query("UPDATE JpaTarget t  SET t.assignedDistributionSet = :set, t.lastModifiedAt = :lastModifiedAt, t.lastModifiedBy = :lastModifiedBy, t.updateStatus = :status WHERE t.id IN :targets")
+    @Query("UPDATE JpaTarget t SET t.assignedDistributionSet = :set, t.lastModifiedAt = :lastModifiedAt, t.lastModifiedBy = :lastModifiedBy, t.updateStatus = :status WHERE t.id IN :targets")
     void setAssignedDistributionSetAndUpdateStatus(@Param("status") TargetUpdateStatus status,
             @Param("set") JpaDistributionSet set, @Param("lastModifiedAt") Long modifiedAt,
             @Param("lastModifiedBy") String modifiedBy, @Param("targets") Collection<Long> targets);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantMetaDataRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantMetaDataRepository.java
@@ -16,7 +16,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -33,7 +32,7 @@ public interface TenantMetaDataRepository extends PagingAndSortingRepository<Jpa
      *            to search for
      * @return found {@link TenantMetaData} or <code>null</code>
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    // @Transactional(propagation = Propagation.REQUIRES_NEW)
     TenantMetaData findByTenantIgnoreCase(String tenant);
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantMetaDataRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TenantMetaDataRepository.java
@@ -32,7 +32,6 @@ public interface TenantMetaDataRepository extends PagingAndSortingRepository<Jpa
      *            to search for
      * @return found {@link TenantMetaData} or <code>null</code>
      */
-    // @Transactional(propagation = Propagation.REQUIRES_NEW)
     TenantMetaData findByTenantIgnoreCase(String tenant);
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/aspects/ExceptionMappingAspectHandler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/aspects/ExceptionMappingAspectHandler.java
@@ -90,7 +90,7 @@ public class ExceptionMappingAspectHandler implements Ordered {
         for (final Class<?> mappedEx : MAPPED_EXCEPTION_ORDER) {
 
             if (!mappedEx.isAssignableFrom(ex.getClass())) {
-                break;
+                continue;
             }
 
             if (EXCEPTION_MAPPING.containsKey(mappedEx.getName())) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/aspects/ExceptionMappingAspectHandler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/aspects/ExceptionMappingAspectHandler.java
@@ -74,16 +74,15 @@ public class ExceptionMappingAspectHandler implements Ordered {
      *            the thrown and catched exception
      * @throws Throwable
      */
-    // FIXME check to further reduce this
-    @AfterThrowing(pointcut = "( execution( * org.springframework.transaction..*.*(..)) "
-            + " || execution( * org.eclipse.hawkbit.repository.*.*(..)) )", throwing = "ex")
+    @AfterThrowing(pointcut = "execution( * org.eclipse.hawkbit.repository.jpa.*Management.*(..))", throwing = "ex")
     // Exception for squid:S00112, squid:S1162
     // It is a AspectJ proxy which deals with exceptions.
     @SuppressWarnings({ "squid:S00112", "squid:S1162" })
     public void catchAndWrapJpaExceptionsService(final Exception ex) throws Throwable {
 
         // Workarround for EclipseLink pre-update where it does not throw
-        // ConstraintViolationException correctly
+        // ConstraintViolationException correctly in case of existing entity
+        // update
         if (ex instanceof TransactionSystemException) {
             throw findConstraintViolationException(ex);
         }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/aspects/ExceptionMappingAspectHandler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/aspects/ExceptionMappingAspectHandler.java
@@ -18,7 +18,6 @@ import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
 import org.eclipse.hawkbit.exception.GenericSpServerException;
 import org.eclipse.hawkbit.repository.exception.ConcurrentModificationException;
-import org.eclipse.hawkbit.repository.exception.ConstraintViolationException;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.InsufficientPermissionException;
 import org.slf4j.Logger;
@@ -67,7 +66,6 @@ public class ExceptionMappingAspectHandler implements Ordered {
         MAPPED_EXCEPTION_ORDER.add(DataIntegrityViolationException.class);
         MAPPED_EXCEPTION_ORDER.add(OptimisticLockingFailureException.class);
         MAPPED_EXCEPTION_ORDER.add(AccessDeniedException.class);
-        MAPPED_EXCEPTION_ORDER.add(javax.validation.ConstraintViolationException.class);
 
         EXCEPTION_MAPPING.put(DuplicateKeyException.class.getName(), EntityAlreadyExistsException.class.getName());
         EXCEPTION_MAPPING.put(DataIntegrityViolationException.class.getName(),
@@ -76,8 +74,6 @@ public class ExceptionMappingAspectHandler implements Ordered {
         EXCEPTION_MAPPING.put(OptimisticLockingFailureException.class.getName(),
                 ConcurrentModificationException.class.getName());
         EXCEPTION_MAPPING.put(AccessDeniedException.class.getName(), InsufficientPermissionException.class.getName());
-        EXCEPTION_MAPPING.put(javax.validation.ConstraintViolationException.class.getName(),
-                ConstraintViolationException.class.getName());
 
     }
 
@@ -107,6 +103,10 @@ public class ExceptionMappingAspectHandler implements Ordered {
 
         if (translatedAccessException == null) {
             translatedAccessException = ex;
+        }
+
+        if (translatedAccessException instanceof javax.validation.ConstraintViolationException) {
+            throw translatedAccessException;
         }
 
         Exception mappingException = translatedAccessException;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/aspects/ExceptionMappingAspectHandler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/aspects/ExceptionMappingAspectHandler.java
@@ -80,8 +80,8 @@ public class ExceptionMappingAspectHandler implements Ordered {
     @SuppressWarnings({ "squid:S00112", "squid:S1162" })
     public void catchAndWrapJpaExceptionsService(final Exception ex) throws Throwable {
 
-        // Workarround for EclipseLink pre-update where it does not throw
-        // ConstraintViolationException correctly in case of existing entity
+        // Workarround for EclipseLink merge where it does not throw
+        // ConstraintViolationException directly in case of existing entity
         // update
         if (ex instanceof TransactionSystemException) {
             throw findConstraintViolationException(ex);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/AbstractJpaNamedEntity.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/AbstractJpaNamedEntity.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.jpa.model;
 
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.eclipse.hawkbit.repository.model.NamedEntity;
@@ -26,12 +27,13 @@ import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 public abstract class AbstractJpaNamedEntity extends AbstractJpaTenantAwareBaseEntity implements NamedEntity {
     private static final long serialVersionUID = 1L;
 
-    @Column(name = "name", nullable = false, length = 64)
-    @Size(min = 1, max = 64)
+    @Column(name = "name", nullable = false, length = NamedEntity.NAME_MAX_SIZE)
+    @Size(min = 1, max = NamedEntity.NAME_MAX_SIZE)
+    @NotNull
     private String name;
 
-    @Column(name = "description", nullable = true, length = 512)
-    @Size(max = 512)
+    @Column(name = "description", nullable = true, length = NamedEntity.DESCRIPTION_MAX_SIZE)
+    @Size(max = NamedEntity.DESCRIPTION_MAX_SIZE)
     private String description;
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/AbstractJpaNamedEntity.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/AbstractJpaNamedEntity.java
@@ -14,7 +14,6 @@ import javax.validation.constraints.Size;
 
 import org.eclipse.hawkbit.repository.model.NamedEntity;
 import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
-import org.hibernate.validator.constraints.NotEmpty;
 
 /**
  * {@link TenantAwareBaseEntity} extension for all entities that are named in
@@ -28,8 +27,7 @@ public abstract class AbstractJpaNamedEntity extends AbstractJpaTenantAwareBaseE
     private static final long serialVersionUID = 1L;
 
     @Column(name = "name", nullable = false, length = 64)
-    @Size(max = 64)
-    @NotEmpty
+    @Size(min = 1, max = 64)
     private String name;
 
     @Column(name = "description", nullable = true, length = 512)

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/AbstractJpaTenantAwareBaseEntity.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/AbstractJpaTenantAwareBaseEntity.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.repository.jpa.model;
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.PrePersist;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.eclipse.hawkbit.repository.exception.TenantNotExistException;
@@ -20,7 +21,6 @@ import org.eclipse.hawkbit.repository.model.helper.SystemManagementHolder;
 import org.eclipse.persistence.annotations.Multitenant;
 import org.eclipse.persistence.annotations.MultitenantType;
 import org.eclipse.persistence.annotations.TenantDiscriminatorColumn;
-import org.hibernate.validator.constraints.NotEmpty;
 
 /**
  * Holder of the base attributes common to all tenant aware entities.
@@ -33,8 +33,8 @@ public abstract class AbstractJpaTenantAwareBaseEntity extends AbstractJpaBaseEn
     private static final long serialVersionUID = 1L;
 
     @Column(name = "tenant", nullable = false, insertable = false, updatable = false, length = 40)
-    @Size(max = 40)
-    @NotEmpty
+    @Size(min = 1, max = 40)
+    @NotNull
     private String tenant;
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -91,8 +91,9 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
     private static final List<String> TARGET_UPDATE_EVENT_IGNORE_FIELDS = Arrays.asList("lastTargetQuery",
             "lastTargetQuery", "address", "optLockRevision", "lastModifiedAt", "lastModifiedBy");
 
-    @Column(name = "controller_id", length = 64)
-    @Size(min = 1, max = 64)
+    @Column(name = "controller_id", length = Target.CONTROLLER_ID_MAX_SIZE)
+    @Size(min = 1, max = Target.CONTROLLER_ID_MAX_SIZE)
+    @NotNull
     @Pattern(regexp = "[.\\S]*", message = "has whitespaces which are not allowed")
     private String controllerId;
 
@@ -111,16 +112,17 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
      * the security token of the target which allows if enabled to authenticate
      * with this security token.
      */
-    @Column(name = "sec_token", updatable = true, nullable = false, length = 128)
-    @Size(min = 1, max = 128)
+    @Column(name = "sec_token", updatable = true, nullable = false, length = Target.SECURITY_TOKEN_MAX_SIZE)
+    @Size(min = 1, max = Target.SECURITY_TOKEN_MAX_SIZE)
+    @NotNull
     private String securityToken;
 
     @CascadeOnDelete
     @OneToMany(mappedBy = "target", fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST })
     private List<RolloutTargetGroup> rolloutTargetGroup;
 
-    @Column(name = "address", length = 512)
-    @Size(max = 512)
+    @Column(name = "address", length = Target.ADDRESS_MAX_SIZE)
+    @Size(max = Target.ADDRESS_MAX_SIZE)
     private String address;
 
     @Column(name = "last_target_query")

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -64,7 +64,6 @@ import org.eclipse.hawkbit.tenancy.configuration.DurationHelper;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
 import org.eclipse.persistence.annotations.CascadeOnDelete;
 import org.eclipse.persistence.descriptors.DescriptorEvent;
-import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,7 +93,6 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
 
     @Column(name = "controller_id", length = 64)
     @Size(min = 1, max = 64)
-    @NotEmpty
     @Pattern(regexp = "[.\\S]*", message = "has whitespaces which are not allowed")
     private String controllerId;
 
@@ -114,8 +112,7 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
      * with this security token.
      */
     @Column(name = "sec_token", updatable = true, nullable = false, length = 128)
-    @Size(max = 128)
-    @NotEmpty
+    @Size(min = 1, max = 128)
     private String securityToken;
 
     @CascadeOnDelete

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialectTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialectTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+
+import javax.persistence.OptimisticLockException;
+import javax.persistence.PersistenceException;
+
+import org.junit.Test;
+import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.orm.jpa.JpaSystemException;
+
+import ru.yandex.qatools.allure.annotations.Description;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Stories;
+
+/**
+ * Mapping tests for {@link HawkBitEclipseLinkJpaDialect}.
+ *
+ */
+@Features("Component Tests - Repository")
+@Stories("Exception handling")
+public class HawkBitEclipseLinkJpaDialectTest {
+    private final HawkBitEclipseLinkJpaDialect hawkBitEclipseLinkJpaDialectUnderTest = new HawkBitEclipseLinkJpaDialect();
+
+    @Test
+    @Description("Use Case: PersistenceException that can be mapped by EclipseLinkJpaDialect into corresponding DataAccessException.")
+    public void jpaOptimisticLockExceptionIsConcurrencyFailureException() {
+        assertThat(
+                hawkBitEclipseLinkJpaDialectUnderTest.translateExceptionIfPossible(mock(OptimisticLockException.class)))
+                        .isInstanceOf(ConcurrencyFailureException.class);
+    }
+
+    @Test
+    @Description("Use Case: PersistenceException that could not be mapped by EclipseLinkJpaDialect directly but "
+            + "instead is wrapped into JpaSystemException. Cause of PersistenceException is an SQLException.")
+    public void jpaSystemExceptionWithSqlDeadLockExceptionIsConcurrencyFailureException() {
+        final PersistenceException persEception = mock(PersistenceException.class);
+        when(persEception.getCause()).thenReturn(new SQLException("simulated transaction ER_LOCK_DEADLOCK", "40001"));
+
+        assertThat(hawkBitEclipseLinkJpaDialectUnderTest
+                .translateExceptionIfPossible(new JpaSystemException(persEception)))
+                        .isInstanceOf(ConcurrencyFailureException.class);
+    }
+
+    @Test
+    @Description("Use Case: PersistenceException that could not be mapped by EclipseLinkJpaDialect directly but instead is wrapped"
+            + " into JpaSystemException. Cause of PersistenceException is not an SQLException.")
+    public void jpaSystemExceptionWithNumberFormatExceptionIsNull() {
+
+        assertThat(hawkBitEclipseLinkJpaDialectUnderTest
+                .translateExceptionIfPossible(new JpaSystemException(new NumberFormatException()))).isNull();
+    }
+
+    @Test
+    @Description("Use Case: RuntimeException that could not be mapped by EclipseLinkJpaDialect directly. Cause of "
+            + "RuntimeException is an SQLException.")
+    public void runtimeExceptionWithSqlDeadLockExceptionIsConcurrencyFailureException() {
+        final RuntimeException persEception = mock(RuntimeException.class);
+        when(persEception.getCause()).thenReturn(new SQLException("simulated transaction ER_LOCK_DEADLOCK", "40001"));
+
+        assertThat(hawkBitEclipseLinkJpaDialectUnderTest.translateExceptionIfPossible(persEception))
+                .isInstanceOf(ConcurrencyFailureException.class);
+    }
+
+    @Test
+    @Description("Use Case: RuntimeException that could not be mapped by EclipseLinkJpaDialect directly. Cause of "
+            + "RuntimeException is not an SQLException.")
+    public void runtimeExceptionWithNumberFormatExceptionIsNull() {
+        final RuntimeException persEception = mock(RuntimeException.class);
+        when(persEception.getCause()).thenReturn(new NumberFormatException());
+
+        assertThat(hawkBitEclipseLinkJpaDialectUnderTest.translateExceptionIfPossible(persEception)).isNull();
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialectTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialectTest.java
@@ -29,7 +29,7 @@ import ru.yandex.qatools.allure.annotations.Stories;
  * Mapping tests for {@link HawkBitEclipseLinkJpaDialect}.
  *
  */
-@Features("Component Tests - Repository")
+@Features("Unit Tests - Repository")
 @Stories("Exception handling")
 public class HawkBitEclipseLinkJpaDialectTest {
     private final HawkBitEclipseLinkJpaDialect hawkBitEclipseLinkJpaDialectUnderTest = new HawkBitEclipseLinkJpaDialect();

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialectTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/HawkBitEclipseLinkJpaDialectTest.java
@@ -19,7 +19,7 @@ import javax.persistence.PersistenceException;
 
 import org.junit.Test;
 import org.springframework.dao.ConcurrencyFailureException;
-import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.dao.UncategorizedDataAccessException;
 
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
@@ -49,18 +49,19 @@ public class HawkBitEclipseLinkJpaDialectTest {
         final PersistenceException persEception = mock(PersistenceException.class);
         when(persEception.getCause()).thenReturn(new SQLException("simulated transaction ER_LOCK_DEADLOCK", "40001"));
 
-        assertThat(hawkBitEclipseLinkJpaDialectUnderTest
-                .translateExceptionIfPossible(new JpaSystemException(persEception)))
-                        .isInstanceOf(ConcurrencyFailureException.class);
+        assertThat(hawkBitEclipseLinkJpaDialectUnderTest.translateExceptionIfPossible(persEception))
+                .isInstanceOf(ConcurrencyFailureException.class);
     }
 
     @Test
     @Description("Use Case: PersistenceException that could not be mapped by EclipseLinkJpaDialect directly but instead is wrapped"
             + " into JpaSystemException. Cause of PersistenceException is not an SQLException.")
     public void jpaSystemExceptionWithNumberFormatExceptionIsNull() {
+        final PersistenceException persEception = mock(PersistenceException.class);
+        when(persEception.getCause()).thenReturn(new NumberFormatException());
 
-        assertThat(hawkBitEclipseLinkJpaDialectUnderTest
-                .translateExceptionIfPossible(new JpaSystemException(new NumberFormatException()))).isNull();
+        assertThat(hawkBitEclipseLinkJpaDialectUnderTest.translateExceptionIfPossible(persEception))
+                .isInstanceOf(UncategorizedDataAccessException.class);
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
@@ -56,11 +56,14 @@ import com.google.common.collect.Iterables;
 
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Step;
 import ru.yandex.qatools.allure.annotations.Stories;
 
 @Features("Component Tests - Repository")
 @Stories("Target Management")
 public class TargetManagementTest extends AbstractJpaIntegrationTest {
+
+    private static final String WHITESPACE_ERROR = "target with whitespaces in controller id should not be created";
 
     @Test
     @Description("Verifies that management get access react as specfied on calls for non existing entities by means "
@@ -176,19 +179,6 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description("Verify that a target with empty controller id cannot be created")
-    @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
-    public void createTargetWithNoControllerId() {
-        assertThatExceptionOfType(ConstraintViolationException.class)
-                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId("")))
-                .as("target with empty controller id should not be created");
-
-        assertThatExceptionOfType(ConstraintViolationException.class)
-                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId(null)))
-                .as("target with null controller id should not be created");
-    }
-
-    @Test
     @Description("Verify that a target with same controller ID than another device cannot be created.")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1) })
     public void createTargetThatViolatesUniqueConstraintFails() {
@@ -199,69 +189,125 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description("Verify that a target with whitespaces in controller id cannot be created")
-    @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
-    public void createTargetWithWhitespaces() {
-        try {
-            targetManagement.createTarget(entityFactory.target().create().controllerId(" "));
-            fail("target with whitespaces in controller id should not be created");
-        } catch (final ConstraintViolationException e) {
-            // ok
-        }
+    @Description("Verify that a target with empty controller id cannot be created")
+    @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1),
+            @Expect(type = TargetUpdatedEvent.class, count = 0) })
+    public void createAndUpdateTargetWithInvalidFields() {
+        final Target target = testdataFactory.createTarget();
 
-        try {
-            targetManagement.createTarget(entityFactory.target().create().controllerId(" a"));
-            fail("target with whitespaces in controller id should not be created");
-        } catch (final ConstraintViolationException e) {
-            // ok
-        }
+        createTargetWithInvalidControllerId();
+        createAndUpdateTargetWithInvalidDescription(target);
+        createAndUpdateTargetWithInvalidName(target);
+        createAndUpdateTargetWithInvalidSecurityToken(target);
+        createAndUpdateTargetWithInvalidAddress(target);
+    }
 
-        try {
-            targetManagement.createTarget(entityFactory.target().create().controllerId("a "));
-            fail("target with whitespaces in controller id should not be created");
-        } catch (final ConstraintViolationException e) {
-            // ok
-        }
+    @Step
+    private void createAndUpdateTargetWithInvalidDescription(final Target target) {
 
-        try {
-            targetManagement.createTarget(entityFactory.target().create().controllerId("a b"));
-            fail("target with whitespaces in controller id should not be created");
-        } catch (final ConstraintViolationException e) {
-            // ok
-        }
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId("a")
+                        .description(RandomStringUtils.randomAlphanumeric(513))))
+                .as("target with too long description should not be created");
 
-        try {
-            targetManagement.createTarget(entityFactory.target().create().controllerId("     "));
-            fail("target with whitespaces in controller id should not be created");
-        } catch (final ConstraintViolationException e) {
-            // ok
-        }
-
-        try {
-            targetManagement.createTarget(entityFactory.target().create().controllerId("aaa   bbb"));
-            fail("target with whitespaces in controller id should not be created");
-        } catch (final ConstraintViolationException e) {
-            // ok
-        }
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.updateTarget(entityFactory.target().update(target.getControllerId())
+                        .description(RandomStringUtils.randomAlphanumeric(513))))
+                .as("target with too long description should not be updated");
 
     }
 
-    @Test
-    @Description("Verify that a target with cannot be created or updated with a field that is to long")
-    @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1) })
-    public void createAndUpdateTargetWithTooLongField() {
+    @Step
+    private void createAndUpdateTargetWithInvalidName(final Target target) {
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId("a")
+                        .name(RandomStringUtils.randomAlphanumeric(65))))
+                .as("target with too long name should not be created");
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.updateTarget(entityFactory.target().update(target.getControllerId())
+                        .name(RandomStringUtils.randomAlphanumeric(65))))
+                .as("target with too long name should not be updated");
+
+        assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(
+                () -> targetManagement.updateTarget(entityFactory.target().update(target.getControllerId()).name("")))
+                .as("target with too short name should not be updated");
+
+    }
+
+    @Step
+    private void createAndUpdateTargetWithInvalidSecurityToken(final Target target) {
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId("a")
+                        .securityToken(RandomStringUtils.randomAlphanumeric(129))))
+                .as("target with too long token should not be created");
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.updateTarget(entityFactory.target().update(target.getControllerId())
+                        .securityToken(RandomStringUtils.randomAlphanumeric(129))))
+                .as("target with too long token should not be updated");
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement
+                        .updateTarget(entityFactory.target().update(target.getControllerId()).securityToken("")))
+                .as("target with too short token should not be updated");
+    }
+
+    @Step
+    private void createAndUpdateTargetWithInvalidAddress(final Target target) {
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId("a")
+                        .address(RandomStringUtils.randomAlphanumeric(513))))
+                .as("target with too long address should not be created");
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.updateTarget(entityFactory.target().update(target.getControllerId())
+                        .address(RandomStringUtils.randomAlphanumeric(513))))
+                .as("target with too long address should not be updated");
+    }
+
+    @Step
+    private void createTargetWithInvalidControllerId() {
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId("")))
+                .as("target with empty controller id should not be created");
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId(null)))
+                .as("target with null controller id should not be created");
 
         assertThatExceptionOfType(ConstraintViolationException.class)
                 .isThrownBy(() -> targetManagement.createTarget(
                         entityFactory.target().create().controllerId(RandomStringUtils.randomAlphanumeric(65))))
                 .as("target with too long controller id should not be created");
 
-        targetManagement.createTarget(entityFactory.target().create().controllerId("a")
-                .description(RandomStringUtils.randomAlphanumeric(512)));
         assertThatExceptionOfType(ConstraintViolationException.class)
-                .isThrownBy(() -> targetManagement.updateTarget(
-                        entityFactory.target().update("a").description(RandomStringUtils.randomAlphanumeric(513))))
-                .as("target with too long description should not be updated");
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId(" ")))
+                .as(WHITESPACE_ERROR);
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId(" a")))
+                .as(WHITESPACE_ERROR);
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId("a ")))
+                .as(WHITESPACE_ERROR);
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId("a b")))
+                .as(WHITESPACE_ERROR);
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(() -> targetManagement.createTarget(entityFactory.target().create().controllerId("     ")))
+                .as(WHITESPACE_ERROR);
+
+        assertThatExceptionOfType(ConstraintViolationException.class)
+                .isThrownBy(
+                        () -> targetManagement.createTarget(entityFactory.target().create().controllerId("aaa   bbb")))
+                .as(WHITESPACE_ERROR);
 
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
@@ -189,7 +189,7 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description("Verify that a target with empty controller id cannot be created")
+    @Description("Verify that a target with with invalid properties cannot be created or updated")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1),
             @Expect(type = TargetUpdatedEvent.class, count = 0) })
     public void createAndUpdateTargetWithInvalidFields() {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
@@ -177,6 +177,8 @@ public class RSQLTargetFieldTest extends AbstractJpaIntegrationTest {
         assertRSQLQuery(TargetFields.LASTCONTROLLERREQUESTAT.name() + "=lt=" + target2.getLastTargetQuery(), 1);
         assertRSQLQuery(TargetFields.LASTCONTROLLERREQUESTAT.name() + "=gt=" + target.getLastTargetQuery(), 1);
         assertRSQLQuery(TargetFields.LASTCONTROLLERREQUESTAT.name() + "=gt=" + target2.getLastTargetQuery(), 0);
+        assertRSQLQuery(TargetFields.LASTCONTROLLERREQUESTAT.name() + "=le=${NOW_TS}", 2);
+        assertRSQLQuery(TargetFields.LASTCONTROLLERREQUESTAT.name() + "=gt=${OVERDUE_TS}", 2);
     }
 
     private void assertRSQLQuery(final String rsqlParam, final long expcetedTargets) {

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
@@ -9,6 +9,7 @@
 
 package org.eclipse.hawkbit.repository.test.matcher;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.Iterator;
@@ -18,6 +19,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.hawkbit.repository.event.remote.RemoteIdEvent;
+import org.eclipse.hawkbit.repository.event.remote.RemoteTenantAwareEvent;
+import org.eclipse.hawkbit.repository.event.remote.TargetAssignDistributionSetEvent;
 import org.eclipse.hawkbit.repository.test.util.TestContextProvider;
 import org.junit.Assert;
 import org.junit.rules.TestRule;
@@ -120,6 +124,21 @@ public class EventVerifier implements TestRule {
         @Override
         public void onApplicationEvent(final RemoteApplicationEvent event) {
             LOGGER.debug("Received event {}", event.getClass().getSimpleName());
+
+            if (event instanceof RemoteTenantAwareEvent) {
+                assertThat(((RemoteTenantAwareEvent) event).getTenant()).isNotEmpty();
+            }
+
+            if (event instanceof RemoteIdEvent) {
+                assertThat(((RemoteIdEvent) event).getEntityId()).isNotNull();
+            }
+
+            if (event instanceof TargetAssignDistributionSetEvent) {
+                assertThat(((TargetAssignDistributionSetEvent) event).getActionId()).isNotNull();
+                assertThat(((TargetAssignDistributionSetEvent) event).getControllerId()).isNotEmpty();
+                assertThat(((TargetAssignDistributionSetEvent) event).getDistributionSetId()).isNotNull();
+            }
+
             capturedEvents.add(event.getClass());
         }
 


### PR DESCRIPTION
Fixed several issues and worked a bit on API documentation:

* Fixed issue where repository on update operations does not throw ConstraintViolation (as on create) if bean violates a constraint after update.
* Fixed issue where assignDs operations do not throw spring exceptions as expected but native EclipseLink or MySQL exceptions.
* Fixed deadlock on JDBC connections in high load scenarios.
* Added constraint documentation on builders for target and added a few more test as well (should be done for the other entities in similar fashion later on).

Piggy backed a small changed on mgmt API into the request: add "modules" link to DS resource.