### PR TITLE
Cleanup MaxFieldLength for UI text fields.

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleAddUpdateWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleAddUpdateWindow.java
@@ -212,10 +212,10 @@ public class SoftwareModuleAddUpdateWindow extends CustomComponent {
     private void createRequiredComponents() {
 
         nameTextField = createTextField("textfield.name", UIComponentIdProvider.SOFT_MODULE_NAME);
-        nameTextField.addValidator(new EmptyStringValidator(i18n));
+        nameTextField.addValidator(new EmptyStringValidator(i18n, SoftwareModule.NAME_MAX_SIZE));
 
         versionTextField = createTextField("textfield.version", UIComponentIdProvider.SOFT_MODULE_VERSION);
-        versionTextField.addValidator(new EmptyStringValidator(i18n));
+        versionTextField.addValidator(new EmptyStringValidator(i18n, SoftwareModule.VERSION_MAX_SIZE));
 
         vendorTextField = createTextField("textfield.vendor", UIComponentIdProvider.SOFT_MODULE_VENDOR);
         vendorTextField.setRequired(false);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/CreateUpdateSoftwareTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtype/CreateUpdateSoftwareTypeLayout.java
@@ -101,11 +101,14 @@ public class CreateUpdateSoftwareTypeLayout extends CreateUpdateTypeLayout<Softw
 
         multiAssign = new LabelBuilder().name(multiAssignStr).buildLabel();
 
-        tagName = createTextField("textfield.name", SPUIDefinitions.TYPE_NAME, SPUIDefinitions.NEW_SOFTWARE_TYPE_NAME);
+        tagName = createTextField("textfield.name", SPUIDefinitions.TYPE_NAME, SPUIDefinitions.NEW_SOFTWARE_TYPE_NAME,
+                SoftwareModuleType.NAME_MAX_SIZE);
 
-        typeKey = createTextField("textfield.key", SPUIDefinitions.TYPE_KEY, SPUIDefinitions.NEW_SOFTWARE_TYPE_KEY);
+        typeKey = createTextField("textfield.key", SPUIDefinitions.TYPE_KEY, SPUIDefinitions.NEW_SOFTWARE_TYPE_KEY,
+                SoftwareModuleType.KEY_MAX_SIZE);
 
         tagDesc = new TextAreaBuilder().caption(i18n.getMessage("textfield.description"))
+                .maxLengthAllowed(SoftwareModuleType.DESCRIPTION_MAX_SIZE)
                 .styleName(ValoTheme.TEXTFIELD_TINY + " " + SPUIDefinitions.TYPE_DESC)
                 .prompt(i18n.getMessage("textfield.description")).immediate(true)
                 .id(SPUIDefinitions.NEW_SOFTWARE_TYPE_DESC).buildTextComponent();
@@ -127,10 +130,11 @@ public class CreateUpdateSoftwareTypeLayout extends CreateUpdateTypeLayout<Softw
         return ColorPickerHelper.rgbToColorConverter(ColorPickerConstants.DEFAULT_COLOR);
     }
 
-    private TextField createTextField(final String in18Key, final String styleName, final String id) {
+    private TextField createTextField(final String in18Key, final String styleName, final String id,
+            final int maxLength) {
         return new TextFieldBuilder().caption(i18n.getMessage(in18Key))
                 .styleName(ValoTheme.TEXTFIELD_TINY + " " + styleName).required(true).prompt(i18n.getMessage(in18Key))
-                .validator(new EmptyStringValidator(i18n)).immediate(true).id(id).buildTextComponent();
+                .validator(new EmptyStringValidator(i18n, maxLength)).immediate(true).id(id).buildTextComponent();
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/AbstractMetadataPopupLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/AbstractMetadataPopupLayout.java
@@ -239,7 +239,7 @@ public abstract class AbstractMetadataPopupLayout<E extends NamedVersionedEntity
         final TextField keyField = new TextFieldBuilder().caption(i18n.getMessage("textfield.key")).required(true)
                 .prompt(i18n.getMessage("textfield.key")).immediate(true)
                 .id(UIComponentIdProvider.METADATA_KEY_FIELD_ID).maxLengthAllowed(MetaData.KEY_MAX_SIZE)
-                .validator(new EmptyStringValidator(i18n)).buildTextComponent();
+                .validator(new EmptyStringValidator(i18n, MetaData.KEY_MAX_SIZE)).buildTextComponent();
         keyField.addTextChangeListener(this::onKeyChange);
         keyField.setTextChangeEventMode(TextChangeEventMode.EAGER);
         keyField.setWidth("100%");
@@ -248,9 +248,9 @@ public abstract class AbstractMetadataPopupLayout<E extends NamedVersionedEntity
 
     private TextArea createValueTextField() {
         valueTextArea = new TextAreaBuilder().caption(i18n.getMessage("textfield.value")).required(true)
-                .validator(new EmptyStringValidator(i18n)).prompt(i18n.getMessage("textfield.value")).immediate(true)
-                .id(UIComponentIdProvider.METADATA_VALUE_ID).maxLengthAllowed(MetaData.VALUE_MAX_SIZE)
-                .buildTextComponent();
+                .validator(new EmptyStringValidator(i18n, MetaData.VALUE_MAX_SIZE))
+                .prompt(i18n.getMessage("textfield.value")).immediate(true).id(UIComponentIdProvider.METADATA_VALUE_ID)
+                .maxLengthAllowed(MetaData.VALUE_MAX_SIZE).buildTextComponent();
         valueTextArea.setNullRepresentation("");
         valueTextArea.setSizeFull();
         valueTextArea.setHeight(100, Unit.PERCENTAGE);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/EmptyStringValidator.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/EmptyStringValidator.java
@@ -23,18 +23,6 @@ public class EmptyStringValidator extends StringLengthValidator {
 
     private static final String MESSAGE_KEY = "validator.textfield.min.length";
 
-    private static final int TEXT_FIELD_DEFAULT_MAX_LENGTH = 64;
-
-    /**
-     * Constructor for EmptyStringValidator
-     * 
-     * @param i18n
-     *            {@link VaadinMessageSource}
-     */
-    public EmptyStringValidator(final VaadinMessageSource i18n) {
-        super(i18n.getMessage(MESSAGE_KEY), 1, TEXT_FIELD_DEFAULT_MAX_LENGTH, false);
-    }
-
     /**
      * Constructor for EmptyStringValidator
      * 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/CreateUpdateDistSetTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/disttype/CreateUpdateDistSetTypeLayout.java
@@ -124,22 +124,24 @@ public class CreateUpdateDistSetTypeLayout extends CreateUpdateTypeLayout<Distri
         super.createRequiredComponents();
 
         tagName = createTextField("textfield.name", SPUIDefinitions.DIST_SET_TYPE_NAME,
-                SPUIDefinitions.NEW_DISTRIBUTION_TYPE_NAME);
+                SPUIDefinitions.NEW_DISTRIBUTION_TYPE_NAME, DistributionSetType.NAME_MAX_SIZE);
 
         typeKey = createTextField("textfield.key", SPUIDefinitions.DIST_SET_TYPE_KEY,
-                SPUIDefinitions.NEW_DISTRIBUTION_TYPE_KEY);
+                SPUIDefinitions.NEW_DISTRIBUTION_TYPE_KEY, DistributionSetType.KEY_MAX_SIZE);
 
         tagDesc = new TextAreaBuilder().caption(i18n.getMessage("textfield.description"))
+                .maxLengthAllowed(DistributionSetType.DESCRIPTION_MAX_SIZE)
                 .styleName(ValoTheme.TEXTFIELD_TINY + " " + SPUIDefinitions.DIST_SET_TYPE_DESC)
                 .prompt(i18n.getMessage("textfield.description")).immediate(true)
                 .id(SPUIDefinitions.NEW_DISTRIBUTION_TYPE_DESC).buildTextComponent();
         tagDesc.setNullRepresentation("");
     }
 
-    private TextField createTextField(final String in18Key, final String styleName, final String id) {
+    private TextField createTextField(final String in18Key, final String styleName, final String id,
+            final int maxSize) {
         return new TextFieldBuilder().caption(i18n.getMessage(in18Key))
                 .styleName(ValoTheme.TEXTFIELD_TINY + " " + styleName).required(true).prompt(i18n.getMessage(in18Key))
-                .validator(new EmptyStringValidator(i18n)).immediate(true).id(id).buildTextComponent();
+                .validator(new EmptyStringValidator(i18n, maxSize)).immediate(true).id(id).buildTextComponent();
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/AutoCompleteTextFieldComponent.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/AutoCompleteTextFieldComponent.java
@@ -15,11 +15,11 @@ import java.util.concurrent.Executor;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.eclipse.hawkbit.repository.rsql.RsqlValidationOracle;
 import org.eclipse.hawkbit.ui.common.builder.TextFieldBuilder;
 import org.eclipse.hawkbit.ui.filtermanagement.event.CustomFilterUIEvent;
 import org.eclipse.hawkbit.ui.filtermanagement.state.FilterManagementUIState;
-import org.eclipse.hawkbit.ui.utils.SPUILabelDefinitions;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -196,7 +196,7 @@ public class AutoCompleteTextFieldComponent extends HorizontalLayout {
 
     private TextField createSearchField() {
         final TextField textField = new TextFieldBuilder().immediate(true).id(UIComponentIdProvider.CUSTOM_FILTER_QUERY)
-                .maxLengthAllowed(SPUILabelDefinitions.TARGET_FILTER_QUERY_TEXT_FIELD_LENGTH).buildTextComponent();
+                .maxLengthAllowed(TargetFilterQuery.QUERY_MAX_SIZE).buildTextComponent();
         textField.addStyleName("target-filter-textfield");
         textField.setWidth(900.0F, Unit.PIXELS);
         textField.setTextChangeEventMode(TextChangeEventMode.EAGER);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/AbstractCreateUpdateTagLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/AbstractCreateUpdateTagLayout.java
@@ -194,12 +194,14 @@ public abstract class AbstractCreateUpdateTagLayout<E extends NamedEntity> exten
         tagName = new TextFieldBuilder().caption(i18n.getMessage("textfield.name"))
                 .styleName(ValoTheme.TEXTFIELD_TINY + " " + SPUIDefinitions.TAG_NAME).required(true)
                 .prompt(i18n.getMessage("textfield.name")).immediate(true).id(SPUIDefinitions.NEW_TARGET_TAG_NAME)
-                .validator(new EmptyStringValidator(i18n)).buildTextComponent();
+                .maxLengthAllowed(NamedEntity.NAME_MAX_SIZE)
+                .validator(new EmptyStringValidator(i18n, NamedEntity.NAME_MAX_SIZE)).buildTextComponent();
 
         tagDesc = new TextAreaBuilder().caption(i18n.getMessage("textfield.description"))
                 .styleName(ValoTheme.TEXTFIELD_TINY + " " + SPUIDefinitions.TAG_DESC)
                 .prompt(i18n.getMessage("textfield.description")).immediate(true)
-                .id(SPUIDefinitions.NEW_TARGET_TAG_DESC).buildTextComponent();
+                .maxLengthAllowed(NamedEntity.DESCRIPTION_MAX_SIZE).id(SPUIDefinitions.NEW_TARGET_TAG_DESC)
+                .buildTextComponent();
 
         tagDesc.setNullRepresentation("");
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
@@ -222,8 +222,10 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
      * Create required UI components.
      */
     private void createRequiredComponents() {
-        distNameTextField = createTextField("textfield.name", UIComponentIdProvider.DIST_ADD_NAME);
-        distVersionTextField = createTextField("textfield.version", UIComponentIdProvider.DIST_ADD_VERSION);
+        distNameTextField = createTextField("textfield.name", UIComponentIdProvider.DIST_ADD_NAME,
+                DistributionSet.NAME_MAX_SIZE);
+        distVersionTextField = createTextField("textfield.version", UIComponentIdProvider.DIST_ADD_VERSION,
+                DistributionSet.VERSION_MAX_SIZE);
 
         distsetTypeNameComboBox = SPUIComponentProvider.getComboBox(i18n.getMessage("label.combobox.type"), "", null,
                 "", false, "", i18n.getMessage("label.combobox.type"));
@@ -233,7 +235,8 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
 
         descTextArea = new TextAreaBuilder().caption(i18n.getMessage("textfield.description")).style("text-area-style")
                 .prompt(i18n.getMessage("textfield.description")).immediate(true)
-                .id(UIComponentIdProvider.DIST_ADD_DESC).buildTextComponent();
+                .maxLengthAllowed(DistributionSet.DESCRIPTION_MAX_SIZE).id(UIComponentIdProvider.DIST_ADD_DESC)
+                .buildTextComponent();
         descTextArea.setNullRepresentation("");
 
         reqMigStepCheckbox = SPUIComponentProvider.getCheckBox(i18n.getMessage("checkbox.dist.required.migration.step"),
@@ -242,10 +245,10 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
         reqMigStepCheckbox.setId(UIComponentIdProvider.DIST_ADD_MIGRATION_CHECK);
     }
 
-    private TextField createTextField(final String in18Key, final String id) {
+    private TextField createTextField(final String in18Key, final String id, final int maxLength) {
         final TextField buildTextField = new TextFieldBuilder().caption(i18n.getMessage(in18Key)).required(true)
-                .validator(new EmptyStringValidator(i18n)).prompt(i18n.getMessage(in18Key)).immediate(true).id(id)
-                .buildTextComponent();
+                .validator(new EmptyStringValidator(i18n, maxLength)).prompt(i18n.getMessage(in18Key)).immediate(true)
+                .id(id).buildTextComponent();
         buildTextField.setNullRepresentation("");
         return buildTextField;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetAddUpdateWindowLayout.java
@@ -106,7 +106,8 @@ public class TargetAddUpdateWindowLayout extends CustomComponent {
 
         descTextArea = new TextAreaBuilder().caption(i18n.getMessage("textfield.description")).style("text-area-style")
                 .prompt(i18n.getMessage("textfield.description")).immediate(true)
-                .id(UIComponentIdProvider.TARGET_ADD_DESC).buildTextComponent();
+                .maxLengthAllowed(Target.DESCRIPTION_MAX_SIZE).id(UIComponentIdProvider.TARGET_ADD_DESC)
+                .buildTextComponent();
         descTextArea.setNullRepresentation("");
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
@@ -16,6 +16,7 @@ import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TargetTagManagement;
+import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.builder.TextAreaBuilder;
@@ -98,9 +99,9 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
     TargetBulkUpdateWindowLayout(final VaadinMessageSource i18n, final TargetManagement targetManagement,
             final UIEventBus eventBus, final ManagementUIState managementUIState,
             final DeploymentManagement deploymentManagement, final UiProperties uiproperties,
-            final SpPermissionChecker checker, final UINotification uinotification, final TargetTagManagement tagManagement,
-            final DistributionSetManagement distributionSetManagement, final EntityFactory entityFactory,
-            final Executor uiExecutor) {
+            final SpPermissionChecker checker, final UINotification uinotification,
+            final TargetTagManagement tagManagement, final DistributionSetManagement distributionSetManagement,
+            final EntityFactory entityFactory, final Executor uiExecutor) {
         this.i18n = i18n;
         this.targetManagement = targetManagement;
         this.eventBus = eventBus;
@@ -196,7 +197,8 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
     private TextArea getDescriptionTextArea() {
         final TextArea description = new TextAreaBuilder().caption(i18n.getMessage("textfield.description"))
                 .style("text-area-style").prompt(i18n.getMessage("textfield.description")).immediate(true)
-                .id(UIComponentIdProvider.BULK_UPLOAD_DESC).buildTextComponent();
+                .maxLengthAllowed(Target.DESCRIPTION_MAX_SIZE).id(UIComponentIdProvider.BULK_UPLOAD_DESC)
+                .buildTextComponent();
         description.setNullRepresentation("");
         description.setWidth("100%");
         return description;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
@@ -333,7 +333,8 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
 
         private Long getScheduledStartTime() {
             return AutoStartOptionGroupLayout.AutoStartOption.SCHEDULED.equals(getAutoStartOption())
-                    ? autoStartOptionGroupLayout.getStartAtDateField().getValue().getTime() : null;
+                    ? autoStartOptionGroupLayout.getStartAtDateField().getValue().getTime()
+                    : null;
         }
 
         private int getErrorThresholdPercentage(final int amountGroup) {
@@ -617,7 +618,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
     private static TextArea createTargetFilterQuery() {
         final TextArea filterField = new TextAreaBuilder().style("text-area-style")
                 .id(UIComponentIdProvider.ROLLOUT_TARGET_FILTER_QUERY_FIELD)
-                .maxLengthAllowed(SPUILabelDefinitions.TARGET_FILTER_QUERY_TEXT_FIELD_LENGTH).buildTextComponent();
+                .maxLengthAllowed(TargetFilterQuery.QUERY_MAX_SIZE).buildTextComponent();
 
         filterField.setId(UIComponentIdProvider.ROLLOUT_TARGET_FILTER_QUERY_FIELD);
         filterField.setNullRepresentation("");
@@ -779,7 +780,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
     private TextArea createDescription() {
         final TextArea descriptionField = new TextAreaBuilder().style("text-area-style")
                 .prompt(i18n.getMessage("textfield.description")).id(UIComponentIdProvider.ROLLOUT_DESCRIPTION_ID)
-                .buildTextComponent();
+                .maxLengthAllowed(Rollout.DESCRIPTION_MAX_SIZE).buildTextComponent();
         descriptionField.setNullRepresentation("");
         descriptionField.setSizeUndefined();
         return descriptionField;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/DefineGroupsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/DefineGroupsLayout.java
@@ -476,7 +476,7 @@ public class DefineGroupsLayout extends GridLayout {
         private TextArea createTargetFilterQuery() {
             final TextArea filterField = new TextAreaBuilder().style("text-area-style")
                     .id(UIComponentIdProvider.ROLLOUT_TARGET_FILTER_QUERY_FIELD)
-                    .maxLengthAllowed(SPUILabelDefinitions.TARGET_FILTER_QUERY_TEXT_FIELD_LENGTH).buildTextComponent();
+                    .maxLengthAllowed(TargetFilterQuery.QUERY_MAX_SIZE).buildTextComponent();
 
             filterField.setNullRepresentation("");
             filterField.setEnabled(false);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUILabelDefinitions.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUILabelDefinitions.java
@@ -273,11 +273,6 @@ public final class SPUILabelDefinitions {
     public static final String STATUS_ICON = "statusIcon";
 
     /**
-     * Create custom target filter header - query text field length.
-     */
-    public static final int TARGET_FILTER_QUERY_TEXT_FIELD_LENGTH = 1024;
-
-    /**
      * Status - column property.
      */
     public static final String VAR_STATUS = "status";


### PR DESCRIPTION
Very often not set at all or wrong (i.e. not taking the repository defined values but use UI custom ones).

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>