### PR TITLE
Readd skip type for upcoming maintenance window feature

### DIFF
--- a/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeployment.java
+++ b/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeployment.java
@@ -64,9 +64,14 @@ public class DdiDeployment {
     }
 
     /**
-     * Handling type for the update action.
+     * The handling type for the update action.
      */
     public enum HandlingType {
+
+        /**
+         * Not necessary for the command.
+         */
+        SKIP("skip"),
 
         /**
          * Try to execute (local applications may intervene by SP control API).


### PR DESCRIPTION
Readd the previously removed `skip` status, as it will be used soon for the maintenance window feature (see  [here](https://github.com/eclipse/hawkbit/pull/571#issuecomment-326530905])).

This basically reverts commit: https://github.com/eclipse/hawkbit/pull/571/commits/54c4c8d1f0d7c8d354277d33660b834ca90cab96