### PR TITLE
Consistent listing of hypermedia links

### DIFF
--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetMapper.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetMapper.java
@@ -117,6 +117,10 @@ public final class MgmtDistributionSetMapper {
         response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getDistributionSet(response.getDsId()))
                 .withSelfRel());
 
+        return response;
+    }
+
+    static void addLinks(final DistributionSet distributionSet, final MgmtDistributionSet response) {
         response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getAssignedSoftwareModules(response.getDsId(),
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null))
@@ -128,8 +132,6 @@ public final class MgmtDistributionSetMapper {
         response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getMetadata(response.getDsId(),
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null)).withRel("metadata"));
-
-        return response;
     }
 
     static MgmtTargetAssignmentResponseBody toResponse(final DistributionSetAssignmentResult dsAssignmentResult) {

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResource.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResource.java
@@ -117,7 +117,10 @@ public class MgmtDistributionSetResource implements MgmtDistributionSetRestApi {
             @PathVariable("distributionSetId") final Long distributionSetId) {
         final DistributionSet foundDs = findDistributionSetWithExceptionIfNotFound(distributionSetId);
 
-        return ResponseEntity.ok(MgmtDistributionSetMapper.toResponse(foundDs));
+        final MgmtDistributionSet response = MgmtDistributionSetMapper.toResponse(foundDs);
+        MgmtDistributionSetMapper.addLinks(foundDs, response);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override
@@ -149,10 +152,14 @@ public class MgmtDistributionSetResource implements MgmtDistributionSetRestApi {
             @PathVariable("distributionSetId") final Long distributionSetId,
             @RequestBody final MgmtDistributionSetRequestBodyPut toUpdate) {
 
-        return ResponseEntity.ok(
-                MgmtDistributionSetMapper.toResponse(distributionSetManagement.update(entityFactory.distributionSet()
-                        .update(distributionSetId).name(toUpdate.getName()).description(toUpdate.getDescription())
-                        .version(toUpdate.getVersion()).requiredMigrationStep(toUpdate.isRequiredMigrationStep()))));
+        final DistributionSet updated = distributionSetManagement.update(entityFactory.distributionSet()
+                .update(distributionSetId).name(toUpdate.getName()).description(toUpdate.getDescription())
+                .version(toUpdate.getVersion()).requiredMigrationStep(toUpdate.isRequiredMigrationStep()));
+
+        final MgmtDistributionSet response = MgmtDistributionSetMapper.toResponse(updated);
+        MgmtDistributionSetMapper.addLinks(updated, response);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTagResource.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTagResource.java
@@ -91,8 +91,12 @@ public class MgmtDistributionSetTagResource implements MgmtDistributionSetTagRes
     @Override
     public ResponseEntity<MgmtTag> getDistributionSetTag(
             @PathVariable("distributionsetTagId") final Long distributionsetTagId) {
-        final DistributionSetTag tag = findDistributionTagById(distributionsetTagId);
-        return ResponseEntity.ok(MgmtTagMapper.toResponse(tag));
+        final DistributionSetTag distributionSetTag = findDistributionTagById(distributionsetTagId);
+
+        final MgmtTag response = MgmtTagMapper.toResponse(distributionSetTag);
+        MgmtTagMapper.addLinks(distributionSetTag, response);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override
@@ -111,9 +115,14 @@ public class MgmtDistributionSetTagResource implements MgmtDistributionSetTagRes
             @PathVariable("distributionsetTagId") final Long distributionsetTagId,
             @RequestBody final MgmtTagRequestBodyPut restDSTagRest) {
 
-        return ResponseEntity.ok(MgmtTagMapper.toResponse(distributionSetTagManagement
+        final DistributionSetTag distributionSetTag = distributionSetTagManagement
                 .update(entityFactory.tag().update(distributionsetTagId).name(restDSTagRest.getName())
-                        .description(restDSTagRest.getDescription()).colour(restDSTagRest.getColour()))));
+                        .description(restDSTagRest.getDescription()).colour(restDSTagRest.getColour()));
+
+        final MgmtTag response = MgmtTagMapper.toResponse(distributionSetTag);
+        MgmtTagMapper.addLinks(distributionSetTag, response);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTypeMapper.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTypeMapper.java
@@ -92,13 +92,16 @@ final class MgmtDistributionSetTypeMapper {
         result.add(linkTo(methodOn(MgmtDistributionSetTypeRestApi.class).getDistributionSetType(result.getModuleId()))
                 .withSelfRel());
 
+        return result;
+    }
+
+    static void addLinks(final MgmtDistributionSetType result) {
+
         result.add(linkTo(methodOn(MgmtDistributionSetTypeRestApi.class).getMandatoryModules(result.getModuleId()))
                 .withRel(MgmtRestConstants.DISTRIBUTIONSETTYPE_V1_MANDATORY_MODULES));
 
         result.add(linkTo(methodOn(MgmtDistributionSetTypeRestApi.class).getOptionalModules(result.getModuleId()))
                 .withRel(MgmtRestConstants.DISTRIBUTIONSETTYPE_V1_OPTIONAL_MODULES));
-
-        return result;
     }
 
 }

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTypeResource.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTypeResource.java
@@ -89,7 +89,11 @@ public class MgmtDistributionSetTypeResource implements MgmtDistributionSetTypeR
             @PathVariable("distributionSetTypeId") final Long distributionSetTypeId) {
 
         final DistributionSetType foundType = findDistributionSetTypeWithExceptionIfNotFound(distributionSetTypeId);
-        return ResponseEntity.ok(MgmtDistributionSetTypeMapper.toResponse(foundType));
+
+        final MgmtDistributionSetType reponse = MgmtDistributionSetTypeMapper.toResponse(foundType);
+        MgmtDistributionSetTypeMapper.addLinks(reponse);
+
+        return ResponseEntity.ok(reponse);
     }
 
     @Override
@@ -105,10 +109,14 @@ public class MgmtDistributionSetTypeResource implements MgmtDistributionSetTypeR
             @PathVariable("distributionSetTypeId") final Long distributionSetTypeId,
             @RequestBody final MgmtDistributionSetTypeRequestBodyPut restDistributionSetType) {
 
-        return ResponseEntity.ok(MgmtDistributionSetTypeMapper
-                .toResponse(distributionSetTypeManagement.update(entityFactory.distributionSetType()
-                        .update(distributionSetTypeId).description(restDistributionSetType.getDescription())
-                        .colour(restDistributionSetType.getColour()))));
+        final DistributionSetType updated = distributionSetTypeManagement.update(entityFactory.distributionSetType()
+                .update(distributionSetTypeId).description(restDistributionSetType.getDescription())
+                .colour(restDistributionSetType.getColour()));
+
+        final MgmtDistributionSetType reponse = MgmtDistributionSetTypeMapper.toResponse(updated);
+        MgmtDistributionSetTypeMapper.addLinks(reponse);
+
+        return ResponseEntity.ok(reponse);
     }
 
     @Override

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
@@ -83,16 +83,16 @@ final class MgmtRolloutMapper {
                 body.addTotalTargetsPerStatus(status.name().toLowerCase(),
                         rollout.getTotalTargetCountStatus().getTotalTargetCountByStatus(status));
             }
+
+            body.add(linkTo(methodOn(MgmtRolloutRestApi.class).start(rollout.getId())).withRel("start"));
+            body.add(linkTo(methodOn(MgmtRolloutRestApi.class).pause(rollout.getId())).withRel("pause"));
+            body.add(linkTo(methodOn(MgmtRolloutRestApi.class).resume(rollout.getId())).withRel("resume"));
+            body.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRolloutGroups(rollout.getId(),
+                    MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
+                    MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null)).withRel("groups"));
         }
 
         body.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRollout(rollout.getId())).withSelfRel());
-        body.add(linkTo(methodOn(MgmtRolloutRestApi.class).start(rollout.getId())).withRel("start"));
-        body.add(linkTo(methodOn(MgmtRolloutRestApi.class).pause(rollout.getId())).withRel("pause"));
-        body.add(linkTo(methodOn(MgmtRolloutRestApi.class).resume(rollout.getId())).withRel("resume"));
-        body.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRolloutGroups(rollout.getId(),
-                MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
-                MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null))
-                        .withRel("groups"));
         return body;
     }
 

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleMapper.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleMapper.java
@@ -92,38 +92,38 @@ public final class MgmtSoftwareModuleMapper {
         return metadataRest;
     }
 
-    static MgmtSoftwareModule toResponse(final SoftwareModule baseSofwareModule) {
-        if (baseSofwareModule == null) {
+    static MgmtSoftwareModule toResponse(final SoftwareModule softwareModule) {
+        if (softwareModule == null) {
             return null;
         }
 
         final MgmtSoftwareModule response = new MgmtSoftwareModule();
-        MgmtRestModelMapper.mapNamedToNamed(response, baseSofwareModule);
-        response.setModuleId(baseSofwareModule.getId());
-        response.setVersion(baseSofwareModule.getVersion());
-        response.setType(baseSofwareModule.getType().getKey());
-        response.setVendor(baseSofwareModule.getVendor());
+        MgmtRestModelMapper.mapNamedToNamed(response, softwareModule);
+        response.setModuleId(softwareModule.getId());
+        response.setVersion(softwareModule.getVersion());
+        response.setType(softwareModule.getType().getKey());
+        response.setVendor(softwareModule.getVendor());
 
-        response.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class).getArtifacts(response.getModuleId()))
-                .withRel(MgmtRestConstants.SOFTWAREMODULE_V1_ARTIFACT));
         response.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class).getSoftwareModule(response.getModuleId()))
                 .withSelfRel());
 
-        response.add(linkTo(methodOn(MgmtSoftwareModuleTypeRestApi.class)
-                .getSoftwareModuleType(baseSofwareModule.getType().getId()))
+        return response;
+    }
+
+    static void addLinks(final SoftwareModule softwareModule, final MgmtSoftwareModule response) {
+        response.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class).getArtifacts(response.getModuleId()))
+                .withRel(MgmtRestConstants.SOFTWAREMODULE_V1_ARTIFACT));
+
+        response.add(linkTo(
+                methodOn(MgmtSoftwareModuleTypeRestApi.class).getSoftwareModuleType(softwareModule.getType().getId()))
                         .withRel(MgmtRestConstants.SOFTWAREMODULE_V1_TYPE));
 
         response.add(linkTo(methodOn(MgmtSoftwareModuleResource.class).getMetadata(response.getModuleId(),
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null)).withRel("metadata")
                         .expand());
-        return response;
     }
 
-    /**
-     * @param artifact
-     * @return
-     */
     static MgmtArtifact toResponse(final Artifact artifact) {
         final MgmtArtifact artifactRest = new MgmtArtifact();
         artifactRest.setArtifactId(artifact.getId());
@@ -137,10 +137,13 @@ public final class MgmtSoftwareModuleMapper {
         artifactRest.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class)
                 .getArtifact(artifact.getSoftwareModule().getId(), artifact.getId())).withSelfRel());
 
-        artifactRest.add(linkTo(methodOn(MgmtDownloadArtifactResource.class)
-                .downloadArtifact(artifact.getSoftwareModule().getId(), artifact.getId())).withRel("download"));
-
         return artifactRest;
+    }
+
+    static void addLinks(final Artifact artifact, final MgmtArtifact response) {
+
+        response.add(linkTo(methodOn(MgmtDownloadArtifactResource.class)
+                .downloadArtifact(artifact.getSoftwareModule().getId(), artifact.getId())).withRel("download"));
     }
 
     static List<MgmtArtifact> artifactsToResponse(final Collection<Artifact> artifacts) {

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTagMapper.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTagMapper.java
@@ -62,12 +62,15 @@ final class MgmtTagMapper {
 
         response.add(linkTo(methodOn(MgmtTargetTagRestApi.class).getTargetTag(targetTag.getId())).withSelfRel());
 
+        return response;
+    }
+
+    static void addLinks(final TargetTag targetTag, final MgmtTag response) {
         response.add(linkTo(methodOn(MgmtTargetTagRestApi.class).getAssignedTargets(targetTag.getId(),
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null))
                         .withRel("assignedTargets"));
 
-        return response;
     }
 
     static List<MgmtTag> toResponseDistributionSetTag(final List<DistributionSetTag> distributionSetTags) {
@@ -96,12 +99,14 @@ final class MgmtTagMapper {
                 linkTo(methodOn(MgmtDistributionSetTagRestApi.class).getDistributionSetTag(distributionSetTag.getId()))
                         .withSelfRel());
 
+        return response;
+    }
+
+    static void addLinks(final DistributionSetTag distributionSetTag, final MgmtTag response) {
         response.add(linkTo(methodOn(MgmtDistributionSetTagRestApi.class).getAssignedDistributionSets(
                 distributionSetTag.getId(), MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null))
                         .withRel("assignedDistributionSets"));
-
-        return response;
     }
 
     static List<TagCreate> mapTagFromRequest(final EntityFactory entityFactory,

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetFilterQueryMapper.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetFilterQueryMapper.java
@@ -60,11 +60,13 @@ public final class MgmtTargetFilterQueryMapper {
         }
 
         targetRest.add(linkTo(methodOn(MgmtTargetFilterQueryRestApi.class).getFilter(filter.getId())).withSelfRel());
-        targetRest.add(
-                linkTo(methodOn(MgmtTargetFilterQueryRestApi.class).postAssignedDistributionSet(filter.getId(), null))
-                        .withRel("autoAssignDS"));
 
         return targetRest;
+    }
+
+    static void addLinks(final MgmtTargetFilterQuery targetRest) {
+        targetRest.add(linkTo(methodOn(MgmtTargetFilterQueryRestApi.class)
+                .postAssignedDistributionSet(targetRest.getFilterId(), null)).withRel("autoAssignDS"));
     }
 
     static TargetFilterQueryCreate fromRequest(final EntityFactory entityFactory,

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetFilterQueryResource.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetFilterQueryResource.java
@@ -55,6 +55,7 @@ public class MgmtTargetFilterQueryResource implements MgmtTargetFilterQueryRestA
         final TargetFilterQuery findTarget = findFilterWithExceptionIfNotFound(filterId);
         // to single response include poll status
         final MgmtTargetFilterQuery response = MgmtTargetFilterQueryMapper.toResponse(findTarget);
+        MgmtTargetFilterQueryMapper.addLinks(response);
 
         return ResponseEntity.ok(response);
     }
@@ -74,8 +75,7 @@ public class MgmtTargetFilterQueryResource implements MgmtTargetFilterQueryRestA
         final Slice<TargetFilterQuery> findTargetFiltersAll;
         final Long countTargetsAll;
         if (rsqlParam != null) {
-            final Page<TargetFilterQuery> findFilterPage = filterManagement.findByRsql(pageable,
-                    rsqlParam);
+            final Page<TargetFilterQuery> findFilterPage = filterManagement.findByRsql(pageable, rsqlParam);
             countTargetsAll = findFilterPage.getTotalElements();
             findTargetFiltersAll = findFilterPage;
         } else {
@@ -94,7 +94,10 @@ public class MgmtTargetFilterQueryResource implements MgmtTargetFilterQueryRestA
         final TargetFilterQuery createdTarget = filterManagement
                 .create(MgmtTargetFilterQueryMapper.fromRequest(entityFactory, filter));
 
-        return new ResponseEntity<>(MgmtTargetFilterQueryMapper.toResponse(createdTarget), HttpStatus.CREATED);
+        final MgmtTargetFilterQuery response = MgmtTargetFilterQueryMapper.toResponse(createdTarget);
+        MgmtTargetFilterQueryMapper.addLinks(response);
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
     @Override
@@ -102,11 +105,13 @@ public class MgmtTargetFilterQueryResource implements MgmtTargetFilterQueryRestA
             @RequestBody final MgmtTargetFilterQueryRequestBody targetFilterRest) {
         LOG.debug("updating target filter query {}", filterId);
 
-        final TargetFilterQuery updateFilter = filterManagement
-                .update(entityFactory.targetFilterQuery().update(filterId)
-                        .name(targetFilterRest.getName()).query(targetFilterRest.getQuery()));
+        final TargetFilterQuery updateFilter = filterManagement.update(entityFactory.targetFilterQuery()
+                .update(filterId).name(targetFilterRest.getName()).query(targetFilterRest.getQuery()));
 
-        return ResponseEntity.ok(MgmtTargetFilterQueryMapper.toResponse(updateFilter));
+        final MgmtTargetFilterQuery response = MgmtTargetFilterQueryMapper.toResponse(updateFilter);
+        MgmtTargetFilterQueryMapper.addLinks(response);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override
@@ -120,10 +125,12 @@ public class MgmtTargetFilterQueryResource implements MgmtTargetFilterQueryRestA
     public ResponseEntity<MgmtTargetFilterQuery> postAssignedDistributionSet(
             @PathVariable("filterId") final Long filterId, @RequestBody final MgmtId dsId) {
 
-        final TargetFilterQuery updateFilter = filterManagement.updateAutoAssignDS(filterId,
-                dsId.getId());
+        final TargetFilterQuery updateFilter = filterManagement.updateAutoAssignDS(filterId, dsId.getId());
 
-        return ResponseEntity.ok(MgmtTargetFilterQueryMapper.toResponse(updateFilter));
+        final MgmtTargetFilterQuery response = MgmtTargetFilterQueryMapper.toResponse(updateFilter);
+        MgmtTargetFilterQueryMapper.addLinks(response);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override
@@ -131,9 +138,15 @@ public class MgmtTargetFilterQueryResource implements MgmtTargetFilterQueryRestA
             @PathVariable("filterId") final Long filterId) {
         final TargetFilterQuery filter = findFilterWithExceptionIfNotFound(filterId);
         final DistributionSet autoAssignDistributionSet = filter.getAutoAssignDistributionSet();
-        final MgmtDistributionSet distributionSetRest = MgmtDistributionSetMapper.toResponse(autoAssignDistributionSet);
-        final HttpStatus retStatus = distributionSetRest == null ? HttpStatus.NO_CONTENT : HttpStatus.OK;
-        return new ResponseEntity<>(distributionSetRest, retStatus);
+
+        if (autoAssignDistributionSet == null) {
+            return ResponseEntity.noContent().build();
+        }
+
+        final MgmtDistributionSet response = MgmtDistributionSetMapper.toResponse(autoAssignDistributionSet);
+        MgmtDistributionSetMapper.addLinks(autoAssignDistributionSet, response);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResource.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResource.java
@@ -249,7 +249,12 @@ public class MgmtTargetResource implements MgmtTargetRestApi {
     public ResponseEntity<MgmtDistributionSet> getAssignedDistributionSet(
             @PathVariable("controllerId") final String controllerId) {
         final MgmtDistributionSet distributionSetRest = deploymentManagement.getAssignedDistributionSet(controllerId)
-                .map(MgmtDistributionSetMapper::toResponse).orElse(null);
+                .map(ds -> {
+                    final MgmtDistributionSet response = MgmtDistributionSetMapper.toResponse(ds);
+                    MgmtDistributionSetMapper.addLinks(ds, response);
+
+                    return response;
+                }).orElse(null);
 
         if (distributionSetRest == null) {
             return ResponseEntity.noContent().build();

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResource.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResource.java
@@ -122,7 +122,11 @@ public class MgmtTargetResource implements MgmtTargetRestApi {
                 .name(targetRest.getName()).description(targetRest.getDescription()).address(targetRest.getAddress())
                 .securityToken(targetRest.getSecurityToken()));
 
-        return ResponseEntity.ok(MgmtTargetMapper.toResponse(updateTarget));
+        final MgmtTarget response = MgmtTargetMapper.toResponse(updateTarget);
+        MgmtTargetMapper.addPollStatus(updateTarget, response);
+        MgmtTargetMapper.addTargetLinks(response);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override
@@ -275,11 +279,17 @@ public class MgmtTargetResource implements MgmtTargetRestApi {
     public ResponseEntity<MgmtDistributionSet> getInstalledDistributionSet(
             @PathVariable("controllerId") final String controllerId) {
         final MgmtDistributionSet distributionSetRest = deploymentManagement.getInstalledDistributionSet(controllerId)
-                .map(MgmtDistributionSetMapper::toResponse).orElse(null);
+                .map(set -> {
+                    final MgmtDistributionSet response = MgmtDistributionSetMapper.toResponse(set);
+                    MgmtDistributionSetMapper.addLinks(set, response);
+
+                    return response;
+                }).orElse(null);
 
         if (distributionSetRest == null) {
             return ResponseEntity.noContent().build();
         }
+
         return ResponseEntity.ok(distributionSetRest);
     }
 

--- a/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTagResource.java
+++ b/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTagResource.java
@@ -21,8 +21,8 @@ import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtTargetTagRestApi;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
-import org.eclipse.hawkbit.repository.TargetTagManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.TargetTagManagement;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetTag;
@@ -85,7 +85,11 @@ public class MgmtTargetTagResource implements MgmtTargetTagRestApi {
     @Override
     public ResponseEntity<MgmtTag> getTargetTag(@PathVariable("targetTagId") final Long targetTagId) {
         final TargetTag tag = findTargetTagById(targetTagId);
-        return ResponseEntity.ok(MgmtTagMapper.toResponse(tag));
+
+        final MgmtTag response = MgmtTagMapper.toResponse(tag);
+        MgmtTagMapper.addLinks(tag, response);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override
@@ -107,7 +111,10 @@ public class MgmtTargetTagResource implements MgmtTargetTagRestApi {
 
         LOG.debug("target tag updated");
 
-        return ResponseEntity.ok(MgmtTagMapper.toResponse(updateTargetTag));
+        final MgmtTag response = MgmtTagMapper.toResponse(updateTargetTag);
+        MgmtTagMapper.addLinks(updateTargetTag, response);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResourceTest.java
+++ b/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResourceTest.java
@@ -528,27 +528,18 @@ public class MgmtDistributionSetResourceTest extends AbstractManagementApiIntegr
         assertThat(
                 JsonPath.compile("[0]_links.self.href").read(mvcResult.getResponse().getContentAsString()).toString())
                         .isEqualTo("http://localhost/rest/v1/distributionsets/" + one.getId());
-        assertThat(
-                JsonPath.compile("[0]_links.type.href").read(mvcResult.getResponse().getContentAsString()).toString())
-                        .isEqualTo("http://localhost/rest/v1/distributionsettypes/" + one.getType().getId());
 
         assertThat(JsonPath.compile("[0]id").read(mvcResult.getResponse().getContentAsString()).toString())
                 .isEqualTo(String.valueOf(one.getId()));
         assertThat(
                 JsonPath.compile("[1]_links.self.href").read(mvcResult.getResponse().getContentAsString()).toString())
                         .isEqualTo("http://localhost/rest/v1/distributionsets/" + two.getId());
-        assertThat(
-                JsonPath.compile("[1]_links.type.href").read(mvcResult.getResponse().getContentAsString()).toString())
-                        .isEqualTo("http://localhost/rest/v1/distributionsettypes/" + two.getType().getId());
 
         assertThat(JsonPath.compile("[1]id").read(mvcResult.getResponse().getContentAsString()).toString())
                 .isEqualTo(String.valueOf(two.getId()));
         assertThat(
                 JsonPath.compile("[2]_links.self.href").read(mvcResult.getResponse().getContentAsString()).toString())
                         .isEqualTo("http://localhost/rest/v1/distributionsets/" + three.getId());
-        assertThat(
-                JsonPath.compile("[2]_links.type.href").read(mvcResult.getResponse().getContentAsString()).toString())
-                        .isEqualTo("http://localhost/rest/v1/distributionsettypes/" + three.getType().getId());
 
         assertThat(JsonPath.compile("[2]id").read(mvcResult.getResponse().getContentAsString()).toString())
                 .isEqualTo(String.valueOf(three.getId()));

--- a/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTagResourceTest.java
+++ b/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTagResourceTest.java
@@ -10,7 +10,6 @@ package org.eclipse.hawkbit.mgmt.rest.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -71,14 +70,7 @@ public class MgmtDistributionSetTagResourceTest extends AbstractManagementApiInt
                 .andExpect(applySelfLinkMatcherOnPagedResult(unassigned, DISTRIBUTIONSETTAGS_ROOT + unassigned.getId()))
                 .andExpect(jsonPath(MgmtTargetResourceTest.JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                 .andExpect(jsonPath(MgmtTargetResourceTest.JSON_PATH_PAGED_LIST_SIZE, equalTo(2)))
-                .andExpect(jsonPath(MgmtTargetResourceTest.JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)))
-                .andExpect(jsonPath(
-                        "$.content.[?(@.id==" + assigned.getId() + ")]._links.assignedDistributionSets.href",
-                        contains(DISTRIBUTIONSETTAGS_ROOT + assigned.getId() + "/assigned?offset=0&limit=50{&sort,q}")))
-                .andExpect(
-                        jsonPath("$.content.[?(@.id==" + unassigned.getId() + ")]._links.assignedDistributionSets.href",
-                                contains(DISTRIBUTIONSETTAGS_ROOT + unassigned.getId()
-                                        + "/assigned?offset=0&limit=50{&sort,q}")));
+                .andExpect(jsonPath(MgmtTargetResourceTest.JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)));
     }
 
     @Test

--- a/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTypeResourceTest.java
+++ b/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTypeResourceTest.java
@@ -58,11 +58,10 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
     @Description("Checks the correct behaviour of /rest/v1/distributionsettypes GET requests.")
     public void getDistributionSetTypes() throws Exception {
 
-        DistributionSetType testType = distributionSetTypeManagement
-                .create(entityFactory.distributionSetType().create().key("test123")
-                        .name("TestName123").description("Desc123").colour("col12"));
-        testType = distributionSetTypeManagement.update(
-                entityFactory.distributionSetType().update(testType.getId()).description("Desc1234"));
+        DistributionSetType testType = distributionSetTypeManagement.create(entityFactory.distributionSetType().create()
+                .key("test123").name("TestName123").description("Desc123").colour("col12"));
+        testType = distributionSetTypeManagement
+                .update(entityFactory.distributionSetType().update(testType.getId()).description("Desc1234"));
 
         // 4 types overall (2 hawkbit tenant default, 1 test default and 1
         // generated in this test)
@@ -86,11 +85,6 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
                 .andExpect(jsonPath("$.content.[?(@.key==test123)]$..key", contains("test123")))
                 .andExpect(jsonPath("$.content.[?(@.key==test123)]$.._links.self.href",
                         contains("http://localhost/rest/v1/distributionsettypes/" + testType.getId())))
-                .andExpect(jsonPath("$.content.[?(@.key==test123)]$.._links.mandatorymodules.href",
-                        contains("http://localhost/rest/v1/distributionsettypes/" + testType.getId()
-                                + "/mandatorymoduletypes")))
-                .andExpect(jsonPath("$.content.[?(@.key==test123)]$.._links.optionalmodules.href", contains(
-                        "http://localhost/rest/v1/distributionsettypes/" + testType.getId() + "/optionalmoduletypes")))
                 .andExpect(jsonPath("$.total", equalTo(4)));
     }
 
@@ -99,11 +93,10 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
     @Description("Checks the correct behaviour of /rest/v1/distributionsettypes GET requests with sorting by KEY.")
     public void getDistributionSetTypesSortedByKey() throws Exception {
 
-        DistributionSetType testType = distributionSetTypeManagement
-                .create(entityFactory.distributionSetType().create().key("zzzzz").name("TestName123")
-                        .description("Desc123").colour("col12"));
-        testType = distributionSetTypeManagement.update(
-                entityFactory.distributionSetType().update(testType.getId()).description("Desc1234"));
+        DistributionSetType testType = distributionSetTypeManagement.create(entityFactory.distributionSetType().create()
+                .key("zzzzz").name("TestName123").description("Desc123").colour("col12"));
+        testType = distributionSetTypeManagement
+                .update(entityFactory.distributionSetType().update(testType.getId()).description("Desc1234"));
 
         // descending
         mvc.perform(get("/rest/v1/distributionsettypes").accept(MediaType.APPLICATION_JSON)
@@ -148,12 +141,9 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
 
     @Step
     private void verifyCreatedDistributionSetTypes(final MvcResult mvcResult) throws UnsupportedEncodingException {
-        final DistributionSetType created1 = distributionSetTypeManagement.getByKey("testKey1")
-                .get();
-        final DistributionSetType created2 = distributionSetTypeManagement.getByKey("testKey2")
-                .get();
-        final DistributionSetType created3 = distributionSetTypeManagement.getByKey("testKey3")
-                .get();
+        final DistributionSetType created1 = distributionSetTypeManagement.getByKey("testKey1").get();
+        final DistributionSetType created2 = distributionSetTypeManagement.getByKey("testKey2").get();
+        final DistributionSetType created3 = distributionSetTypeManagement.getByKey("testKey3").get();
 
         assertThat(created1.getMandatoryModuleTypes()).containsOnly(osType);
         assertThat(created1.getOptionalModuleTypes()).containsOnly(runtimeType);
@@ -169,26 +159,6 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
         assertThat(
                 JsonPath.compile("[2]_links.self.href").read(mvcResult.getResponse().getContentAsString()).toString())
                         .isEqualTo("http://localhost/rest/v1/distributionsettypes/" + created3.getId());
-
-        assertThat(JsonPath.compile("[0]_links.mandatorymodules.href")
-                .read(mvcResult.getResponse().getContentAsString()).toString()).isEqualTo(
-                        "http://localhost/rest/v1/distributionsettypes/" + created1.getId() + "/mandatorymoduletypes");
-        assertThat(JsonPath.compile("[1]_links.mandatorymodules.href")
-                .read(mvcResult.getResponse().getContentAsString()).toString()).isEqualTo(
-                        "http://localhost/rest/v1/distributionsettypes/" + created2.getId() + "/mandatorymoduletypes");
-        assertThat(JsonPath.compile("[2]_links.mandatorymodules.href")
-                .read(mvcResult.getResponse().getContentAsString()).toString()).isEqualTo(
-                        "http://localhost/rest/v1/distributionsettypes/" + created3.getId() + "/mandatorymoduletypes");
-
-        assertThat(JsonPath.compile("[0]_links.optionalmodules.href").read(mvcResult.getResponse().getContentAsString())
-                .toString()).isEqualTo(
-                        "http://localhost/rest/v1/distributionsettypes/" + created1.getId() + "/optionalmoduletypes");
-        assertThat(JsonPath.compile("[1]_links.optionalmodules.href").read(mvcResult.getResponse().getContentAsString())
-                .toString()).isEqualTo(
-                        "http://localhost/rest/v1/distributionsettypes/" + created2.getId() + "/optionalmoduletypes");
-        assertThat(JsonPath.compile("[2]_links.optionalmodules.href").read(mvcResult.getResponse().getContentAsString())
-                .toString()).isEqualTo(
-                        "http://localhost/rest/v1/distributionsettypes/" + created3.getId() + "/optionalmoduletypes");
 
         assertThat(distributionSetTypeManagement.count()).isEqualTo(6);
     }
@@ -234,9 +204,8 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
     @WithUser(principal = "uploadTester", allSpPermissions = true)
     @Description("Checks the correct behaviour of /rest/v1/distributionsettypes/{ID}/mandatorymoduletypes POST requests.")
     public void addMandatoryModuleToDistributionSetType() throws Exception {
-        DistributionSetType testType = distributionSetTypeManagement
-                .create(entityFactory.distributionSetType().create().key("test123")
-                        .name("TestName123").description("Desc123").colour("col12"));
+        DistributionSetType testType = distributionSetTypeManagement.create(entityFactory.distributionSetType().create()
+                .key("test123").name("TestName123").description("Desc123").colour("col12"));
         assertThat(testType.getOptLockRevision()).isEqualTo(1);
 
         mvc.perform(post("/rest/v1/distributionsettypes/{dstID}/mandatorymoduletypes", testType.getId())
@@ -254,9 +223,8 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
     @WithUser(principal = "uploadTester", allSpPermissions = true)
     @Description("Checks the correct behaviour of /rest/v1/distributionsettypes/{ID}/optionalmoduletypes POST requests.")
     public void addOptionalModuleToDistributionSetType() throws Exception {
-        DistributionSetType testType = distributionSetTypeManagement
-                .create(entityFactory.distributionSetType().create().key("test123")
-                        .name("TestName123").description("Desc123").colour("col12"));
+        DistributionSetType testType = distributionSetTypeManagement.create(entityFactory.distributionSetType().create()
+                .key("test123").name("TestName123").description("Desc123").colour("col12"));
         assertThat(testType.getOptLockRevision()).isEqualTo(1);
 
         mvc.perform(post("/rest/v1/distributionsettypes/{dstID}/optionalmoduletypes", testType.getId())
@@ -318,8 +286,8 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
     }
 
     private DistributionSetType generateTestType() {
-        final DistributionSetType testType = distributionSetTypeManagement.create(entityFactory
-                .distributionSetType().create().key("test123").name("TestName123").description("Desc123").colour("col")
+        final DistributionSetType testType = distributionSetTypeManagement.create(entityFactory.distributionSetType()
+                .create().key("test123").name("TestName123").description("Desc123").colour("col")
                 .mandatory(Arrays.asList(osType.getId())).optional(Arrays.asList(appType.getId())));
         assertThat(testType.getOptLockRevision()).isEqualTo(1);
         assertThat(testType.getOptionalModuleTypes()).containsExactly(appType);
@@ -383,11 +351,10 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
     @Description("Checks the correct behaviour of /rest/v1/distributionsettypes/{ID} GET requests.")
     public void getDistributionSetType() throws Exception {
 
-        DistributionSetType testType = distributionSetTypeManagement
-                .create(entityFactory.distributionSetType().create().key("test123")
-                        .name("TestName123").description("Desc123").colour("col12"));
-        testType = distributionSetTypeManagement.update(
-                entityFactory.distributionSetType().update(testType.getId()).description("Desc1234"));
+        DistributionSetType testType = distributionSetTypeManagement.create(entityFactory.distributionSetType().create()
+                .key("test123").name("TestName123").description("Desc123").colour("col12"));
+        testType = distributionSetTypeManagement
+                .update(entityFactory.distributionSetType().update(testType.getId()).description("Desc1234"));
 
         mvc.perform(get("/rest/v1/distributionsettypes/{dstId}", testType.getId()).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
@@ -403,9 +370,8 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
     @WithUser(principal = "uploadTester", allSpPermissions = true)
     @Description("Checks the correct behaviour of /rest/v1/DistributionSetTypes/{ID} DELETE requests (hard delete scenario).")
     public void deleteDistributionSetTypeUnused() throws Exception {
-        final DistributionSetType testType = distributionSetTypeManagement
-                .create(entityFactory.distributionSetType().create().key("test123")
-                        .name("TestName123").description("Desc123").colour("col12"));
+        final DistributionSetType testType = distributionSetTypeManagement.create(entityFactory.distributionSetType()
+                .create().key("test123").name("TestName123").description("Desc123").colour("col12"));
 
         assertThat(distributionSetTypeManagement.count()).isEqualTo(DEFAULT_DS_TYPES + 1);
 
@@ -426,12 +392,11 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
     @WithUser(principal = "uploadTester", allSpPermissions = true)
     @Description("Checks the correct behaviour of /rest/v1/DistributionSetTypes/{ID} DELETE requests (soft delete scenario).")
     public void deleteDistributionSetTypeUsed() throws Exception {
-        final DistributionSetType testType = distributionSetTypeManagement
-                .create(entityFactory.distributionSetType().create().key("test123")
-                        .name("TestName123").description("Desc123").colour("col12"));
+        final DistributionSetType testType = distributionSetTypeManagement.create(entityFactory.distributionSetType()
+                .create().key("test123").name("TestName123").description("Desc123").colour("col12"));
 
-        distributionSetManagement.create(entityFactory.distributionSet().create().name("sdfsd")
-                .description("dsfsdf").version("1").type(testType));
+        distributionSetManagement.create(entityFactory.distributionSet().create().name("sdfsd").description("dsfsdf")
+                .version("1").type(testType));
 
         assertThat(distributionSetTypeManagement.count()).isEqualTo(DEFAULT_DS_TYPES + 1);
         assertThat(distributionSetManagement.count()).isEqualTo(1);
@@ -446,9 +411,8 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
     @Test
     @Description("Checks the correct behaviour of /rest/v1/distributionsettypes/{ID} PUT requests.")
     public void updateDistributionSetTypeOnlyDescriptionAndNameUntouched() throws Exception {
-        final DistributionSetType testType = distributionSetTypeManagement
-                .create(entityFactory.distributionSetType().create().key("test123")
-                        .name("TestName123").description("Desc123").colour("col"));
+        final DistributionSetType testType = distributionSetTypeManagement.create(entityFactory.distributionSetType()
+                .create().key("test123").name("TestName123").description("Desc123").colour("col"));
 
         final String body = new JSONObject().put("id", testType.getId()).put("description", "foobardesc")
                 .put("name", "nameShouldNotBeChanged").toString();
@@ -510,8 +474,8 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
         // .createDistributionSetType(entityFactory.distributionSetType().create().key("test123")
         // .name("TestName123").description("Desc123").colour("col"));
 
-        final SoftwareModuleType testSmType = softwareModuleTypeManagement.create(
-                entityFactory.softwareModuleType().create().key("test123").name("TestName123"));
+        final SoftwareModuleType testSmType = softwareModuleTypeManagement
+                .create(entityFactory.softwareModuleType().create().key("test123").name("TestName123"));
 
         // DST does not exist
         mvc.perform(get("/rest/v1/distributionsettypes/12345678")).andDo(MockMvcResultPrinter.print())
@@ -598,10 +562,10 @@ public class MgmtDistributionSetTypeResourceTest extends AbstractManagementApiIn
     @Test
     @Description("Search erquest of software module types.")
     public void searchDistributionSetTypeRsql() throws Exception {
-        distributionSetTypeManagement.create(
-                entityFactory.distributionSetType().create().key("test123").name("TestName123"));
-        distributionSetTypeManagement.create(
-                entityFactory.distributionSetType().create().key("test1234").name("TestName1234"));
+        distributionSetTypeManagement
+                .create(entityFactory.distributionSetType().create().key("test123").name("TestName123"));
+        distributionSetTypeManagement
+                .create(entityFactory.distributionSetType().create().key("test1234").name("TestName1234"));
 
         final String rsqlFindLikeDs1OrDs2 = "name==TestName123,name==TestName1234";
 

--- a/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResourceTest.java
+++ b/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResourceTest.java
@@ -345,14 +345,6 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
                 .andExpect(jsonPath("content[0].totalTargets", equalTo(20)))
                 .andExpect(jsonPath("content[0].totalTargetsPerStatus").doesNotExist())
                 .andExpect(jsonPath("content[0]._links.self.href", startsWith(HREF_ROLLOUT_PREFIX)))
-                .andExpect(jsonPath("content[0]._links.start.href",
-                        allOf(startsWith(HREF_ROLLOUT_PREFIX), endsWith("/start"))))
-                .andExpect(jsonPath("content[0]._links.pause.href",
-                        allOf(startsWith(HREF_ROLLOUT_PREFIX), endsWith("/pause"))))
-                .andExpect(jsonPath("content[0]._links.resume.href",
-                        allOf(startsWith(HREF_ROLLOUT_PREFIX), endsWith("/resume"))))
-                .andExpect(jsonPath("content[0]._links.groups.href",
-                        allOf(startsWith(HREF_ROLLOUT_PREFIX), containsString("/deploygroups"))))
                 .andExpect(jsonPath("content[1].name", equalTo("rollout2")))
                 .andExpect(jsonPath("content[1].status", equalTo("ready")))
                 .andExpect(jsonPath("content[1].targetFilterQuery", equalTo("id==target-0001*")))
@@ -363,15 +355,7 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
                 .andExpect(jsonPath("content[1].lastModifiedAt", not(equalTo(0))))
                 .andExpect(jsonPath("content[1].totalTargets", equalTo(10)))
                 .andExpect(jsonPath("content[1].totalTargetsPerStatus").doesNotExist())
-                .andExpect(jsonPath("content[1]._links.self.href", startsWith(HREF_ROLLOUT_PREFIX)))
-                .andExpect(jsonPath("content[1]._links.start.href",
-                        allOf(startsWith(HREF_ROLLOUT_PREFIX), endsWith("/start"))))
-                .andExpect(jsonPath("content[1]._links.pause.href",
-                        allOf(startsWith(HREF_ROLLOUT_PREFIX), endsWith("/pause"))))
-                .andExpect(jsonPath("content[1]._links.resume.href",
-                        allOf(startsWith(HREF_ROLLOUT_PREFIX), endsWith("/resume"))))
-                .andExpect(jsonPath("content[1]._links.groups.href",
-                        allOf(startsWith(HREF_ROLLOUT_PREFIX), containsString("/deploygroups"))));
+                .andExpect(jsonPath("content[1]._links.self.href", startsWith(HREF_ROLLOUT_PREFIX)));
     }
 
     @Test
@@ -599,11 +583,9 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
                         .successCondition(RolloutGroupSuccessCondition.THRESHOLD, "100").build());
 
         final RolloutGroup firstGroup = rolloutGroupManagement
-                .findByRollout(new PageRequest(0, 1, Direction.ASC, "id"), rollout.getId()).getContent()
-                .get(0);
+                .findByRollout(new PageRequest(0, 1, Direction.ASC, "id"), rollout.getId()).getContent().get(0);
         final RolloutGroup secondGroup = rolloutGroupManagement
-                .findByRollout(new PageRequest(1, 1, Direction.ASC, "id"), rollout.getId()).getContent()
-                .get(0);
+                .findByRollout(new PageRequest(1, 1, Direction.ASC, "id"), rollout.getId()).getContent().get(0);
 
         retrieveAndVerifyRolloutGroupInCreating(rollout, firstGroup);
         retrieveAndVerifyRolloutGroupInReady(rollout, firstGroup);
@@ -696,8 +678,7 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
         final Rollout rollout = createRollout("rollout1", 2, dsA.getId(), "controllerId==rollout*");
 
         final RolloutGroup firstGroup = rolloutGroupManagement
-                .findByRollout(new PageRequest(0, 1, Direction.ASC, "id"), rollout.getId()).getContent()
-                .get(0);
+                .findByRollout(new PageRequest(0, 1, Direction.ASC, "id"), rollout.getId()).getContent().get(0);
 
         // retrieve targets from the first rollout group with known ID
         mvc.perform(
@@ -720,8 +701,7 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
         final Rollout rollout = createRollout("rollout1", 2, dsA.getId(), "controllerId==rollout*");
 
         final RolloutGroup firstGroup = rolloutGroupManagement
-                .findByRollout(new PageRequest(0, 1, Direction.ASC, "id"), rollout.getId()).getContent()
-                .get(0);
+                .findByRollout(new PageRequest(0, 1, Direction.ASC, "id"), rollout.getId()).getContent().get(0);
 
         final String targetInGroup = rolloutGroupManagement.findTargetsOfRolloutGroup(PAGE, firstGroup.getId())
                 .getContent().get(0).getControllerId();
@@ -752,8 +732,7 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
         rolloutManagement.handleRollouts();
 
         final RolloutGroup firstGroup = rolloutGroupManagement
-                .findByRollout(new PageRequest(0, 1, Direction.ASC, "id"), rollout.getId()).getContent()
-                .get(0);
+                .findByRollout(new PageRequest(0, 1, Direction.ASC, "id"), rollout.getId()).getContent().get(0);
 
         // retrieve targets from the first rollout group with known ID
         mvc.perform(

--- a/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
+++ b/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
@@ -70,8 +70,7 @@ public class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegra
 
     @Before
     public void assertPreparationOfRepo() {
-        assertThat(softwareModuleManagement.findAll(PAGE)).as("no softwaremodule should be founded")
-                .hasSize(0);
+        assertThat(softwareModuleManagement.findAll(PAGE)).as("no softwaremodule should be founded").hasSize(0);
     }
 
     @Test
@@ -361,9 +360,6 @@ public class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegra
                 .andExpect(jsonPath("$.[0].hashes.md5", equalTo(artifact.getMd5Hash())))
                 .andExpect(jsonPath("$.[0].hashes.sha1", equalTo(artifact.getSha1Hash())))
                 .andExpect(jsonPath("$.[0].providedFilename", equalTo("file1")))
-                .andExpect(jsonPath("$.[0]._links.download.href",
-                        equalTo("http://localhost/rest/v1/softwaremodules/" + sm.getId() + "/artifacts/"
-                                + artifact.getId() + "/download")))
                 .andExpect(jsonPath("$.[0]._links.self.href",
                         equalTo("http://localhost/rest/v1/softwaremodules/" + sm.getId() + "/artifacts/"
                                 + artifact.getId())))
@@ -371,9 +367,6 @@ public class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegra
                 .andExpect(jsonPath("$.[1].hashes.md5", equalTo(artifact2.getMd5Hash())))
                 .andExpect(jsonPath("$.[1].hashes.sha1", equalTo(artifact2.getSha1Hash())))
                 .andExpect(jsonPath("$.[1].providedFilename", equalTo("file2")))
-                .andExpect(jsonPath("$.[1]._links.download.href",
-                        equalTo("http://localhost/rest/v1/softwaremodules/" + sm.getId() + "/artifacts/"
-                                + artifact2.getId() + "/download")))
                 .andExpect(jsonPath("$.[1]._links.self.href", equalTo(
                         "http://localhost/rest/v1/softwaremodules/" + sm.getId() + "/artifacts/" + artifact2.getId())));
     }
@@ -521,15 +514,8 @@ public class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegra
                 .andExpect(jsonPath("$.content.[?(@.id==" + os.getId() + ")].type", contains("os")))
                 .andExpect(jsonPath("$.content.[?(@.id==" + os.getId() + ")].createdBy", contains("uploadTester")))
                 .andExpect(jsonPath("$.content.[?(@.id==" + os.getId() + ")].createdAt", contains(os.getCreatedAt())))
-                .andExpect(jsonPath("$.content.[?(@.id==" + os.getId() + ")]._links.type.href",
-                        contains("http://localhost/rest/v1/softwaremoduletypes/" + osType.getId())))
                 .andExpect(jsonPath("$.content.[?(@.id==" + os.getId() + ")]._links.self.href",
                         contains("http://localhost/rest/v1/softwaremodules/" + os.getId())))
-                .andExpect(jsonPath("$.content.[?(@.id==" + os.getId() + ")]._links.artifacts.href",
-                        contains("http://localhost/rest/v1/softwaremodules/" + os.getId() + "/artifacts")))
-                .andExpect(jsonPath("$.content.[?(@.id==" + os.getId() + ")]._links.metadata.href",
-                        contains("http://localhost/rest/v1/softwaremodules/" + os.getId()
-                                + "/metadata?offset=0&limit=50")))
                 .andExpect(jsonPath("$.content.[?(@.id==" + app.getId() + ")].name", contains(app.getName())))
                 .andExpect(jsonPath("$.content.[?(@.id==" + app.getId() + ")].version", contains(app.getVersion())))
                 .andExpect(jsonPath("$.content.[?(@.id==" + app.getId() + ")].description",
@@ -538,13 +524,6 @@ public class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegra
                 .andExpect(jsonPath("$.content.[?(@.id==" + app.getId() + ")].type", contains("application")))
                 .andExpect(jsonPath("$.content.[?(@.id==" + app.getId() + ")].createdBy", contains("uploadTester")))
                 .andExpect(jsonPath("$.content.[?(@.id==" + app.getId() + ")].createdAt", contains(app.getCreatedAt())))
-                .andExpect(jsonPath("$.content.[?(@.id==" + app.getId() + ")]._links.artifacts.href",
-                        contains("http://localhost/rest/v1/softwaremodules/" + app.getId() + "/artifacts")))
-                .andExpect(jsonPath("$.content.[?(@.id==" + app.getId() + ")]._links.metadata.href",
-                        contains("http://localhost/rest/v1/softwaremodules/" + app.getId()
-                                + "/metadata?offset=0&limit=50")))
-                .andExpect(jsonPath("$.content.[?(@.id==" + app.getId() + ")]._links.type.href",
-                        contains("http://localhost/rest/v1/softwaremoduletypes/" + appType.getId())))
                 .andExpect(jsonPath("$.content.[?(@.id==" + app.getId() + ")]._links.self.href",
                         contains("http://localhost/rest/v1/softwaremodules/" + app.getId())));
 
@@ -692,17 +671,11 @@ public class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegra
                 JsonPath.compile("[0]_links.self.href").read(mvcResult.getResponse().getContentAsString()).toString())
                         .as("Response contains invalid self href")
                         .isEqualTo("http://localhost/rest/v1/softwaremodules/" + osCreated.getId());
-        assertThat(JsonPath.compile("[0]_links.artifacts.href").read(mvcResult.getResponse().getContentAsString())
-                .toString()).as("Response contains invalid artifacts href")
-                        .isEqualTo("http://localhost/rest/v1/softwaremodules/" + osCreated.getId() + "/artifacts");
 
         assertThat(
                 JsonPath.compile("[1]_links.self.href").read(mvcResult.getResponse().getContentAsString()).toString())
                         .as("Response contains links self href")
                         .isEqualTo("http://localhost/rest/v1/softwaremodules/" + appCreated.getId());
-        assertThat(JsonPath.compile("[1]_links.artifacts.href").read(mvcResult.getResponse().getContentAsString())
-                .toString()).as("Response contains invalid artifacts href")
-                        .isEqualTo("http://localhost/rest/v1/softwaremodules/" + appCreated.getId() + "/artifacts");
 
         assertThat(softwareModuleManagement.findAll(PAGE)).as("Wrong softwaremodule size").hasSize(2);
         assertThat(

--- a/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTagResourceTest.java
+++ b/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTagResourceTest.java
@@ -10,7 +10,6 @@ package org.eclipse.hawkbit.mgmt.rest.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -72,11 +71,7 @@ public class MgmtTargetTagResourceTest extends AbstractManagementApiIntegrationT
                 .andExpect(applySelfLinkMatcherOnPagedResult(unassigned, TARGETTAGS_ROOT + unassigned.getId()))
                 .andExpect(jsonPath(MgmtTargetResourceTest.JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                 .andExpect(jsonPath(MgmtTargetResourceTest.JSON_PATH_PAGED_LIST_SIZE, equalTo(2)))
-                .andExpect(jsonPath(MgmtTargetResourceTest.JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)))
-                .andExpect(jsonPath("$.content.[?(@.id==" + assigned.getId() + ")]._links.assignedTargets.href",
-                        contains(TARGETTAGS_ROOT + assigned.getId() + "/assigned?offset=0&limit=50{&sort,q}")))
-                .andExpect(jsonPath("$.content.[?(@.id==" + unassigned.getId() + ")]._links.assignedTargets.href",
-                        contains(TARGETTAGS_ROOT + unassigned.getId() + "/assigned?offset=0&limit=50{&sort,q}")));
+                .andExpect(jsonPath(MgmtTargetResourceTest.JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)));
 
     }
 


### PR DESCRIPTION
The standard is that we list only the self link in collection GET requests and all links only on single entity GET requests. 

That was actually not implemented constantly for all resources.

Reviewers: @Jonkno 