### PR TITLE
Add missing option searching for empty field (e.g. description=='')

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/EntityFactory.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/EntityFactory.java
@@ -53,7 +53,7 @@ public interface EntityFactory {
      * @return {@link MetaData} object
      */
     MetaData generateMetadata(@Size(min = 1, max = MetaData.KEY_MAX_SIZE) @NotNull String key,
-            @Size(min = 1, max = MetaData.VALUE_MAX_SIZE) @NotNull String value);
+            @Size(max = MetaData.VALUE_MAX_SIZE) String value);
 
     /**
      * @return {@link SoftwareModuleMetadataBuilder} object

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/SoftwareModuleMetadataCreate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/SoftwareModuleMetadataCreate.java
@@ -35,7 +35,7 @@ public interface SoftwareModuleMetadataCreate {
      *            for {@link MetaData#getValue()}
      * @return updated builder instance
      */
-    SoftwareModuleMetadataCreate value(@Size(min = 1, max = MetaData.VALUE_MAX_SIZE) @NotNull String value);
+    SoftwareModuleMetadataCreate value(@Size(max = MetaData.VALUE_MAX_SIZE) String value);
 
     /**
      * @param visible

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaEntityFactory.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaEntityFactory.java
@@ -28,6 +28,7 @@ import org.eclipse.hawkbit.repository.jpa.builder.JpaTargetBuilder;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSetMetadata;
 import org.eclipse.hawkbit.repository.model.MetaData;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 
 /**
@@ -57,7 +58,7 @@ public class JpaEntityFactory implements EntityFactory {
 
     @Override
     public MetaData generateMetadata(final String key, final String value) {
-        return new JpaDistributionSetMetadata(key, value);
+        return new JpaDistributionSetMetadata(key, StringUtils.trimWhitespace(value));
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
@@ -44,6 +44,7 @@ import org.springframework.beans.SimpleTypeConverter;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import cz.jirutka.rsql.parser.RSQLParser;
 import cz.jirutka.rsql.parser.RSQLParserException;
@@ -626,17 +627,35 @@ public final class RSQLUtility {
 
         private Predicate getEqualToPredicate(final Object transformedValue, final Path<Object> fieldPath) {
             if (transformedValue instanceof String) {
+                if (StringUtils.isEmpty(transformedValue)) {
+                    return cb.isNull(pathOfString(fieldPath));
+                }
+
                 final String preFormattedValue = escapeValueToSQL((String) transformedValue);
                 return cb.like(cb.upper(pathOfString(fieldPath)), preFormattedValue.toUpperCase());
             }
+
+            if (transformedValue == null) {
+                return cb.isNull(pathOfString(fieldPath));
+            }
+
             return cb.equal(fieldPath, transformedValue);
         }
 
         private Predicate getNotEqualToPredicate(final Object transformedValue, final Path<Object> fieldPath) {
             if (transformedValue instanceof String) {
+                if (StringUtils.isEmpty(transformedValue)) {
+                    return cb.isNotNull(pathOfString(fieldPath));
+                }
+
                 final String preFormattedValue = escapeValueToSQL((String) transformedValue);
                 return cb.notLike(cb.upper(pathOfString(fieldPath)), preFormattedValue.toUpperCase());
             }
+
+            if (transformedValue == null) {
+                return cb.isNotNull(pathOfString(fieldPath));
+            }
+
             return cb.notEqual(fieldPath, transformedValue);
         }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
@@ -628,7 +628,7 @@ public final class RSQLUtility {
         private Predicate getEqualToPredicate(final Object transformedValue, final Path<Object> fieldPath) {
             if (transformedValue instanceof String) {
                 if (StringUtils.isEmpty(transformedValue)) {
-                    return cb.isNull(pathOfString(fieldPath));
+                    return cb.or(cb.isNull(pathOfString(fieldPath)), cb.equal(pathOfString(fieldPath), ""));
                 }
 
                 final String preFormattedValue = escapeValueToSQL((String) transformedValue);
@@ -645,7 +645,7 @@ public final class RSQLUtility {
         private Predicate getNotEqualToPredicate(final Object transformedValue, final Path<Object> fieldPath) {
             if (transformedValue instanceof String) {
                 if (StringUtils.isEmpty(transformedValue)) {
-                    return cb.isNotNull(pathOfString(fieldPath));
+                    return cb.and(cb.isNotNull(pathOfString(fieldPath)), cb.notEqual(pathOfString(fieldPath), ""));
                 }
 
                 final String preFormattedValue = escapeValueToSQL((String) transformedValue);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLDistributionSetFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLDistributionSetFieldTest.java
@@ -51,28 +51,33 @@ public class RSQLDistributionSetFieldTest extends AbstractJpaIntegrationTest {
         distributionSetTagManagement.create(entityFactory.tag().create().name("Tag4"));
 
         distributionSetManagement.assignTag(Arrays.asList(ds.getId(), ds2.getId()), targetTag.getId());
+
+        distributionSetManagement
+                .create(entityFactory.distributionSet().create().name("test123").version("noDescription"));
     }
 
     @Test
     @Description("Test filter distribution set by id")
     public void testFilterByParameterId() {
-        assertRSQLQuery(DistributionSetFields.ID.name() + "==*", 4);
+        assertRSQLQuery(DistributionSetFields.ID.name() + "==*", 5);
     }
 
     @Test
     @Description("Test filter distribution set by name")
     public void testFilterByParameterName() {
         assertRSQLQuery(DistributionSetFields.NAME.name() + "==DS", 1);
-        assertRSQLQuery(DistributionSetFields.NAME.name() + "!=DS", 3);
+        assertRSQLQuery(DistributionSetFields.NAME.name() + "!=DS", 4);
         assertRSQLQuery(DistributionSetFields.NAME.name() + "==*DS", 4);
         assertRSQLQuery(DistributionSetFields.NAME.name() + "==noExist*", 0);
         assertRSQLQuery(DistributionSetFields.NAME.name() + "=in=(DS,notexist)", 1);
-        assertRSQLQuery(DistributionSetFields.NAME.name() + "=out=(DS,notexist)", 3);
+        assertRSQLQuery(DistributionSetFields.NAME.name() + "=out=(DS,notexist)", 4);
     }
 
     @Test
     @Description("Test filter distribution set by description")
     public void testFilterByParameterDescription() {
+        assertRSQLQuery(DistributionSetFields.DESCRIPTION.name() + "==''", 1);
+        assertRSQLQuery(DistributionSetFields.DESCRIPTION.name() + "!=''", 4);
         assertRSQLQuery(DistributionSetFields.DESCRIPTION.name() + "==DS", 1);
         assertRSQLQuery(DistributionSetFields.DESCRIPTION.name() + "!=DS", 3);
         assertRSQLQuery(DistributionSetFields.DESCRIPTION.name() + "==DS*", 2);
@@ -86,11 +91,11 @@ public class RSQLDistributionSetFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter distribution set by version")
     public void testFilterByParameterVersion() {
         assertRSQLQuery(DistributionSetFields.VERSION.name() + "==" + TestdataFactory.DEFAULT_VERSION, 1);
-        assertRSQLQuery(DistributionSetFields.VERSION.name() + "!=" + TestdataFactory.DEFAULT_VERSION, 3);
+        assertRSQLQuery(DistributionSetFields.VERSION.name() + "!=" + TestdataFactory.DEFAULT_VERSION, 4);
         assertRSQLQuery(
                 DistributionSetFields.VERSION.name() + "=in=(" + TestdataFactory.DEFAULT_VERSION + ",1.0.0,1.0.1)", 3);
         assertRSQLQuery(DistributionSetFields.VERSION.name() + "=out=(" + TestdataFactory.DEFAULT_VERSION + ",error)",
-                3);
+                4);
     }
 
     @Test
@@ -103,7 +108,7 @@ public class RSQLDistributionSetFieldTest extends AbstractJpaIntegrationTest {
         } catch (final RSQLParameterSyntaxException e) {
         }
         assertRSQLQuery(DistributionSetFields.COMPLETE.name() + "=in=(true)", 4);
-        assertRSQLQuery(DistributionSetFields.COMPLETE.name() + "=out=(true)", 0);
+        assertRSQLQuery(DistributionSetFields.COMPLETE.name() + "=out=(true)", 1);
     }
 
     @Test
@@ -124,7 +129,7 @@ public class RSQLDistributionSetFieldTest extends AbstractJpaIntegrationTest {
         assertRSQLQuery(DistributionSetFields.TYPE.name() + "==" + TestdataFactory.DS_TYPE_DEFAULT, 4);
         assertRSQLQuery(DistributionSetFields.TYPE.name() + "==noExist*", 0);
         assertRSQLQuery(DistributionSetFields.TYPE.name() + "=in=(" + TestdataFactory.DS_TYPE_DEFAULT + ",ecl)", 4);
-        assertRSQLQuery(DistributionSetFields.TYPE.name() + "=out=(" + TestdataFactory.DS_TYPE_DEFAULT + ")", 0);
+        assertRSQLQuery(DistributionSetFields.TYPE.name() + "=out=(" + TestdataFactory.DS_TYPE_DEFAULT + ")", 1);
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLDistributionSetMetadataFieldsTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLDistributionSetMetadataFieldsTest.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.repository.jpa.rsql;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.hawkbit.repository.DistributionSetMetadataFields;
@@ -44,20 +45,25 @@ public class RSQLDistributionSetMetadataFieldsTest extends AbstractJpaIntegratio
         }
 
         distributionSetManagement.createMetaData(distributionSetId, metadata);
+
+        distributionSetManagement.createMetaData(distributionSetId,
+                Arrays.asList(entityFactory.generateMetadata("emptyValueTest", null)));
     }
 
     @Test
     @Description("Test filter distribution set metadata by key")
     public void testFilterByParameterKey() {
         assertRSQLQuery(DistributionSetMetadataFields.KEY.name() + "==1", 1);
-        assertRSQLQuery(DistributionSetMetadataFields.KEY.name() + "!=1", 4);
+        assertRSQLQuery(DistributionSetMetadataFields.KEY.name() + "!=1", 5);
         assertRSQLQuery(DistributionSetMetadataFields.KEY.name() + "=in=(1,2)", 2);
-        assertRSQLQuery(DistributionSetMetadataFields.KEY.name() + "=out=(1,2)", 3);
+        assertRSQLQuery(DistributionSetMetadataFields.KEY.name() + "=out=(1,2)", 4);
     }
 
     @Test
     @Description("Test filter distribution set metadata by value")
     public void testFilterByParameterValue() {
+        assertRSQLQuery(DistributionSetMetadataFields.VALUE.name() + "==''", 1);
+        assertRSQLQuery(DistributionSetMetadataFields.VALUE.name() + "!=''", 5);
         assertRSQLQuery(DistributionSetMetadataFields.VALUE.name() + "==1", 1);
         assertRSQLQuery(DistributionSetMetadataFields.VALUE.name() + "!=1", 4);
         assertRSQLQuery(DistributionSetMetadataFields.VALUE.name() + "=in=(1,2)", 2);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLRolloutGroupFields.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLRolloutGroupFields.java
@@ -34,7 +34,7 @@ public class RSQLRolloutGroupFields extends AbstractJpaIntegrationTest {
     private Rollout rollout;
 
     @Before
-    public void seuptBeforeTest() {
+    public void setupBeforeTest() {
         final int amountTargets = 20;
         testdataFactory.createTargets(amountTargets, "rollout", "rollout");
         final DistributionSet dsA = testdataFactory.createDistributionSet("");

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
@@ -37,6 +37,8 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
                 .version("1.7.2").description("aa"));
         softwareModuleManagement.create(
                 entityFactory.softwareModule().create().type(osType).name("poky").version("3.0.2").description("aa"));
+        softwareModuleManagement
+                .create(entityFactory.softwareModule().create().type(osType).name("noDesc").version("noDesc"));
 
         final JpaSoftwareModule ah2 = (JpaSoftwareModule) softwareModuleManagement.create(entityFactory.softwareModule()
                 .create().type(appType).name("agent-hub2").version("1.0.1").description("agent-hub2"));
@@ -53,24 +55,26 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Test filter software module by id")
     public void testFilterByParameterId() {
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==*", 4);
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==*", 5);
     }
 
     @Test
     @Description("Test filter software module by name")
     public void testFilterByParameterName() {
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub", 3);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub", 4);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub*", 2);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub*", 2);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub*", 3);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==noExist*", 0);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=in=(agent-hub,notexist)", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=out=(agent-hub,notexist)", 3);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=out=(agent-hub,notexist)", 4);
     }
 
     @Test
     @Description("Test filter software module by description")
     public void testFilterByParameterDescription() {
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==''", 1);
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=''", 4);
         assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==agent-hub", 1);
         assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=agent-hub", 3);
         assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==noExist*", 0);
@@ -82,19 +86,19 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter software module by version")
     public void testFilterByParameterVersion() {
         assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "==1.0.1", 2);
-        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "!=v1.0", 4);
+        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "!=v1.0", 5);
         assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=in=(1.0.1,1.0.2)", 2);
-        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=out=(1.0.1)", 2);
+        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=out=(1.0.1)", 3);
     }
 
     @Test
     @Description("Test filter software module by type")
     public void testFilterByType() {
         assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==" + TestdataFactory.SM_TYPE_APP, 2);
-        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "!=" + TestdataFactory.SM_TYPE_APP, 2);
+        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "!=" + TestdataFactory.SM_TYPE_APP, 3);
         assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==noExist*", 0);
         assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=in=(" + TestdataFactory.SM_TYPE_APP + ")", 2);
-        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=out=(" + TestdataFactory.SM_TYPE_APP + ")", 2);
+        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=out=(" + TestdataFactory.SM_TYPE_APP + ")", 3);
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleMetadataFieldsTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleMetadataFieldsTest.java
@@ -49,6 +49,8 @@ public class RSQLSoftwareModuleMetadataFieldsTest extends AbstractJpaIntegration
 
         metadata.add(entityFactory.softwareModuleMetadata().create(softwareModule.getId()).key("targetVisible")
                 .value("targetVisible").targetVisible(true));
+        metadata.add(entityFactory.softwareModuleMetadata().create(softwareModule.getId()).key("emptyMd")
+                .targetVisible(true));
 
         softwareModuleManagement.createMetaData(metadata);
 
@@ -58,14 +60,16 @@ public class RSQLSoftwareModuleMetadataFieldsTest extends AbstractJpaIntegration
     @Description("Test filter software module metadata by key")
     public void testFilterByParameterKey() {
         assertRSQLQuery(SoftwareModuleMetadataFields.KEY.name() + "==1", 1);
-        assertRSQLQuery(SoftwareModuleMetadataFields.KEY.name() + "!=1", 5);
+        assertRSQLQuery(SoftwareModuleMetadataFields.KEY.name() + "!=1", 6);
         assertRSQLQuery(SoftwareModuleMetadataFields.KEY.name() + "=in=(1,2)", 2);
-        assertRSQLQuery(SoftwareModuleMetadataFields.KEY.name() + "=out=(1,2)", 4);
+        assertRSQLQuery(SoftwareModuleMetadataFields.KEY.name() + "=out=(1,2)", 5);
     }
 
     @Test
     @Description("Test fitler software module metadata by value")
     public void testFilterByParameterValue() {
+        assertRSQLQuery(SoftwareModuleMetadataFields.VALUE.name() + "==''", 1);
+        assertRSQLQuery(SoftwareModuleMetadataFields.VALUE.name() + "!=''", 6);
         assertRSQLQuery(SoftwareModuleMetadataFields.VALUE.name() + "==1", 1);
         assertRSQLQuery(SoftwareModuleMetadataFields.VALUE.name() + "!=1", 5);
         assertRSQLQuery(SoftwareModuleMetadataFields.VALUE.name() + "=in=(1,2)", 2);
@@ -75,9 +79,9 @@ public class RSQLSoftwareModuleMetadataFieldsTest extends AbstractJpaIntegration
     @Test
     @Description("Test fitler software module metadata by target visible")
     public void testFilterByParameterTargetVisible() {
-        assertRSQLQuery(SoftwareModuleMetadataFields.TARGETVISIBLE.name() + "==true", 1);
+        assertRSQLQuery(SoftwareModuleMetadataFields.TARGETVISIBLE.name() + "==true", 2);
         assertRSQLQuery(SoftwareModuleMetadataFields.TARGETVISIBLE.name() + "==false", 5);
-        assertRSQLQuery(SoftwareModuleMetadataFields.TARGETVISIBLE.name() + "!=false", 1);
+        assertRSQLQuery(SoftwareModuleMetadataFields.TARGETVISIBLE.name() + "!=false", 2);
         assertRSQLQuery(SoftwareModuleMetadataFields.TARGETVISIBLE.name() + "!=true", 5);
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleTypeFieldsTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleTypeFieldsTest.java
@@ -42,6 +42,8 @@ public class RSQLSoftwareModuleTypeFieldsTest extends AbstractJpaIntegrationTest
     @Test
     @Description("Test filter software module test type by description")
     public void testFilterByParameterDescription() {
+        assertRSQLQuery(SoftwareModuleTypeFields.DESCRIPTION.name() + "==''", 0);
+        assertRSQLQuery(SoftwareModuleTypeFields.DESCRIPTION.name() + "!=''", 3);
         assertRSQLQuery(SoftwareModuleTypeFields.DESCRIPTION.name() + "==Updated*", 3);
         assertRSQLQuery(SoftwareModuleTypeFields.DESCRIPTION.name() + "!=Updated*", 0);
         assertRSQLQuery(SoftwareModuleTypeFields.DESCRIPTION.name() + "==noExist*", 0);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTagFieldsTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTagFieldsTest.java
@@ -42,6 +42,8 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Test filter target tag by name")
     public void testFilterTargetTagByParameterName() {
+        assertRSQLQueryTarget(TagFields.NAME.name() + "==''", 0);
+        assertRSQLQueryTarget(TagFields.NAME.name() + "!=''", 5);
         assertRSQLQueryTarget(TagFields.NAME.name() + "==1", 1);
         assertRSQLQueryTarget(TagFields.NAME.name() + "!=1", 4);
         assertRSQLQueryTarget(TagFields.NAME.name() + "==*", 5);
@@ -53,6 +55,8 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Test filter target tag by description")
     public void testFilterTargetTagByParameterDescription() {
+        assertRSQLQueryTarget(TagFields.DESCRIPTION.name() + "==''", 0);
+        assertRSQLQueryTarget(TagFields.DESCRIPTION.name() + "!=''", 5);
         assertRSQLQueryTarget(TagFields.DESCRIPTION.name() + "==1", 1);
         assertRSQLQueryTarget(TagFields.DESCRIPTION.name() + "!=1", 4);
         assertRSQLQueryTarget(TagFields.DESCRIPTION.name() + "==*", 5);
@@ -64,6 +68,8 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Test filter target tag by colour")
     public void testFilterTargetTagByParameterColour() {
+        assertRSQLQueryTarget(TagFields.COLOUR.name() + "==''", 0);
+        assertRSQLQueryTarget(TagFields.COLOUR.name() + "!=''", 5);
         assertRSQLQueryTarget(TagFields.COLOUR.name() + "==red", 3);
         assertRSQLQueryTarget(TagFields.COLOUR.name() + "!=red", 2);
         assertRSQLQueryTarget(TagFields.COLOUR.name() + "==r*", 3);
@@ -75,6 +81,8 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Test filter distribution set tag by name")
     public void testFilterDistributionSetTagByParameterName() {
+        assertRSQLQueryDistributionSet(TagFields.NAME.name() + "==''", 0);
+        assertRSQLQueryDistributionSet(TagFields.NAME.name() + "!=''", 5);
         assertRSQLQueryDistributionSet(TagFields.NAME.name() + "==1", 1);
         assertRSQLQueryDistributionSet(TagFields.NAME.name() + "!=1", 4);
         assertRSQLQueryDistributionSet(TagFields.NAME.name() + "==*", 5);
@@ -86,6 +94,8 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Test filter distribution set by description")
     public void testFilterDistributionSetTagByParameterDescription() {
+        assertRSQLQueryDistributionSet(TagFields.DESCRIPTION.name() + "==''", 0);
+        assertRSQLQueryDistributionSet(TagFields.DESCRIPTION.name() + "!=''", 5);
         assertRSQLQueryDistributionSet(TagFields.DESCRIPTION.name() + "==1", 1);
         assertRSQLQueryDistributionSet(TagFields.DESCRIPTION.name() + "!=1", 4);
         assertRSQLQueryDistributionSet(TagFields.DESCRIPTION.name() + "==*", 5);
@@ -97,6 +107,8 @@ public class RSQLTagFieldsTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Test filter distribution set by colour")
     public void testFilterDistributionSetTagByParameterColour() {
+        assertRSQLQueryDistributionSet(TagFields.COLOUR.name() + "==''", 0);
+        assertRSQLQueryDistributionSet(TagFields.COLOUR.name() + "!=''", 5);
         assertRSQLQueryDistributionSet(TagFields.COLOUR.name() + "==red", 3);
         assertRSQLQueryDistributionSet(TagFields.COLOUR.name() + "!=red", 2);
         assertRSQLQueryDistributionSet(TagFields.COLOUR.name() + "==r*", 3);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
@@ -100,6 +100,8 @@ public class RSQLTargetFieldTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Test filter target by description")
     public void testFilterByParameterDescription() {
+        assertRSQLQuery(TargetFields.DESCRIPTION.name() + "==''", 3);
+        assertRSQLQuery(TargetFields.DESCRIPTION.name() + "!=''", 2);
         assertRSQLQuery(TargetFields.DESCRIPTION.name() + "==targetDesc123", 1);
         assertRSQLQuery(TargetFields.DESCRIPTION.name() + "==target*", 2);
         assertRSQLQuery(TargetFields.DESCRIPTION.name() + "==noExist*", 0);


### PR DESCRIPTION
Fixed in addition a work builder constraint that metadata value cannot be empty which is in fact not how the entity is defined.


Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>