### PR TITLE
chore: update documentation links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docker images: [![Docker](https://images.microbadger.com/badges/version/hawkbit/
 
 # Documentation
 
-see [hawkBit Documentation](https://www.eclipse.org/hawkbit/documentation/overview/introduction.html)
+see [hawkBit Documentation](https://www.eclipse.org/hawkbit/)
 
 # Contact us
 
@@ -72,7 +72,7 @@ Open the update server in your browser:
 
 [localhost:8080](http://localhost:8080)
 
-See below for how to build and run the update server on your own. In addition we have a [guide](http://www.eclipse.org/hawkbit/documentation/guide/runhawkbit.html) for setting up a complete landscape.
+See below for how to build and run the update server on your own. In addition we have a [guide](https://www.eclipse.org/hawkbit/gettingstarted/) for setting up a complete landscape.
 
 # hawkBit (Spring boot) starters
 


### PR DESCRIPTION
Links to documentation are not working, gives 404 error. 
- updated with official links
Please review.