### PR TITLE
Change length of createdBy and lastModifiedBy property to 64 characters

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Rollout.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Rollout.java
@@ -28,8 +28,7 @@ public interface Rollout extends NamedEntity {
     /**
      * Maximum length of author name.
      */
-    int APPROVED_BY_MAX_SIZE = 40;
-
+    int APPROVED_BY_MAX_SIZE = 64;
 
     /**
      * Maximum length on comment regarding approval decision.

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/AbstractJpaBaseEntity.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/AbstractJpaBaseEntity.java
@@ -67,7 +67,7 @@ public abstract class AbstractJpaBaseEntity implements BaseEntity {
 
     @Override
     @Access(AccessType.PROPERTY)
-    @Column(name = "created_by", insertable = true, updatable = false, nullable = false, length = 40)
+    @Column(name = "created_by", insertable = true, updatable = false, nullable = false, length = 64)
     public String getCreatedBy() {
         return createdBy;
     }
@@ -81,7 +81,7 @@ public abstract class AbstractJpaBaseEntity implements BaseEntity {
 
     @Override
     @Access(AccessType.PROPERTY)
-    @Column(name = "last_modified_by", insertable = true, updatable = true, nullable = false, length = 40)
+    @Column(name = "last_modified_by", insertable = true, updatable = true, nullable = false, length = 64)
     public String getLastModifiedBy() {
         return lastModifiedBy;
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_7__add_rollout_approval_fields___DB2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_7__add_rollout_approval_fields___DB2.sql
@@ -1,2 +1,2 @@
-ALTER TABLE sp_rollout ADD column approval_decided_by varchar(40);
-ALTER TABLE sp_rollout ADD column approval_remark varchar(255);
+ALTER TABLE sp_rollout ADD COLUMN approval_decided_by varchar(40);
+ALTER TABLE sp_rollout ADD COLUMN approval_remark varchar(255);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_8__change_length_of_created_last_modified_by___DB2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_8__change_length_of_created_last_modified_by___DB2.sql
@@ -21,6 +21,7 @@ ALTER TABLE sp_distribution_set_type ALTER COLUMN last_modified_by SET DATA TYPE
 
 ALTER TABLE sp_rollout ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
 ALTER TABLE sp_rollout ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_rollout ALTER COLUMN approval_decided_by SET DATA TYPE VARCHAR(64);
 
 ALTER TABLE sp_rolloutgroup ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
 ALTER TABLE sp_rolloutgroup ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_8__change_length_of_created_last_modified_by___DB2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_8__change_length_of_created_last_modified_by___DB2.sql
@@ -1,0 +1,44 @@
+ALTER TABLE sp_action ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_action ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_action_status ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_action_status ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_artifact ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_artifact ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_base_software_module ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_base_software_module ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_distributionset_tag ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_distributionset_tag ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_distribution_set ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_distribution_set ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_distribution_set_type ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_distribution_set_type ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_rollout ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_rollout ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_rolloutgroup ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_rolloutgroup ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_software_module_type ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_software_module_type ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_target ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_target ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_target_filter_query ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_target_filter_query ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_target_tag ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_target_tag ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_tenant ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_tenant ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);
+
+ALTER TABLE sp_tenant_configuration ALTER COLUMN created_by SET DATA TYPE VARCHAR(64);
+ALTER TABLE sp_tenant_configuration ALTER COLUMN last_modified_by SET DATA TYPE VARCHAR(64);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_8__change_length_of_created_last_modified_by___H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_8__change_length_of_created_last_modified_by___H2.sql
@@ -1,0 +1,44 @@
+ALTER TABLE sp_action ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_action ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_action_status ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_action_status ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_artifact ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_artifact ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_base_software_module ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_base_software_module ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_distributionset_tag ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_distributionset_tag ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_distribution_set ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_distribution_set ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_distribution_set_type ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_distribution_set_type ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_rollout ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_rollout ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_rolloutgroup ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_rolloutgroup ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_software_module_type ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_software_module_type ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_target ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_target ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_target_filter_query ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_target_filter_query ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_target_tag ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_target_tag ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_tenant ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_tenant ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_tenant_configuration ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_tenant_configuration ALTER COLUMN last_modified_by VARCHAR(64);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_8__change_length_of_created_last_modified_by___H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_8__change_length_of_created_last_modified_by___H2.sql
@@ -21,6 +21,7 @@ ALTER TABLE sp_distribution_set_type ALTER COLUMN last_modified_by VARCHAR(64);
 
 ALTER TABLE sp_rollout ALTER COLUMN created_by VARCHAR(64);
 ALTER TABLE sp_rollout ALTER COLUMN last_modified_by VARCHAR(64);
+ALTER TABLE sp_rollout ALTER COLUMN approval_decided_by VARCHAR(64);
 
 ALTER TABLE sp_rolloutgroup ALTER COLUMN created_by VARCHAR(64);
 ALTER TABLE sp_rolloutgroup ALTER COLUMN last_modified_by VARCHAR(64);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_8__change_length_of_created_last_modified_by___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_8__change_length_of_created_last_modified_by___MYSQL.sql
@@ -21,6 +21,7 @@ ALTER TABLE sp_distribution_set_type MODIFY last_modified_by VARCHAR(64);
 
 ALTER TABLE sp_rollout MODIFY created_by VARCHAR(64);
 ALTER TABLE sp_rollout MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_rollout MODIFY approval_decided_by VARCHAR(64);
 
 ALTER TABLE sp_rolloutgroup MODIFY created_by VARCHAR(64);
 ALTER TABLE sp_rolloutgroup MODIFY last_modified_by VARCHAR(64);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_8__change_length_of_created_last_modified_by___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_8__change_length_of_created_last_modified_by___MYSQL.sql
@@ -1,0 +1,44 @@
+ALTER TABLE sp_action MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_action MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_action_status MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_action_status MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_artifact MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_artifact MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_base_software_module MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_base_software_module MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_distributionset_tag MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_distributionset_tag MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_distribution_set MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_distribution_set MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_distribution_set_type MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_distribution_set_type MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_rollout MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_rollout MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_rolloutgroup MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_rolloutgroup MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_software_module_type MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_software_module_type MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_target MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_target MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_target_filter_query MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_target_filter_query MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_target_tag MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_target_tag MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_tenant MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_tenant MODIFY last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_tenant_configuration MODIFY created_by VARCHAR(64);
+ALTER TABLE sp_tenant_configuration MODIFY last_modified_by VARCHAR(64);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_8__change_length_of_created_last_modified_by___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_8__change_length_of_created_last_modified_by___MYSQL.sql
@@ -1,45 +1,29 @@
-ALTER TABLE sp_action MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_action MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_action MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_action_status MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_action_status MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_action_status MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_artifact MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_artifact MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_artifact MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_base_software_module MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_base_software_module MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_base_software_module MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_distributionset_tag MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_distributionset_tag MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_distributionset_tag MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_distribution_set MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_distribution_set MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_distribution_set MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_distribution_set_type MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_distribution_set_type MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_distribution_set_type MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_rollout MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_rollout MODIFY last_modified_by VARCHAR(64);
-ALTER TABLE sp_rollout MODIFY approval_decided_by VARCHAR(64);
+ALTER TABLE sp_rollout MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64), MODIFY approval_decided_by VARCHAR(64);
 
-ALTER TABLE sp_rolloutgroup MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_rolloutgroup MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_rolloutgroup MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_software_module_type MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_software_module_type MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_software_module_type MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_target MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_target MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_target MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_target_filter_query MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_target_filter_query MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_target_filter_query MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_target_tag MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_target_tag MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_target_tag MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_tenant MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_tenant MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_tenant MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);
 
-ALTER TABLE sp_tenant_configuration MODIFY created_by VARCHAR(64);
-ALTER TABLE sp_tenant_configuration MODIFY last_modified_by VARCHAR(64);
+ALTER TABLE sp_tenant_configuration MODIFY created_by VARCHAR(64), MODIFY last_modified_by VARCHAR(64);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_7__add_rollout_approval_fields___SQL_SERVER.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_7__add_rollout_approval_fields___SQL_SERVER.sql
@@ -1,2 +1,2 @@
-ALTER TABLE sp_rollout ADD column approval_decided_by varchar(40);
-ALTER TABLE sp_rollout ADD column approval_remark varchar(255);
+ALTER TABLE sp_rollout ADD approval_decided_by varchar(40);
+ALTER TABLE sp_rollout ADD approval_remark varchar(255);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_8__change_length_of_created_last_modified_by___SQL_SERVER.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_8__change_length_of_created_last_modified_by___SQL_SERVER.sql
@@ -1,0 +1,44 @@
+ALTER TABLE sp_action ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_action ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_action_status ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_action_status ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_artifact ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_artifact ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_base_software_module ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_base_software_module ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_distributionset_tag ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_distributionset_tag ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_distribution_set ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_distribution_set ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_distribution_set_type ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_distribution_set_type ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_rollout ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_rollout ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_rolloutgroup ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_rolloutgroup ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_software_module_type ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_software_module_type ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_target ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_target ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_target_filter_query ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_target_filter_query ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_target_tag ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_target_tag ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_tenant ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_tenant ALTER COLUMN last_modified_by VARCHAR(64);
+
+ALTER TABLE sp_tenant_configuration ALTER COLUMN created_by VARCHAR(64);
+ALTER TABLE sp_tenant_configuration ALTER COLUMN last_modified_by VARCHAR(64);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_8__change_length_of_created_last_modified_by___SQL_SERVER.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_8__change_length_of_created_last_modified_by___SQL_SERVER.sql
@@ -21,6 +21,7 @@ ALTER TABLE sp_distribution_set_type ALTER COLUMN last_modified_by VARCHAR(64);
 
 ALTER TABLE sp_rollout ALTER COLUMN created_by VARCHAR(64);
 ALTER TABLE sp_rollout ALTER COLUMN last_modified_by VARCHAR(64);
+ALTER TABLE sp_rollout ALTER COLUMN approval_decided_by VARCHAR(64);
 
 ALTER TABLE sp_rolloutgroup ALTER COLUMN created_by VARCHAR(64);
 ALTER TABLE sp_rolloutgroup ALTER COLUMN last_modified_by VARCHAR(64);

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/HawkbitSecurityProperties.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/HawkbitSecurityProperties.java
@@ -147,7 +147,7 @@ public class HawkbitSecurityProperties {
         /**
          * Maximum number of targets per rollout group
          */
-        private int maxActionsPerTarget = 500;
+        private int maxActionsPerTarget = 2000;
 
         /**
          * Maximum number of targets for a manual distribution set assignment.


### PR DESCRIPTION
The length of the columns created_by and last_modified_by is increased to 64 characters.
 
Signed-off-by: Melanie Retter <melanie.retter@bosch-si.com>