### PR TITLE
Move controller attribute validation from DMF to Repository

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/exception/SpServerError.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/exception/SpServerError.java
@@ -47,6 +47,11 @@ public enum SpServerError {
     /**
      *
      */
+    SP_TARGET_ATTRIBUTES_INVALID("hawkbit.server.error.repo.invalidTargetAttributes", "The given target attributes are invalid"),
+
+    /**
+     *
+     */
     SP_REST_SORT_PARAM_SYNTAX("hawkbit.server.error.rest.param.sortParamSyntax", "The given sort paramter is not well formed"),
 
     /**

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -252,29 +252,9 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
     private void updateAttributes(final Message message) {
         final DmfAttributeUpdate attributeUpdate = convertMessage(message, DmfAttributeUpdate.class);
         final String thingId = getStringHeaderKey(message, MessageHeaderKey.THING_ID, "ThingId is null");
-        // reject messages with invalid attributes
-        if (attributeUpdate.getAttributes().entrySet().stream()
-                .anyMatch(e -> !AmqpMessageHandlerService.isAttributeEntryValid(e))) {
-            throw new MessageConversionException(
-                    "The received UPDATE_ATTRIBUTES message contains attribute entries which violate the existing length constraints (keys must not exceed 32 characters, values must not exceed 128 characters).");
-        }
+
         controllerManagement.updateControllerAttributes(thingId, attributeUpdate.getAttributes(),
                 getUpdateMode(attributeUpdate));
-    }
-
-    private static boolean isAttributeEntryValid(final Entry<String, String> e) {
-        if (e == null) {
-            return true;
-        }
-        return isAttributeKeyValid(e.getKey()) && isAttributeValueValid(e.getValue());
-    }
-
-    private static boolean isAttributeKeyValid(final String key) {
-        return key != null && key.length() <= 32;
-    }
-
-    private static boolean isAttributeValueValid(final String value) {
-        return value == null || value.length() <= 128;
     }
 
     /**

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/DelayedRequeueExceptionStrategy.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/DelayedRequeueExceptionStrategy.java
@@ -15,7 +15,7 @@ import javax.validation.ConstraintViolationException;
 import org.eclipse.hawkbit.repository.exception.CancelActionNotAllowedException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.InvalidTargetAddressException;
-import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributesException;
+import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributeException;
 import org.eclipse.hawkbit.repository.exception.QuotaExceededException;
 import org.eclipse.hawkbit.repository.exception.TenantNotExistException;
 import org.slf4j.Logger;
@@ -82,6 +82,6 @@ public class DelayedRequeueExceptionStrategy extends ConditionalRejectingErrorHa
     private static boolean invalidContent(final Throwable cause) {
         return cause instanceof ConstraintViolationException || cause instanceof InvalidTargetAddressException
                 || cause instanceof MessageConversionException || cause instanceof MessageHandlingException
-                || cause instanceof InvalidTargetAttributesException;
+                || cause instanceof InvalidTargetAttributeException;
     }
 }

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/DelayedRequeueExceptionStrategy.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/DelayedRequeueExceptionStrategy.java
@@ -15,6 +15,7 @@ import javax.validation.ConstraintViolationException;
 import org.eclipse.hawkbit.repository.exception.CancelActionNotAllowedException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.InvalidTargetAddressException;
+import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributesException;
 import org.eclipse.hawkbit.repository.exception.QuotaExceededException;
 import org.eclipse.hawkbit.repository.exception.TenantNotExistException;
 import org.slf4j.Logger;
@@ -80,6 +81,7 @@ public class DelayedRequeueExceptionStrategy extends ConditionalRejectingErrorHa
 
     private static boolean invalidContent(final Throwable cause) {
         return cause instanceof ConstraintViolationException || cause instanceof InvalidTargetAddressException
-                || cause instanceof MessageConversionException || cause instanceof MessageHandlingException;
+                || cause instanceof MessageConversionException || cause instanceof MessageHandlingException
+                || cause instanceof InvalidTargetAttributesException;
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -25,6 +25,7 @@ import org.eclipse.hawkbit.repository.exception.CancelActionNotAllowedException;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.QuotaExceededException;
+import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributeException;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
@@ -335,7 +336,7 @@ public interface ControllerManagement {
      *             if target that has to be updated could not be found
      * @throws QuotaExceededException
      *             if maximum number of attributes per target is exceeded
-     * @throws IllegalArgumentException
+     * @throws InvalidTargetAttributeException
      *             if attributes violate constraints
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -334,7 +334,9 @@ public interface ControllerManagement {
      * @throws EntityNotFoundException
      *             if target that has to be updated could not be found
      * @throws QuotaExceededException
-     *             if maximum number of attribzes per target is exceeded
+     *             if maximum number of attributes per target is exceeded
+     * @throws IllegalArgumentException
+     *             if attributes violate constraints
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
     Target updateControllerAttributes(@NotEmpty String controllerId, @NotNull Map<String, String> attributes,

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/InvalidTargetAttributeException.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/InvalidTargetAttributeException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
@@ -12,7 +12,7 @@ package org.eclipse.hawkbit.repository.exception;
 import org.eclipse.hawkbit.exception.AbstractServerRtException;
 import org.eclipse.hawkbit.exception.SpServerError;
 
-public class InvalidTargetAttributesException extends AbstractServerRtException {
+public class InvalidTargetAttributeException extends AbstractServerRtException {
 
     private static final long serialVersionUID = 1L;
     private static final SpServerError THIS_ERROR = SpServerError.SP_TARGET_ATTRIBUTES_INVALID;
@@ -20,7 +20,7 @@ public class InvalidTargetAttributesException extends AbstractServerRtException 
     /**
      * Default constructor.
      */
-    public InvalidTargetAttributesException() {
+    public InvalidTargetAttributeException() {
         super(THIS_ERROR);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/InvalidTargetAttributesException.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/InvalidTargetAttributesException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.repository.exception;
+
+import org.eclipse.hawkbit.exception.AbstractServerRtException;
+import org.eclipse.hawkbit.exception.SpServerError;
+
+public class InvalidTargetAttributesException extends AbstractServerRtException {
+
+    private static final long serialVersionUID = 1L;
+    private static final SpServerError THIS_ERROR = SpServerError.SP_TARGET_ATTRIBUTES_INVALID;
+
+    /**
+     * Default constructor.
+     */
+    public InvalidTargetAttributesException() {
+        super(THIS_ERROR);
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
@@ -36,6 +36,16 @@ public interface Target extends NamedEntity {
     int ADDRESS_MAX_SIZE = 512;
 
     /**
+     * Maximum length of key of controller attribute
+     */
+    int CONTROLLER_ATTRIBUTE_KEY_SIZE = 32;
+
+    /**
+     * Maximum length of value of controller attribute
+     */
+    int CONTROLLER_ATTRIBUTE_VALUE_SIZE = 32;
+
+    /**
      * @return business identifier of the {@link Target}
      */
     String getControllerId();

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
@@ -43,7 +43,7 @@ public interface Target extends NamedEntity {
     /**
      * Maximum length of value of controller attribute
      */
-    int CONTROLLER_ATTRIBUTE_VALUE_SIZE = 32;
+    int CONTROLLER_ATTRIBUTE_VALUE_SIZE = 128;
 
     /**
      * @return business identifier of the {@link Target}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -44,6 +44,7 @@ import org.eclipse.hawkbit.repository.event.remote.TargetPollEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.CancelTargetAssignmentEvent;
 import org.eclipse.hawkbit.repository.exception.CancelActionNotAllowedException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
+import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributesException;
 import org.eclipse.hawkbit.repository.jpa.builder.JpaActionStatusCreate;
 import org.eclipse.hawkbit.repository.jpa.configuration.Constants;
 import org.eclipse.hawkbit.repository.jpa.executor.AfterTransactionCommitExecutor;
@@ -666,8 +667,7 @@ public class JpaControllerManagement implements ControllerManagement {
          */
         if (data.entrySet().stream()
                 .anyMatch(e -> !JpaControllerManagement.isAttributeEntryValid(e))) {
-            throw new IllegalArgumentException(
-                    "The received controller attributes contain entries which violate the existing length constraints (keys must not exceed 32 characters, values must not exceed 128 characters).");
+            throw new InvalidTargetAttributesException();
         }
 
         final JpaTarget target = (JpaTarget) targetRepository.findByControllerId(controllerId)

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -96,6 +96,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
+import static org.eclipse.hawkbit.repository.model.Target.CONTROLLER_ATTRIBUTE_KEY_SIZE;
+import static org.eclipse.hawkbit.repository.model.Target.CONTROLLER_ATTRIBUTE_VALUE_SIZE;
+
 /**
  * JPA based {@link ControllerManagement} implementation.
  *
@@ -659,7 +662,7 @@ public class JpaControllerManagement implements ControllerManagement {
             final UpdateMode mode) {
 
         /*
-            Constraint is not validated by EclipseLink. Therefore, constraints have to be checked here.
+            Constraints on attribute keys & values are not validated by EclipseLink. Hence, they are validated here.
          */
         if (data.entrySet().stream()
                 .anyMatch(e -> !JpaControllerManagement.isAttributeEntryValid(e))) {
@@ -700,18 +703,15 @@ public class JpaControllerManagement implements ControllerManagement {
     }
 
     private static boolean isAttributeEntryValid(final Map.Entry<String, String> e) {
-        if (e == null) {
-            return true;
-        }
         return isAttributeKeyValid(e.getKey()) && isAttributeValueValid(e.getValue());
     }
 
     private static boolean isAttributeKeyValid(final String key) {
-        return key != null && key.length() <= 32;
+        return key != null && key.length() <= CONTROLLER_ATTRIBUTE_KEY_SIZE;
     }
 
     private static boolean isAttributeValueValid(final String value) {
-        return value == null || value.length() <= 128;
+        return value == null || value.length() <= CONTROLLER_ATTRIBUTE_VALUE_SIZE;
     }
 
     private static void copy(final Map<String, String> src, final Map<String, String> trg) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -666,7 +666,7 @@ public class JpaControllerManagement implements ControllerManagement {
             Constraints on attribute keys & values are not validated by EclipseLink. Hence, they are validated here.
          */
         if (data.entrySet().stream()
-                .anyMatch(e -> !JpaControllerManagement.isAttributeEntryValid(e))) {
+                .anyMatch(e -> !isAttributeEntryValid(e))) {
             throw new InvalidTargetAttributeException();
         }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -44,7 +44,7 @@ import org.eclipse.hawkbit.repository.event.remote.TargetPollEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.CancelTargetAssignmentEvent;
 import org.eclipse.hawkbit.repository.exception.CancelActionNotAllowedException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
-import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributesException;
+import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributeException;
 import org.eclipse.hawkbit.repository.jpa.builder.JpaActionStatusCreate;
 import org.eclipse.hawkbit.repository.jpa.configuration.Constants;
 import org.eclipse.hawkbit.repository.jpa.executor.AfterTransactionCommitExecutor;
@@ -667,7 +667,7 @@ public class JpaControllerManagement implements ControllerManagement {
          */
         if (data.entrySet().stream()
                 .anyMatch(e -> !JpaControllerManagement.isAttributeEntryValid(e))) {
-            throw new InvalidTargetAttributesException();
+            throw new InvalidTargetAttributeException();
         }
 
         final JpaTarget target = (JpaTarget) targetRepository.findByControllerId(controllerId)

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -833,6 +834,39 @@ public class ControllerManagementTest extends AbstractJpaIntegrationTest {
             testData.put(keyPrefix + i, valuePrefix);
         }
         controllerManagement.updateControllerAttributes(controllerId, testData, null);
+    }
+
+    @Test
+    @Description("Checks if invalid values of attribute-key and attribute-value are handled correctly")
+    public void updateTargetAttributesFailsForInvalidAttributes() {
+        final String keyTooLong = "123456789012345678901234567890123";
+        final String keyValid = "12345678901234567890123456789012";
+        final String valueTooLong = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
+        final String valueValid = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678";
+        final String keyNull = null;
+
+        final String controllerId = "targetId123";
+        testdataFactory.createTarget(controllerId);
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
+                        Collections.singletonMap(keyTooLong, valueValid), null))
+                .as("Attribute with key too long should not be created");
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
+                        Collections.singletonMap(keyTooLong, valueTooLong), null))
+                .as("Attribute with key too long and value too long should not be created");
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
+                        Collections.singletonMap(keyValid, valueTooLong), null))
+                .as("Attribute with value too long should not be created");
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
+                        Collections.singletonMap(keyNull, valueValid), null))
+                .as("Attribute with key NULL should not be created");
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
@@ -39,7 +39,7 @@ import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleUpdatedE
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetUpdatedEvent;
 import org.eclipse.hawkbit.repository.exception.CancelActionNotAllowedException;
-import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributesException;
+import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributeException;
 import org.eclipse.hawkbit.repository.exception.QuotaExceededException;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
@@ -849,22 +849,22 @@ public class ControllerManagementTest extends AbstractJpaIntegrationTest {
         final String controllerId = "targetId123";
         testdataFactory.createTarget(controllerId);
 
-        assertThatExceptionOfType(InvalidTargetAttributesException.class)
+        assertThatExceptionOfType(InvalidTargetAttributeException.class)
                 .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
                         Collections.singletonMap(keyTooLong, valueValid), null))
                 .as("Attribute with key too long should not be created");
 
-        assertThatExceptionOfType(InvalidTargetAttributesException.class)
+        assertThatExceptionOfType(InvalidTargetAttributeException.class)
                 .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
                         Collections.singletonMap(keyTooLong, valueTooLong), null))
                 .as("Attribute with key too long and value too long should not be created");
 
-        assertThatExceptionOfType(InvalidTargetAttributesException.class)
+        assertThatExceptionOfType(InvalidTargetAttributeException.class)
                 .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
                         Collections.singletonMap(keyValid, valueTooLong), null))
                 .as("Attribute with value too long should not be created");
 
-        assertThatExceptionOfType(InvalidTargetAttributesException.class)
+        assertThatExceptionOfType(InvalidTargetAttributeException.class)
                 .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
                         Collections.singletonMap(keyNull, valueValid), null))
                 .as("Attribute with key NULL should not be created");

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
@@ -39,6 +39,7 @@ import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleUpdatedE
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetUpdatedEvent;
 import org.eclipse.hawkbit.repository.exception.CancelActionNotAllowedException;
+import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributesException;
 import org.eclipse.hawkbit.repository.exception.QuotaExceededException;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
@@ -848,22 +849,22 @@ public class ControllerManagementTest extends AbstractJpaIntegrationTest {
         final String controllerId = "targetId123";
         testdataFactory.createTarget(controllerId);
 
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatExceptionOfType(InvalidTargetAttributesException.class)
                 .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
                         Collections.singletonMap(keyTooLong, valueValid), null))
                 .as("Attribute with key too long should not be created");
 
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatExceptionOfType(InvalidTargetAttributesException.class)
                 .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
                         Collections.singletonMap(keyTooLong, valueTooLong), null))
                 .as("Attribute with key too long and value too long should not be created");
 
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatExceptionOfType(InvalidTargetAttributesException.class)
                 .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
                         Collections.singletonMap(keyValid, valueTooLong), null))
                 .as("Attribute with value too long should not be created");
 
-        assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatExceptionOfType(InvalidTargetAttributesException.class)
                 .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
                         Collections.singletonMap(keyNull, valueValid), null))
                 .as("Attribute with key NULL should not be created");

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
@@ -495,39 +495,6 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
         }
     }
 
-    @Test
-    @Description("Checks if vales of attribute-key and attribute-value are handled correctly")
-    public void createTargetAttributes() {
-        final String keyTooLong = "123456789012345678901234567890123";
-        final String keyValid = "12345678901234567890123456789012";
-        final String valueTooLong = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
-        final String valueValid = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678";
-        final String keyNull = null;
-
-        final Target target = targetManagement.create(entityFactory.target().create().controllerId("targetId123"));
-        final String controllerId = target.getControllerId();
-
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
-                        Collections.singletonMap(keyTooLong, valueValid), null))
-                .as("Attribute with key too long should not be created");
-
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
-                        Collections.singletonMap(keyTooLong, valueTooLong), null))
-                .as("Attribute with key too long and value too long should not be created");
-
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
-                        Collections.singletonMap(keyValid, valueTooLong), null))
-                .as("Attribute with value too long should not be created");
-
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> controllerManagement.updateControllerAttributes(controllerId,
-                        Collections.singletonMap(keyNull, valueValid), null))
-                .as("Attribute with key NULL should not be created");
-    }
-
     /**
      * verifies, that all {@link TargetTag} of parameter. NOTE: it's accepted
      * that the target have additional tags assigned to them which are not

--- a/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfigDataTest.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfigDataTest.java
@@ -52,7 +52,6 @@ public class DdiConfigDataTest extends AbstractDDiApiIntegrationTest {
     private static final String KEY_VALID = "12345678901234567890123456789012";
     private static final String VALUE_TOO_LONG = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
     private static final String VALUE_VALID = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678";
-    private static final String KEY_NULLL = null;
 
     @Test
     @Description("We verify that the config data (i.e. device attributes like serial number, hardware revision etc.) "
@@ -102,7 +101,7 @@ public class DdiConfigDataTest extends AbstractDDiApiIntegrationTest {
 
         // initial
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("dsafsdf", "sdsds");
+        attributes.put(KEY_VALID, VALUE_VALID);
 
         mvc.perform(put("/{tenant}/controller/v1/4717/configData", tenantAware.getCurrentTenant())
                 .content(JsonBuilder.configData("", attributes, "closed")).contentType(MediaType.APPLICATION_JSON))

--- a/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfigDataTest.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfigDataTest.java
@@ -18,10 +18,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.hawkbit.exception.SpServerError;
+import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributesException;
 import org.eclipse.hawkbit.repository.exception.QuotaExceededException;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.rest.util.JsonBuilder;
@@ -45,6 +47,12 @@ import ru.yandex.qatools.allure.annotations.Stories;
 @Features("Component Tests - Direct Device Integration API")
 @Stories("Config Data Resource")
 public class DdiConfigDataTest extends AbstractDDiApiIntegrationTest {
+
+    private static final String KEY_TOO_LONG = "123456789012345678901234567890123";
+    private static final String KEY_VALID = "12345678901234567890123456789012";
+    private static final String VALUE_TOO_LONG = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
+    private static final String VALUE_VALID = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678";
+    private static final String KEY_NULLL = null;
 
     @Test
     @Description("We verify that the config data (i.e. device attributes like serial number, hardware revision etc.) "
@@ -136,7 +144,7 @@ public class DdiConfigDataTest extends AbstractDDiApiIntegrationTest {
 
     @Test
     @Description("We verify that the config data (i.e. device attributes like serial number, hardware revision etc.) "
-            + "resource behaves as exptected in cae of invalid request attempts.")
+            + "resource behaves as expected in case of invalid request attempts.")
     public void badConfigData() throws Exception {
         testdataFactory.createTarget("4712");
 
@@ -167,6 +175,43 @@ public class DdiConfigDataTest extends AbstractDDiApiIntegrationTest {
         mvc.perform(put("/{tenant}/controller/v1/4712/configData", tenantAware.getCurrentTenant())
                 .content("{\"id\": \"51659181\"}").contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @Description("Verifies that invalid config data attributes are handled correctly.")
+    public void putConfigDataWithInvalidAttributes() throws Exception {
+        // create a target
+        final String controllerId = "4718";
+        testdataFactory.createTarget(controllerId);
+        final String configDataPath = "/{tenant}/controller/v1/" + controllerId + "/configData";
+
+        putConfigDataWithKeyTooLong(configDataPath);
+
+        putConfigDataWithValueTooLong(configDataPath);
+    }
+
+    @Step
+    private void putConfigDataWithKeyTooLong(final String configDataPath) throws Exception {
+
+        final Map<String, String> attributes = Collections.singletonMap(KEY_TOO_LONG, VALUE_VALID);
+
+        mvc.perform(put(configDataPath, tenantAware.getCurrentTenant())
+                .content(JsonBuilder.configData("", attributes, "closed")).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.exceptionClass", equalTo(InvalidTargetAttributesException.class.getName())))
+                .andExpect(jsonPath("$.errorCode", equalTo(SpServerError.SP_TARGET_ATTRIBUTES_INVALID.getKey())));
+    }
+
+    @Step
+    private void putConfigDataWithValueTooLong(final String configDataPath) throws Exception {
+
+        final Map<String, String> attributes = Collections.singletonMap(KEY_VALID, VALUE_TOO_LONG);
+
+        mvc.perform(put(configDataPath, tenantAware.getCurrentTenant())
+                .content(JsonBuilder.configData("", attributes, "closed")).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.exceptionClass", equalTo(InvalidTargetAttributesException.class.getName())))
+                .andExpect(jsonPath("$.errorCode", equalTo(SpServerError.SP_TARGET_ATTRIBUTES_INVALID.getKey())));
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfigDataTest.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfigDataTest.java
@@ -185,13 +185,13 @@ public class DdiConfigDataTest extends AbstractDDiApiIntegrationTest {
         testdataFactory.createTarget(controllerId);
         final String configDataPath = "/{tenant}/controller/v1/" + controllerId + "/configData";
 
-        putConfigDataWithKeyTooLong(configDataPath);
+        putAndVerifyConfigDataWithKeyTooLong(configDataPath);
 
-        putConfigDataWithValueTooLong(configDataPath);
+        putAndVerifyConfigDataWithValueTooLong(configDataPath);
     }
 
     @Step
-    private void putConfigDataWithKeyTooLong(final String configDataPath) throws Exception {
+    private void putAndVerifyConfigDataWithKeyTooLong(final String configDataPath) throws Exception {
 
         final Map<String, String> attributes = Collections.singletonMap(KEY_TOO_LONG, VALUE_VALID);
 
@@ -203,7 +203,7 @@ public class DdiConfigDataTest extends AbstractDDiApiIntegrationTest {
     }
 
     @Step
-    private void putConfigDataWithValueTooLong(final String configDataPath) throws Exception {
+    private void putAndVerifyConfigDataWithValueTooLong(final String configDataPath) throws Exception {
 
         final Map<String, String> attributes = Collections.singletonMap(KEY_VALID, VALUE_TOO_LONG);
 

--- a/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfigDataTest.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfigDataTest.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.hawkbit.exception.SpServerError;
-import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributesException;
+import org.eclipse.hawkbit.repository.exception.InvalidTargetAttributeException;
 import org.eclipse.hawkbit.repository.exception.QuotaExceededException;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.rest.util.JsonBuilder;
@@ -198,7 +198,7 @@ public class DdiConfigDataTest extends AbstractDDiApiIntegrationTest {
         mvc.perform(put(configDataPath, tenantAware.getCurrentTenant())
                 .content(JsonBuilder.configData("", attributes, "closed")).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.exceptionClass", equalTo(InvalidTargetAttributesException.class.getName())))
+                .andExpect(jsonPath("$.exceptionClass", equalTo(InvalidTargetAttributeException.class.getName())))
                 .andExpect(jsonPath("$.errorCode", equalTo(SpServerError.SP_TARGET_ATTRIBUTES_INVALID.getKey())));
     }
 
@@ -210,7 +210,7 @@ public class DdiConfigDataTest extends AbstractDDiApiIntegrationTest {
         mvc.perform(put(configDataPath, tenantAware.getCurrentTenant())
                 .content(JsonBuilder.configData("", attributes, "closed")).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.exceptionClass", equalTo(InvalidTargetAttributesException.class.getName())))
+                .andExpect(jsonPath("$.exceptionClass", equalTo(InvalidTargetAttributeException.class.getName())))
                 .andExpect(jsonPath("$.errorCode", equalTo(SpServerError.SP_TARGET_ATTRIBUTES_INVALID.getKey())));
     }
 

--- a/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/exception/ResponseExceptionHandler.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/exception/ResponseExceptionHandler.java
@@ -75,6 +75,7 @@ public class ResponseExceptionHandler {
         ERROR_TO_HTTP_STATUS.put(SpServerError.SP_REPO_OPERATION_NOT_SUPPORTED, HttpStatus.GONE);
         ERROR_TO_HTTP_STATUS.put(SpServerError.SP_REPO_CONCURRENT_MODIFICATION, HttpStatus.CONFLICT);
         ERROR_TO_HTTP_STATUS.put(SpServerError.SP_MAINTENANCE_SCHEDULE_INVALID, HttpStatus.BAD_REQUEST);
+        ERROR_TO_HTTP_STATUS.put(SpServerError.SP_TARGET_ATTRIBUTES_INVALID, HttpStatus.BAD_REQUEST);
 
     }
 


### PR DESCRIPTION
*Rational:* Constraint validation on key & value of a map is currently not
supported by EclipseLink Maven Plugin (2.7.1.1). Therefore, this check has 
to be done by hawkBit. The check is required for both APIs (DMF + DDI).

* remove check in AmqpMessageHandlerService
* add check in JpaControllerManagement
* introduce custom exception for invalid target attributes
* add tests for attribute validation (+ DMF & DDI integration tests)

Signed-off-by: Jeroen Laverman <jeroen.laverman@bosch-si.com>