### PR TITLE
Fix RSQL duplicate entries

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
@@ -165,6 +165,7 @@ public final class RSQLUtility {
         @Override
         public Predicate toPredicate(final Root<T> root, final CriteriaQuery<?> query, final CriteriaBuilder cb) {
             final Node rootNode = parseRsql(rsql);
+            query.distinct(true);
 
             final JpqQueryRSQLVisitor<A, T> jpqQueryRSQLVisitor = new JpqQueryRSQLVisitor<>(root, cb, enumType,
                     virtualPropertyReplacer);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLActionFieldsTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLActionFieldsTest.java
@@ -66,6 +66,7 @@ public class RSQLActionFieldsTest extends AbstractJpaIntegrationTest {
     @Description("Test filter action by id")
     public void testFilterByParameterId() {
         assertRSQLQuery(ActionFields.ID.name() + "==" + action.getId(), 1);
+        assertRSQLQuery(ActionFields.ID.name() + "!=" + action.getId(), 10);
         assertRSQLQuery(ActionFields.ID.name() + "==noExist*", 0);
         assertRSQLQuery(ActionFields.ID.name() + "=in=(" + action.getId() + ",1000000)", 1);
         assertRSQLQuery(ActionFields.ID.name() + "=out=(" + action.getId() + ",1000000)", 10);
@@ -75,6 +76,7 @@ public class RSQLActionFieldsTest extends AbstractJpaIntegrationTest {
     @Description("Test action by status")
     public void testFilterByParameterStatus() {
         assertRSQLQuery(ActionFields.STATUS.name() + "==pending", 5);
+        assertRSQLQuery(ActionFields.STATUS.name() + "!=pending", 6);
         assertRSQLQuery(ActionFields.STATUS.name() + "=in=(pending)", 5);
         assertRSQLQuery(ActionFields.STATUS.name() + "=out=(pending)", 6);
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLDistributionSetFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLDistributionSetFieldTest.java
@@ -63,6 +63,7 @@ public class RSQLDistributionSetFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter distribution set by name")
     public void testFilterByParameterName() {
         assertRSQLQuery(DistributionSetFields.NAME.name() + "==DS", 1);
+        assertRSQLQuery(DistributionSetFields.NAME.name() + "!=DS", 3);
         assertRSQLQuery(DistributionSetFields.NAME.name() + "==*DS", 4);
         assertRSQLQuery(DistributionSetFields.NAME.name() + "==noExist*", 0);
         assertRSQLQuery(DistributionSetFields.NAME.name() + "=in=(DS,notexist)", 1);
@@ -73,6 +74,7 @@ public class RSQLDistributionSetFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter distribution set by description")
     public void testFilterByParameterDescription() {
         assertRSQLQuery(DistributionSetFields.DESCRIPTION.name() + "==DS", 1);
+        assertRSQLQuery(DistributionSetFields.DESCRIPTION.name() + "!=DS", 3);
         assertRSQLQuery(DistributionSetFields.DESCRIPTION.name() + "==DS*", 2);
         assertRSQLQuery(DistributionSetFields.DESCRIPTION.name() + "==DS%", 1);
         assertRSQLQuery(DistributionSetFields.DESCRIPTION.name() + "==noExist*", 0);
@@ -108,10 +110,12 @@ public class RSQLDistributionSetFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter distribution set by tag")
     public void testFilterByTag() {
         assertRSQLQuery(DistributionSetFields.TAG.name() + "==Tag1", 2);
+        // does not include untagged sets
+        assertRSQLQuery(DistributionSetFields.TAG.name() + "!=Tag1", 0);
         assertRSQLQuery(DistributionSetFields.TAG.name() + "==T*", 2);
         assertRSQLQuery(DistributionSetFields.TAG.name() + "==noExist*", 0);
         assertRSQLQuery(DistributionSetFields.TAG.name() + "=in=(Tag1,notexist)", 2);
-        assertRSQLQuery(DistributionSetFields.TAG.name() + "=out=(Tag1,notexist)", 0);
+        assertRSQLQuery(DistributionSetFields.TAG.name() + "=out=(null)", 2);
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLRolloutGroupFields.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLRolloutGroupFields.java
@@ -41,14 +41,14 @@ public class RSQLRolloutGroupFields extends AbstractJpaIntegrationTest {
         rollout = createRollout("rollout1", 4, dsA.getId(), "controllerId==rollout*");
         rollout = rolloutManagement.get(rollout.getId()).get();
 
-        this.rolloutGroupId = rolloutGroupManagement.findByRollout(PAGE, rollout.getId()).getContent()
-                .get(0).getId();
+        this.rolloutGroupId = rolloutGroupManagement.findByRollout(PAGE, rollout.getId()).getContent().get(0).getId();
     }
 
     @Test
     @Description("Test filter rollout group by  id")
     public void testFilterByParameterId() {
         assertRSQLQuery(RolloutGroupFields.ID.name() + "==" + rolloutGroupId, 1);
+        assertRSQLQuery(RolloutGroupFields.ID.name() + "!=" + rolloutGroupId, 3);
         assertRSQLQuery(RolloutGroupFields.ID.name() + "==noExist*", 0);
         assertRSQLQuery(RolloutGroupFields.ID.name() + "=in=(" + rolloutGroupId + ")", 1);
         assertRSQLQuery(RolloutGroupFields.ID.name() + "=out=(" + rolloutGroupId + ")", 3);
@@ -58,6 +58,7 @@ public class RSQLRolloutGroupFields extends AbstractJpaIntegrationTest {
     @Description("Test filter rollout group by name")
     public void testFilterByParameterName() {
         assertRSQLQuery(RolloutGroupFields.NAME.name() + "==group-1", 1);
+        assertRSQLQuery(RolloutGroupFields.NAME.name() + "!=group-1", 3);
         assertRSQLQuery(RolloutGroupFields.NAME.name() + "==*", 4);
         assertRSQLQuery(RolloutGroupFields.NAME.name() + "==noExist*", 0);
         assertRSQLQuery(RolloutGroupFields.NAME.name() + "=in=(group-1,group-2)", 2);
@@ -68,6 +69,7 @@ public class RSQLRolloutGroupFields extends AbstractJpaIntegrationTest {
     @Description("Test filter rollout group by description")
     public void testFilterByParameterDescription() {
         assertRSQLQuery(RolloutGroupFields.DESCRIPTION.name() + "==group-1", 1);
+        assertRSQLQuery(RolloutGroupFields.DESCRIPTION.name() + "!=group-1", 3);
         assertRSQLQuery(RolloutGroupFields.DESCRIPTION.name() + "==group*", 4);
         assertRSQLQuery(RolloutGroupFields.DESCRIPTION.name() + "==noExist*", 0);
         assertRSQLQuery(RolloutGroupFields.DESCRIPTION.name() + "=in=(group-1,notexist)", 1);
@@ -85,8 +87,7 @@ public class RSQLRolloutGroupFields extends AbstractJpaIntegrationTest {
     private Rollout createRollout(final String name, final int amountGroups, final long distributionSetId,
             final String targetFilterQuery) {
         return rolloutManagement.create(
-                entityFactory.rollout().create()
-                        .set(distributionSetManagement.get(distributionSetId).get()).name(name)
+                entityFactory.rollout().create().set(distributionSetManagement.get(distributionSetId).get()).name(name)
                         .targetFilterQuery(targetFilterQuery),
                 amountGroups, new RolloutGroupConditionBuilder().withDefaults()
                         .successCondition(RolloutGroupSuccessCondition.THRESHOLD, "100").build());

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
@@ -60,6 +60,7 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter software module by name")
     public void testFilterByParameterName() {
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub", 3);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub*", 2);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub*", 2);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==noExist*", 0);
@@ -71,6 +72,7 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter software module by description")
     public void testFilterByParameterDescription() {
         assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==agent-hub", 1);
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=agent-hub", 3);
         assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==noExist*", 0);
         assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=in=(agent-hub,notexist)", 1);
         assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=out=(agent-hub,notexist)", 3);
@@ -89,6 +91,7 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter software module by type")
     public void testFilterByType() {
         assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==" + TestdataFactory.SM_TYPE_APP, 2);
+        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "!=" + TestdataFactory.SM_TYPE_APP, 2);
         assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==noExist*", 0);
         assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=in=(" + TestdataFactory.SM_TYPE_APP + ")", 2);
         assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=out=(" + TestdataFactory.SM_TYPE_APP + ")", 2);
@@ -98,6 +101,8 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter software module by metadata")
     public void testFilterByMetadata() {
         assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==metaValue", 1);
+        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey!=metaValue", 1);
+        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey!=notexist", 2);
         assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==*v*", 2);
         assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==noExist*", 0);
         assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey=in=(metaValue,value)", 2);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleTypeFieldsTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleTypeFieldsTest.java
@@ -36,12 +36,14 @@ public class RSQLSoftwareModuleTypeFieldsTest extends AbstractJpaIntegrationTest
     @Description("Test filter software module test type by name")
     public void testFilterByParameterName() {
         assertRSQLQuery(SoftwareModuleTypeFields.NAME.name() + "==" + Constants.SMT_DEFAULT_OS_NAME, 1);
+        assertRSQLQuery(SoftwareModuleTypeFields.NAME.name() + "!=" + Constants.SMT_DEFAULT_OS_NAME, 2);
     }
 
     @Test
     @Description("Test filter software module test type by description")
     public void testFilterByParameterDescription() {
         assertRSQLQuery(SoftwareModuleTypeFields.DESCRIPTION.name() + "==Updated*", 3);
+        assertRSQLQuery(SoftwareModuleTypeFields.DESCRIPTION.name() + "!=Updated*", 0);
         assertRSQLQuery(SoftwareModuleTypeFields.DESCRIPTION.name() + "==noExist*", 0);
     }
 
@@ -49,6 +51,7 @@ public class RSQLSoftwareModuleTypeFieldsTest extends AbstractJpaIntegrationTest
     @Description("Test filter software module test type by key")
     public void testFilterByParameterKey() {
         assertRSQLQuery(SoftwareModuleTypeFields.KEY.name() + "==os", 1);
+        assertRSQLQuery(SoftwareModuleTypeFields.KEY.name() + "!=os", 2);
         assertRSQLQuery(SoftwareModuleTypeFields.KEY.name() + "=in=(os)", 1);
         assertRSQLQuery(SoftwareModuleTypeFields.KEY.name() + "=out=(os)", 2);
     }
@@ -57,6 +60,7 @@ public class RSQLSoftwareModuleTypeFieldsTest extends AbstractJpaIntegrationTest
     @Description("Test filter software module test type by max")
     public void testFilterByMaxAssignment() {
         assertRSQLQuery(SoftwareModuleTypeFields.MAXASSIGNMENTS.name() + "==1", 2);
+        assertRSQLQuery(SoftwareModuleTypeFields.MAXASSIGNMENTS.name() + "!=1", 1);
     }
 
     private void assertRSQLQuery(final String rsqlParam, final long excpectedEntity) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTagFieldsTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTagFieldsTest.java
@@ -43,6 +43,7 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Description("Test filter target tag by name")
     public void testFilterTargetTagByParameterName() {
         assertRSQLQueryTarget(TagFields.NAME.name() + "==1", 1);
+        assertRSQLQueryTarget(TagFields.NAME.name() + "!=1", 4);
         assertRSQLQueryTarget(TagFields.NAME.name() + "==*", 5);
         assertRSQLQueryTarget(TagFields.NAME.name() + "==noExist*", 0);
         assertRSQLQueryTarget(TagFields.NAME.name() + "=in=(1,notexist)", 1);
@@ -53,6 +54,7 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Description("Test filter target tag by description")
     public void testFilterTargetTagByParameterDescription() {
         assertRSQLQueryTarget(TagFields.DESCRIPTION.name() + "==1", 1);
+        assertRSQLQueryTarget(TagFields.DESCRIPTION.name() + "!=1", 4);
         assertRSQLQueryTarget(TagFields.DESCRIPTION.name() + "==*", 5);
         assertRSQLQueryTarget(TagFields.DESCRIPTION.name() + "==noExist*", 0);
         assertRSQLQueryTarget(TagFields.DESCRIPTION.name() + "=in=(1,notexist)", 1);
@@ -63,6 +65,7 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Description("Test filter target tag by colour")
     public void testFilterTargetTagByParameterColour() {
         assertRSQLQueryTarget(TagFields.COLOUR.name() + "==red", 3);
+        assertRSQLQueryTarget(TagFields.COLOUR.name() + "!=red", 2);
         assertRSQLQueryTarget(TagFields.COLOUR.name() + "==r*", 3);
         assertRSQLQueryTarget(TagFields.COLOUR.name() + "==noExist*", 0);
         assertRSQLQueryTarget(TagFields.COLOUR.name() + "=in=(red,notexist)", 3);
@@ -73,6 +76,7 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Description("Test filter distribution set tag by name")
     public void testFilterDistributionSetTagByParameterName() {
         assertRSQLQueryDistributionSet(TagFields.NAME.name() + "==1", 1);
+        assertRSQLQueryDistributionSet(TagFields.NAME.name() + "!=1", 4);
         assertRSQLQueryDistributionSet(TagFields.NAME.name() + "==*", 5);
         assertRSQLQueryDistributionSet(TagFields.NAME.name() + "==noExist*", 0);
         assertRSQLQueryDistributionSet(TagFields.NAME.name() + "=in=(1,2)", 2);
@@ -83,6 +87,7 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Description("Test filter distribution set by description")
     public void testFilterDistributionSetTagByParameterDescription() {
         assertRSQLQueryDistributionSet(TagFields.DESCRIPTION.name() + "==1", 1);
+        assertRSQLQueryDistributionSet(TagFields.DESCRIPTION.name() + "!=1", 4);
         assertRSQLQueryDistributionSet(TagFields.DESCRIPTION.name() + "==*", 5);
         assertRSQLQueryDistributionSet(TagFields.DESCRIPTION.name() + "==noExist*", 0);
         assertRSQLQueryDistributionSet(TagFields.DESCRIPTION.name() + "=in=(1,2)", 2);
@@ -93,6 +98,7 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Description("Test filter distribution set by colour")
     public void testFilterDistributionSetTagByParameterColour() {
         assertRSQLQueryDistributionSet(TagFields.COLOUR.name() + "==red", 3);
+        assertRSQLQueryDistributionSet(TagFields.COLOUR.name() + "!=red", 2);
         assertRSQLQueryDistributionSet(TagFields.COLOUR.name() + "==r*", 3);
         assertRSQLQueryDistributionSet(TagFields.COLOUR.name() + "==noExist*", 0);
         assertRSQLQueryDistributionSet(TagFields.COLOUR.name() + "=in=(red,notexist)", 3);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
@@ -169,21 +169,13 @@ public class RSQLTargetFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter target by tag")
     public void testFilterByTag() {
         assertRSQLQuery(TargetFields.TAG.name() + "==Tag1", 2);
-
-        // FIXME: should be 3 (2 tagged with something else, 1 untagged)
-        assertRSQLQuery(TargetFields.TAG.name() + "!=Tag1", 3);
-
+        assertRSQLQuery(TargetFields.TAG.name() + "!=Tag1", 2);
         assertRSQLQuery(TargetFields.TAG.name() + "==T*", 4);
         assertRSQLQuery(TargetFields.TAG.name() + "==noExist*", 0);
         assertRSQLQuery(TargetFields.TAG.name() + "!=notexist", 4);
         assertRSQLQuery(TargetFields.TAG.name() + "=in=(Tag1,notexist)", 2);
-
-        // FIXME: should be 1 (untagged) , Note: works with out -> see below
-        assertRSQLQuery(TargetFields.TAG.name() + "=in=(null)", 1);
-
-        // FIXME: should be 3 (2 tagged with something else, 1 untagged)
-        assertRSQLQuery(TargetFields.TAG.name() + "=out=(Tag1,notexist)", 3);
-
+        assertRSQLQuery(TargetFields.TAG.name() + "=in=(null)", 0);
+        assertRSQLQuery(TargetFields.TAG.name() + "=out=(Tag1,notexist)", 2);
         assertRSQLQuery(TargetFields.TAG.name() + "=out=(null)", 4);
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
@@ -81,7 +81,7 @@ public class RSQLTargetFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter target by (controller) id")
     public void testFilterByParameterId() {
         assertRSQLQuery(TargetFields.ID.name() + "==targetId123", 1);
-        assertRSQLQuery(TargetFields.ID.name() + "==target*", 4);
+        assertRSQLQuery(TargetFields.ID.name() + "==target*", 5);
         assertRSQLQuery(TargetFields.ID.name() + "==noExist*", 0);
         assertRSQLQuery(TargetFields.ID.name() + "=in=(targetId123,notexist)", 1);
         assertRSQLQuery(TargetFields.ID.name() + "=out=(targetId123,notexist)", 4);
@@ -91,7 +91,7 @@ public class RSQLTargetFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter target by name")
     public void testFilterByParameterName() {
         assertRSQLQuery(TargetFields.NAME.name() + "==targetName123", 1);
-        assertRSQLQuery(TargetFields.NAME.name() + "==target*", 4);
+        assertRSQLQuery(TargetFields.NAME.name() + "==target*", 5);
         assertRSQLQuery(TargetFields.NAME.name() + "==noExist*", 0);
         assertRSQLQuery(TargetFields.NAME.name() + "=in=(targetName123,notexist)", 1);
         assertRSQLQuery(TargetFields.NAME.name() + "=out=(targetName123,notexist)", 4);
@@ -111,7 +111,7 @@ public class RSQLTargetFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter target by controller id")
     public void testFilterByParameterControllerId() {
         assertRSQLQuery(TargetFields.CONTROLLERID.name() + "==targetId123", 1);
-        assertRSQLQuery(TargetFields.CONTROLLERID.name() + "==target*", 4);
+        assertRSQLQuery(TargetFields.CONTROLLERID.name() + "==target*", 5);
         assertRSQLQuery(TargetFields.CONTROLLERID.name() + "==noExist*", 0);
         assertRSQLQuery(TargetFields.CONTROLLERID.name() + "=in=(targetId123,notexist)", 1);
         assertRSQLQuery(TargetFields.CONTROLLERID.name() + "=out=(targetId123,notexist)", 4);


### PR DESCRIPTION
In some scenarios RSQL queries might result in duplicate entries.

Added distinct to queries and added a few more tests as well.

