### PR TITLE
Fix action AutoClose feature which does not work with Rollout Management

### DIFF
--- a/3rd-dependencies/Release_0_2_0.md
+++ b/3rd-dependencies/Release_0_2_0.md
@@ -4,6 +4,7 @@
 
 | Group ID  | Artifact ID  | Version  | CQ  |
 |---|---|---|---|
+|com.cronutils|cron-utils|5.0.5| [CQ15762](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=15762) |
 |com.github.ben-manes.caffeine|caffeine|2.3.5| [CQ13563](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13563) |
 |aopalliance|aopalliance|1.0| [CQ10346](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=10346) |
 |ch.qos.logback|logback-classic|1.1.3| [CQ10347](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=10347) |

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -448,8 +448,18 @@ public class JpaDeploymentManagement implements DeploymentManagement {
 
     private JpaAction startScheduledActionIfNoCancelationHasToBeHandledFirst(final JpaAction action) {
         // check if we need to override running update actions
-        final List<Long> overrideObsoleteUpdateActions = onlineDsAssignmentStrategy
-                .overrideObsoleteUpdateActions(Collections.singletonList(action.getTarget().getId()));
+        final List<Long> overrideObsoleteUpdateActions;
+
+        if (systemSecurityContext.runAsSystem(() -> tenantConfigurationManagement
+                .getConfigurationValue(TenantConfigurationKey.REPOSITORY_ACTIONS_AUTOCLOSE_ENABLED, Boolean.class)
+                .getValue())) {
+            overrideObsoleteUpdateActions = Collections.emptyList();
+            onlineDsAssignmentStrategy
+                    .closeObsoleteUpdateActions(Collections.singletonList(action.getTarget().getId()));
+        } else {
+            overrideObsoleteUpdateActions = onlineDsAssignmentStrategy
+                    .overrideObsoleteUpdateActions(Collections.singletonList(action.getTarget().getId()));
+        }
 
         action.setActive(true);
         action.setStatus(Status.RUNNING);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -65,6 +65,7 @@ import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
+import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
 import org.junit.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
@@ -116,6 +117,49 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final Action rolloutCreatedAction = actionsByKnownTarget.stream()
                 .filter(action -> !action.getId().equals(manuallyAssignedActionId)).findAny().get();
         assertThat(rolloutCreatedAction.getStatus()).isEqualTo(Status.FINISHED);
+
+    }
+
+    @Test
+    @Description("Verifies that a running action is auto canceled by a rollout which assigns another distribution-set.")
+    public void rolloutAssignesNewDistributionSetAndAutoCloseActiveActions() {
+        tenantConfigurationManagement
+                .addOrUpdateConfiguration(TenantConfigurationKey.REPOSITORY_ACTIONS_AUTOCLOSE_ENABLED, true);
+
+        try {
+            // manually assign distribution set to target
+            final String knownControllerId = "controller12345";
+            final DistributionSet firstDistributionSet = testdataFactory.createDistributionSet();
+            final DistributionSet secondDistributionSet = testdataFactory.createDistributionSet("second");
+            testdataFactory.createTarget(knownControllerId);
+            final DistributionSetAssignmentResult assignmentResult = deploymentManagement.assignDistributionSet(
+                    firstDistributionSet.getId(), ActionType.FORCED, 0, Collections.singleton(knownControllerId));
+            final Long manuallyAssignedActionId = assignmentResult.getActions().get(0);
+
+            // create rollout with the same distribution set already assigned
+            // start rollout
+            final Rollout rollout = testdataFactory.createRolloutByVariables("rolloutNotCancelRunningAction",
+                    "description", 1, "name==*", secondDistributionSet, "50", "5");
+            rolloutManagement.start(rollout.getId());
+            rolloutManagement.handleRollouts();
+
+            // verify that manually created action is canceled and action
+            // created from rollout is running
+            final List<Action> actionsByKnownTarget = deploymentManagement.findActionsByTarget(knownControllerId, PAGE)
+                    .getContent();
+            // should be 2 actions, one manually and one from the rollout
+            assertThat(actionsByKnownTarget).hasSize(2);
+            // verify that manually assigned action is still running
+            assertThat(deploymentManagement.findAction(manuallyAssignedActionId).get().getStatus())
+                    .isEqualTo(Status.CANCELED);
+            // verify that rollout management created action is running
+            final Action rolloutCreatedAction = actionsByKnownTarget.stream()
+                    .filter(action -> !action.getId().equals(manuallyAssignedActionId)).findAny().get();
+            assertThat(rolloutCreatedAction.getStatus()).isEqualTo(Status.RUNNING);
+        } finally {
+            tenantConfigurationManagement
+                    .addOrUpdateConfiguration(TenantConfigurationKey.REPOSITORY_ACTIONS_AUTOCLOSE_ENABLED, false);
+        }
 
     }
 


### PR DESCRIPTION
AutoClose actions is not working if the new action is applied by Rollout Management instead of manual.

Signed-off-by: kaizimmerm kai.zimmermann@bosch-si.com
