### PR TITLE
Fix missing message property

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
@@ -222,7 +222,9 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         final AbstractSelectTargetDetails dropData = (AbstractSelectTargetDetails) event.getTargetDetails();
 
         final Object distItemId = dropData.getItemIdOver();
-        handleDropEvent(source, softwareModulesIdList, distItemId);
+        if (distItemId != null) {
+            handleDropEvent(source, softwareModulesIdList, distItemId);
+        }
     }
 
     @Override

--- a/hawkbit-ui/src/main/resources/messages.properties
+++ b/hawkbit-ui/src/main/resources/messages.properties
@@ -426,6 +426,7 @@ message.software.assignment = {0} Software Module(s) Assignment(s) done
 message.dist.inuse = Distribution {0} is already assigned to target
 message.software.dist.already.assigned = Software Module {0} is already assigned to Distribution {1}
 message.software.dist.type.notallowed = Software Module {0} cannot be assigned, because Distribution {1} does not support the Software Module Type {2}
+message.software.already.dragged = Software Module {0} was already dragged to this Distribution.
 message.target.assigned =  {0} is assigned to {1}
 message.dist.type.delete = {0} Distribution Type(s) deleted successfully.
 message.sw.module.type.delete = {0} Software Module Type(s) deleted successfully.


### PR DESCRIPTION
- Added missing message property when dragging a software module twice to a distribution without saving.
- Added null check in case a software module was dragged but not dropped over a distribution set.