### PR TITLE
Target attributes update can be (re-)triggered by management API

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/amqp/api/EventTopic.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/amqp/api/EventTopic.java
@@ -32,6 +32,10 @@ public enum EventTopic {
     /**
      * Topic when sending a download only task, skipping the install.
      */
-    DOWNLOAD;
+    DOWNLOAD,
+    /**
+     * Topic when an update of device attributes is requested.
+     */
+    REQUEST_ATTRIBUTES_UPDATE;
 
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
@@ -109,8 +109,7 @@ public interface TargetManagement {
             Long installedOrAssignedDistributionSetId, Boolean selectTargetWithNoTag, String... tagNames);
 
     /**
-     * Counts number of targets with given
-     * {@link Target#getInstalledDistributionSet()}.
+     * Counts number of targets with given with given distribution set Id
      *
      * @param distId
      *            to search for
@@ -630,4 +629,25 @@ public interface TargetManagement {
      *             if target with given ID does not exist
      */
     Map<String, String> getControllerAttributes(@NotEmpty String controllerId);
+
+    /**
+     * Trigger given {@link Target} to update its attributes.
+     *
+     * @param controllerId
+     *            of the target
+     *
+     * @throws EntityNotFoundException
+     *             if target with given ID does not exist
+     */
+    void requestControllerAttributes(@NotEmpty String controllerId);
+
+    /**
+     * Check if update of given {@link Target} attributes is already requested.
+     * 
+     * @param controllerId
+     *            of target
+     * @return {@code true}: update of controller attributes triggered.
+     *         {@code false}: update of controller attributes not requested.
+     */
+    boolean isControllerAttributesRequested(@NotEmpty String controllerId);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/TargetUpdate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/TargetUpdate.java
@@ -67,4 +67,10 @@ public interface TargetUpdate {
      * @return updated builder instance
      */
     TargetUpdate status(@NotNull TargetUpdateStatus status);
+
+    /**
+     * @param requestAttributes for {@link Target#isRequestControllerAttributes()}
+     * @return updated builder instance
+     */
+    TargetUpdate requestAttributes(Boolean requestAttributes);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetAttributesRequestedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetAttributesRequestedEvent.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.event.remote;
+
+import org.eclipse.hawkbit.repository.model.Target;
+
+/**
+ * Defines the remote event of triggering attribute updates of a {@link Target}.
+ */
+public class TargetAttributesRequestedEvent extends RemoteIdEvent {
+    private static final long serialVersionUID = 1L;
+    private String controllerId;
+    private String targetAddress;
+
+    /**
+     * Default constructor.
+     */
+    public TargetAttributesRequestedEvent() {
+        // for serialization libs like jackson
+    }
+
+    /**
+     * Constructor json serialization
+     *
+     * @param tenant
+     *            the tenant
+     * @param entityId
+     *            the entity id
+     * @param controllerId
+     *            the controllerId of the target
+     * @param targetAddress
+     *            the target address
+     * @param entityClass
+     *            the entity class
+     * @param applicationId
+     *            the origin application id
+     */
+    public TargetAttributesRequestedEvent(final String tenant, final Long entityId, final String controllerId,
+            final String targetAddress, final String entityClass, final String applicationId) {
+        super(entityId, tenant, entityClass, applicationId);
+        this.controllerId = controllerId;
+        this.targetAddress = targetAddress;
+    }
+
+    public String getControllerId() {
+        return controllerId;
+    }
+
+    public String getTargetAddress() {
+        return targetAddress;
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/builder/AbstractTargetUpdateCreate.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/builder/AbstractTargetUpdateCreate.java
@@ -34,6 +34,8 @@ public class AbstractTargetUpdateCreate<T> extends AbstractNamedEntityBuilder<T>
     protected Long lastTargetQuery;
     protected TargetUpdateStatus status;
 
+    protected  Boolean requestAttributes;
+
     protected AbstractTargetUpdateCreate(final String controllerId) {
         this.controllerId = StringUtils.trimWhitespace(controllerId);
     }
@@ -59,6 +61,11 @@ public class AbstractTargetUpdateCreate<T> extends AbstractNamedEntityBuilder<T>
 
     public T securityToken(final String securityToken) {
         this.securityToken = StringUtils.trimWhitespace(securityToken);
+        return (T) this;
+    }
+
+    public T requestAttributes(final Boolean requestAttributes) {
+        this.requestAttributes = requestAttributes;
         return (T) this;
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -32,6 +32,7 @@ import org.eclipse.hawkbit.repository.TimestampCalculator;
 import org.eclipse.hawkbit.repository.builder.TargetCreate;
 import org.eclipse.hawkbit.repository.builder.TargetUpdate;
 import org.eclipse.hawkbit.repository.event.remote.TargetDeletedEvent;
+import org.eclipse.hawkbit.repository.event.remote.TargetAttributesRequestedEvent;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.jpa.builder.JpaTargetCreate;
 import org.eclipse.hawkbit.repository.jpa.builder.JpaTargetUpdate;
@@ -638,6 +639,26 @@ public class JpaTargetManagement implements TargetManagement {
                 .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
 
         return target.getControllerAttributes();
+    }
+
+    @Override
+    public void requestControllerAttributes(final String controllerId) {
+        final JpaTarget target = (JpaTarget) getByControllerID(controllerId)
+                .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
+
+        target.setRequestControllerAttributes(true);
+
+        eventPublisher.publishEvent(new TargetAttributesRequestedEvent(tenantAware.getCurrentTenant(), target.getId(),
+                target.getControllerId(), target.getAddress() != null ? target.getAddress().toString() : null,
+                JpaTarget.class.getName(), applicationContext.getId()));
+    }
+
+    @Override
+    public boolean isControllerAttributesRequested(final String controllerId) {
+        final JpaTarget target = (JpaTarget) getByControllerID(controllerId)
+                .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
+
+        return target.isRequestControllerAttributes();
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
@@ -178,8 +178,7 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
     Page<Target> findByAssignedDistributionSetId(final Pageable pageable, final Long setID);
 
     /**
-     * Counts number of targets with given
-     * {@link Target#getAssignedDistributionSet()}.
+     * Counts number of targets with given distribution set Id.
      *
      * @param distId
      *            to search for
@@ -189,8 +188,7 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
     Long countByAssignedDistributionSetId(final Long distId);
 
     /**
-     * Counts number of targets with given
-     * {@link Target#getInstalledDistributionSet()}.
+     * Counts number of targets with given distribution set Id.
      *
      * @param distId
      *            to search for

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
@@ -880,4 +880,16 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
         final List<Long> collect = foundDs.stream().map(Target::getId).collect(Collectors.toList());
         assertThat(collect).containsAll(searchIds);
     }
+
+    @Test
+    @Description("Verify that the flag for requesting controller attributes is set correctly.")
+    public void verifyRequestControllerAttributes() {
+        final String knownTargetId = "KnownControllerId";
+        createTargetWithAttributes(knownTargetId);
+
+        assertThat(targetManagement.isControllerAttributesRequested(knownTargetId)).isFalse();
+        targetManagement.requestControllerAttributes(knownTargetId);
+        assertThat(targetManagement.isControllerAttributesRequested(knownTargetId)).isTrue();
+
+    }
 }

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTarget.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTarget.java
@@ -46,6 +46,9 @@ public class MgmtTarget extends MgmtNamedEntity {
     @JsonProperty
     private String securityToken;
 
+    @JsonProperty
+    private boolean requestAttributes;
+
     /**
      * @return the controllerId
      */
@@ -166,5 +169,14 @@ public class MgmtTarget extends MgmtNamedEntity {
     @JsonIgnore
     public void setSecurityToken(final String securityToken) {
         this.securityToken = securityToken;
+    }
+
+    public boolean isRequestAttributes() {
+        return requestAttributes;
+    }
+
+    @JsonIgnore
+    public void setRequestAttributes(final boolean requestAttributes) {
+        this.requestAttributes = requestAttributes;
     }
 }

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTargetRequestBody.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTargetRequestBody.java
@@ -24,6 +24,9 @@ public class MgmtTargetRequestBody {
     @JsonProperty
     private String securityToken;
 
+    @JsonProperty
+    private Boolean requestAttributes;
+
     public String getSecurityToken() {
         return securityToken;
     }
@@ -88,4 +91,11 @@ public class MgmtTargetRequestBody {
         this.address = address;
     }
 
+    public Boolean isRequestAttributes() {
+        return requestAttributes;
+    }
+
+    public void setRequestAttributes(final Boolean requestAttributes) {
+        this.requestAttributes = requestAttributes;
+    }
 }

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
@@ -133,6 +133,7 @@ public final class MgmtTargetMapper {
         targetRest.setLastModifiedAt(target.getLastModifiedAt());
 
         targetRest.setSecurityToken(target.getSecurityToken());
+        targetRest.setRequestAttributes(target.isRequestControllerAttributes());
 
         // last target query is the last controller request date
         final Long lastTargetQuery = target.getLastTargetQuery();

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResource.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResource.java
@@ -120,9 +120,18 @@ public class MgmtTargetResource implements MgmtTargetRestApi {
     public ResponseEntity<MgmtTarget> updateTarget(@PathVariable("controllerId") final String controllerId,
             @RequestBody final MgmtTargetRequestBody targetRest) {
 
+        if (targetRest.isRequestAttributes() != null) {
+            if (targetRest.isRequestAttributes()) {
+                targetManagement.requestControllerAttributes(controllerId);
+            } else {
+                return ResponseEntity.badRequest().build();
+            }
+        }
+
         final Target updateTarget = this.targetManagement.update(entityFactory.target().update(controllerId)
                 .name(targetRest.getName()).description(targetRest.getDescription()).address(targetRest.getAddress())
-                .securityToken(targetRest.getSecurityToken()));
+                .securityToken(targetRest.getSecurityToken()).requestAttributes(targetRest.isRequestAttributes()));
+
 
         final MgmtTarget response = MgmtTargetMapper.toResponse(updateTarget);
         MgmtTargetMapper.addPollStatus(updateTarget, response);

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/AbstractApiRestDocumentation.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/AbstractApiRestDocumentation.java
@@ -219,6 +219,8 @@ public abstract class AbstractApiRestDocumentation extends AbstractRestIntegrati
                         .type("enum")
                         .attributes(key("value").value("['error', 'in_sync', 'pending', 'registered', 'unknown']")),
                 fieldWithPath(fieldArrayPrefix + "securityToken").description(MgmtApiModelProperties.SECURITY_TOKEN),
+                fieldWithPath(fieldArrayPrefix + "requestAttributes")
+                        .description(MgmtApiModelProperties.REQUEST_ATTRIBUTES),
                 fieldWithPath(fieldArrayPrefix + "installedAt").description(MgmtApiModelProperties.INSTALLED_AT),
                 fieldWithPath(fieldArrayPrefix + "lastModifiedAt")
                         .description(ApiModelPropertiesGeneric.LAST_MODIFIED_AT).type("Number"),

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
@@ -141,6 +141,8 @@ public final class MgmtApiModelProperties {
 
     public static final String SECURITY_TOKEN = "Pre-Shared key that allows targets to authenticate at Direct Device Integration API if enabled in the tenant settings.";
 
+    public static final String REQUEST_ATTRIBUTES = "Request re-transmission of target attributes.";
+
     public static final String META_DATA = "List of metadata.";
 
     public static final String META_DATA_KEY = "Metadata property key.";

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
@@ -90,6 +90,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 .type("enum").attributes(
                                         key("value").value("['error', 'in_sync', 'pending', 'registered', 'unknown']")),
                         fieldWithPath("content[].securityToken").description(MgmtApiModelProperties.SECURITY_TOKEN),
+                        fieldWithPath("content[].requestAttributes").description(MgmtApiModelProperties.REQUEST_ATTRIBUTES),
                         fieldWithPath("content[].installedAt").description(MgmtApiModelProperties.INSTALLED_AT),
                         fieldWithPath("content[].lastModifiedAt")
                                 .description(ApiModelPropertiesGeneric.LAST_MODIFIED_AT).type("Number"),
@@ -141,6 +142,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                         .attributes(key("value")
                                                 .value("['error', 'in_sync', 'pending', 'registered', 'unknown']")),
                                 fieldWithPath("[]securityToken").description(MgmtApiModelProperties.SECURITY_TOKEN),
+                                fieldWithPath("[]requestAttributes").description(MgmtApiModelProperties.REQUEST_ATTRIBUTES),
                                 fieldWithPath("[]_links.self").ignored())));
     }
 
@@ -180,12 +182,13 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                 .andDo(this.document.document(
                         pathParameters(
                                 parameterWithName("controllerId").description(ApiModelPropertiesGeneric.ITEM_ID)),
-                        requestFields(requestFieldWithPath("name").description(ApiModelPropertiesGeneric.NAME),
-                                requestFieldWithPath("description").description(ApiModelPropertiesGeneric.DESCRPTION),
-                                requestFieldWithPath("controllerId").description(ApiModelPropertiesGeneric.ITEM_ID),
-                                requestFieldWithPath("address").description(MgmtApiModelProperties.ADDRESS),
-                                requestFieldWithPath("securityToken")
-                                        .description(MgmtApiModelProperties.SECURITY_TOKEN)),
+                        requestFields(optionalRequestFieldWithPath("name").description(ApiModelPropertiesGeneric.NAME),
+                                optionalRequestFieldWithPath("description").description(ApiModelPropertiesGeneric.DESCRPTION),
+                                optionalRequestFieldWithPath("controllerId").description(ApiModelPropertiesGeneric.ITEM_ID),
+                                optionalRequestFieldWithPath("address").description(MgmtApiModelProperties.ADDRESS),
+                                optionalRequestFieldWithPath("securityToken")
+                                        .description(MgmtApiModelProperties.SECURITY_TOKEN),
+                                optionalRequestFieldWithPath("requestAttributes").description(MgmtApiModelProperties.REQUEST_ATTRIBUTES)),
                         getResponseFieldTarget(false)));
     }
 
@@ -570,6 +573,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
         target.put("name", name);
         target.put("address", "https://192.168.0.1");
         target.put("securityToken", "2345678DGGDGFTDzztgf");
+        target.put("requestAttributes", true);
         return this.objectMapper.writeValueAsString(target);
     }
 


### PR DESCRIPTION
**Current State**
Targets are only "*triggered*" once to provide their attributes (via `configData` resource).

**With this PR**
Targets can be requested (via the Management-API) to re-transmit their attributes. In the DDI case this is done by providing the link to the `configData` resource. For DMF, a new event topic has been introduced.

**Summary**
* extend Management API with attribute `requestAttributes`
* introduce new DMF Event Topic `REQUEST_ATTRIBUTES_UPDATE`
* enhance REST documentation by new functionality
* add tests for:
  * Management API
  * Amqp Message Dispatcher Service
  * Repository (Target Management)

Signed-off-by: Jeroen Jan Laverman (INST/ESY3) <jeroen.laverman@bosch-si.com>