### PR TITLE
Add only eventbus subscription where a method listens to it.

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SoftwareModuleTableHeader.java
@@ -48,7 +48,7 @@ public class SoftwareModuleTableHeader extends AbstractSoftwareModuleTableHeader
     @Override
     protected void showFilterButtonsLayout() {
         getArtifactUploadState().setSwTypeFilterClosed(false);
-        eventbus.publish(this, UploadArtifactUIEvent.SHOW_FILTER_BY_TYPE);
+        eventBus.publish(this, UploadArtifactUIEvent.SHOW_FILTER_BY_TYPE);
 
     }
 
@@ -56,20 +56,20 @@ public class SoftwareModuleTableHeader extends AbstractSoftwareModuleTableHeader
     protected void resetSearchText() {
         if (getArtifactUploadState().getSoftwareModuleFilters().getSearchText().isPresent()) {
             getArtifactUploadState().getSoftwareModuleFilters().setSearchText(null);
-            eventbus.publish(this, new RefreshSoftwareModuleByFilterEvent());
+            eventBus.publish(this, new RefreshSoftwareModuleByFilterEvent());
         }
     }
 
     @Override
     public void maximizeTable() {
         getArtifactUploadState().setSwModuleTableMaximized(Boolean.TRUE);
-        eventbus.publish(this, new SoftwareModuleEvent(BaseEntityEventType.MAXIMIZED));
+        eventBus.publish(this, new SoftwareModuleEvent(BaseEntityEventType.MAXIMIZED));
     }
 
     @Override
     public void minimizeTable() {
         getArtifactUploadState().setSwModuleTableMaximized(Boolean.FALSE);
-        eventbus.publish(this, new SoftwareModuleEvent(BaseEntityEventType.MINIMIZED));
+        eventBus.publish(this, new SoftwareModuleEvent(BaseEntityEventType.MINIMIZED));
     }
 
     @Override
@@ -85,7 +85,7 @@ public class SoftwareModuleTableHeader extends AbstractSoftwareModuleTableHeader
     @Override
     protected void searchBy(final String newSearchText) {
         getArtifactUploadState().getSoftwareModuleFilters().setSearchText(newSearchText);
-        eventbus.publish(this, new RefreshSoftwareModuleByFilterEvent());
+        eventBus.publish(this, new RefreshSoftwareModuleByFilterEvent());
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractDistributionSetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractDistributionSetDetails.java
@@ -82,7 +82,8 @@ public abstract class AbstractDistributionSetDetails
 
     @Override
     protected void onEdit(final ClickEvent event) {
-        final Window newDistWindow = distributionAddUpdateWindowLayout.getWindowForUpdateDistributionSet(getSelectedBaseEntityId());
+        final Window newDistWindow = distributionAddUpdateWindowLayout
+                .getWindowForUpdateDistributionSet(getSelectedBaseEntityId());
         UI.getCurrent().addWindow(newDistWindow);
         newDistWindow.setVisible(Boolean.TRUE);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
@@ -71,11 +71,14 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
 
     private final ManagementUIState managementUIState;
 
+    private final transient UIEventBus eventBus;
+
     protected AbstractTableDetailsLayout(final VaadinMessageSource i18n, final UIEventBus eventBus,
             final SpPermissionChecker permissionChecker, final ManagementUIState managementUIState) {
         this.i18n = i18n;
         this.permissionChecker = permissionChecker;
         this.managementUIState = managementUIState;
+        this.eventBus = eventBus;
         detailsLayout = createTabLayout();
         descriptionLayout = createTabLayout();
         logLayout = createTabLayout();
@@ -83,6 +86,15 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
         tagsLayout = createTabLayout();
         createComponents();
         buildLayout();
+        subscribeToEventBus();
+    }
+
+    /**
+     * Subscribes the view to the eventBus. Method has to be overriden if the
+     * view does not contain any listener to avoid Vaadin blowing up our logs
+     * with warnings.
+     */
+    protected void subscribeToEventBus() {
         eventBus.subscribe(this);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractTableDetailsLayout.java
@@ -71,14 +71,11 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
 
     private final ManagementUIState managementUIState;
 
-    private final transient UIEventBus eventBus;
-
     protected AbstractTableDetailsLayout(final VaadinMessageSource i18n, final UIEventBus eventBus,
             final SpPermissionChecker permissionChecker, final ManagementUIState managementUIState) {
         this.i18n = i18n;
         this.permissionChecker = permissionChecker;
         this.managementUIState = managementUIState;
-        this.eventBus = eventBus;
         detailsLayout = createTabLayout();
         descriptionLayout = createTabLayout();
         logLayout = createTabLayout();
@@ -86,16 +83,18 @@ public abstract class AbstractTableDetailsLayout<T extends NamedEntity> extends 
         tagsLayout = createTabLayout();
         createComponents();
         buildLayout();
-        subscribeToEventBus();
+        if (doSubscribeToEventBus()) {
+            eventBus.subscribe(this);
+        }
     }
 
     /**
-     * Subscribes the view to the eventBus. Method has to be overriden if the
-     * view does not contain any listener to avoid Vaadin blowing up our logs
-     * with warnings.
+     * Subscribes the view to the eventBus. Method has to be overriden (return
+     * false) if the view does not contain any listener to avoid Vaadin blowing
+     * up our logs with warnings.
      */
-    protected void subscribeToEventBus() {
-        eventBus.subscribe(this);
+    protected boolean doSubscribeToEventBus() {
+        return true;
     }
 
     public void setSelectedBaseEntity(final T selectedBaseEntity) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
@@ -53,6 +53,15 @@ public abstract class AbstractFilterButtons extends Table {
 
         this.filterButtonClickBehaviour = filterButtonClickBehaviour;
         createTable();
+        subscribeToEventBus();
+    }
+
+    /**
+     * Subscribes the view to the eventBus. Method has to be overriden if the
+     * view does not contain any listener to avoid Vaadin blowing up our logs
+     * with warnings.
+     */
+    protected void subscribeToEventBus() {
         eventBus.subscribe(this);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/filterlayout/AbstractFilterButtons.java
@@ -53,16 +53,18 @@ public abstract class AbstractFilterButtons extends Table {
 
         this.filterButtonClickBehaviour = filterButtonClickBehaviour;
         createTable();
-        subscribeToEventBus();
+        if (doSubscribeToEventBus()) {
+            eventBus.subscribe(this);
+        }
     }
 
     /**
-     * Subscribes the view to the eventBus. Method has to be overriden if the
-     * view does not contain any listener to avoid Vaadin blowing up our logs
-     * with warnings.
+     * Subscribes the view to the eventBus. Method has to be overriden (return
+     * false) if the view does not contain any listener to avoid Vaadin blowing
+     * up our logs with warnings.
      */
-    protected void subscribeToEventBus() {
-        eventBus.subscribe(this);
+    protected boolean doSubscribeToEventBus() {
+        return true;
     }
 
     private void createTable() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/footer/AbstractDeleteActionsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/footer/AbstractDeleteActionsLayout.java
@@ -64,17 +64,18 @@ public abstract class AbstractDeleteActionsLayout extends VerticalLayout impleme
         this.permChecker = permChecker;
         this.eventBus = eventBus;
         this.notification = notification;
-
-        subscribeToEventBus();
+        if (doSubscribeToEventBus()) {
+            eventBus.subscribe(this);
+        }
     }
 
     /**
-     * Subscribes the view to the eventBus. Method has to be overriden if the
-     * view does not contain any listener to avoid Vaadin blowing up our logs
-     * with warnings.
+     * Subscribes the view to the eventBus. Method has to be overriden (return
+     * false) if the view does not contain any listener to avoid Vaadin blowing
+     * up our logs with warnings.
      */
-    protected void subscribeToEventBus() {
-        eventBus.subscribe(this);
+    protected boolean doSubscribeToEventBus() {
+        return true;
     }
 
     protected void init() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/footer/AbstractDeleteActionsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/footer/AbstractDeleteActionsLayout.java
@@ -65,6 +65,15 @@ public abstract class AbstractDeleteActionsLayout extends VerticalLayout impleme
         this.eventBus = eventBus;
         this.notification = notification;
 
+        subscribeToEventBus();
+    }
+
+    /**
+     * Subscribes the view to the eventBus. Method has to be overriden if the
+     * view does not contain any listener to avoid Vaadin blowing up our logs
+     * with warnings.
+     */
+    protected void subscribeToEventBus() {
         eventBus.subscribe(this);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGrid.java
@@ -79,6 +79,15 @@ public abstract class AbstractGrid<T extends Indexed> extends Grid implements Re
         }
         setColumnReorderingAllowed(true);
         addNewContainerDS();
+        subscribeToEventBus();
+    }
+
+    /**
+     * Subscribes the view to the eventBus. Method has to be overriden if the
+     * view does not contain any listener to avoid Vaadin blowing up our logs
+     * with warnings.
+     */
+    protected void subscribeToEventBus() {
         eventBus.subscribe(this);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGrid.java
@@ -79,16 +79,18 @@ public abstract class AbstractGrid<T extends Indexed> extends Grid implements Re
         }
         setColumnReorderingAllowed(true);
         addNewContainerDS();
-        subscribeToEventBus();
+        if (doSubscribeToEventBus()) {
+            eventBus.subscribe(this);
+        }
     }
 
     /**
-     * Subscribes the view to the eventBus. Method has to be overriden if the
-     * view does not contain any listener to avoid Vaadin blowing up our logs
-     * with warnings.
+     * Subscribes the view to the eventBus. Method has to be overriden (return
+     * false) if the view does not contain any listener to avoid Vaadin blowing
+     * up our logs with warnings.
      */
-    protected void subscribeToEventBus() {
-        eventBus.subscribe(this);
+    protected boolean doSubscribeToEventBus() {
+        return true;
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGridComponentLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGridComponentLayout.java
@@ -56,16 +56,18 @@ public abstract class AbstractGridComponentLayout extends VerticalLayout {
         buildLayout();
         setSizeFull();
         setImmediate(true);
-        subscribeToEventBus();
+        if (doSubscribeToEventBus()) {
+            eventBus.subscribe(this);
+        }
     }
 
     /**
-     * Subscribes the view to the eventBus. Method has to be overriden if the
-     * view does not contain any listener to avoid Vaadin blowing up our logs
-     * with warnings.
+     * Subscribes the view to the eventBus. Method has to be overriden (return
+     * false) if the view does not contain any listener to avoid Vaadin blowing
+     * up our logs with warnings.
      */
-    protected void subscribeToEventBus() {
-        eventBus.subscribe(this);
+    protected boolean doSubscribeToEventBus() {
+        return true;
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGridComponentLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGridComponentLayout.java
@@ -40,10 +40,7 @@ public abstract class AbstractGridComponentLayout extends VerticalLayout {
      * Constructor.
      *
      * @param i18n
-     * @param deploymentManagement
      * @param eventBus
-     * @param notification
-     * @param managementUIState
      */
     public AbstractGridComponentLayout(final VaadinMessageSource i18n, final UIEventBus eventBus) {
         this.i18n = i18n;
@@ -59,6 +56,15 @@ public abstract class AbstractGridComponentLayout extends VerticalLayout {
         buildLayout();
         setSizeFull();
         setImmediate(true);
+        subscribeToEventBus();
+    }
+
+    /**
+     * Subscribes the view to the eventBus. Method has to be overriden if the
+     * view does not contain any listener to avoid Vaadin blowing up our logs
+     * with warnings.
+     */
+    protected void subscribeToEventBus() {
         eventBus.subscribe(this);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTable.java
@@ -83,6 +83,15 @@ public abstract class AbstractTable<E extends NamedEntity> extends Table impleme
         setDefault();
         addValueChangeListener(event -> onValueChange());
         setPageLength(SPUIDefinitions.PAGE_SIZE);
+        subscribeToEventBus();
+    }
+
+    /**
+     * Subscribes the view to the eventBus. Method has to be overriden if the
+     * view does not contain any listener to avoid Vaadin blowing up our logs
+     * with warnings.
+     */
+    protected void subscribeToEventBus() {
         eventBus.subscribe(this);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTable.java
@@ -83,16 +83,18 @@ public abstract class AbstractTable<E extends NamedEntity> extends Table impleme
         setDefault();
         addValueChangeListener(event -> onValueChange());
         setPageLength(SPUIDefinitions.PAGE_SIZE);
-        subscribeToEventBus();
+        if (doSubscribeToEventBus()) {
+            eventBus.subscribe(this);
+        }
     }
 
     /**
-     * Subscribes the view to the eventBus. Method has to be overriden if the
-     * view does not contain any listener to avoid Vaadin blowing up our logs
-     * with warnings.
+     * Subscribes the view to the eventBus. Method has to be overriden (return
+     * false) if the view does not contain any listener to avoid Vaadin blowing
+     * up our logs with warnings.
      */
-    protected void subscribeToEventBus() {
-        eventBus.subscribe(this);
+    protected boolean doSubscribeToEventBus() {
+        return true;
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableHeader.java
@@ -46,7 +46,7 @@ public abstract class AbstractTableHeader extends VerticalLayout {
 
     protected SpPermissionChecker permChecker;
 
-    protected transient EventBus.UIEventBus eventbus;
+    protected transient EventBus.UIEventBus eventBus;
 
     private Label headerCaption;
 
@@ -71,18 +71,27 @@ public abstract class AbstractTableHeader extends VerticalLayout {
     private final ArtifactUploadState artifactUploadState;
 
     protected AbstractTableHeader(final VaadinMessageSource i18n, final SpPermissionChecker permChecker,
-            final UIEventBus eventbus, final ManagementUIState managementUIState,
+            final UIEventBus eventBus, final ManagementUIState managementUIState,
             final ManageDistUIState manageDistUIstate, final ArtifactUploadState artifactUploadState) {
         this.i18n = i18n;
         this.permChecker = permChecker;
-        this.eventbus = eventbus;
+        this.eventBus = eventBus;
         this.managementUIState = managementUIState;
         this.manageDistUIstate = manageDistUIstate;
         this.artifactUploadState = artifactUploadState;
         createComponents();
         buildLayout();
         restoreState();
-        eventbus.subscribe(this);
+        subscribeToEventBus();
+    }
+
+    /**
+     * Subscribes the view to the eventBus. Method has to be overriden if the
+     * view does not contain any listener to avoid Vaadin blowing up our logs
+     * with warnings.
+     */
+    protected void subscribeToEventBus() {
+        eventBus.subscribe(this);
     }
 
     private void createComponents() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/table/AbstractTableHeader.java
@@ -82,16 +82,18 @@ public abstract class AbstractTableHeader extends VerticalLayout {
         createComponents();
         buildLayout();
         restoreState();
-        subscribeToEventBus();
+        if (doSubscribeToEventBus()) {
+            eventBus.subscribe(this);
+        }
     }
 
     /**
-     * Subscribes the view to the eventBus. Method has to be overriden if the
-     * view does not contain any listener to avoid Vaadin blowing up our logs
-     * with warnings.
+     * Subscribes the view to the eventBus. Method has to be overriden (return
+     * false) if the view does not contain any listener to avoid Vaadin blowing
+     * up our logs with warnings.
      */
-    protected void subscribeToEventBus() {
-        eventBus.subscribe(this);
+    protected boolean doSubscribeToEventBus() {
+        return true;
     }
 
     private void createComponents() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/AbstractTagToken.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/AbstractTagToken.java
@@ -88,16 +88,18 @@ public abstract class AbstractTagToken<T extends BaseEntity> implements Serializ
         this.managementUIState = managementUIState;
         createTokenField();
         checkIfTagAssignedIsAllowed();
-        subscribeToEventBus();
+        if (doSubscribeToEventBus()) {
+            eventBus.subscribe(this);
+        }
     }
 
     /**
-     * Subscribes the view to the eventBus. Method has to be overriden if the
-     * view does not contain any listener to avoid Vaadin blowing up our logs
-     * with warnings.
+     * Subscribes the view to the eventBus. Method has to be overriden (return
+     * false) if the view does not contain any listener to avoid Vaadin blowing
+     * up our logs with warnings.
      */
-    protected void subscribeToEventBus() {
-        eventBus.subscribe(this);
+    protected boolean doSubscribeToEventBus() {
+        return true;
     }
 
     protected void onBaseEntityEvent(final BaseUIEntityEvent<T> baseEntityEvent) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/AbstractTagToken.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/tagdetails/AbstractTagToken.java
@@ -88,6 +88,15 @@ public abstract class AbstractTagToken<T extends BaseEntity> implements Serializ
         this.managementUIState = managementUIState;
         createTokenField();
         checkIfTagAssignedIsAllowed();
+        subscribeToEventBus();
+    }
+
+    /**
+     * Subscribes the view to the eventBus. Method has to be overriden if the
+     * view does not contain any listener to avoid Vaadin blowing up our logs
+     * with warnings.
+     */
+    protected void subscribeToEventBus() {
         eventBus.subscribe(this);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/AbstractNotificationView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/AbstractNotificationView.java
@@ -63,6 +63,15 @@ public abstract class AbstractNotificationView extends VerticalLayout implements
         this.notificationUnreadButton = notificationUnreadButton;
         this.viewUnreadNotifcations = new AtomicInteger(0);
         skipUiEventsCache = CacheBuilder.newBuilder().expireAfterAccess(10, SECONDS).build();
+        subscribeToEventBus();
+    }
+
+    /**
+     * Subscribes the view to the eventBus. Method has to be overriden if the
+     * view does not contain any listener to avoid Vaadin blowing up our logs
+     * with warnings.
+     */
+    protected void subscribeToEventBus() {
         eventBus.subscribe(this);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/AbstractNotificationView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/AbstractNotificationView.java
@@ -63,16 +63,18 @@ public abstract class AbstractNotificationView extends VerticalLayout implements
         this.notificationUnreadButton = notificationUnreadButton;
         this.viewUnreadNotifcations = new AtomicInteger(0);
         skipUiEventsCache = CacheBuilder.newBuilder().expireAfterAccess(10, SECONDS).build();
-        subscribeToEventBus();
+        if (doSubscribeToEventBus()) {
+            eventBus.subscribe(this);
+        }
     }
 
     /**
-     * Subscribes the view to the eventBus. Method has to be overriden if the
-     * view does not contain any listener to avoid Vaadin blowing up our logs
-     * with warnings.
+     * Subscribes the view to the eventBus. Method has to be overriden (return
+     * false) if the view does not contain any listener to avoid Vaadin blowing
+     * up our logs with warnings.
      */
-    protected void subscribeToEventBus() {
-        eventBus.subscribe(this);
+    protected boolean doSubscribeToEventBus() {
+        return true;
     }
 
     @EventBusListenerMethod(scope = EventScope.UI)

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableHeader.java
@@ -56,27 +56,27 @@ public class DistributionSetTableHeader extends AbstractDistributionSetTableHead
     @Override
     protected void showFilterButtonsLayout() {
         getManageDistUIstate().setDistTypeFilterClosed(false);
-        eventbus.publish(this, DistributionsUIEvent.SHOW_DIST_FILTER_BY_TYPE);
+        eventBus.publish(this, DistributionsUIEvent.SHOW_DIST_FILTER_BY_TYPE);
     }
 
     @Override
     protected void resetSearchText() {
         if (getManageDistUIstate().getManageDistFilters().getSearchText().isPresent()) {
             getManageDistUIstate().getManageDistFilters().setSearchText(null);
-            eventbus.publish(this, new RefreshDistributionTableByFilterEvent());
+            eventBus.publish(this, new RefreshDistributionTableByFilterEvent());
         }
     }
 
     @Override
     public void maximizeTable() {
         getManageDistUIstate().setDsTableMaximized(Boolean.TRUE);
-        eventbus.publish(this, new DistributionTableEvent(BaseEntityEventType.MAXIMIZED));
+        eventBus.publish(this, new DistributionTableEvent(BaseEntityEventType.MAXIMIZED));
     }
 
     @Override
     public void minimizeTable() {
         getManageDistUIstate().setDsTableMaximized(Boolean.FALSE);
-        eventbus.publish(this, new DistributionTableEvent(BaseEntityEventType.MINIMIZED));
+        eventBus.publish(this, new DistributionTableEvent(BaseEntityEventType.MINIMIZED));
     }
 
     @Override
@@ -92,7 +92,7 @@ public class DistributionSetTableHeader extends AbstractDistributionSetTableHead
     @Override
     protected void searchBy(final String newSearchText) {
         getManageDistUIstate().getManageDistFilters().setSearchText(newSearchText);
-        eventbus.publish(this, new RefreshDistributionTableByFilterEvent());
+        eventBus.publish(this, new RefreshDistributionTableByFilterEvent());
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwModuleTableHeader.java
@@ -50,28 +50,28 @@ public class SwModuleTableHeader extends AbstractSoftwareModuleTableHeader {
     @Override
     protected void showFilterButtonsLayout() {
         getManageDistUIstate().setSwTypeFilterClosed(false);
-        eventbus.publish(this, DistributionsUIEvent.SHOW_SM_FILTER_BY_TYPE);
+        eventBus.publish(this, DistributionsUIEvent.SHOW_SM_FILTER_BY_TYPE);
     }
 
     @Override
     protected void resetSearchText() {
         if (getManageDistUIstate().getSoftwareModuleFilters().getSearchText().isPresent()) {
             getManageDistUIstate().getSoftwareModuleFilters().setSearchText(null);
-            eventbus.publish(this, new RefreshSoftwareModuleByFilterEvent());
+            eventBus.publish(this, new RefreshSoftwareModuleByFilterEvent());
         }
     }
 
     @Override
     public void maximizeTable() {
         getManageDistUIstate().setSwModuleTableMaximized(Boolean.TRUE);
-        eventbus.publish(this, new SoftwareModuleEvent(BaseEntityEventType.MAXIMIZED));
+        eventBus.publish(this, new SoftwareModuleEvent(BaseEntityEventType.MAXIMIZED));
 
     }
 
     @Override
     public void minimizeTable() {
         getManageDistUIstate().setSwModuleTableMaximized(Boolean.FALSE);
-        eventbus.publish(this, new SoftwareModuleEvent(BaseEntityEventType.MINIMIZED));
+        eventBus.publish(this, new SoftwareModuleEvent(BaseEntityEventType.MINIMIZED));
     }
 
     @Override
@@ -87,7 +87,7 @@ public class SwModuleTableHeader extends AbstractSoftwareModuleTableHeader {
     @Override
     protected void searchBy(final String newSearchText) {
         getManageDistUIstate().getSoftwareModuleFilters().setSearchText(newSearchText);
-        eventbus.publish(this, new RefreshSoftwareModuleByFilterEvent());
+        eventBus.publish(this, new RefreshSoftwareModuleByFilterEvent());
     }
 
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/AbstractCreateUpdateTagLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/AbstractCreateUpdateTagLayout.java
@@ -178,16 +178,18 @@ public abstract class AbstractCreateUpdateTagLayout<E extends NamedEntity> exten
         createRequiredComponents();
         buildLayout();
         addListeners();
-        subscribeToEventBus();
+        if (doSubscribeToEventBus()) {
+            eventBus.subscribe(this);
+        }
     }
 
     /**
-     * Subscribes the view to the eventBus. Method has to be overriden if the
-     * view does not contain any listener to avoid Vaadin blowing up our logs
-     * with warnings.
+     * Subscribes the view to the eventBus. Method has to be overriden (return
+     * false) if the view does not contain any listener to avoid Vaadin blowing
+     * up our logs with warnings.
      */
-    protected void subscribeToEventBus() {
-        eventBus.subscribe(this);
+    protected boolean doSubscribeToEventBus() {
+        return true;
     }
 
     protected void createRequiredComponents() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/AbstractCreateUpdateTagLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/AbstractCreateUpdateTagLayout.java
@@ -174,11 +174,19 @@ public abstract class AbstractCreateUpdateTagLayout<E extends NamedEntity> exten
      * Init the layout.
      */
     public void init() {
-
         setSizeUndefined();
         createRequiredComponents();
         buildLayout();
         addListeners();
+        subscribeToEventBus();
+    }
+
+    /**
+     * Subscribes the view to the eventBus. Method has to be overriden if the
+     * view does not contain any listener to avoid Vaadin blowing up our logs
+     * with warnings.
+     */
+    protected void subscribeToEventBus() {
         eventBus.subscribe(this);
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/CreateUpdateTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/CreateUpdateTypeLayout.java
@@ -52,8 +52,8 @@ public abstract class CreateUpdateTypeLayout<E extends NamedEntity> extends Abst
     }
 
     @Override
-    protected void subscribeToEventBus() {
-        // nothing to listen
+    protected boolean doSubscribeToEventBus() {
+        return false;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/CreateUpdateTypeLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/layouts/CreateUpdateTypeLayout.java
@@ -52,6 +52,11 @@ public abstract class CreateUpdateTypeLayout<E extends NamedEntity> extends Abst
     }
 
     @Override
+    protected void subscribeToEventBus() {
+        // nothing to listen
+    }
+
+    @Override
     protected void addListeners() {
         super.addListeners();
         optiongroup.addValueChangeListener(this::optionValueChanged);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusGrid.java
@@ -64,8 +64,8 @@ public class ActionStatusGrid extends AbstractGrid<LazyQueryContainer> {
     }
 
     @Override
-    protected void subscribeToEventBus() {
-        // nothing to listen
+    protected boolean doSubscribeToEventBus() {
+        return false;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusGrid.java
@@ -64,6 +64,11 @@ public class ActionStatusGrid extends AbstractGrid<LazyQueryContainer> {
     }
 
     @Override
+    protected void subscribeToEventBus() {
+        // nothing to listen
+    }
+
+    @Override
     protected LazyQueryContainer createContainer() {
         configureQueryFactory();
         return new LazyQueryContainer(

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusLayout.java
@@ -37,8 +37,8 @@ public class ActionStatusLayout extends AbstractGridComponentLayout {
     }
 
     @Override
-    protected void subscribeToEventBus() {
-        // nothing to listen
+    protected boolean doSubscribeToEventBus() {
+        return false;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusLayout.java
@@ -37,6 +37,11 @@ public class ActionStatusLayout extends AbstractGridComponentLayout {
     }
 
     @Override
+    protected void subscribeToEventBus() {
+        // nothing to listen
+    }
+
+    @Override
     public DefaultGridHeader createGridHeader() {
         return new DefaultGridHeader(managementUIState, "Action States").init();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusMsgGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusMsgGrid.java
@@ -75,8 +75,8 @@ public class ActionStatusMsgGrid extends AbstractGrid<LazyQueryContainer> {
     }
 
     @Override
-    protected void subscribeToEventBus() {
-        // nothing to listen
+    protected boolean doSubscribeToEventBus() {
+        return false;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusMsgGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusMsgGrid.java
@@ -75,6 +75,11 @@ public class ActionStatusMsgGrid extends AbstractGrid<LazyQueryContainer> {
     }
 
     @Override
+    protected void subscribeToEventBus() {
+        // nothing to listen
+    }
+
+    @Override
     protected LazyQueryContainer createContainer() {
         configureQueryFactory();
         return new LazyQueryContainer(new LazyQueryDefinition(true, SPUIDefinitions.PAGE_SIZE, null), targetQF);
@@ -207,4 +212,5 @@ public class ActionStatusMsgGrid extends AbstractGrid<LazyQueryContainer> {
             return null;
         }
     }
+
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusMsgLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusMsgLayout.java
@@ -37,8 +37,8 @@ public class ActionStatusMsgLayout extends AbstractGridComponentLayout {
     }
 
     @Override
-    protected void subscribeToEventBus() {
-        // nothing to listen
+    protected boolean doSubscribeToEventBus() {
+        return false;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusMsgLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusMsgLayout.java
@@ -37,6 +37,11 @@ public class ActionStatusMsgLayout extends AbstractGridComponentLayout {
     }
 
     @Override
+    protected void subscribeToEventBus() {
+        // nothing to listen
+    }
+
+    @Override
     public DefaultGridHeader createGridHeader() {
         return new DefaultGridHeader(managementUIState, "Messages").init();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTableHeader.java
@@ -52,27 +52,27 @@ public class DistributionTableHeader extends AbstractDistributionSetTableHeader 
     @Override
     protected void showFilterButtonsLayout() {
         getManagementUIState().setDistTagFilterClosed(false);
-        eventbus.publish(this, ManagementUIEvent.SHOW_DISTRIBUTION_TAG_LAYOUT);
+        eventBus.publish(this, ManagementUIEvent.SHOW_DISTRIBUTION_TAG_LAYOUT);
     }
 
     @Override
     protected void resetSearchText() {
         if (getManagementUIState().getDistributionTableFilters().getSearchText().isPresent()) {
             getManagementUIState().getDistributionTableFilters().setSearchText(null);
-            eventbus.publish(this, new RefreshDistributionTableByFilterEvent());
+            eventBus.publish(this, new RefreshDistributionTableByFilterEvent());
         }
     }
 
     @Override
     public void maximizeTable() {
         getManagementUIState().setDsTableMaximized(Boolean.TRUE);
-        eventbus.publish(this, new DistributionTableEvent(BaseEntityEventType.MAXIMIZED));
+        eventBus.publish(this, new DistributionTableEvent(BaseEntityEventType.MAXIMIZED));
     }
 
     @Override
     public void minimizeTable() {
         getManagementUIState().setDsTableMaximized(Boolean.FALSE);
-        eventbus.publish(this, new DistributionTableEvent(BaseEntityEventType.MINIMIZED));
+        eventBus.publish(this, new DistributionTableEvent(BaseEntityEventType.MINIMIZED));
     }
 
     @Override
@@ -88,7 +88,7 @@ public class DistributionTableHeader extends AbstractDistributionSetTableHeader 
     @Override
     protected void searchBy(final String newSearchText) {
         getManagementUIState().getDistributionTableFilters().setSearchText(newSearchText);
-        eventbus.publish(this, new RefreshDistributionTableByFilterEvent());
+        eventBus.publish(this, new RefreshDistributionTableByFilterEvent());
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
@@ -56,8 +56,8 @@ public class CreateUpdateDistributionTagLayoutWindow extends AbstractCreateUpdat
     }
 
     @Override
-    protected void subscribeToEventBus() {
-        // nothing to listen
+    protected boolean doSubscribeToEventBus() {
+        return false;
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/CreateUpdateDistributionTagLayoutWindow.java
@@ -55,6 +55,11 @@ public class CreateUpdateDistributionTagLayoutWindow extends AbstractCreateUpdat
         this.distributionSetTagManagement = distributionSetTagManagement;
     }
 
+    @Override
+    protected void subscribeToEventBus() {
+        // nothing to listen
+    }
+
     /**
      * @return the color which should be selected in the color-picker component.
      */

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtons.java
@@ -67,6 +67,11 @@ public class DistributionTagButtons extends AbstractFilterButtons implements Ref
     }
 
     @Override
+    protected void subscribeToEventBus() {
+        // nothing to listen
+    }
+
+    @Override
     protected String getButtonsTableId() {
         return UIComponentIdProvider.DISTRIBUTION_TAG_TABLE_ID;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstag/DistributionTagButtons.java
@@ -67,8 +67,8 @@ public class DistributionTagButtons extends AbstractFilterButtons implements Ref
     }
 
     @Override
-    protected void subscribeToEventBus() {
-        // nothing to listen
+    protected boolean doSubscribeToEventBus() {
+        return false;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableHeader.java
@@ -228,14 +228,14 @@ public class TargetTableHeader extends AbstractTableHeader {
     @Override
     protected void showFilterButtonsLayout() {
         getManagementUIState().setTargetTagFilterClosed(false);
-        eventbus.publish(this, ManagementUIEvent.SHOW_TARGET_TAG_LAYOUT);
+        eventBus.publish(this, ManagementUIEvent.SHOW_TARGET_TAG_LAYOUT);
     }
 
     @Override
     protected void resetSearchText() {
         if (getManagementUIState().getTargetTableFilters().getSearchText().isPresent()) {
             getManagementUIState().getTargetTableFilters().setSearchText(null);
-            eventbus.publish(this, TargetFilterEvent.REMOVE_FILTER_BY_TEXT);
+            eventBus.publish(this, TargetFilterEvent.REMOVE_FILTER_BY_TEXT);
         }
     }
 
@@ -251,13 +251,13 @@ public class TargetTableHeader extends AbstractTableHeader {
     @Override
     public void maximizeTable() {
         getManagementUIState().setTargetTableMaximized(Boolean.TRUE);
-        eventbus.publish(this, new TargetTableEvent(BaseEntityEventType.MAXIMIZED));
+        eventBus.publish(this, new TargetTableEvent(BaseEntityEventType.MAXIMIZED));
     }
 
     @Override
     public void minimizeTable() {
         getManagementUIState().setTargetTableMaximized(Boolean.FALSE);
-        eventbus.publish(this, new TargetTableEvent(BaseEntityEventType.MINIMIZED));
+        eventBus.publish(this, new TargetTableEvent(BaseEntityEventType.MINIMIZED));
     }
 
     @Override
@@ -273,7 +273,7 @@ public class TargetTableHeader extends AbstractTableHeader {
     @Override
     protected void searchBy(final String newSearchText) {
         getManagementUIState().getTargetTableFilters().setSearchText(newSearchText);
-        eventbus.publish(this, TargetFilterEvent.FILTER_BY_TEXT);
+        eventBus.publish(this, TargetFilterEvent.FILTER_BY_TEXT);
     }
 
     @Override
@@ -400,7 +400,7 @@ public class TargetTableHeader extends AbstractTableHeader {
         getFilterDroppedInfo().addComponent(filteredDistLabel);
         getFilterDroppedInfo().addComponent(filterLabelClose);
         getFilterDroppedInfo().setExpandRatio(filteredDistLabel, 1.0F);
-        eventbus.publish(this, TargetFilterEvent.FILTER_BY_DISTRIBUTION);
+        eventBus.publish(this, TargetFilterEvent.FILTER_BY_DISTRIBUTION);
     }
 
     private void closeFilterByDistribution() {
@@ -412,7 +412,7 @@ public class TargetTableHeader extends AbstractTableHeader {
         getManagementUIState().getTargetTableFilters().setDistributionSet(null);
 
         /* Reload the table */
-        eventbus.publish(this, TargetFilterEvent.REMOVE_FILTER_BY_DISTRIBUTION);
+        eventBus.publish(this, TargetFilterEvent.REMOVE_FILTER_BY_DISTRIBUTION);
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CreateUpdateTargetTagLayoutWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CreateUpdateTargetTagLayoutWindow.java
@@ -65,6 +65,11 @@ public class CreateUpdateTargetTagLayoutWindow extends AbstractCreateUpdateTagLa
     }
 
     @Override
+    protected void subscribeToEventBus() {
+        // nothing to listen
+    }
+
+    @Override
     protected void addListeners() {
         super.addListeners();
         optiongroup.addValueChangeListener(this::optionValueChanged);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CreateUpdateTargetTagLayoutWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/CreateUpdateTargetTagLayoutWindow.java
@@ -65,8 +65,8 @@ public class CreateUpdateTargetTagLayoutWindow extends AbstractCreateUpdateTagLa
     }
 
     @Override
-    protected void subscribeToEventBus() {
-        // nothing to listen
+    protected boolean doSubscribeToEventBus() {
+        return false;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
@@ -8,7 +8,6 @@
  */
 package org.eclipse.hawkbit.ui.rollout.rollout;
 
-import static org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.*;
 import static org.eclipse.hawkbit.ui.rollout.DistributionBarHelper.getTooltip;
 
 import java.util.Arrays;
@@ -31,6 +30,7 @@ import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.Rollout.RolloutStatus;
 import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus;
 import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus.Status;
+import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.CommonDialogWindow;
@@ -113,7 +113,8 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
     private static final List<RolloutStatus> RUN_BUTTON_ENABLED = Arrays.asList(RolloutStatus.READY,
             RolloutStatus.PAUSED);
 
-    private static final List<RolloutStatus> APPROVE_BUTTON_ENABLED = Collections.singletonList(RolloutStatus.WAITING_FOR_APPROVAL);
+    private static final List<RolloutStatus> APPROVE_BUTTON_ENABLED = Collections
+            .singletonList(RolloutStatus.WAITING_FOR_APPROVAL);
 
     private static final Map<RolloutStatus, StatusFontIcon> statusIconMap = new EnumMap<>(RolloutStatus.class);
 
@@ -146,13 +147,12 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
     }
 
     RolloutListGrid(final VaadinMessageSource i18n, final UIEventBus eventBus,
-                    final RolloutManagement rolloutManagement, final UINotification uiNotification,
-                    final RolloutUIState rolloutUIState, final SpPermissionChecker permissionChecker,
-                    final TargetManagement targetManagement, final EntityFactory entityFactory,
-                    final UiProperties uiProperties,
-                    final TargetFilterQueryManagement targetFilterQueryManagement,
-                    final RolloutGroupManagement rolloutGroupManagement, final QuotaManagement quotaManagement,
-                    final TenantConfigurationManagement tenantConfigManagement) {
+            final RolloutManagement rolloutManagement, final UINotification uiNotification,
+            final RolloutUIState rolloutUIState, final SpPermissionChecker permissionChecker,
+            final TargetManagement targetManagement, final EntityFactory entityFactory, final UiProperties uiProperties,
+            final TargetFilterQueryManagement targetFilterQueryManagement,
+            final RolloutGroupManagement rolloutGroupManagement, final QuotaManagement quotaManagement,
+            final TenantConfigurationManagement tenantConfigManagement) {
         super(i18n, eventBus, permissionChecker);
         this.rolloutManagement = rolloutManagement;
         this.rolloutGroupManagement = rolloutGroupManagement;
@@ -267,8 +267,8 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
                 false);
         rolloutGridContainer.addContainerProperty(SPUILabelDefinitions.VAR_CREATED_DATE, String.class, null, false,
                 false);
-        rolloutGridContainer.addContainerProperty(SPUILabelDefinitions.VAR_APPROVAL_DECIDED_BY, String.class, null, false,
-                false);
+        rolloutGridContainer.addContainerProperty(SPUILabelDefinitions.VAR_APPROVAL_DECIDED_BY, String.class, null,
+                false, false);
         rolloutGridContainer.addContainerProperty(SPUILabelDefinitions.VAR_APPROVAL_REMARK, String.class, null, false,
                 false);
         rolloutGridContainer.addContainerProperty(SPUILabelDefinitions.VAR_MODIFIED_DATE, String.class, null, false,
@@ -339,7 +339,8 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
         getColumn(SPUILabelDefinitions.VAR_MODIFIED_DATE).setHeaderCaption(i18n.getMessage("header.modifiedDate"));
         getColumn(SPUILabelDefinitions.VAR_MODIFIED_BY).setHeaderCaption(i18n.getMessage("header.modifiedBy"));
         getColumn(SPUILabelDefinitions.VAR_APPROVAL_REMARK).setHeaderCaption(i18n.getMessage("header.approvalRemark"));
-        getColumn(SPUILabelDefinitions.VAR_APPROVAL_DECIDED_BY).setHeaderCaption(i18n.getMessage("header.approvalDecidedBy"));
+        getColumn(SPUILabelDefinitions.VAR_APPROVAL_DECIDED_BY)
+                .setHeaderCaption(i18n.getMessage("header.approvalDecidedBy"));
         getColumn(SPUILabelDefinitions.VAR_DESC).setHeaderCaption(i18n.getMessage("header.description"));
         getColumn(SPUILabelDefinitions.VAR_TOTAL_TARGETS_COUNT_STATUS)
                 .setHeaderCaption(i18n.getMessage("header.detail.status"));
@@ -357,8 +358,8 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
 
     private HeaderCell joinColumns() {
 
-        return getDefaultHeaderRow().join(VIRT_PROP_RUN, VIRT_PROP_APPROVE, VIRT_PROP_PAUSE, VIRT_PROP_UPDATE, VIRT_PROP_COPY,
-                VIRT_PROP_DELETE);
+        return getDefaultHeaderRow().join(VIRT_PROP_RUN, VIRT_PROP_APPROVE, VIRT_PROP_PAUSE, VIRT_PROP_UPDATE,
+                VIRT_PROP_COPY, VIRT_PROP_DELETE);
     }
 
     @Override
@@ -372,8 +373,8 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
         final List<String> columnsToShowInOrder = Arrays.asList(ROLLOUT_RENDERER_DATA,
                 SPUILabelDefinitions.VAR_DIST_NAME_VERSION, SPUILabelDefinitions.VAR_STATUS,
                 SPUILabelDefinitions.VAR_TOTAL_TARGETS_COUNT_STATUS, SPUILabelDefinitions.VAR_NUMBER_OF_GROUPS,
-                SPUILabelDefinitions.VAR_TOTAL_TARGETS, VIRT_PROP_APPROVE, VIRT_PROP_RUN, VIRT_PROP_PAUSE, VIRT_PROP_UPDATE,
-                VIRT_PROP_COPY, VIRT_PROP_DELETE, SPUILabelDefinitions.VAR_CREATED_DATE,
+                SPUILabelDefinitions.VAR_TOTAL_TARGETS, VIRT_PROP_APPROVE, VIRT_PROP_RUN, VIRT_PROP_PAUSE,
+                VIRT_PROP_UPDATE, VIRT_PROP_COPY, VIRT_PROP_DELETE, SPUILabelDefinitions.VAR_CREATED_DATE,
                 SPUILabelDefinitions.VAR_CREATED_USER, SPUILabelDefinitions.VAR_MODIFIED_DATE,
                 SPUILabelDefinitions.VAR_MODIFIED_BY, SPUILabelDefinitions.VAR_APPROVAL_DECIDED_BY,
                 SPUILabelDefinitions.VAR_APPROVAL_REMARK, SPUILabelDefinitions.VAR_DESC);
@@ -789,9 +790,8 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
         if (!permissionChecker.hasRolloutCreatePermission()) {
             modifiableColumnsList.remove(VIRT_PROP_COPY);
         }
-        if (!permissionChecker.hasRolloutApprovalPermission() ||
-                !tenantConfigManagement.getConfigurationValue(
-                        TenantConfigurationKey.ROLLOUT_APPROVAL_ENABLED, Boolean.class).getValue()) {
+        if (!permissionChecker.hasRolloutApprovalPermission() || !tenantConfigManagement
+                .getConfigurationValue(TenantConfigurationKey.ROLLOUT_APPROVAL_ENABLED, Boolean.class).getValue()) {
             modifiableColumnsList.remove(VIRT_PROP_APPROVE);
         }
         if (!permissionChecker.hasRolloutDeletePermission()) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListView.java
@@ -70,8 +70,8 @@ public class RolloutListView extends AbstractGridComponentLayout {
     }
 
     @Override
-    protected void subscribeToEventBus() {
-        // nothing to listen
+    protected boolean doSubscribeToEventBus() {
+        return false;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListView.java
@@ -47,13 +47,12 @@ public class RolloutListView extends AbstractGridComponentLayout {
     private final UiProperties uiProperties;
 
     public RolloutListView(final SpPermissionChecker permissionChecker, final RolloutUIState rolloutUIState,
-                           final UIEventBus eventBus, final RolloutManagement rolloutManagement,
-                           final TargetManagement targetManagement, final UINotification uiNotification,
-                           final UiProperties uiProperties, final EntityFactory entityFactory,
-                           final VaadinMessageSource i18n,
-                           final TargetFilterQueryManagement targetFilterQueryManagement,
-                           final RolloutGroupManagement rolloutGroupManagement, final QuotaManagement quotaManagement,
-                           final TenantConfigurationManagement tenantConfigManagement) {
+            final UIEventBus eventBus, final RolloutManagement rolloutManagement,
+            final TargetManagement targetManagement, final UINotification uiNotification,
+            final UiProperties uiProperties, final EntityFactory entityFactory, final VaadinMessageSource i18n,
+            final TargetFilterQueryManagement targetFilterQueryManagement,
+            final RolloutGroupManagement rolloutGroupManagement, final QuotaManagement quotaManagement,
+            final TenantConfigurationManagement tenantConfigManagement) {
         super(i18n, eventBus);
         this.permissionChecker = permissionChecker;
         this.rolloutUIState = rolloutUIState;
@@ -68,6 +67,11 @@ public class RolloutListView extends AbstractGridComponentLayout {
         this.tenantConfigManagement = tenantConfigManagement;
 
         init();
+    }
+
+    @Override
+    protected void subscribeToEventBus() {
+        // nothing to listen
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupListGrid.java
@@ -297,8 +297,7 @@ public class RolloutGroupListGrid extends AbstractGrid<LazyQueryContainer> {
 
         @Override
         public void click(final RendererClickEvent event) {
-            final Optional<RolloutGroup> group = rolloutGroupManagement
-                    .getWithDetailedStatus((Long) event.getItemId());
+            final Optional<RolloutGroup> group = rolloutGroupManagement.getWithDetailedStatus((Long) event.getItemId());
             if (!group.isPresent()) {
                 eventBus.publish(this, RolloutEvent.SHOW_ROLLOUTS);
                 return;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupsListView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupsListView.java
@@ -53,8 +53,8 @@ public class RolloutGroupsListView extends AbstractGridComponentLayout {
     }
 
     @Override
-    protected void subscribeToEventBus() {
-        // nothing to listen
+    protected boolean doSubscribeToEventBus() {
+        return false;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupsListView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupsListView.java
@@ -53,6 +53,11 @@ public class RolloutGroupsListView extends AbstractGridComponentLayout {
     }
 
     @Override
+    protected void subscribeToEventBus() {
+        // nothing to listen
+    }
+
+    @Override
     public RolloutGroupsListHeader createGridHeader() {
         return new RolloutGroupsListHeader(eventBus, rolloutUIState, i18n);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListView.java
@@ -34,8 +34,8 @@ public class RolloutGroupTargetsListView extends AbstractGridComponentLayout {
     }
 
     @Override
-    protected void subscribeToEventBus() {
-        // nothing to listen
+    protected boolean doSubscribeToEventBus() {
+        return false;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsListView.java
@@ -34,6 +34,11 @@ public class RolloutGroupTargetsListView extends AbstractGridComponentLayout {
     }
 
     @Override
+    protected void subscribeToEventBus() {
+        // nothing to listen
+    }
+
+    @Override
     public AbstractOrderedLayout createGridHeader() {
         return new RolloutGroupTargetsListHeader(eventBus, i18n, rolloutUIState);
     }


### PR DESCRIPTION
If an eventbus is subscribed to a view where no listener method exists, Vaadin framework is logging a warning. To avoid blowing up log files with this warning, we subscribe only views to the eventbus where exists at least one method that listens to it.

Signed-off-by: Melanie Retter <melanie.retter@bosch-si.com>