### PR TITLE
Ignore cookies with script content in login UI

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUI.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.ui.login;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 import javax.servlet.http.Cookie;
 
@@ -81,6 +82,7 @@ public abstract class AbstractHawkbitLoginUI extends UI {
 
     private static final String SP_LOGIN_USER = "sp-login-user";
     private static final String SP_LOGIN_TENANT = "sp-login-tenant";
+    private static final Pattern FORBIDDEN_COOKIE_CONTENT = Pattern.compile(".*(<|>).*");
 
     private final transient ApplicationContext context;
 
@@ -365,8 +367,10 @@ public abstract class AbstractHawkbitLoginUI extends UI {
 
         if (usernameCookie != null) {
             final String previousUser = usernameCookie.getValue();
-            username.setValue(previousUser);
-            password.focus();
+            if (!FORBIDDEN_COOKIE_CONTENT.matcher(previousUser).matches()) {
+                username.setValue(previousUser);
+                password.focus();
+            }
         } else {
             username.focus();
         }
@@ -375,7 +379,9 @@ public abstract class AbstractHawkbitLoginUI extends UI {
 
         if (tenantCookie != null && multiTenancyIndicator.isMultiTenancySupported()) {
             final String previousTenant = tenantCookie.getValue();
-            tenant.setValue(previousTenant.toUpperCase());
+            if (!FORBIDDEN_COOKIE_CONTENT.matcher(previousTenant).matches()) {
+                tenant.setValue(previousTenant.toUpperCase());
+            }
         } else if (multiTenancyIndicator.isMultiTenancySupported()) {
             tenant.focus();
         } else {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUI.java
@@ -367,7 +367,7 @@ public abstract class AbstractHawkbitLoginUI extends UI {
 
         if (usernameCookie != null) {
             final String previousUser = usernameCookie.getValue();
-            if (isAllowedCookieContent(previousUser)) {
+            if (isAllowedCookieValue(previousUser)) {
                 username.setValue(previousUser);
                 password.focus();
             }
@@ -379,7 +379,7 @@ public abstract class AbstractHawkbitLoginUI extends UI {
 
         if (tenantCookie != null && multiTenancyIndicator.isMultiTenancySupported()) {
             final String previousTenant = tenantCookie.getValue();
-            if (isAllowedCookieContent(previousTenant)) {
+            if (isAllowedCookieValue(previousTenant)) {
                 tenant.setValue(previousTenant.toUpperCase());
             }
         } else if (multiTenancyIndicator.isMultiTenancySupported()) {
@@ -389,7 +389,7 @@ public abstract class AbstractHawkbitLoginUI extends UI {
         }
     }
 
-    protected static boolean isAllowedCookieContent(final String previousTenant) {
+    protected static boolean isAllowedCookieValue(final String previousTenant) {
         return !FORBIDDEN_COOKIE_CONTENT.matcher(previousTenant).matches();
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUI.java
@@ -82,7 +82,7 @@ public abstract class AbstractHawkbitLoginUI extends UI {
 
     private static final String SP_LOGIN_USER = "sp-login-user";
     private static final String SP_LOGIN_TENANT = "sp-login-tenant";
-    private static final Pattern FORBIDDEN_COOKIE_CONTENT = Pattern.compile(".*(<|>).*");
+    private static final Pattern FORBIDDEN_COOKIE_CONTENT = Pattern.compile("(\\s|.)*(<|>)(\\s|.)*");
 
     private final transient ApplicationContext context;
 
@@ -367,7 +367,7 @@ public abstract class AbstractHawkbitLoginUI extends UI {
 
         if (usernameCookie != null) {
             final String previousUser = usernameCookie.getValue();
-            if (!FORBIDDEN_COOKIE_CONTENT.matcher(previousUser).matches()) {
+            if (isAllowedCookieContent(previousUser)) {
                 username.setValue(previousUser);
                 password.focus();
             }
@@ -379,7 +379,7 @@ public abstract class AbstractHawkbitLoginUI extends UI {
 
         if (tenantCookie != null && multiTenancyIndicator.isMultiTenancySupported()) {
             final String previousTenant = tenantCookie.getValue();
-            if (!FORBIDDEN_COOKIE_CONTENT.matcher(previousTenant).matches()) {
+            if (isAllowedCookieContent(previousTenant)) {
                 tenant.setValue(previousTenant.toUpperCase());
             }
         } else if (multiTenancyIndicator.isMultiTenancySupported()) {
@@ -387,6 +387,10 @@ public abstract class AbstractHawkbitLoginUI extends UI {
         } else {
             username.focus();
         }
+    }
+
+    protected static boolean isAllowedCookieContent(final String previousTenant) {
+        return !FORBIDDEN_COOKIE_CONTENT.matcher(previousTenant).matches();
     }
 
     private void setCookies() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUITest.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUITest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.ui.login;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import ru.yandex.qatools.allure.annotations.Description;
+
+/**
+ * Tests for {@link AbstractHawkbitLoginUI}
+ *
+ */
+public class AbstractHawkbitLoginUITest {
+
+    @Test
+    @Description("Verfies that forbidden content is disallowed.")
+    public void isAllowedCookieContent() {
+        assertThat(AbstractHawkbitLoginUI.isAllowedCookieContent("<script>test</script>")).isFalse();
+        assertThat(AbstractHawkbitLoginUI.isAllowedCookieContent("\n<script>test</script>foobar")).isFalse();
+        assertThat(AbstractHawkbitLoginUI.isAllowedCookieContent("foobar<script>test</script>")).isFalse();
+        assertThat(AbstractHawkbitLoginUI.isAllowedCookieContent("\nfoobar<script>test</script>")).isFalse();
+    }
+
+}

--- a/hawkbit-ui/src/test/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUITest.java
+++ b/hawkbit-ui/src/test/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUITest.java
@@ -26,11 +26,11 @@ public class AbstractHawkbitLoginUITest {
 
     @Test
     @Description("Verfies that forbidden content is disallowed.")
-    public void isAllowedCookieContent() {
-        assertThat(AbstractHawkbitLoginUI.isAllowedCookieContent("<script>test</script>")).isFalse();
-        assertThat(AbstractHawkbitLoginUI.isAllowedCookieContent("\n<script>test</script>foobar")).isFalse();
-        assertThat(AbstractHawkbitLoginUI.isAllowedCookieContent("foobar<script>test</script>")).isFalse();
-        assertThat(AbstractHawkbitLoginUI.isAllowedCookieContent("\nfoobar<script>test</script>")).isFalse();
+    public void isAllowedCookieValue() {
+        assertThat(AbstractHawkbitLoginUI.isAllowedCookieValue("<script>test</script>")).isFalse();
+        assertThat(AbstractHawkbitLoginUI.isAllowedCookieValue("\n<script>test</script>foobar")).isFalse();
+        assertThat(AbstractHawkbitLoginUI.isAllowedCookieValue("foobar<script>test</script>")).isFalse();
+        assertThat(AbstractHawkbitLoginUI.isAllowedCookieValue("\nfoobar<script>test</script>")).isFalse();
     }
 
 }

--- a/hawkbit-ui/src/test/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUITest.java
+++ b/hawkbit-ui/src/test/java/org/eclipse/hawkbit/ui/login/AbstractHawkbitLoginUITest.java
@@ -13,11 +13,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
 import ru.yandex.qatools.allure.annotations.Description;
+import ru.yandex.qatools.allure.annotations.Features;
+import ru.yandex.qatools.allure.annotations.Stories;
 
 /**
  * Tests for {@link AbstractHawkbitLoginUI}
  *
  */
+@Features("Unit Tests - Management UI")
+@Stories("Login UI")
 public class AbstractHawkbitLoginUITest {
 
     @Test


### PR DESCRIPTION
Reduce risk that an attacker can inject a script into the cookie values and execute scripts
locally on a victim’s computer.

Signed-off-by: kaizimmerm <kai.zimmermann@bosch-si.com>