### PR TITLE
Feature add missing entity events

### DIFF
--- a/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootControllerTest.java
+++ b/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootControllerTest.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.ddi.rest.resource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions.CONTROLLER_ROLE;
 import static org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions.CONTROLLER_ROLE_ANONYMOUS;
 import static org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION;
@@ -51,8 +52,6 @@ import org.eclipse.hawkbit.util.IpUtil;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;

--- a/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootControllerTest.java
+++ b/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootControllerTest.java
@@ -8,7 +8,6 @@
  */
 package org.eclipse.hawkbit.ddi.rest.resource;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions.CONTROLLER_ROLE;
 import static org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions.CONTROLLER_ROLE_ANONYMOUS;
 import static org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions.HAS_AUTH_TENANT_CONFIGURATION;
@@ -31,7 +30,9 @@ import org.eclipse.hawkbit.repository.event.remote.TargetPollEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.ActionCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.ActionUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetTypeCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleTypeCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.Action;
@@ -50,6 +51,8 @@ import org.eclipse.hawkbit.util.IpUtil;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
@@ -73,13 +76,15 @@ public class DdiRootControllerTest extends AbstractDDiApiIntegrationTest {
     @WithUser(tenantId = "tenantDoesNotExists", allSpPermissions = true, authorities = { CONTROLLER_ROLE,
             SYSTEM_ROLE }, autoCreateTenant = false)
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1),
-            @Expect(type = TargetPollEvent.class, count = 1) })
+            @Expect(type = TargetPollEvent.class, count = 1),
+            @Expect(type = DistributionSetTypeCreatedEvent.class, count = 3),
+            @Expect(type = SoftwareModuleTypeCreatedEvent.class, count = 2) })
     public void targetCannotBeRegisteredIfTenantDoesNotExistsButWhenExists() throws Exception {
 
         mvc.perform(get("/default-tenant/", tenantAware.getCurrentTenant())).andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
 
-        // create tenant
+        // create tenant -- creates softwaremoduletypes and distributionsettypes
         systemManagement.getTenantMetadata("tenantDoesNotExists");
 
         mvc.perform(get("/{}/controller/v1/aControllerId", tenantAware.getCurrentTenant()))

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entitiy/EntityCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entitiy/EntityCreatedEvent.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.event.entitiy;
+
+/**
+ * Marker interface to indicate event has created a newly entity.
+ */
+public interface EntityCreatedEvent extends EntityIdEvent {
+
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entitiy/EntityDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entitiy/EntityDeletedEvent.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.event.entitiy;
+
+/**
+ * Marker interface to indicate event has deleted an entity.
+ */
+public interface EntityDeletedEvent extends EntityIdEvent {
+
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entitiy/EntityIdEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entitiy/EntityIdEvent.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.event.entitiy;
+
+/**
+ * Interface to indicate an entity event which contains at least an entity id.
+ */
+public interface EntityIdEvent {
+
+    /**
+     * @return the class of the entity of this event.
+     */
+    String getEntityClass();
+
+    /**
+     * @return the ID of the entity of this event.
+     */
+    Long getEntityId();
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entitiy/EntityIdEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entitiy/EntityIdEvent.java
@@ -8,10 +8,12 @@
  */
 package org.eclipse.hawkbit.repository.event.entitiy;
 
+import org.eclipse.hawkbit.repository.event.TenantAwareEvent;
+
 /**
  * Interface to indicate an entity event which contains at least an entity id.
  */
-public interface EntityIdEvent {
+public interface EntityIdEvent extends TenantAwareEvent {
 
     /**
      * @return the class of the entity of this event.

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entitiy/EntityUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entitiy/EntityUpdatedEvent.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.event.entitiy;
+
+/**
+ * Marker interface to indicate event has updated an entity.
+ */
+public interface EntityUpdatedEvent extends EntityIdEvent {
+
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetDeletedEvent.java
@@ -8,12 +8,13 @@
  */
 package org.eclipse.hawkbit.repository.event.remote;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 
 /**
  * Defines the remote event for deletion of {@link DistributionSet}.
  */
-public class DistributionSetDeletedEvent extends RemoteIdEvent {
+public class DistributionSetDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetTagDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetTagDeletedEvent.java
@@ -8,12 +8,13 @@
  */
 package org.eclipse.hawkbit.repository.event.remote;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.DistributionSetTag;
 
 /**
  * Defines the the remote event of delete a {@link DistributionSetTag}.
  */
-public class DistributionSetTagDeletedEvent extends RemoteIdEvent {
+public class DistributionSetTagDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetTypeDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetTypeDeletedEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,20 +9,20 @@
 package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entitiy.EntityDeletedEvent;
-import org.eclipse.hawkbit.repository.model.TargetTag;
+import org.eclipse.hawkbit.repository.model.DistributionSetType;
 
 /**
- * Defines the remote event of delete a {@link TargetTag}.
  *
+ * Defines the remote event of deleting a {@link DistributionSetType}.
  */
-public class TargetTagDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
+public class DistributionSetTypeDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
 
     private static final long serialVersionUID = 1L;
 
     /**
      * Default constructor.
      */
-    public TargetTagDeletedEvent() {
+    public DistributionSetTypeDeletedEvent() {
         // for serialization libs like jackson
     }
 
@@ -38,8 +38,9 @@ public class TargetTagDeletedEvent extends RemoteIdEvent implements EntityDelete
      * @param applicationId
      *            the origin application id
      */
-    public TargetTagDeletedEvent(final String tenant, final Long entityId, final String entityClass,
+    public DistributionSetTypeDeletedEvent(final String tenant, final Long entityId, final String entityClass,
             final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
+
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RolloutDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RolloutDeletedEvent.java
@@ -8,13 +8,14 @@
  */
 package org.eclipse.hawkbit.repository.event.remote;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.Rollout;
 
 /**
  *
  * Defines the remote event of deleting a {@link Rollout}.
  */
-public class RolloutDeletedEvent extends RemoteIdEvent {
+public class RolloutDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RolloutGroupDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RolloutGroupDeletedEvent.java
@@ -8,13 +8,14 @@
  */
 package org.eclipse.hawkbit.repository.event.remote;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
 
 /**
  *
  * Defines the remote event of deleting a {@link RolloutGroup}.
  */
-public class RolloutGroupDeletedEvent extends RemoteIdEvent {
+public class RolloutGroupDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/SoftwareModuleDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/SoftwareModuleDeletedEvent.java
@@ -8,13 +8,14 @@
  */
 package org.eclipse.hawkbit.repository.event.remote;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 
 /**
  *
  * Defines the remote event of deleting a {@link SoftwareModule}.
  */
-public class SoftwareModuleDeletedEvent extends RemoteIdEvent {
+public class SoftwareModuleDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/SoftwareModuleTypeDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/SoftwareModuleTypeDeletedEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,20 +9,20 @@
 package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entitiy.EntityDeletedEvent;
-import org.eclipse.hawkbit.repository.model.TargetTag;
+import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 
 /**
- * Defines the remote event of delete a {@link TargetTag}.
  *
+ * Defines the remote event of deleting a {@link SoftwareModuleType}.
  */
-public class TargetTagDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
+public class SoftwareModuleTypeDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
 
     private static final long serialVersionUID = 1L;
 
     /**
      * Default constructor.
      */
-    public TargetTagDeletedEvent() {
+    public SoftwareModuleTypeDeletedEvent() {
         // for serialization libs like jackson
     }
 
@@ -38,8 +38,9 @@ public class TargetTagDeletedEvent extends RemoteIdEvent implements EntityDelete
      * @param applicationId
      *            the origin application id
      */
-    public TargetTagDeletedEvent(final String tenant, final Long entityId, final String entityClass,
+    public SoftwareModuleTypeDeletedEvent(final String tenant, final Long entityId, final String entityClass,
             final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
+
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetDeletedEvent.java
@@ -8,13 +8,14 @@
  */
 package org.eclipse.hawkbit.repository.event.remote;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.Target;
 
 /**
  *
  * Defines the remote event of deleting a {@link Target}.
  */
-public class TargetDeletedEvent extends RemoteIdEvent {
+public class TargetDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
 
     private static final long serialVersionUID = 2L;
     private String controllerId;

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetFilterQueryDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetFilterQueryDeletedEvent.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.event.remote;
+
+import org.eclipse.hawkbit.repository.event.entitiy.EntityDeletedEvent;
+import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
+
+/**
+ *
+ * Defines the remote event of deleting a {@link TargetFilterQuery}.
+ */
+public class TargetFilterQueryDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
+
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Default constructor.
+     */
+    public TargetFilterQueryDeletedEvent() {
+        // for serialization libs like jackson
+    }
+
+    /**
+     *
+     * @param tenant
+     *            the tenant
+     * @param entityId
+     *            the entity id
+     * @param entityClass
+     *            the entity class
+     * @param applicationId
+     *            the origin application id
+     */
+    public TargetFilterQueryDeletedEvent(final String tenant, final Long entityId, final String entityClass,
+            final String applicationId) {
+        super(entityId, tenant, entityClass, applicationId);
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/ActionCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/ActionCreatedEvent.java
@@ -8,12 +8,13 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityCreatedEvent;
 import org.eclipse.hawkbit.repository.model.Action;
 
 /**
  * Defines the remote event of creating a new {@link Action}.
  */
-public class ActionCreatedEvent extends AbstractActionEvent {
+public class ActionCreatedEvent extends AbstractActionEvent implements EntityCreatedEvent {
     private static final long serialVersionUID = 2L;
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/ActionUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/ActionUpdatedEvent.java
@@ -8,12 +8,13 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.Action;
 
 /**
  * Defines the remote event of updated a {@link Action}.
  */
-public class ActionUpdatedEvent extends AbstractActionEvent {
+public class ActionUpdatedEvent extends AbstractActionEvent implements EntityUpdatedEvent {
     private static final long serialVersionUID = 2L;
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetCreatedEvent.java
@@ -8,13 +8,14 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityCreatedEvent;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 
 /**
  * Defines the the remote of creating a new {@link DistributionSet}.
  *
  */
-public class DistributionSetCreatedEvent extends RemoteEntityEvent<DistributionSet> {
+public class DistributionSetCreatedEvent extends RemoteEntityEvent<DistributionSet> implements EntityCreatedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetTagUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetTagUpdatedEvent.java
@@ -8,13 +8,15 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.DistributionSetTag;
 
 /**
  * Defines the remote event for update a {@link DistributionSetTag}.
  *
  */
-public class DistributionSetTagUpdatedEvent extends RemoteEntityEvent<DistributionSetTag> {
+public class DistributionSetTagUpdatedEvent extends RemoteEntityEvent<DistributionSetTag>
+        implements EntityUpdatedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetTypeCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetTypeCreatedEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,34 +9,33 @@
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
 import org.eclipse.hawkbit.repository.event.entitiy.EntityCreatedEvent;
-import org.eclipse.hawkbit.repository.model.DistributionSetTag;
+import org.eclipse.hawkbit.repository.model.DistributionSetType;
 
 /**
- * Defines the {@link RemoteEntityEvent} for creation of a new
- * {@link DistributionSetTag}.
+ * Defines the remote event of creating a new {@link DistributionSetType}.
  *
  */
-public class DistributionSetTagCreatedEvent extends RemoteEntityEvent<DistributionSetTag>
+public class DistributionSetTypeCreatedEvent extends RemoteEntityEvent<DistributionSetType>
         implements EntityCreatedEvent {
-
     private static final long serialVersionUID = 1L;
 
     /**
      * Default constructor.
      */
-    public DistributionSetTagCreatedEvent() {
+    public DistributionSetTypeCreatedEvent() {
         // for serialization libs like jackson
     }
 
     /**
      * Constructor.
      * 
-     * @param tag
-     *            the tag which is deleted
+     * @param baseEntity
+     *            the DistributionSetType
      * @param applicationId
      *            the origin application id
      */
-    public DistributionSetTagCreatedEvent(final DistributionSetTag tag, final String applicationId) {
-        super(tag, applicationId);
+    public DistributionSetTypeCreatedEvent(final DistributionSetType baseEntity, final String applicationId) {
+        super(baseEntity, applicationId);
     }
+
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetTypeUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetTypeUpdatedEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,20 +9,22 @@
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
 import org.eclipse.hawkbit.repository.event.entitiy.EntityUpdatedEvent;
-import org.eclipse.hawkbit.repository.model.SoftwareModule;
+import org.eclipse.hawkbit.repository.model.DistributionSetType;
+import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 
 /**
- * Defines the remote event for updating a {@link SoftwareModule}.
+ * Defines the remote event for updating a {@link SoftwareModuleType}.
  *
  */
-public class SoftwareModuleUpdatedEvent extends RemoteEntityEvent<SoftwareModule> implements EntityUpdatedEvent {
+public class DistributionSetTypeUpdatedEvent extends RemoteEntityEvent<DistributionSetType>
+        implements EntityUpdatedEvent {
 
     private static final long serialVersionUID = 1L;
 
     /**
      * Default constructor.
      */
-    public SoftwareModuleUpdatedEvent() {
+    public DistributionSetTypeUpdatedEvent() {
         // for serialization libs like jackson
     }
 
@@ -30,11 +32,11 @@ public class SoftwareModuleUpdatedEvent extends RemoteEntityEvent<SoftwareModule
      * Constructor.
      * 
      * @param baseEntity
-     *            the software module
+     *            DistributionSetType
      * @param applicationId
      *            the origin application id
      */
-    public SoftwareModuleUpdatedEvent(final SoftwareModule baseEntity, final String applicationId) {
+    public DistributionSetTypeUpdatedEvent(final DistributionSetType baseEntity, final String applicationId) {
         super(baseEntity, applicationId);
     }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetUpdatedEvent.java
@@ -8,13 +8,14 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 
 /**
  * Defines the remote event for updating a {@link DistributionSet}.
  *
  */
-public class DistributionSetUpdatedEvent extends RemoteEntityEvent<DistributionSet> {
+public class DistributionSetUpdatedEvent extends RemoteEntityEvent<DistributionSet> implements EntityUpdatedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutCreatedEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,34 +9,32 @@
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
 import org.eclipse.hawkbit.repository.event.entitiy.EntityCreatedEvent;
-import org.eclipse.hawkbit.repository.model.DistributionSetTag;
+import org.eclipse.hawkbit.repository.model.Rollout;
 
 /**
- * Defines the {@link RemoteEntityEvent} for creation of a new
- * {@link DistributionSetTag}.
+ * Defines the remote event of creating a new {@link Rollout}.
  *
  */
-public class DistributionSetTagCreatedEvent extends RemoteEntityEvent<DistributionSetTag>
-        implements EntityCreatedEvent {
-
+public class RolloutCreatedEvent extends RemoteEntityEvent<Rollout> implements EntityCreatedEvent {
     private static final long serialVersionUID = 1L;
 
     /**
      * Default constructor.
      */
-    public DistributionSetTagCreatedEvent() {
+    public RolloutCreatedEvent() {
         // for serialization libs like jackson
     }
 
     /**
      * Constructor.
      * 
-     * @param tag
-     *            the tag which is deleted
+     * @param baseEntity
+     *            the Rollout
      * @param applicationId
      *            the origin application id
      */
-    public DistributionSetTagCreatedEvent(final DistributionSetTag tag, final String applicationId) {
-        super(tag, applicationId);
+    public RolloutCreatedEvent(final Rollout baseEntity, final String applicationId) {
+        super(baseEntity, applicationId);
     }
+
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutGroupCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutGroupCreatedEvent.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityCreatedEvent;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
 
 /**
@@ -15,7 +16,7 @@ import org.eclipse.hawkbit.repository.model.RolloutGroup;
  * has been created for a specific rollout.
  *
  */
-public class RolloutGroupCreatedEvent extends AbstractRolloutGroupEvent {
+public class RolloutGroupCreatedEvent extends AbstractRolloutGroupEvent implements EntityCreatedEvent {
     private static final long serialVersionUID = 1L;
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutGroupUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutGroupUpdatedEvent.java
@@ -8,12 +8,13 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
 
 /**
  * Defines the remote event of updated a {@link RolloutGroup}.
  */
-public class RolloutGroupUpdatedEvent extends AbstractRolloutGroupEvent {
+public class RolloutGroupUpdatedEvent extends AbstractRolloutGroupEvent implements EntityUpdatedEvent {
 
     private static final long serialVersionUID = 2L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutUpdatedEvent.java
@@ -8,12 +8,13 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.Rollout;
 
 /**
  * Defines the remote event of updated a {@link Rollout}.
  */
-public class RolloutUpdatedEvent extends RemoteEntityEvent<Rollout> {
+public class RolloutUpdatedEvent extends RemoteEntityEvent<Rollout> implements EntityUpdatedEvent {
     private static final long serialVersionUID = 1L;
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/SoftwareModuleCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/SoftwareModuleCreatedEvent.java
@@ -8,13 +8,14 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityCreatedEvent;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 
 /**
  * Defines the remote event of creating a new {@link SoftwareModule}.
  *
  */
-public class SoftwareModuleCreatedEvent extends RemoteEntityEvent<SoftwareModule> {
+public class SoftwareModuleCreatedEvent extends RemoteEntityEvent<SoftwareModule> implements EntityCreatedEvent {
     private static final long serialVersionUID = 1L;
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/SoftwareModuleTypeCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/SoftwareModuleTypeCreatedEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,34 +9,33 @@
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
 import org.eclipse.hawkbit.repository.event.entitiy.EntityCreatedEvent;
-import org.eclipse.hawkbit.repository.model.DistributionSetTag;
+import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 
 /**
- * Defines the {@link RemoteEntityEvent} for creation of a new
- * {@link DistributionSetTag}.
+ * Defines the remote event of creating a new {@link SoftwareModuleType}.
  *
  */
-public class DistributionSetTagCreatedEvent extends RemoteEntityEvent<DistributionSetTag>
+public class SoftwareModuleTypeCreatedEvent extends RemoteEntityEvent<SoftwareModuleType>
         implements EntityCreatedEvent {
-
     private static final long serialVersionUID = 1L;
 
     /**
      * Default constructor.
      */
-    public DistributionSetTagCreatedEvent() {
+    public SoftwareModuleTypeCreatedEvent() {
         // for serialization libs like jackson
     }
 
     /**
      * Constructor.
      * 
-     * @param tag
-     *            the tag which is deleted
+     * @param baseEntity
+     *            the SoftwareModuleType
      * @param applicationId
      *            the origin application id
      */
-    public DistributionSetTagCreatedEvent(final DistributionSetTag tag, final String applicationId) {
-        super(tag, applicationId);
+    public SoftwareModuleTypeCreatedEvent(final SoftwareModuleType baseEntity, final String applicationId) {
+        super(baseEntity, applicationId);
     }
+
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/SoftwareModuleTypeUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/SoftwareModuleTypeUpdatedEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,21 +8,20 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
-import org.eclipse.hawkbit.repository.event.entitiy.EntityUpdatedEvent;
-import org.eclipse.hawkbit.repository.model.SoftwareModule;
+import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 
 /**
- * Defines the remote event for updating a {@link SoftwareModule}.
+ * Defines the remote event for updating a {@link SoftwareModuleType}.
  *
  */
-public class SoftwareModuleUpdatedEvent extends RemoteEntityEvent<SoftwareModule> implements EntityUpdatedEvent {
+public class SoftwareModuleTypeUpdatedEvent extends RemoteEntityEvent<SoftwareModuleType> {
 
     private static final long serialVersionUID = 1L;
 
     /**
      * Default constructor.
      */
-    public SoftwareModuleUpdatedEvent() {
+    public SoftwareModuleTypeUpdatedEvent() {
         // for serialization libs like jackson
     }
 
@@ -30,11 +29,11 @@ public class SoftwareModuleUpdatedEvent extends RemoteEntityEvent<SoftwareModule
      * Constructor.
      * 
      * @param baseEntity
-     *            the software module
+     *            SoftwareModuleType entity
      * @param applicationId
      *            the origin application id
      */
-    public SoftwareModuleUpdatedEvent(final SoftwareModule baseEntity, final String applicationId) {
+    public SoftwareModuleTypeUpdatedEvent(final SoftwareModuleType baseEntity, final String applicationId) {
         super(baseEntity, applicationId);
     }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetCreatedEvent.java
@@ -8,13 +8,14 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityCreatedEvent;
 import org.eclipse.hawkbit.repository.model.Target;
 
 /**
  * Defines the remote event of creating a new {@link Target}.
  *
  */
-public class TargetCreatedEvent extends RemoteEntityEvent<Target> {
+public class TargetCreatedEvent extends RemoteEntityEvent<Target> implements EntityCreatedEvent {
     private static final long serialVersionUID = 1L;
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetFilterQueryCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetFilterQueryCreatedEvent.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.event.remote.entity;
+
+import org.eclipse.hawkbit.repository.event.entitiy.EntityCreatedEvent;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
+
+/**
+ * Defines the remote event of creating a new {@link Target}.
+ *
+ */
+public class TargetFilterQueryCreatedEvent extends RemoteEntityEvent<TargetFilterQuery> implements EntityCreatedEvent {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Default constructor.
+     */
+    public TargetFilterQueryCreatedEvent() {
+        // for serialization libs like jackson
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param baseEntity
+     *            the TargetFilterQuery
+     * @param applicationId
+     *            the origin application id
+     */
+    public TargetFilterQueryCreatedEvent(final TargetFilterQuery baseEntity, final String applicationId) {
+        super(baseEntity, applicationId);
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetFilterQueryCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetFilterQueryCreatedEvent.java
@@ -9,11 +9,10 @@
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
 import org.eclipse.hawkbit.repository.event.entitiy.EntityCreatedEvent;
-import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 
 /**
- * Defines the remote event of creating a new {@link Target}.
+ * Defines the remote event of creating a new {@link TargetFilterQuery}.
  *
  */
 public class TargetFilterQueryCreatedEvent extends RemoteEntityEvent<TargetFilterQuery> implements EntityCreatedEvent {

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetFilterQueryUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetFilterQueryUpdatedEvent.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.event.remote.entity;
+
+import org.eclipse.hawkbit.repository.event.entitiy.EntityUpdatedEvent;
+import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
+
+/**
+ * Defines the remote event for updating a {@link TargetFilterQuery}.
+ *
+ */
+public class TargetFilterQueryUpdatedEvent extends RemoteEntityEvent<TargetFilterQuery> implements EntityUpdatedEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Default constructor.
+     */
+    public TargetFilterQueryUpdatedEvent() {
+        // for serialization libs like jackson
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param baseEntity
+     *            TargetFilterQuery entity
+     * @param applicationId
+     *            the origin application id
+     */
+    public TargetFilterQueryUpdatedEvent(final TargetFilterQuery baseEntity, final String applicationId) {
+        super(baseEntity, applicationId);
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagCreatedEvent.java
@@ -8,13 +8,14 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityCreatedEvent;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 
 /**
  * Defines the remote event for the creation of a new {@link TargetTag}.
  *
  */
-public class TargetTagCreatedEvent extends RemoteEntityEvent<TargetTag> {
+public class TargetTagCreatedEvent extends RemoteEntityEvent<TargetTag> implements EntityCreatedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagUpdatedEvent.java
@@ -8,13 +8,14 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 
 /**
  * Defines the remote event for updating a {@link TargetTag}.
  *
  */
-public class TargetTagUpdatedEvent extends RemoteEntityEvent<TargetTag> {
+public class TargetTagUpdatedEvent extends RemoteEntityEvent<TargetTag> implements EntityUpdatedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetUpdatedEvent.java
@@ -8,13 +8,14 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import org.eclipse.hawkbit.repository.event.entitiy.EntityUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.Target;
 
 /**
  * Defines the remote event for updating a {@link Target}.
  *
  */
-public class TargetUpdatedEvent extends RemoteEntityEvent<Target> {
+public class TargetUpdatedEvent extends RemoteEntityEvent<Target> implements EntityUpdatedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/event/EventType.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/event/EventType.java
@@ -14,12 +14,15 @@ import java.util.Optional;
 
 import org.eclipse.hawkbit.repository.event.remote.DistributionSetDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.DistributionSetTagDeletedEvent;
+import org.eclipse.hawkbit.repository.event.remote.DistributionSetTypeDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.DownloadProgressEvent;
 import org.eclipse.hawkbit.repository.event.remote.RolloutDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.RolloutGroupDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.SoftwareModuleDeletedEvent;
+import org.eclipse.hawkbit.repository.event.remote.SoftwareModuleTypeDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.TargetAssignDistributionSetEvent;
 import org.eclipse.hawkbit.repository.event.remote.TargetDeletedEvent;
+import org.eclipse.hawkbit.repository.event.remote.TargetFilterQueryDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.TargetPollEvent;
 import org.eclipse.hawkbit.repository.event.remote.TargetTagDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.ActionCreatedEvent;
@@ -28,13 +31,20 @@ import org.eclipse.hawkbit.repository.event.remote.entity.CancelTargetAssignment
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetTagCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetTagUpdatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetTypeCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetTypeUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetUpdatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.RolloutCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutGroupCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutGroupUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleTypeCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleTypeUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.TargetFilterQueryCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.TargetFilterQueryUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetTagCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetTagUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetUpdatedEvent;
@@ -101,6 +111,23 @@ public class EventType {
         TYPES.put(24, TargetPollEvent.class);
         TYPES.put(25, RolloutDeletedEvent.class);
         TYPES.put(26, RolloutGroupDeletedEvent.class);
+        TYPES.put(27, RolloutCreatedEvent.class);
+
+        // distribution set type
+        TYPES.put(28, DistributionSetTypeCreatedEvent.class);
+        TYPES.put(29, DistributionSetTypeUpdatedEvent.class);
+        TYPES.put(30, DistributionSetTypeDeletedEvent.class);
+
+        // software module type
+        TYPES.put(31, SoftwareModuleTypeCreatedEvent.class);
+        TYPES.put(32, SoftwareModuleTypeUpdatedEvent.class);
+        TYPES.put(33, SoftwareModuleTypeDeletedEvent.class);
+
+        // target filter query
+        TYPES.put(34, TargetFilterQueryCreatedEvent.class);
+        TYPES.put(35, TargetFilterQueryUpdatedEvent.class);
+        TYPES.put(36, TargetFilterQueryDeletedEvent.class);
+
     }
 
     private int value;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
@@ -25,11 +25,16 @@ import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import org.eclipse.hawkbit.repository.event.remote.DistributionSetDeletedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetTypeCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetTypeUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
+import org.eclipse.hawkbit.repository.model.helper.EventPublisherHolder;
 import org.eclipse.persistence.annotations.CascadeOnDelete;
+import org.eclipse.persistence.descriptors.DescriptorEvent;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -46,7 +51,7 @@ import org.springframework.util.CollectionUtils;
 // exception squid:S2160 - BaseEntity equals/hashcode is handling correctly for
 // sub entities
 @SuppressWarnings("squid:S2160")
-public class JpaDistributionSetType extends AbstractJpaNamedEntity implements DistributionSetType {
+public class JpaDistributionSetType extends AbstractJpaNamedEntity implements DistributionSetType, EventAwareEntity {
     private static final long serialVersionUID = 1L;
 
     @CascadeOnDelete
@@ -230,4 +235,21 @@ public class JpaDistributionSetType extends AbstractJpaNamedEntity implements Di
         return "DistributionSetType [key=" + key + ", isDeleted()=" + isDeleted() + ", getId()=" + getId() + "]";
     }
 
+    @Override
+    public void fireCreateEvent(final DescriptorEvent descriptorEvent) {
+        EventPublisherHolder.getInstance().getEventPublisher().publishEvent(
+                new DistributionSetTypeCreatedEvent(this, EventPublisherHolder.getInstance().getApplicationId()));
+    }
+
+    @Override
+    public void fireUpdateEvent(final DescriptorEvent descriptorEvent) {
+        EventPublisherHolder.getInstance().getEventPublisher().publishEvent(
+                new DistributionSetTypeUpdatedEvent(this, EventPublisherHolder.getInstance().getApplicationId()));
+    }
+
+    @Override
+    public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
+        EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new DistributionSetDeletedEvent(getTenant(),
+                getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+    }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
@@ -27,6 +27,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.eclipse.hawkbit.repository.event.remote.RolloutDeletedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.RolloutCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.ActionType;
@@ -230,7 +231,8 @@ public class JpaRollout extends AbstractJpaNamedEntity implements Rollout, Event
 
     @Override
     public void fireCreateEvent(final DescriptorEvent descriptorEvent) {
-        // there is no rollout creation event
+        EventPublisherHolder.getInstance().getEventPublisher()
+                .publishEvent(new RolloutCreatedEvent(this, EventPublisherHolder.getInstance().getApplicationId()));
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModuleType.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModuleType.java
@@ -17,7 +17,12 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import org.eclipse.hawkbit.repository.event.remote.SoftwareModuleTypeDeletedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleTypeCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleTypeUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
+import org.eclipse.hawkbit.repository.model.helper.EventPublisherHolder;
+import org.eclipse.persistence.descriptors.DescriptorEvent;
 
 /**
  * Type of a software modules.
@@ -32,7 +37,7 @@ import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 // exception squid:S2160 - BaseEntity equals/hashcode is handling correctly for
 // sub entities
 @SuppressWarnings("squid:S2160")
-public class JpaSoftwareModuleType extends AbstractJpaNamedEntity implements SoftwareModuleType {
+public class JpaSoftwareModuleType extends AbstractJpaNamedEntity implements SoftwareModuleType, EventAwareEntity {
     private static final long serialVersionUID = 1L;
 
     @Column(name = "type_key", nullable = false, length = SoftwareModuleType.KEY_MAX_SIZE)
@@ -137,5 +142,23 @@ public class JpaSoftwareModuleType extends AbstractJpaNamedEntity implements Sof
 
     public void setKey(final String key) {
         this.key = key;
+    }
+
+    @Override
+    public void fireCreateEvent(final DescriptorEvent descriptorEvent) {
+        EventPublisherHolder.getInstance().getEventPublisher().publishEvent(
+                new SoftwareModuleTypeCreatedEvent(this, EventPublisherHolder.getInstance().getApplicationId()));
+    }
+
+    @Override
+    public void fireUpdateEvent(final DescriptorEvent descriptorEvent) {
+        EventPublisherHolder.getInstance().getEventPublisher().publishEvent(
+                new SoftwareModuleTypeUpdatedEvent(this, EventPublisherHolder.getInstance().getApplicationId()));
+    }
+
+    @Override
+    public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
+        EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new SoftwareModuleTypeDeletedEvent(
+                getTenant(), getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetFilterQuery.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetFilterQuery.java
@@ -20,9 +20,14 @@ import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 
+import org.eclipse.hawkbit.repository.event.remote.TargetFilterQueryDeletedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.TargetFilterQueryCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.TargetFilterQueryUpdatedEvent;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.NamedEntity;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
+import org.eclipse.hawkbit.repository.model.helper.EventPublisherHolder;
+import org.eclipse.persistence.descriptors.DescriptorEvent;
 
 /**
  * Stored target filter.
@@ -34,7 +39,8 @@ import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 // exception squid:S2160 - BaseEntity equals/hashcode is handling correctly for
 // sub entities
 @SuppressWarnings("squid:S2160")
-public class JpaTargetFilterQuery extends AbstractJpaTenantAwareBaseEntity implements TargetFilterQuery {
+public class JpaTargetFilterQuery extends AbstractJpaTenantAwareBaseEntity
+        implements TargetFilterQuery, EventAwareEntity {
     private static final long serialVersionUID = 7493966984413479089L;
 
     @Column(name = "name", length = NamedEntity.NAME_MAX_SIZE, nullable = false)
@@ -97,5 +103,23 @@ public class JpaTargetFilterQuery extends AbstractJpaTenantAwareBaseEntity imple
 
     public void setAutoAssignDistributionSet(final JpaDistributionSet distributionSet) {
         this.autoAssignDistributionSet = distributionSet;
+    }
+
+    @Override
+    public void fireCreateEvent(final DescriptorEvent descriptorEvent) {
+        EventPublisherHolder.getInstance().getEventPublisher().publishEvent(
+                new TargetFilterQueryCreatedEvent(this, EventPublisherHolder.getInstance().getApplicationId()));
+    }
+
+    @Override
+    public void fireUpdateEvent(final DescriptorEvent descriptorEvent) {
+        EventPublisherHolder.getInstance().getEventPublisher().publishEvent(
+                new TargetFilterQueryUpdatedEvent(this, EventPublisherHolder.getInstance().getApplicationId()));
+    }
+
+    @Override
+    public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
+        EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new TargetFilterQueryDeletedEvent(
+                getTenant(), getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTypeManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTypeManagementTest.java
@@ -8,10 +8,6 @@
  */
 package org.eclipse.hawkbit.repository.jpa;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.util.Arrays;
 
 import javax.validation.ConstraintViolationException;
@@ -19,6 +15,7 @@ import javax.validation.ConstraintViolationException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetTypeCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleCreatedEvent;
 import org.eclipse.hawkbit.repository.exception.EntityReadOnlyException;
@@ -30,6 +27,10 @@ import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
 import org.junit.Test;
 
 import com.google.common.collect.Sets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
@@ -56,7 +57,8 @@ public class DistributionSetTypeManagementTest extends AbstractJpaIntegrationTes
     @Test
     @Description("Verifies that management queries react as specfied on calls for non existing entities "
             + " by means of throwing EntityNotFoundException.")
-    @ExpectEvents({ @Expect(type = DistributionSetCreatedEvent.class, count = 0) })
+    @ExpectEvents({ @Expect(type = DistributionSetCreatedEvent.class, count = 0),
+            @Expect(type = DistributionSetTypeCreatedEvent.class, count = 1) })
     public void entityQueriesReferringToNotExistingEntitiesThrowsException() {
 
         verifyThrownExceptionBy(() -> distributionSetTypeManagement.assignMandatorySoftwareModuleTypes(NOT_EXIST_IDL,

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutGroupManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutGroupManagementTest.java
@@ -8,10 +8,9 @@
  */
 package org.eclipse.hawkbit.repository.jpa;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.eclipse.hawkbit.repository.event.remote.RolloutDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.RolloutCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutGroupCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutGroupUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutUpdatedEvent;
@@ -20,6 +19,8 @@ import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
@@ -47,24 +48,26 @@ public class RolloutGroupManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = RolloutGroupUpdatedEvent.class, count = 10),
             @Expect(type = DistributionSetCreatedEvent.class, count = 1),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
-            @Expect(type = RolloutUpdatedEvent.class, count = 1),
-            @Expect(type = TargetCreatedEvent.class, count = 10) })
+            @Expect(type = RolloutUpdatedEvent.class, count = 1), @Expect(type = TargetCreatedEvent.class, count = 10),
+            @Expect(type = RolloutCreatedEvent.class, count = 1) })
     public void entityQueriesReferringToNotExistingEntitiesThrowsException() {
         testdataFactory.createRollout("xxx");
 
         verifyThrownExceptionBy(() -> rolloutGroupManagement.countByRollout(NOT_EXIST_IDL), "Rollout");
         verifyThrownExceptionBy(() -> rolloutGroupManagement.countTargetsOfRolloutsGroup(NOT_EXIST_IDL),
                 "RolloutGroup");
+        verifyThrownExceptionBy(() -> rolloutGroupManagement.findByRolloutWithDetailedStatus(PAGE, NOT_EXIST_IDL),
+                "Rollout");
         verifyThrownExceptionBy(
-                () -> rolloutGroupManagement.findByRolloutWithDetailedStatus(PAGE, NOT_EXIST_IDL), "Rollout");
-        verifyThrownExceptionBy(() -> rolloutGroupManagement.findAllTargetsOfRolloutGroupWithActionStatus(PAGE, NOT_EXIST_IDL),
+                () -> rolloutGroupManagement.findAllTargetsOfRolloutGroupWithActionStatus(PAGE, NOT_EXIST_IDL),
                 "RolloutGroup");
         verifyThrownExceptionBy(() -> rolloutGroupManagement.findByRolloutAndRsql(PAGE, NOT_EXIST_IDL, "name==*"),
                 "Rollout");
 
         verifyThrownExceptionBy(() -> rolloutGroupManagement.findTargetsOfRolloutGroup(PAGE, NOT_EXIST_IDL),
                 "RolloutGroup");
-        verifyThrownExceptionBy(() -> rolloutGroupManagement.findTargetsOfRolloutGroupByRsql(PAGE, NOT_EXIST_IDL, "name==*"),
+        verifyThrownExceptionBy(
+                () -> rolloutGroupManagement.findTargetsOfRolloutGroupByRsql(PAGE, NOT_EXIST_IDL, "name==*"),
                 "RolloutGroup");
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -8,9 +8,6 @@
  */
 package org.eclipse.hawkbit.repository.jpa;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,6 +30,7 @@ import org.eclipse.hawkbit.repository.event.remote.TargetAssignDistributionSetEv
 import org.eclipse.hawkbit.repository.event.remote.entity.ActionCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.ActionUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.RolloutCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutGroupCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutGroupUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.RolloutUpdatedEvent;
@@ -70,6 +68,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
@@ -137,7 +138,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = RolloutGroupUpdatedEvent.class, count = 10),
             @Expect(type = DistributionSetCreatedEvent.class, count = 1),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
-            @Expect(type = RolloutUpdatedEvent.class, count = 1),
+            @Expect(type = RolloutUpdatedEvent.class, count = 1), @Expect(type = RolloutCreatedEvent.class, count = 1),
             @Expect(type = TargetCreatedEvent.class, count = 10) })
     public void entityQueriesReferringToNotExistingEntitiesThrowsException() {
         testdataFactory.createRollout("xxx");
@@ -1419,7 +1420,8 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = RolloutGroupCreatedEvent.class, count = 5),
             @Expect(type = RolloutGroupDeletedEvent.class, count = 5),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
-            @Expect(type = RolloutGroupUpdatedEvent.class, count = 5) })
+            @Expect(type = RolloutGroupUpdatedEvent.class, count = 5),
+            @Expect(type = RolloutCreatedEvent.class, count = 1) })
     public void deleteRolloutWhichHasNeverStartedIsHardDeleted() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
@@ -1450,7 +1452,8 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = RolloutGroupCreatedEvent.class, count = 5),
             @Expect(type = RolloutGroupDeletedEvent.class, count = 5),
             @Expect(type = ActionCreatedEvent.class, count = 10), @Expect(type = ActionUpdatedEvent.class, count = 2),
-            @Expect(type = RolloutDeletedEvent.class, count = 1) })
+            @Expect(type = RolloutDeletedEvent.class, count = 1),
+            @Expect(type = RolloutCreatedEvent.class, count = 1) })
     public void deleteRolloutWhichHasBeenStartedBeforeIsSoftDeleted() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
@@ -9,6 +9,7 @@
 
 package org.eclipse.hawkbit.repository.test.matcher;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.lang.reflect.Method;
@@ -39,8 +40,6 @@ import com.google.common.collect.Sets;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.core.ConditionTimeoutException;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  * Test rule to setup and verify the event count for a method.
  */
@@ -55,6 +54,10 @@ public class EventVerifier extends AbstractTestExecutionListener {
      * {@code @Before} annotations which are actually counted to the executed
      * test-method and maybe fire events which are not covered / recognized by
      * the test-method itself and reset the counter again.
+     * 
+     * Note that this approach is only working when using a single-thread
+     * executor in the ApplicationEventMultiCaster, so the order of the events
+     * keep the same.
      * 
      * @param publisher
      *            the {@link ApplicationEventPublisher} to publish the marker


### PR DESCRIPTION
1. Introduce missing entity events 
 * DistributionSetTypeCreatedEvent
 * DistributionSetTypeUpdatedEvent
 * DistributionSetTypeDeletedEvent
 * SoftwareModuleTypeCreatedEvent
 * SoftwareModuleTypeUpdatedEvent
 * SoftwareModuleTypeDeletedEvent
 * TargetFilterQueryTypeCreatedEvent
 * TargetFilterQueryTypeUpdatedEvent
 * TargetFilterQueryTypeDeletedEvent
 * RolloutCreatedEvent

2. Introduce marker interfaces to indicate `create`, `update` or `deleted` entity event which allows to easiy listener for a specific typed event
 * EntityCreatedEvent 
 * EntityUpdatedEvent 
 * EntityDeletedEvent 

3. Allow to reset `EventVerifier` counter in tests because introducing newly `DistributionSetType` and `SoftwareModuleType`-events are sent in the `@Before` test setup when setting up the tenant automatically and tests are not aware of the setup creation events are on the event bus then and fail because they are not using the `@ExpectEvent` annotation then.