### PR TITLE
Include attribute values in target search text filter

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -316,7 +316,7 @@ public class JpaTargetManagement implements TargetManagement {
                     .hasInstalledOrAssignedDistributionSet(filterParams.getFilterByDistributionId()));
         }
         if (!StringUtils.isEmpty(filterParams.getFilterBySearchText())) {
-            specList.add(TargetSpecifications.likeIdOrNameOrDescription(filterParams.getFilterBySearchText()));
+            specList.add(TargetSpecifications.likeIdOrNameOrDescriptionOrAttributeValue(filterParams.getFilterBySearchText()));
         }
         if (isHasTagsFilterActive(filterParams)) {
             specList.add(TargetSpecifications.hasTags(filterParams.getFilterByTagNames(),

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
@@ -38,6 +38,7 @@ import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.domain.Specifications;
 
 /**
  * Specifications class for {@link Target}s. The class provides Spring Data JPQL
@@ -165,6 +166,18 @@ public final class TargetSpecifications {
             query.distinct(true);
             return cb.like(cb.lower(attributeMap.value()), searchTextToLower);
         };
+    }
+
+    /**
+     * {@link Specification} for retrieving {@link Target}s by "like
+     * controllerId or like name or like description or like attribute value".
+     *
+     * @param searchText
+     *            to be filtered on
+     * @return the {@link Target} {@link Specification}
+     */
+    public static Specification<JpaTarget> likeIdOrNameOrDescriptionOrAttributeValue(final String searchText) {
+        return Specifications.where(likeIdOrNameOrDescription(searchText)).or(likeAttributeValue(searchText));
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
@@ -18,6 +18,7 @@ import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.SetJoin;
+import javax.persistence.criteria.MapJoin;
 import javax.validation.constraints.NotNull;
 
 import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
@@ -145,6 +146,24 @@ public final class TargetSpecifications {
             return cb.or(cb.like(cb.lower(targetRoot.get(JpaTarget_.controllerId)), searchTextToLower),
                     cb.like(cb.lower(targetRoot.get(JpaTarget_.name)), searchTextToLower),
                     cb.like(cb.lower(targetRoot.get(JpaTarget_.description)), searchTextToLower));
+        };
+    }
+
+    /**
+     * {@link Specification} for retrieving {@link Target}s by "like attribute
+     * value".
+     *
+     * @param searchText
+     *            to be filtered on
+     * @return the {@link Target} {@link Specification}
+     */
+    public static Specification<JpaTarget> likeAttributeValue(final String searchText) {
+        return (targetRoot, query, cb) -> {
+            final String searchTextToLower = searchText.toLowerCase();
+            final MapJoin<JpaTarget, String, String> attributeMap = targetRoot.join(JpaTarget_.controllerAttributes,
+                    JoinType.LEFT);
+            query.distinct(true);
+            return cb.like(cb.lower(attributeMap.value()), searchTextToLower);
         };
     }
 


### PR DESCRIPTION
Most of our devices are registered through plug&play so the majority of useful information is in the controller attributes. This PR also applies the search text filter to the attribute values.