### PR TITLE
Unused enum constant "skip" removed

### DIFF
--- a/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeployment.java
+++ b/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeployment.java
@@ -64,14 +64,9 @@ public class DdiDeployment {
     }
 
     /**
-     * The handling type for the update action.
+     * Handling type for the update action.
      */
     public enum HandlingType {
-
-        /**
-         * Not necessary for the command.
-         */
-        SKIP("skip"),
 
         /**
          * Try to execute (local applications may intervene by SP control API).


### PR DESCRIPTION
The HandlingType "skip" is a leftover from the early days of HawkBit. Actually it was never used neither returned at API level (see [here](https://github.com/eclipse/hawkbit/blob/master/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java#L277])). So it can be removed to prevent confusion.