### PR TITLE
Extend MultipartException Logging

### DIFF
--- a/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/exception/ResponseExceptionHandler.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/exception/ResponseExceptionHandler.java
@@ -200,6 +200,12 @@ public class ResponseExceptionHandler {
 
         final List<Throwable> throwables = ExceptionUtils.getThrowableList(ex);
         final Throwable responseCause = Iterables.getLast(throwables);
+
+        if (responseCause.getMessage().isEmpty()) {
+            LOG.warn("Request {} lead to MultipartException without root cause message:\n{}", request.getRequestURL(),
+                    ex.getStackTrace());
+        }
+
         final ExceptionInfo response = createExceptionInfo(new MultiPartFileUploadException(responseCause));
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }


### PR DESCRIPTION
to log stacktrace for MultipartExceptions with root cause without a message

Signed-off-by: Jeroen Laverman <jeroen.laverman@bosch-si.com>