### PR TITLE
Security header filter supports additional separator and is case insensitive.

### DIFF
--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilter.java
@@ -128,7 +128,7 @@ public class ControllerPreAuthenticatedSecurityHeaderFilter extends AbstractCont
         int iHeader = 1;
         String foundHash;
         while ((foundHash = secruityToken.getHeader(String.format(sslIssuerHashBasicHeader, iHeader))) != null) {
-            if (knownHashes.contains(foundHash)) {
+            if (knownHashes.contains(foundHash.toLowerCase())) {
                 if (LOGGER.isTraceEnabled()) {
                     LOGGER.trace("Found matching ssl issuer hash at position {}", iHeader);
                 }
@@ -156,6 +156,6 @@ public class ControllerPreAuthenticatedSecurityHeaderFilter extends AbstractCont
     }
 
     private static List<String> splitMultiHashBySemicolon(final String knownIssuerHashes) {
-        return Arrays.asList(knownIssuerHashes.split(";"));
+        return Arrays.stream(knownIssuerHashes.split(";|,")).map(String::toLowerCase).collect(Collectors.toList());
     }
 }

--- a/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
+++ b/hawkbit-security-integration/src/test/java/org/eclipse/hawkbit/security/ControllerPreAuthenticatedSecurityHeaderFilterTest.java
@@ -51,9 +51,10 @@ public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
 
     private static final String SINGLE_HASH = "hash1";
     private static final String SECOND_HASH = "hash2";
+    private static final String THIRD_HASH = "hash3";
     private static final String UNKNOWN_HASH = "unknown";
 
-    private static final String MULTI_HASH = "hash1;hash2;hash3";
+    private static final String MULTI_HASH = "HASH1;hash2,HASH3,HASH1";
 
     private static final TenantConfigurationValue<String> CONFIG_VALUE_SINGLE_HASH = TenantConfigurationValue
             .<String> builder().value(SINGLE_HASH).build();
@@ -81,12 +82,13 @@ public class ControllerPreAuthenticatedSecurityHeaderFilterTest {
     @Test
     @Description("Tests the filter for issuer hash based authentication with multiple known hashes")
     public void testIssuerHashBasedAuthenticationWithMultipleKnownHashes() {
-        final DmfTenantSecurityToken securityToken = prepareSecurityToken(SINGLE_HASH);
         // use multiple known hashes
         when(tenantConfigurationManagementMock.getConfigurationValue(
                 eq(TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_AUTHORITY_NAME), eq(String.class)))
                         .thenReturn(CONFIG_VALUE_MULTI_HASH);
-        assertThat(underTest.getPreAuthenticatedPrincipal(securityToken)).isNotNull();
+        assertThat(underTest.getPreAuthenticatedPrincipal(prepareSecurityToken(SINGLE_HASH))).isNotNull();
+        assertThat(underTest.getPreAuthenticatedPrincipal(prepareSecurityToken(SECOND_HASH))).isNotNull();
+        assertThat(underTest.getPreAuthenticatedPrincipal(prepareSecurityToken(THIRD_HASH))).isNotNull();
     }
 
     @Test


### PR DESCRIPTION

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>