### PR TITLE
Building code behind a proxy added to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ see [hawkBit Documentation](https://www.eclipse.org/hawkbit/documentation/overvi
 
 We offer a sandbox installation that is free for everyone to try out hawkBit. However, keep in mind that the sandbox database will be reset from time to time. It is also not possible to upload any artifacts into the sandbox. But you can use it to try out the Management UI, Management API and DDI API.
 
-https://hawkbit.eu-gb.mybluemix.net/UI/
+https://hawkbit.eu-gb.mybluemix.net/UI/ (currently unavailable - will be back soon)
 
 # Device Integration
 

--- a/extensions/hawkbit-extension-artifact-repository-mongo/README.md
+++ b/extensions/hawkbit-extension-artifact-repository-mongo/README.md
@@ -13,11 +13,13 @@ For using this extension in the hawkbit-example-application you just need to add
 </dependency>
 ```
 
-If you do not have a mongoDB running you can use the the flapdoodle project to download and start an mongoDB on demand
+If you do not have a mongoDB running you can use the the flapdoodle project to download and start a mongoDB on demand
 ```
 <dependency>
   <groupId>de.flapdoodle.embed</groupId>
   <artifactId>de.flapdoodle.embed.mongo</artifactId>
   <version>${flapdoodle.version}</version>
 </dependency>
-``` 
+```
+
+Maven test execution of this module is backed by flapdoodle. In case you don't have a mongoDB and run behind a proxy you may set the `JAVA_TOOL_OPTIONS` as global environment variable with your proxy settings. So flapdoodle is able to download the mongoDB dependency.


### PR DESCRIPTION
HawkBit sandbox removed (not available anymore) and added documentation for building source code behind a proxy

Signed-off-by: Dominic Schabel <dominic.schabel@bosch-si.com>