### PR TITLE
Fix DistributionSet type should not be updatable

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/DistributionSetUpdate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/DistributionSetUpdate.java
@@ -8,13 +8,10 @@
  */
 package org.eclipse.hawkbit.repository.builder;
 
-import java.util.Optional;
-
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.eclipse.hawkbit.repository.model.DistributionSet;
-import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.NamedEntity;
 import org.eclipse.hawkbit.repository.model.NamedVersionedEntity;
 
@@ -44,22 +41,6 @@ public interface DistributionSetUpdate {
      * @return updated builder instance
      */
     DistributionSetUpdate description(@Size(max = NamedEntity.DESCRIPTION_MAX_SIZE) String description);
-
-    /**
-     * @param typeKey
-     *            for {@link DistributionSet#getType()}
-     * @return updated builder instance
-     */
-    DistributionSetUpdate type(@Size(min = 1, max = DistributionSetType.KEY_MAX_SIZE) @NotNull String typeKey);
-
-    /**
-     * @param type
-     *            for {@link DistributionSet#getType()}
-     * @return updated builder instance
-     */
-    default DistributionSetUpdate type(final DistributionSetType type) {
-        return type(Optional.ofNullable(type).map(DistributionSetType::getKey).orElse(null));
-    }
 
     /**
      * @param requiredMigrationStep

--- a/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/builder/AbstractDistributionSetUpdateCreate.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/builder/AbstractDistributionSetUpdateCreate.java
@@ -25,8 +25,7 @@ public abstract class AbstractDistributionSetUpdateCreate<T> extends AbstractNam
     protected String version;
     protected Boolean requiredMigrationStep;
 
-    @ValidString
-    protected String type;
+
     protected Collection<Long> modules;
 
     public T modules(final Collection<Long> modules) {
@@ -36,15 +35,6 @@ public abstract class AbstractDistributionSetUpdateCreate<T> extends AbstractNam
 
     public Collection<Long> getModules() {
         return modules;
-    }
-
-    public T type(final String type) {
-        this.type = StringUtils.trimWhitespace(type);
-        return (T) this;
-    }
-
-    public String getType() {
-        return type;
     }
 
     public T requiredMigrationStep(final Boolean requiredMigrationStep) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
@@ -38,7 +38,6 @@ import org.eclipse.hawkbit.repository.jpa.model.DsMetadataCompositeKey;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSetMetadata;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSetMetadata_;
-import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSetType;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet_;
 import org.eclipse.hawkbit.repository.jpa.model.JpaSoftwareModule;
 import org.eclipse.hawkbit.repository.jpa.rsql.RSQLUtility;
@@ -229,15 +228,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
             set.setRequiredMigrationStep(update.isRequiredMigrationStep());
         }
 
-        assertDistributionSetTypeHasNotChanged(update, set);
-
         return distributionSetRepository.save(set);
-    }
-
-    private JpaDistributionSetType findDistributionSetTypeAndThrowExceptionIfNotFound(final String key) {
-        return (JpaDistributionSetType) distributionSetTypeManagement.getByKey(key)
-                .orElseThrow(() -> new EntityNotFoundException(DistributionSetType.class, key));
-
     }
 
     private JpaDistributionSet findDistributionSetAndThrowExceptionIfNotFound(final Long setId) {
@@ -627,17 +618,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
             specList.add(spec);
         }
         return specList;
-    }
-
-    private void assertDistributionSetTypeHasNotChanged(final GenericDistributionSetUpdate update,
-            final JpaDistributionSet set) {
-        if (update.getType() != null) {
-            final DistributionSetType type = findDistributionSetTypeAndThrowExceptionIfNotFound(update.getType());
-            if (!type.getId().equals(set.getType().getId())) {
-                throw new EntityReadOnlyException("Distribution set type is readonly and therfore cannot be changed");
-            }
-        }
-
     }
 
     private void assertDistributionSetIsNotAssignedToTargets(final Long distributionSet) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/builder/JpaDistributionSetCreate.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/builder/JpaDistributionSetCreate.java
@@ -32,7 +32,7 @@ public class JpaDistributionSetCreate extends AbstractDistributionSetUpdateCreat
         implements DistributionSetCreate {
 
     @ValidString
-    protected String type;
+    private String type;
 
     private final DistributionSetTypeManagement distributionSetTypeManagement;
     private final SoftwareModuleManagement softwareModuleManagement;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/builder/JpaDistributionSetCreate.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/builder/JpaDistributionSetCreate.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 
 import org.eclipse.hawkbit.repository.DistributionSetTypeManagement;
 import org.eclipse.hawkbit.repository.SoftwareModuleManagement;
+import org.eclipse.hawkbit.repository.ValidString;
 import org.eclipse.hawkbit.repository.builder.AbstractDistributionSetUpdateCreate;
 import org.eclipse.hawkbit.repository.builder.DistributionSetCreate;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
@@ -21,6 +22,7 @@ import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Create/build implementation.
@@ -28,6 +30,9 @@ import org.springframework.util.CollectionUtils;
  */
 public class JpaDistributionSetCreate extends AbstractDistributionSetUpdateCreate<DistributionSetCreate>
         implements DistributionSetCreate {
+
+    @ValidString
+    protected String type;
 
     private final DistributionSetTypeManagement distributionSetTypeManagement;
     private final SoftwareModuleManagement softwareModuleManagement;
@@ -44,6 +49,16 @@ public class JpaDistributionSetCreate extends AbstractDistributionSetUpdateCreat
                 Optional.ofNullable(type).map(this::findDistributionSetTypeWithExceptionIfNotFound).orElse(null),
                 findSoftwareModuleWithExceptionIfNotFound(modules),
                 Optional.ofNullable(requiredMigrationStep).orElse(Boolean.FALSE));
+    }
+
+    @Override
+    public DistributionSetCreate type(final String type) {
+        this.type = StringUtils.trimWhitespace(type);
+        return this;
+    }
+
+    public String getType() {
+        return type;
     }
 
     private DistributionSetType findDistributionSetTypeWithExceptionIfNotFound(final String distributionSetTypekey) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractDistributionSetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractDistributionSetDetails.java
@@ -82,8 +82,7 @@ public abstract class AbstractDistributionSetDetails
 
     @Override
     protected void onEdit(final ClickEvent event) {
-        final Window newDistWindow = distributionAddUpdateWindowLayout.getWindowForUpdate(getSelectedBaseEntityId());
-        newDistWindow.setCaption(getI18n().getMessage(UIComponentIdProvider.DIST_UPDATE_CAPTION));
+        final Window newDistWindow = distributionAddUpdateWindowLayout.getWindowForUpdateDistributionSet(getSelectedBaseEntityId());
         UI.getCurrent().addWindow(newDistWindow);
         newDistWindow.setVisible(Boolean.TRUE);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractDistributionSetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractDistributionSetDetails.java
@@ -82,7 +82,7 @@ public abstract class AbstractDistributionSetDetails
 
     @Override
     protected void onEdit(final ClickEvent event) {
-        final Window newDistWindow = distributionAddUpdateWindowLayout.getWindow(getSelectedBaseEntityId());
+        final Window newDistWindow = distributionAddUpdateWindowLayout.getWindowForUpdate(getSelectedBaseEntityId());
         newDistWindow.setCaption(getI18n().getMessage(UIComponentIdProvider.DIST_UPDATE_CAPTION));
         UI.getCurrent().addWindow(newDistWindow);
         newDistWindow.setVisible(Boolean.TRUE);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
@@ -98,7 +98,7 @@ public class DistributionSetTableHeader extends AbstractDistributionSetTableHead
 
     @Override
     protected void addNewItem(final ClickEvent event) {
-        final Window newDistWindow = addUpdateWindowLayout.getWindow(null);
+        final Window newDistWindow = addUpdateWindowLayout.getWindowForCreation();
         newDistWindow.setCaption(i18n.getMessage(UIComponentIdProvider.DIST_ADD_CAPTION));
         UI.getCurrent().addWindow(newDistWindow);
         newDistWindow.setVisible(Boolean.TRUE);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
@@ -16,7 +16,6 @@ import org.eclipse.hawkbit.ui.distributions.state.ManageDistUIState;
 import org.eclipse.hawkbit.ui.management.dstable.DistributionAddUpdateWindowLayout;
 import org.eclipse.hawkbit.ui.management.event.DistributionTableEvent;
 import org.eclipse.hawkbit.ui.management.event.RefreshDistributionTableByFilterEvent;
-import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
 import org.vaadin.spring.events.EventBus.UIEventBus;
 import org.vaadin.spring.events.EventScope;
@@ -98,8 +97,7 @@ public class DistributionSetTableHeader extends AbstractDistributionSetTableHead
 
     @Override
     protected void addNewItem(final ClickEvent event) {
-        final Window newDistWindow = addUpdateWindowLayout.getWindowForCreation();
-        newDistWindow.setCaption(i18n.getMessage(UIComponentIdProvider.DIST_ADD_CAPTION));
+        final Window newDistWindow = addUpdateWindowLayout.getWindowForCreateDistributionSet();
         UI.getCurrent().addWindow(newDistWindow);
         newDistWindow.setVisible(Boolean.TRUE);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
@@ -134,7 +134,7 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
             distributionSetTypeManagement.get(distSetTypeId).ifPresent(type -> {
                 final DistributionSet currentDS = distributionSetManagement.update(entityFactory.distributionSet()
                         .update(editDistId).name(distNameTextField.getValue()).description(descTextArea.getValue())
-                        .version(distVersionTextField.getValue()).requiredMigrationStep(isMigStepReq).type(type));
+                        .version(distVersionTextField.getValue()).requiredMigrationStep(isMigStepReq));
                 notificationMessage.displaySuccess(i18n.getMessage("message.new.dist.save.success",
                         new Object[] { currentDS.getName(), currentDS.getVersion() }));
                 // update table row+details layout

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
@@ -73,8 +73,6 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
     private TextArea descTextArea;
     private CheckBox reqMigStepCheckbox;
     private ComboBox distsetTypeNameComboBox;
-    private boolean editDistribution;
-    private Long editDistId;
 
     private FormLayout formLayout;
 
@@ -115,27 +113,19 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
     }
 
     /**
-     * Save or update distribution set.
-     *
+     * Updates the distribution set on close.
      */
-    private final class SaveOnCloseDialogListener implements SaveDialogCloseListener {
+    private final class UpdateOnCloseDialogListener implements SaveDialogCloseListener {
+
+        private final Long editDistId;
+
+        public UpdateOnCloseDialogListener(final Long editDistId) {
+            this.editDistId = editDistId;
+        }
+
         @Override
         public void saveOrUpdate() {
-            if (editDistribution) {
-                updateDistribution();
-                return;
-            }
-            addNewDistribution();
-        }
-
-        @Override
-        public boolean canWindowSaveOrUpdate() {
-            return !isDuplicate();
-        }
-
-        private void updateDistribution() {
-
-            if (isDuplicate()) {
+            if (isDuplicate(editDistId)) {
                 return;
             }
             final boolean isMigStepReq = reqMigStepCheckbox.getValue();
@@ -152,12 +142,20 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
             });
         }
 
-        /**
-         * Add new Distribution set.
-         */
-        private void addNewDistribution() {
-            editDistribution = Boolean.FALSE;
+        @Override
+        public boolean canWindowSaveOrUpdate() {
+            return !isDuplicate(editDistId);
+        }
+    }
 
+    /**
+     * Creates the distribution set on close.
+     *
+     */
+    private final class CreateOnCloseDialogListener implements SaveDialogCloseListener {
+
+        @Override
+        public void saveOrUpdate() {
             final String name = distNameTextField.getValue();
             final String version = distVersionTextField.getValue();
             final Long distSetTypeId = (Long) distsetTypeNameComboBox.getValue();
@@ -176,31 +174,33 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
             distributionSetTable.setValue(Sets.newHashSet(newDist.getId()));
         }
 
-        private boolean isDuplicate() {
-            final String name = distNameTextField.getValue();
-            final String version = distVersionTextField.getValue();
+        @Override
+        public boolean canWindowSaveOrUpdate() {
+            return !isDuplicate(null);
+        }
+    }
 
-            final Optional<DistributionSet> existingDs = distributionSetManagement.getByNameAndVersion(name, version);
-            /*
-             * Distribution should not exists with the same name & version.
-             * Display error message, when the "existingDs" is not null and it
-             * is add window (or) when the "existingDs" is not null and it is
-             * edit window and the distribution Id of the edit window is
-             * different then the "existingDs"
-             */
-            if (existingDs.isPresent() && !existingDs.get().getId().equals(editDistId)) {
-                distNameTextField.addStyleName(SPUIStyleDefinitions.SP_TEXTFIELD_LAYOUT_ERROR_HIGHTLIGHT);
-                distVersionTextField.addStyleName(SPUIStyleDefinitions.SP_TEXTFIELD_LAYOUT_ERROR_HIGHTLIGHT);
-                notificationMessage.displayValidationError(i18n.getMessage("message.duplicate.dist",
-                        new Object[] { existingDs.get().getName(), existingDs.get().getVersion() }));
+    private boolean isDuplicate(final Long editDistId) {
+        final String name = distNameTextField.getValue();
+        final String version = distVersionTextField.getValue();
 
-                return true;
-            }
+        final Optional<DistributionSet> existingDs = distributionSetManagement.getByNameAndVersion(name, version);
+        /*
+         * Distribution should not exists with the same name & version. Display
+         * error message, when the "existingDs" is not null and it is add window
+         * (or) when the "existingDs" is not null and it is edit window and the
+         * distribution Id of the edit window is different then the "existingDs"
+         */
+        if (existingDs.isPresent() && !existingDs.get().getId().equals(editDistId)) {
+            distNameTextField.addStyleName(SPUIStyleDefinitions.SP_TEXTFIELD_LAYOUT_ERROR_HIGHTLIGHT);
+            distVersionTextField.addStyleName(SPUIStyleDefinitions.SP_TEXTFIELD_LAYOUT_ERROR_HIGHTLIGHT);
+            notificationMessage.displayValidationError(i18n.getMessage("message.duplicate.dist",
+                    new Object[] { existingDs.get().getName(), existingDs.get().getVersion() }));
 
-            return false;
-
+            return true;
         }
 
+        return false;
     }
 
     private void buildLayout() {
@@ -277,53 +277,64 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
      * clear all the fields.
      */
     public void resetComponents() {
-        editDistribution = Boolean.FALSE;
         distNameTextField.clear();
         distNameTextField.removeStyleName("v-textfield-error");
         distVersionTextField.clear();
         distVersionTextField.removeStyleName(SPUIStyleDefinitions.SP_TEXTFIELD_LAYOUT_ERROR_HIGHTLIGHT);
         distsetTypeNameComboBox.removeStyleName(SPUIStyleDefinitions.SP_TEXTFIELD_LAYOUT_ERROR_HIGHTLIGHT);
+        distsetTypeNameComboBox.clear();
+        distsetTypeNameComboBox.setEnabled(true);
         descTextArea.clear();
         reqMigStepCheckbox.clear();
     }
 
     private void populateValuesOfDistribution(final Long editDistId) {
-        this.editDistId = editDistId;
-
-        if (editDistId == null) {
-            return;
-        }
 
         final Optional<DistributionSet> distSet = distributionSetManagement.getWithDetails(editDistId);
         if (!distSet.isPresent()) {
             return;
         }
 
-        editDistribution = Boolean.TRUE;
         distNameTextField.setValue(distSet.get().getName());
         distVersionTextField.setValue(distSet.get().getVersion());
         if (distSet.get().getType().isDeleted()) {
             distsetTypeNameComboBox.addItem(distSet.get().getType().getId());
         }
         distsetTypeNameComboBox.setValue(distSet.get().getType().getId());
+        distsetTypeNameComboBox.setEnabled(false);
 
         reqMigStepCheckbox.setValue(distSet.get().isRequiredMigrationStep());
         descTextArea.setValue(distSet.get().getDescription());
     }
 
     /**
-     * Returns the dialog window for the distributions.
+     * Returns the dialog window for creating a distribution.
      * 
-     * @param editDistId
      * @return window
      */
-    public CommonDialogWindow getWindow(final Long editDistId) {
+    public CommonDialogWindow getWindowForCreation() {
+        resetComponents();
+        populateDistSetTypeNameCombo();
+        return new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW)
+                .caption(i18n.getMessage(UIComponentIdProvider.DIST_ADD_CAPTION)).content(this).layout(formLayout)
+                .i18n(i18n).saveDialogCloseListener(new CreateOnCloseDialogListener()).buildCommonDialogWindow();
+    }
+
+    /**
+     * Returns the dialog window for updating a distribution.
+     * 
+     * @param editDistId
+     *            the id of the distribution that should be updated
+     * @return window
+     */
+    public CommonDialogWindow getWindowForUpdate(final Long editDistId) {
         resetComponents();
         populateDistSetTypeNameCombo();
         populateValuesOfDistribution(editDistId);
         return new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW)
                 .caption(i18n.getMessage(UIComponentIdProvider.DIST_ADD_CAPTION)).content(this).layout(formLayout)
-                .i18n(i18n).saveDialogCloseListener(new SaveOnCloseDialogListener()).buildCommonDialogWindow();
+                .i18n(i18n).saveDialogCloseListener(new UpdateOnCloseDialogListener(editDistId))
+                .buildCommonDialogWindow();
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
@@ -312,12 +312,8 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
      * 
      * @return window
      */
-    public CommonDialogWindow getWindowForCreation() {
-        resetComponents();
-        populateDistSetTypeNameCombo();
-        return new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW)
-                .caption(i18n.getMessage(UIComponentIdProvider.DIST_ADD_CAPTION)).content(this).layout(formLayout)
-                .i18n(i18n).saveDialogCloseListener(new CreateOnCloseDialogListener()).buildCommonDialogWindow();
+    public CommonDialogWindow getWindowForCreateDistributionSet() {
+        return getWindow(null);
     }
 
     /**
@@ -327,13 +323,39 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
      *            the id of the distribution that should be updated
      * @return window
      */
-    public CommonDialogWindow getWindowForUpdate(final Long editDistId) {
+    public CommonDialogWindow getWindowForUpdateDistributionSet(final Long editDistId) {
+        return getWindow(editDistId);
+    }
+
+    /**
+     * Internal method to create a window to create or update a DistributionSet.
+     * 
+     * @param editDistId
+     *            if <code>null</code> is provided the window is configured to
+     *            create a DistributionSet otherwise it is configured for
+     *            update.
+     * @return
+     */
+    private CommonDialogWindow getWindow(final Long editDistId) {
+
+        final SaveDialogCloseListener saveDialogCloseListener;
+        String captionId;
+
         resetComponents();
         populateDistSetTypeNameCombo();
-        populateValuesOfDistribution(editDistId);
-        return new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW)
-                .caption(i18n.getMessage(UIComponentIdProvider.DIST_ADD_CAPTION)).content(this).layout(formLayout)
-                .i18n(i18n).saveDialogCloseListener(new UpdateOnCloseDialogListener(editDistId))
+
+        if (editDistId == null) {
+            saveDialogCloseListener = new CreateOnCloseDialogListener();
+            captionId = UIComponentIdProvider.DIST_ADD_CAPTION;
+        } else {
+            saveDialogCloseListener = new UpdateOnCloseDialogListener(editDistId);
+            captionId = UIComponentIdProvider.DIST_UPDATE_CAPTION;
+
+            populateValuesOfDistribution(editDistId);
+        }
+
+        return new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW).caption(i18n.getMessage(captionId)).content(this)
+                .layout(formLayout).i18n(i18n).saveDialogCloseListener(saveDialogCloseListener)
                 .buildCommonDialogWindow();
     }
 


### PR DESCRIPTION
For an existing DistributionSet the type attribute should not be updatable. The Combobox showing the type of a Distributionset is now readonly in the Deployment View and Distribution View.

Reviewers: @stefbehl