### PR TITLE
Fix JavaDoc syntax errors. Add check to circle build.

### DIFF
--- a/.circleci/run-qa.sh
+++ b/.circleci/run-qa.sh
@@ -12,7 +12,7 @@
 
 # Run SonarQube only for master branch
 if [ $CIRCLE_BRANCH = master ] ; then
-  mvn verify license:check sonar:sonar -Dsonar.login=$SONAR_ACCESS_TOKEN --batch-mode
+  mvn verify license:check javadoc:javadoc sonar:sonar -Dsonar.login=$SONAR_ACCESS_TOKEN --batch-mode
 else
-  mvn verify license:check --batch-mode
+  mvn verify license:check javadoc:javadoc --batch-mode
 fi

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/FieldNameProvider.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/FieldNameProvider.java
@@ -28,17 +28,16 @@ public interface FieldNameProvider {
     String SUB_ATTRIBUTE_SEPERATOR = ".";
 
     /**
-     * @return the string representation of the underlying persistence field
-     *         name e.g. in case of sorting. Never {@code null}.
+     * @return the string representation of the underlying persistence field name
+     *         e.g. in case of sorting. Never {@code null}.
      */
     String getFieldName();
 
     /**
      * Contains the sub entity the given field.
      *
-     * @param propertyField
-     *            the given field
-     * @return <true> contains <false> contains not
+     * @param propertyField the given field
+     * @return true contains <code>false</code> contains not
      */
     default boolean containsSubEntityAttribute(final String propertyField) {
 
@@ -76,7 +75,7 @@ public interface FieldNameProvider {
     /**
      * Is the entity field a {@link Map}.
      *
-     * @return <true> is a map <false> is not a map
+     * @return <code>true</code> is a map false is not a map
      */
     default boolean isMap() {
         return false;

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/FieldNameProvider.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/FieldNameProvider.java
@@ -28,16 +28,17 @@ public interface FieldNameProvider {
     String SUB_ATTRIBUTE_SEPERATOR = ".";
 
     /**
-     * @return the string representation of the underlying persistence field name
-     *         e.g. in case of sorting. Never {@code null}.
+     * @return the string representation of the underlying persistence field
+     *         name e.g. in case of sorting. Never {@code null}.
      */
     String getFieldName();
 
     /**
      * Contains the sub entity the given field.
      *
-     * @param propertyField the given field
-     * @return true contains <code>false</code> contains not
+     * @param propertyField
+     *            the given field
+     * @return <code>true</code> contains <code>false</code> contains not
      */
     default boolean containsSubEntityAttribute(final String propertyField) {
 

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/FieldNameProvider.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/FieldNameProvider.java
@@ -76,7 +76,7 @@ public interface FieldNameProvider {
     /**
      * Is the entity field a {@link Map}.
      *
-     * @return <code>true</code> is a map false is not a map
+     * @return <code>true</code> is a map <code>false</code> is not a map
      */
     default boolean isMap() {
         return false;

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -374,19 +374,19 @@ public interface ControllerManagement {
     /**
      * Retrieves the specified number of messages from action history of the
      * given {@link Action} based on messageCount. Regardless of the value of
-     * messageCount, in order to restrict resource utilization by controllers,
+     * messageCount, in order to restrict resource utilisation by controllers,
      * maximum number of messages that are retrieved from database is limited by
-     * {@link RepositoryConstants#MAX_ACTION_HISTORY_MSG_COUNT}. messageCount <
-     * 0, retrieves the maximum allowed number of action status messages from
-     * history; messageCount = 0, does not retrieve any message; and
-     * messageCount > 0, retrieves the specified number of messages, limited by
-     * maximum allowed number. A controller sends the feedback for an
-     * {@link ActionStatus} as a list of messages; while returning the messages,
-     * even though the messages from multiple {@link ActionStatus} are retrieved
-     * in descending order by the reported time
-     * ({@link ActionStatus#getOccurredAt()}), i.e. latest ActionStatus first,
-     * the sub-ordering of messages from within single {@link ActionStatus} is
-     * unspecified.
+     * {@link RepositoryConstants#MAX_ACTION_HISTORY_MSG_COUNT}. messageCount
+     * less then zero, retrieves the maximum allowed number of action status
+     * messages from history; messageCount equal zero, does not retrieve any
+     * message; and messageCount larger then zero, retrieves the specified
+     * number of messages, limited by maximum allowed number. A controller sends
+     * the feedback for an {@link ActionStatus} as a list of messages; while
+     * returning the messages, even though the messages from multiple
+     * {@link ActionStatus} are retrieved in descending order by the reported
+     * time ({@link ActionStatus#getOccurredAt()}), i.e. latest ActionStatus
+     * first, the sub-ordering of messages from within single
+     * {@link ActionStatus} is unspecified.
      *
      * @param actionId
      *            to be filtered on

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/UnsupportedSoftwareModuleForThisDistributionSetException.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/UnsupportedSoftwareModuleForThisDistributionSetException.java
@@ -16,17 +16,11 @@ import org.eclipse.hawkbit.repository.model.SoftwareModule;
 
 /**
  * Thrown if user tries to add a {@link SoftwareModule} to a
- * {@link DistributionSet} that is not defined by< the
+ * {@link DistributionSet} that is not defined by the
  * {@link DistributionSetType}.
- *
- *
- *
- *
  */
 public class UnsupportedSoftwareModuleForThisDistributionSetException extends AbstractServerRtException {
-    /**
-    *
-    */
+
     private static final long serialVersionUID = 1L;
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/TargetFilterQuery.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/TargetFilterQuery.java
@@ -13,22 +13,22 @@ package org.eclipse.hawkbit.repository.model;
  * 
  * Supported operators.
  * <ul>
- * <li>Equal to : ==</li>
- * <li>Not equal to : !=</li>
- * <li>Less than : =lt= or <</li>
- * <li>Less than or equal to : =le= or <=</li>
- * <li>Greater than operator : =gt= or ></li>
- * <li>Greater than or equal to : =ge= or >=</li>
+ * <li>{@code Equal to : ==}</li>
+ * <li>{@code Not equal to : !=}</li>
+ * <li>{@code Less than : =lt= or <}</li>
+ * <li>{@code Less than or equal to : =le= or <=}</li>
+ * <li>{@code Greater than operator : =gt= or >}</li>
+ * <li>{@code Greater than or equal to : =ge= or >=}</li>
  * </ul>
  * Examples of RSQL expressions in both FIQL-like and alternative notation:
  * <ul>
- * <li>version==2.0.0</li>
- * <li>name==targetId1;description==plugAndPlay</li>
- * <li>name==targetId1 and description==plugAndPlay</li>
- * <li>name==targetId1;description==plugAndPlay</li>
- * <li>name==targetId1 and description==plugAndPlay</li>
- * <li>name==targetId1,description==plugAndPlay,updateStatus==UNKNOWN</li>
- * <li>name==targetId1 or description==plugAndPlay or updateStatus==UNKNOWN</li>
+ * <li>{@code version==2.0.0}</li>
+ * <li>{@code name==targetId1;description==plugAndPlay}</li>
+ * <li>{@code name==targetId1 and description==plugAndPlay}</li>
+ * <li>{@code name==targetId1;description==plugAndPlay}</li>
+ * <li>{@code name==targetId1 and description==plugAndPlay}</li>
+ * <li>{@code name==targetId1,description==plugAndPlay,updateStatus==UNKNOWN}</li>
+ * <li>{@code name==targetId1 or description==plugAndPlay or updateStatus==UNKNOWN}</li>
  * </ul>
  *
  */

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -431,7 +431,7 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
      * @param pageable
      *            page parameters
      * @param rolloutId
-     *            the rollout the actions beglong to
+     *            the rollout the actions belong to
      * @param actionStatus
      *            the status of the actions
      * @return the actions referring a specific rollout an in a specific status

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/EntityInterceptor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/EntityInterceptor.java
@@ -6,77 +6,85 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.hawkbit.repository.model;
+package org.eclipse.hawkbit.repository.jpa;
+
+import javax.persistence.PostLoad;
+import javax.persistence.PostPersist;
+import javax.persistence.PostRemove;
+import javax.persistence.PostUpdate;
+import javax.persistence.PrePersist;
+import javax.persistence.PreRemove;
+import javax.persistence.PreUpdate;
 
 /**
  * Interface for the entity interceptor lifecycle.
  */
 // Exception squid:EmptyStatementUsageCheck - don't want to force users to
-// impelemnt all methods
+// implement all methods
 @SuppressWarnings("squid:EmptyStatementUsageCheck")
 public interface EntityInterceptor {
 
     /**
-     * Callback for the {@link @PrePersist} lifecycle event.
+     * Callback for the {@link PrePersist} lifecycle event.
      * 
      * @param entity
      *            the model entity
      */
     default void prePersist(final Object entity) {
-    };
+    }
 
     /**
-     * Callback for the {@link @PostPersist} lifecycle event.
+     * Callback for the {@link PostPersist} lifecycle event.
      * 
      * @param entity
      *            the model entity
      */
     default void postPersist(final Object entity) {
-    };
+    }
 
     /**
-     * Callback for the {@link @PostRemove} lifecycle event.
+     * Callback for the {@link PostRemove} lifecycle event.
      * 
      * @param entity
      *            the model entity
      */
     default void postRemove(final Object entity) {
-    };
+    }
 
     /**
-     * Callback for the {@link @PreRemove} lifecycle event.
+     * Callback for the {@link PreRemove} lifecycle event.
      * 
      * @param entity
      *            the model entity
      */
     default void preRemove(final Object entity) {
-    };
+    }
 
     /**
-     * Callback for the {@link @PostLoad} lifecycle event.
+     * Callback for the {@link PostLoad} lifecycle event.
      * 
      * @param entity
      *            the model entity
      */
     default void postLoad(final Object entity) {
-    };
+    }
 
     /**
-     * Callback for the {@link @PreUpdate} lifecycle event.
+     * Callback for the {@link PreUpdate} lifecycle event.
      * 
      * @param entity
      *            the model entity
      */
     default void preUpdate(final Object entity) {
-    };
+    }
 
     /**
-     * Callback for the {@link @PostUpdate} lifecycle event.
+     * Callback for the {@link PostUpdate} lifecycle event.
      * 
      * @param entity
      *            the model entity
      */
     default void postUpdate(final Object entity) {
-    };
+    }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/EntityInterceptorListener.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/EntityInterceptorListener.java
@@ -18,8 +18,8 @@ import javax.persistence.PrePersist;
 import javax.persistence.PreRemove;
 import javax.persistence.PreUpdate;
 
+import org.eclipse.hawkbit.repository.jpa.EntityInterceptor;
 import org.eclipse.hawkbit.repository.jpa.model.helper.EntityInterceptorHolder;
-import org.eclipse.hawkbit.repository.model.EntityInterceptor;
 
 /**
  * Entity listener which calls the callback's of all registered entity

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/helper/EntityInterceptorHolder.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/helper/EntityInterceptorHolder.java
@@ -11,7 +11,7 @@ package org.eclipse.hawkbit.repository.jpa.model.helper;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.hawkbit.repository.model.EntityInterceptor;
+import org.eclipse.hawkbit.repository.jpa.EntityInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
@@ -65,21 +65,21 @@ import cz.jirutka.rsql.parser.ast.RSQLVisitor;
  * entities. RSQL parser library: https://github.com/jirutka/rsql-parser
  *
  * <ul>
- * <li>Equal to : ==</li>
- * <li>Not equal to : !=</li>
- * <li>Less than : =lt= or <</li>
- * <li>Less than or equal to : =le= or <=</li>
- * <li>Greater than operator : =gt= or ></li>
- * <li>Greater than or equal to : =ge= or >=</li>
+ * <li>{@code Equal to : ==}</li>
+ * <li>{@code Not equal to : !=}</li>
+ * <li>{@code Less than : =lt= or <}</li>
+ * <li>{@code Less than or equal to : =le= or <=}</li>
+ * <li>{@code Greater than operator : =gt= or >}</li>
+ * <li>{@code Greater than or equal to : =ge= or >=}</li>
  * </ul>
  * <p>
  * Examples of RSQL expressions in both FIQL-like and alternative notation:
  * <ul>
- * <li>version==2.0.0</li>
- * <li>name==targetId1;description==plugAndPlay</li>
- * <li>name==targetId1 and description==plugAndPlay</li>
- * <li>name==targetId1,description==plugAndPlay,updateStatus==UNKNOWN</li>
- * <li>name==targetId1 or description==plugAndPlay or updateStatus==UNKNOWN</li>
+ * <li>{@code version==2.0.0}</li>
+ * <li>{@code name==targetId1;description==plugAndPlay}</li>
+ * <li>{@code name==targetId1 and description==plugAndPlay}</li>
+ * <li>{@code name==targetId1,description==plugAndPlay,updateStatus==UNKNOWN}</li>
+ * <li>{@code name==targetId1 or description==plugAndPlay or updateStatus==UNKNOWN}</li>
  * </ul>
  * <p>
  * There is also a mechanism that allows to refer to known macros that can

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/DistributionSetTypeSpecification.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/DistributionSetTypeSpecification.java
@@ -52,7 +52,7 @@ public final class DistributionSetTypeSpecification {
 
     /**
      * {@link Specification} for retrieving {@link DistributionSetType} with
-     * given {@link DistributionSetType#getName())} including fetching the
+     * given {@link DistributionSetType#getName()} including fetching the
      * elements list.
      *
      * @param name

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/model/EntityInterceptorListenerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/model/EntityInterceptorListenerTest.java
@@ -11,8 +11,8 @@ package org.eclipse.hawkbit.repository.jpa.model;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.hawkbit.repository.jpa.AbstractJpaIntegrationTest;
+import org.eclipse.hawkbit.repository.jpa.EntityInterceptor;
 import org.eclipse.hawkbit.repository.jpa.model.helper.EntityInterceptorHolder;
-import org.eclipse.hawkbit.repository.model.EntityInterceptor;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.junit.After;

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/TestdataFactory.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/TestdataFactory.java
@@ -104,19 +104,19 @@ public class TestdataFactory {
     public static final String DS_TYPE_DEFAULT = "test_default_ds_type";
 
     /**
-     * Key of test "os" {@link SoftwareModuleType} -> mandatory firmware in
+     * Key of test "os" {@link SoftwareModuleType} : mandatory firmware in
      * {@link #DS_TYPE_DEFAULT}.
      */
     public static final String SM_TYPE_OS = "os";
 
     /**
-     * Key of test "runtime" {@link SoftwareModuleType} -> optional firmware in
+     * Key of test "runtime" {@link SoftwareModuleType} : optional firmware in
      * {@link #DS_TYPE_DEFAULT}.
      */
     public static final String SM_TYPE_RT = "runtime";
 
     /**
-     * Key of test "application" {@link SoftwareModuleType} -> optional software
+     * Key of test "application" {@link SoftwareModuleType} : optional software
      * in {@link #DS_TYPE_DEFAULT}.
      */
     public static final String SM_TYPE_APP = "application";
@@ -466,9 +466,8 @@ public class TestdataFactory {
         for (int i = 0; i < 3; i++) {
             final String artifactData = "some test data" + i;
             final InputStream stubInputStream = IOUtils.toInputStream(artifactData, Charset.forName("UTF-8"));
-            artifacts.add(
-                    artifactManagement.create(new ArtifactUpload(stubInputStream, moduleId, "filename" + i, false,
-                            artifactData.length())));
+            artifacts.add(artifactManagement.create(
+                    new ArtifactUpload(stubInputStream, moduleId, "filename" + i, false, artifactData.length())));
 
         }
 

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/WithUser.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/WithUser.java
@@ -47,7 +47,7 @@ public @interface WithUser {
     /**
      * Should tenant auto created.
      * 
-     * @return <true> = auto create <false> not create
+     * @return <code>true</code> = auto create <code>false</code> not create
      */
     boolean autoCreateTenant() default true;
 

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/rest/api/DdiRootControllerRestApi.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/rest/api/DdiRootControllerRestApi.java
@@ -143,11 +143,12 @@ public interface DdiRootControllerRestApi {
      *            resource utilization by controllers, maximum number of
      *            messages that are retrieved from database is limited by
      *            {@link RepositoryConstants#MAX_ACTION_HISTORY_MSG_COUNT}.
-     *            actionHistoryMessageCount < 0, retrieves the maximum allowed
-     *            number of action status messages from history;
-     *            actionHistoryMessageCount = 0, does not retrieve any message;
-     *            and actionHistoryMessageCount > 0, retrieves the specified
-     *            number of messages, limited by maximum allowed number.
+     *            actionHistoryMessageCount less then zero, retrieves the
+     *            maximum allowed number of action status messages from history;
+     *            actionHistoryMessageCount equal to zero, does not retrieve any
+     *            message; and actionHistoryMessageCount greater then zero,
+     *            retrieves the specified number of messages, limited by maximum
+     *            allowed number.
      * @param request
      *            the HTTP request injected by spring
      * @return the response

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
@@ -26,12 +26,13 @@ import org.springframework.security.core.GrantedAuthority;
  * </p>
  *
  * <p>
- * The Permissions cover CRUD for two data areas of SP:<br/>
- * <br/>
+ * The Permissions cover CRUD for two data areas:
+ * 
  * XX_Target_CRUD which covers the following entities: {@link Target} entities
- * including metadata, {@link TargetTag}s, {@link TargetRegistrationRule}s<br/>
+ * including metadata, {@link TargetTag}s, {@link TargetRegistrationRule}s
  * XX_Repository CRUD which covers: {@link DistributionSet}s,
- * {@link SoftwareModule}s, DS Tags<br/>
+ * {@link SoftwareModule}s, DS Tags
+ * </p>
  */
 public final class SpPermission {
 
@@ -179,11 +180,14 @@ public final class SpPermission {
     }
 
     /**
+     * <p>
      * Contains all the spring security evaluation expressions for the
      * {@link PreAuthorize} annotation for method security.
-     * <p/>
+     * </p>
+     * 
+     * <p>
      * Examples:
-     * <p/>
+     * 
      * {@code
      * hasRole([role])   Returns true if the current principal has the specified role.
      * hasAnyRole([role1,role2])  Returns true if the current principal has any of the supplied roles (given as a comma-separated list of strings)
@@ -196,7 +200,7 @@ public final class SpPermission {
      * isAuthenticated() Returns true if the user is not anonymous
      * isFullyAuthenticated()  Returns true if the user is not an anonymous or a remember-me user
      * }
-     *
+     * </p>
      */
     public static final class SpringEvalExpressions {
         /*

--- a/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthenticationFilter.java
+++ b/hawkbit-security-integration/src/main/java/org/eclipse/hawkbit/security/PreAuthenticationFilter.java
@@ -22,17 +22,15 @@ public interface PreAuthenticationFilter {
     /**
      * Check if the filter is enabled.
      *
-     * @param secruityToken
-     *            the secruity info
-     * @return <true> is enabled <false> diabled
+     * @param secruityToken the secruity info
+     * @return <code>true</code> is enabled <code>false</code> diabled
      */
     boolean isEnable(DmfTenantSecurityToken secruityToken);
 
     /**
      * Extract the principal information from the current secruityToken.
      *
-     * @param secruityToken
-     *            the secruityToken
+     * @param secruityToken the secruityToken
      * @return the extracted tenant and controller id
      */
     HeaderAuthentication getPreAuthenticatedPrincipal(DmfTenantSecurityToken secruityToken);
@@ -40,18 +38,16 @@ public interface PreAuthenticationFilter {
     /**
      * Extract the principal credentials from the current secruityToken.
      *
-     * @param secruityToken
-     *            the secruityToken
+     * @param secruityToken the secruityToken
      * @return the extracted tenant and controller id
      */
     Object getPreAuthenticatedCredentials(DmfTenantSecurityToken secruityToken);
 
     /**
-     * Allows to add additional authorities to the successful authenticated
-     * token.
+     * Allows to add additional authorities to the successful authenticated token.
      *
-     * @return the authorities granted to the principal, or an empty collection
-     *         if the token has not been authenticated. Never null.
+     * @return the authorities granted to the principal, or an empty collection if
+     *         the token has not been authenticated. Never null.
      * @see Authentication#getAuthorities()
      */
     default Collection<GrantedAuthority> getSuccessfulAuthenticationAuthorities() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/AbstractHawkbitUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/AbstractHawkbitUI.java
@@ -85,7 +85,8 @@ public abstract class AbstractHawkbitUI extends UI implements DetachListener {
 
     protected AbstractHawkbitUI(final EventPushStrategy pushStrategy, final UIEventBus eventBus,
             final SpringViewProvider viewProvider, final ApplicationContext context, final DashboardMenu dashboardMenu,
-            final ErrorView errorview, final NotificationUnreadButton notificationUnreadButton, final UiProperties uiProperties) {
+            final ErrorView errorview, final NotificationUnreadButton notificationUnreadButton,
+            final UiProperties uiProperties) {
         this.pushStrategy = pushStrategy;
         this.eventBus = eventBus;
         this.viewProvider = viewProvider;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/SpPermissionChecker.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/SpPermissionChecker.java
@@ -27,7 +27,7 @@ public class SpPermissionChecker implements Serializable {
     }
 
     /**
-     * Gets the read Target & Dist Permission.
+     * Gets the read Target and repository Permission.
      * 
      * @return TARGET_REPOSITORY_READ boolean value
      */

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
@@ -43,8 +43,6 @@ public class UiProperties implements Serializable {
         this.gravatar = gravatar;
     }
 
-
-
     /**
      * Localization information
      */
@@ -57,7 +55,7 @@ public class UiProperties implements Serializable {
         private String defaultLocal = "en";
 
         /**
-         *  List of available localizations
+         * List of available localizations
          */
         private List<String> availableLocals = Collections.singletonList("en");
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerVaadinUpload.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerVaadinUpload.java
@@ -89,7 +89,7 @@ public class FileTransferHandlerVaadinUpload extends AbstractFileTransferHandler
                         fileUploadId);
                 interruptUploadDueToIllegalFilename();
                 event.getUpload().interruptUpload();
-            }else if (isFileAlreadyContainedInSoftwareModule(fileUploadId, softwareModule)) {
+            } else if (isFileAlreadyContainedInSoftwareModule(fileUploadId, softwareModule)) {
                 LOG.info("File {} already contained in Software Module {}", fileUploadId.getFilename(), softwareModule);
                 interruptUploadDueToDuplicateFile();
                 event.getUpload().interruptUpload();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/colorpicker/ColorPickerHelper.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/colorpicker/ColorPickerHelper.java
@@ -42,7 +42,7 @@ public final class ColorPickerHelper {
     }
 
     /**
-     * Covert RGB code to {@Color}.
+     * Covert RGB code to {@link Color}.
      *
      * @param value
      *            RGB vale

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/AbstractMetadataPopupLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/AbstractMetadataPopupLayout.java
@@ -61,8 +61,7 @@ import com.vaadin.ui.renderers.ClickableRenderer.RendererClickEvent;
  *            M is the metadata
  * 
  */
-public abstract class AbstractMetadataPopupLayout<E extends NamedEntity, M extends MetaData>
-        extends CustomComponent {
+public abstract class AbstractMetadataPopupLayout<E extends NamedEntity, M extends MetaData> extends CustomComponent {
 
     private static final String DELETE_BUTTON = "DELETE_BUTTON";
 
@@ -136,13 +135,13 @@ public abstract class AbstractMetadataPopupLayout<E extends NamedEntity, M exten
      *            entity for which metadata data is displayed
      * @param metaDatakey
      *            metadata key to be selected
-     * @return @link{CommonDialogWindow}
+     * @return {@link CommonDialogWindow}
      */
     public CommonDialogWindow getWindow(final E entity, final String metaDatakey) {
         selectedEntity = entity;
 
-        metadataWindow = new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW)
-                .caption(getMetadataCaption()).content(this).cancelButtonClickListener(event -> onCancel())
+        metadataWindow = new WindowBuilder(SPUIDefinitions.CREATE_UPDATE_WINDOW).caption(getMetadataCaption())
+                .content(this).cancelButtonClickListener(event -> onCancel())
                 .id(UIComponentIdProvider.METADATA_POPUP_ID).layout(mainLayout).i18n(i18n)
                 .saveDialogCloseListener(new SaveOnDialogCloseListener()).buildCommonDialogWindow();
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
@@ -570,7 +570,8 @@ public class CommonDialogWindow extends Window {
         }
 
         /**
-         * Saves/Updates action. Is called if canWindowSaveOrUpdate is true.
+         * Saves/Updates action. Is called if canWindowSaveOrUpdate is
+         * <code>true</code>.
          *
          */
         void saveOrUpdate();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
@@ -103,13 +103,20 @@ public class CommonDialogWindow extends Window {
     /**
      * Constructor.
      *
-     * @param caption                   the caption
-     * @param content                   the content
-     * @param helpLink                  the helpLinks
-     * @param closeListener             the saveDialogCloseListener
-     * @param cancelButtonClickListener the cancelButtonClickListener
-     * @param layout                    the abstract layout
-     * @param i18n                      the i18n service
+     * @param caption
+     *            the caption
+     * @param content
+     *            the content
+     * @param helpLink
+     *            the helpLinks
+     * @param closeListener
+     *            the saveDialogCloseListener
+     * @param cancelButtonClickListener
+     *            the cancelButtonClickListener
+     * @param layout
+     *            the abstract layout
+     * @param i18n
+     *            the i18n service
      */
     public CommonDialogWindow(final String caption, final Component content, final String helpLink,
             final SaveDialogCloseListener closeListener, final ClickListener cancelButtonClickListener,
@@ -223,7 +230,8 @@ public class CommonDialogWindow extends Window {
     }
 
     /**
-     * saves the original values in a Map so we can use them for detecting changes
+     * saves the original values in a Map so we can use them for detecting
+     * changes
      */
     public final void setOrginaleValues() {
         for (final AbstractField<?> field : allComponents) {
@@ -515,7 +523,8 @@ public class CommonDialogWindow extends Window {
      * ValueChangeListener to it. Necessary in Update Distribution Type as the
      * CheckBox concerned is an ItemProperty...
      *
-     * @param component AbstractField
+     * @param component
+     *            AbstractField
      */
     public void updateAllComponents(final AbstractField<?> component) {
 
@@ -536,8 +545,8 @@ public class CommonDialogWindow extends Window {
     }
 
     /**
-     * Check if the safe action can executed. After a the save action the listener
-     * checks if the dialog can closed.
+     * Check if the safe action can executed. After a the save action the
+     * listener checks if the dialog can closed.
      *
      */
     public interface SaveDialogCloseListener {
@@ -545,16 +554,16 @@ public class CommonDialogWindow extends Window {
         /**
          * Checks if the safe action can executed.
          *
-         * @return <code>true</code> = save action can executed <code>false</code> =
-         *         cannot execute safe action .
+         * @return <code>true</code> = save action can executed
+         *         <code>false</code> = cannot execute safe action .
          */
         boolean canWindowSaveOrUpdate();
 
         /**
          * Checks if the window can closed after the safe action is executed
          *
-         * @return <code>true</code> = window will close <code>false</code> = will not
-         *         closed.
+         * @return <code>true</code> = window will close <code>false</code> =
+         *         will not closed.
          */
         default boolean canWindowClose() {
             return true;
@@ -568,10 +577,11 @@ public class CommonDialogWindow extends Window {
     }
 
     /**
-     * Updates the field allComponents. All components existing on the given layout
-     * are added to the list of allComponents
+     * Updates the field allComponents. All components existing on the given
+     * layout are added to the list of allComponents
      *
-     * @param layout AbstractLayout
+     * @param layout
+     *            AbstractLayout
      */
     public void updateAllComponents(final AbstractLayout layout) {
         allComponents = getAllComponents(layout);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/CommonDialogWindow.java
@@ -103,20 +103,13 @@ public class CommonDialogWindow extends Window {
     /**
      * Constructor.
      *
-     * @param caption
-     *            the caption
-     * @param content
-     *            the content
-     * @param helpLink
-     *            the helpLinks
-     * @param closeListener
-     *            the saveDialogCloseListener
-     * @param cancelButtonClickListener
-     *            the cancelButtonClickListener
-     * @param layout
-     *            the abstract layout
-     * @param i18n
-     *            the i18n service
+     * @param caption                   the caption
+     * @param content                   the content
+     * @param helpLink                  the helpLinks
+     * @param closeListener             the saveDialogCloseListener
+     * @param cancelButtonClickListener the cancelButtonClickListener
+     * @param layout                    the abstract layout
+     * @param i18n                      the i18n service
      */
     public CommonDialogWindow(final String caption, final Component content, final String helpLink,
             final SaveDialogCloseListener closeListener, final ClickListener cancelButtonClickListener,
@@ -230,8 +223,7 @@ public class CommonDialogWindow extends Window {
     }
 
     /**
-     * saves the original values in a Map so we can use them for detecting
-     * changes
+     * saves the original values in a Map so we can use them for detecting changes
      */
     public final void setOrginaleValues() {
         for (final AbstractField<?> field : allComponents) {
@@ -523,8 +515,7 @@ public class CommonDialogWindow extends Window {
      * ValueChangeListener to it. Necessary in Update Distribution Type as the
      * CheckBox concerned is an ItemProperty...
      *
-     * @param component
-     *            AbstractField
+     * @param component AbstractField
      */
     public void updateAllComponents(final AbstractField<?> component) {
 
@@ -545,8 +536,8 @@ public class CommonDialogWindow extends Window {
     }
 
     /**
-     * Check if the safe action can executed. After a the save action the
-     * listener checks if the dialog can closed.
+     * Check if the safe action can executed. After a the save action the listener
+     * checks if the dialog can closed.
      *
      */
     public interface SaveDialogCloseListener {
@@ -554,33 +545,33 @@ public class CommonDialogWindow extends Window {
         /**
          * Checks if the safe action can executed.
          *
-         * @return <true> = save action can executed <false> = cannot execute
-         *         safe action .
+         * @return <code>true</code> = save action can executed <code>false</code> =
+         *         cannot execute safe action .
          */
         boolean canWindowSaveOrUpdate();
 
         /**
          * Checks if the window can closed after the safe action is executed
          *
-         * @return <true> = window will close <false> = will not closed.
+         * @return <code>true</code> = window will close <code>false</code> = will not
+         *         closed.
          */
         default boolean canWindowClose() {
             return true;
         }
 
         /**
-         * Saves/Updates action. Is called if canWindowSaveOrUpdate is <true>.
+         * Saves/Updates action. Is called if canWindowSaveOrUpdate is true.
          *
          */
         void saveOrUpdate();
     }
 
     /**
-     * Updates the field allComponents. All components existing on the given
-     * layout are added to the list of allComponents
+     * Updates the field allComponents. All components existing on the given layout
+     * are added to the list of allComponents
      *
-     * @param layout
-     *            AbstractLayout
+     * @param layout AbstractLayout
      */
     public void updateAllComponents(final AbstractLayout layout) {
         allComponents = getAllComponents(layout);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/UserDetailsFormatter.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/UserDetailsFormatter.java
@@ -37,9 +37,8 @@ public final class UserDetailsFormatter {
 
     /**
      * Load user details by the user name and format the user name to max 100
-     * characters.
-     * 
-     * @see {@link UserDetailsFormatter#loadAndFormatUsername(String, int)}
+     * characters. See
+     * {@link UserDetailsFormatter#loadAndFormatUsername(String, int)}.
      * 
      * @param username
      *            the user name

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/TargetMetadataDetailsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/TargetMetadataDetailsLayout.java
@@ -44,8 +44,7 @@ public class TargetMetadataDetailsLayout extends AbstractMetadataDetailsLayout {
      * @param targetMetadataPopupLayout
      *            the target metadata popup layout
      */
-    public TargetMetadataDetailsLayout(final VaadinMessageSource i18n,
-            final TargetManagement targetManagement,
+    public TargetMetadataDetailsLayout(final VaadinMessageSource i18n, final TargetManagement targetManagement,
             final TargetMetadataPopupLayout targetMetadataPopupLayout) {
         super(i18n);
         this.targetManagement = targetManagement;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/AbstractGrid.java
@@ -291,53 +291,53 @@ public abstract class AbstractGrid<T extends Indexed> extends Grid implements Re
     }
 
     /**
-     * Template method invoked by {@link this#addNewContainerDS()} for creating
-     * a container instance.
+     * Template method invoked by {@link #addNewContainerDS()} for creating a
+     * container instance.
      *
      * @return new container instance used by the grid.
      */
     protected abstract T createContainer();
 
     /**
-     * Template method invoked by {@link this#addNewContainerDS()} for adding
+     * Template method invoked by {@link #addNewContainerDS()} for adding
      * properties to the container (usually by invoking { @link
      * Container#addContainerProperty(Object, Class, Object))})
      */
     protected abstract void addContainerProperties();
 
     /**
-     * Template method invoked by {@link this#addNewContainerDS()} for setting
-     * the expand ratio of the columns.
+     * Template method invoked by {@link #addNewContainerDS()} for setting the
+     * expand ratio of the columns.
      */
     protected abstract void setColumnExpandRatio();
 
     /**
-     * Template method invoked by {@link this#addNewContainerDS()} for setting
-     * the column names.
+     * Template method invoked by {@link #addNewContainerDS()} for setting the
+     * column names.
      */
     protected abstract void setColumnHeaderNames();
 
     /**
-     * Template method invoked by {@link this#addNewContainerDS()} for setting
-     * the column properties to the grid.
+     * Template method invoked by {@link #addNewContainerDS()} for setting the
+     * column properties to the grid.
      */
     protected abstract void setColumnProperties();
 
     /**
-     * Template method invoked by {@link this#addNewContainerDS()} for adding
+     * Template method invoked by {@link #addNewContainerDS()} for adding
      * special column renderers if needed.
      */
     protected abstract void addColumnRenderes();
 
     /**
-     * Template method invoked by {@link this#addNewContainerDS()} that hides
-     * columns. If a column is hidable and hidden, it can be made visible via
+     * Template method invoked by {@link #addNewContainerDS()} that hides
+     * columns. If a column is hideable and hidden, it can be made visible via
      * grid column menu.
      */
     protected abstract void setHiddenColumns();
 
     /**
-     * Template method invoked by {@link this#addNewContainerDS()} for adding a
+     * Template method invoked by {@link #addNewContainerDS()} for adding a
      * CellDescriptionGenerator to the grid.
      */
     protected abstract CellDescriptionGenerator getDescriptionGenerator();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPUIComponentProvider.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/components/SPUIComponentProvider.java
@@ -236,8 +236,8 @@ public final class SPUIComponentProvider {
     }
 
     /**
-     * Create label which represents the
-     * {@link BaseEntity#getLastModifiedBy()()} by user name
+     * Create label which represents the {@link BaseEntity#getLastModifiedBy()}
+     * by user name
      *
      * @param i18n
      *            the i18n

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
@@ -244,9 +244,8 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
             }
             assignSoftwareModulesToDs(softwareModules, ds);
 
-            openConfirmationWindowForAssignment(ds.getName(),
-                    softwareModules.stream().map(SoftwareModuleIdName::new)
-                            .toArray(size -> new SoftwareModuleIdName[size]));
+            openConfirmationWindowForAssignment(ds.getName(), softwareModules.stream().map(SoftwareModuleIdName::new)
+                    .toArray(size -> new SoftwareModuleIdName[size]));
         });
     }
 
@@ -256,7 +255,7 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         for (final Long softwareModuleId : softwareModulesIds) {
             final Optional<SoftwareModule> softwareModule = softwareModuleManagement.get(softwareModuleId);
             softwareModule.ifPresent(sm -> {
-                if (validateAssignment(sm, distributionSet)){
+                if (validateAssignment(sm, distributionSet)) {
                     assignableModules.add(sm);
                 }
             });
@@ -269,15 +268,13 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         addSoftwareModulesToConsolidatedDsAssignmentMap(distributionSet, softwareModules);
 
         final Set<SoftwareModuleIdName> softwareModulesThatNeedToBeAssigned = new HashSet<>();
-        getConsolidatedAssignmentMap(distributionSet).values()
-                .forEach(softwareModulesThatNeedToBeAssigned::addAll);
+        getConsolidatedAssignmentMap(distributionSet).values().forEach(softwareModulesThatNeedToBeAssigned::addAll);
 
         manageDistUIState.getAssignedList().put(new DistributionSetIdName(distributionSet),
                 softwareModulesThatNeedToBeAssigned);
     }
 
-    private Map<Long, Set<SoftwareModuleIdName>> getConsolidatedAssignmentMap(
-            final DistributionSet distributionSet) {
+    private Map<Long, Set<SoftwareModuleIdName>> getConsolidatedAssignmentMap(final DistributionSet distributionSet) {
         final DistributionSetIdName distributionSetIdName = new DistributionSetIdName(distributionSet);
         final Map<Long, Set<SoftwareModuleIdName>> map;
         if (manageDistUIState.getConsolidatedDistSoftwareList().containsKey(distributionSetIdName)) {
@@ -358,8 +355,8 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         });
 
         int count = 0;
-        for (final Entry<DistributionSetIdName, Set<SoftwareModuleIdName>> entry : manageDistUIState
-                .getAssignedList().entrySet()) {
+        for (final Entry<DistributionSetIdName, Set<SoftwareModuleIdName>> entry : manageDistUIState.getAssignedList()
+                .entrySet()) {
             count += entry.getValue().size();
         }
 
@@ -378,7 +375,6 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         manageDistUIState.getConsolidatedDistSoftwareList().clear();
     }
 
-
     private boolean validateAssignment(final SoftwareModule sm, final DistributionSet ds) {
         final String dsNameAndVersion = HawkbitCommonUtil.concatStrings(":", ds.getName(), ds.getVersion());
         final String smNameAndVersion = HawkbitCommonUtil.concatStrings(":", sm.getName(), sm.getVersion());
@@ -388,17 +384,15 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         if (sm.getType().getMaxAssignments() < 1) {
             return false;
         }
-        if (targetManagement.countByFilters(null, null, null, ds.getId(), Boolean.FALSE,
-                new String[] {}) > 0) {
+        if (targetManagement.countByFilters(null, null, null, ds.getId(), Boolean.FALSE, new String[] {}) > 0) {
             /* Distribution is already assigned */
-            getNotification().displayValidationError(getI18n().getMessage("message.dist.inuse",
-                    dsNameAndVersion));
+            getNotification().displayValidationError(getI18n().getMessage("message.dist.inuse", dsNameAndVersion));
             return false;
         }
         if (ds.getModules().contains(sm)) {
             /* Already has software module */
-            getNotification().displayValidationError(getI18n().getMessage("message.software.dist.already.assigned",
-                    smNameAndVersion, dsNameAndVersion));
+            getNotification().displayValidationError(
+                    getI18n().getMessage("message.software.dist.already.assigned", smNameAndVersion, dsNameAndVersion));
             return false;
         }
         if (!ds.getType().containsModuleType(sm.getType())) {
@@ -408,17 +402,16 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
             return false;
         }
         if (distributionSetManagement.isInUse(ds.getId())) {
-            getNotification()
-                    .displayValidationError(getI18n().getMessage("message.error.notification.ds.target.assigned",
-                            ds.getName(), ds.getVersion()));
+            getNotification().displayValidationError(getI18n()
+                    .getMessage("message.error.notification.ds.target.assigned", ds.getName(), ds.getVersion()));
             return false;
         }
         return true;
     }
 
     private boolean isSoftwareModuleDragged(final Long distId, final SoftwareModule sm) {
-        for (final Entry<DistributionSetIdName, Set<SoftwareModuleIdName>> entry : manageDistUIState
-                .getAssignedList().entrySet()) {
+        for (final Entry<DistributionSetIdName, Set<SoftwareModuleIdName>> entry : manageDistUIState.getAssignedList()
+                .entrySet()) {
             if (!distId.equals(entry.getKey().getId())) {
                 continue;
             }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwMetadataPopupLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/smtable/SwMetadataPopupLayout.java
@@ -32,7 +32,8 @@ import com.vaadin.ui.VerticalLayout;
 /**
  * Pop up layout to display software module metadata.
  */
-public class SwMetadataPopupLayout extends AbstractMetadataPopupLayoutVersioned<SoftwareModule, SoftwareModuleMetadata> {
+public class SwMetadataPopupLayout
+        extends AbstractMetadataPopupLayoutVersioned<SoftwareModule, SoftwareModuleMetadata> {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CreateOrUpdateFilterHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CreateOrUpdateFilterHeader.java
@@ -186,7 +186,8 @@ public class CreateOrUpdateFilterHeader extends VerticalLayout implements Button
         saveButton = createSaveButton();
         searchIcon = createSearchIcon();
 
-        helpLink = SPUIComponentProvider.getHelpLink(i18n, uiProperties.getLinks().getDocumentation().getTargetfilterView());
+        helpLink = SPUIComponentProvider.getHelpLink(i18n,
+                uiProperties.getLinks().getDocumentation().getTargetfilterView());
 
         closeIcon = createSearchResetIcon();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBulkUpdateWindowLayout.java
@@ -144,8 +144,8 @@ public class TargetBulkUpdateWindowLayout extends CustomComponent {
         progressBar = creatreProgressBar();
         targetsCountLabel = getStatusCountLabel();
         bulkUploader = getBulkUploadHandler();
-        linkToSystemConfigHelp = SPUIComponentProvider
-                .getHelpLink(i18n, uiproperties.getLinks().getDocumentation().getDeploymentView());
+        linkToSystemConfigHelp = SPUIComponentProvider.getHelpLink(i18n,
+                uiproperties.getLinks().getDocumentation().getDeploymentView());
         windowCaption = new Label(i18n.getMessage("caption.bulk.upload.targets"));
         minimizeButton = getMinimizeButton();
         closeButton = getCloseButton();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
@@ -57,7 +57,7 @@ public class TargetDetails extends AbstractTableDetailsLayout<Target> {
     private static final long serialVersionUID = 1L;
 
     private final TargetTagToken targetTagToken;
-    
+
     private final TargetMetadataDetailsLayout targetMetadataTable;
 
     private final TargetAddUpdateWindowLayout targetAddUpdateWindowLayout;
@@ -84,14 +84,12 @@ public class TargetDetails extends AbstractTableDetailsLayout<Target> {
         this.targetTagToken = new TargetTagToken(permissionChecker, i18n, uiNotification, eventBus, managementUIState,
                 tagManagement, targetManagement);
         this.targetAddUpdateWindowLayout = new TargetAddUpdateWindowLayout(i18n, targetManagement, eventBus,
-                uiNotification,
-                entityFactory, targetTable);
+                uiNotification, entityFactory, targetTable);
         this.uiNotification = uiNotification;
         this.targetManagement = targetManagement;
         this.deploymentManagement = deploymentManagement;
         this.targetMetadataPopupLayout = targetMetadataPopupLayout;
-        this.targetMetadataTable = new TargetMetadataDetailsLayout(i18n, targetManagement,
-                targetMetadataPopupLayout);
+        this.targetMetadataTable = new TargetMetadataDetailsLayout(i18n, targetManagement, targetMetadataPopupLayout);
         addDetailsTab();
         restoreState();
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetMetadataPopupLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetMetadataPopupLayout.java
@@ -49,10 +49,8 @@ public class TargetMetadataPopupLayout extends AbstractMetadataPopupLayout<Targe
 
     @Override
     protected MetaData createMetadata(final Target entity, final String key, final String value) {
-        final TargetMetadata metaData = targetManagement
-                .createMetaData(entity.getControllerId(),
-                        Collections.singletonList(entityFactory.generateTargetMetadata(key, value)))
-                .get(0);
+        final TargetMetadata metaData = targetManagement.createMetaData(entity.getControllerId(),
+                Collections.singletonList(entityFactory.generateTargetMetadata(key, value))).get(0);
         setSelectedEntity(metaData.getTarget());
         return metaData;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableLayout.java
@@ -51,7 +51,8 @@ public class TargetTableLayout extends AbstractTableLayout<TargetTable> {
                 eventBus, targetManagement, entityFactory, permissionChecker);
         this.eventBus = eventBus;
         this.targetDetails = new TargetDetails(i18n, eventBus, permissionChecker, managementUIState, uiNotification,
-                tagManagement, targetManagement, targetMetadataPopupLayout, deploymentManagement, entityFactory, targetTable);
+                tagManagement, targetManagement, targetMetadataPopupLayout, deploymentManagement, entityFactory,
+                targetTable);
         this.targetTableHeader = new TargetTableHeader(i18n, permissionChecker, eventBus, uiNotification,
                 managementUIState, managementViewClientCriterion, targetManagement, deploymentManagement, uiProperties,
                 entityFactory, uiNotification, tagManagement, distributionSetManagement, uiExecutor, targetTable);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
@@ -255,13 +255,11 @@ public final class DashboardMenu extends CustomComponent {
     }
 
     /**
-     * Creates the wrapper which contains the menu item and the adjacent label
-     * for displaying the occurred events
+     * Creates the wrapper which contains the menu item and the adjacent label for
+     * displaying the occurred events
      * 
-     * @param menuItemButton
-     *            the menu item
-     * @param notificationLabel
-     *            the label for displaying the occurred events
+     * @param menuItemButton    the menu item
+     * @param notificationLabel the label for displaying the occurred events
      * @return Component of type CssLayout
      */
     private static Component buildLabelWrapper(final ValoMenuItemButton menuItemButton,
@@ -281,8 +279,8 @@ public final class DashboardMenu extends CustomComponent {
      * Returns all views which are currently accessible by the current logged in
      * user.
      *
-     * @return a list of all views which are currently visible and accessible
-     *         for the current logged in user
+     * @return a list of all views which are currently visible and accessible for
+     *         the current logged in user
      */
     private List<DashboardMenuItem> getAccessibleViews() {
         return this.dashboardVaadinViews.stream()
@@ -310,19 +308,18 @@ public final class DashboardMenu extends CustomComponent {
     /**
      * Is a View available.
      *
-     * @return the accessibleViewsEmpty <true> no rights for any view <false> a
-     *         view is available
+     * @return the accessibleViewsEmpty <code>true</code> no rights for any view
+     *         <code>false</code> a view is available
      */
     public boolean isAccessibleViewsEmpty() {
         return accessibleViewsEmpty;
     }
 
     /**
-     * notifies the dashboard that the view has been changed and the button
-     * needs to be re-styled.
+     * notifies the dashboard that the view has been changed and the button needs to
+     * be re-styled.
      *
-     * @param event
-     *            the post view change event
+     * @param event the post view change event
      */
     public void postViewChange(final PostViewChangeEvent event) {
         menuButtons.forEach(button -> button.postViewChange(event));
@@ -331,10 +328,9 @@ public final class DashboardMenu extends CustomComponent {
     /**
      * Returns the dashboard view type by a given view name.
      *
-     * @param viewName
-     *            the name of the view to retrieve
-     * @return the dashboard view for a given viewname or {@code null} if view
-     *         with given viewname does not exists
+     * @param viewName the name of the view to retrieve
+     * @return the dashboard view for a given viewname or {@code null} if view with
+     *         given viewname does not exists
      */
     public DashboardMenuItem getByViewName(final String viewName) {
         final Optional<DashboardMenuItem> findFirst = dashboardVaadinViews.stream()
@@ -350,9 +346,8 @@ public final class DashboardMenu extends CustomComponent {
     /**
      * Is the given view accessible.
      *
-     * @param viewName
-     *            the view name
-     * @return <true> = denied, <false> = accessible
+     * @param viewName the view name
+     * @return <code>true</code> = denied, <code>false</code> = accessible
      */
     public boolean isAccessDenied(final String viewName) {
         final List<DashboardMenuItem> accessibleViews = getAccessibleViews();
@@ -392,11 +387,9 @@ public final class DashboardMenu extends CustomComponent {
         private final DashboardMenuItem view;
 
         /**
-         * creates a new button in case of pressed switches to the given
-         * {@code view}.
+         * creates a new button in case of pressed switches to the given {@code view}.
          *
-         * @param view
-         *            the view to switch to in case the button is pressed
+         * @param view the view to switch to in case the button is pressed
          */
         public ValoMenuItemButton(final DashboardMenuItem view) {
             this.view = view;
@@ -413,8 +406,7 @@ public final class DashboardMenu extends CustomComponent {
         /**
          * notifies the button to change his style.
          *
-         * @param event
-         *            the post view change event
+         * @param event the post view change event
          */
         public void postViewChange(final PostViewChangeEvent event) {
             removeStyleName(STYLE_SELECTED);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
@@ -255,11 +255,13 @@ public final class DashboardMenu extends CustomComponent {
     }
 
     /**
-     * Creates the wrapper which contains the menu item and the adjacent label for
-     * displaying the occurred events
+     * Creates the wrapper which contains the menu item and the adjacent label
+     * for displaying the occurred events
      * 
-     * @param menuItemButton    the menu item
-     * @param notificationLabel the label for displaying the occurred events
+     * @param menuItemButton
+     *            the menu item
+     * @param notificationLabel
+     *            the label for displaying the occurred events
      * @return Component of type CssLayout
      */
     private static Component buildLabelWrapper(final ValoMenuItemButton menuItemButton,
@@ -279,8 +281,8 @@ public final class DashboardMenu extends CustomComponent {
      * Returns all views which are currently accessible by the current logged in
      * user.
      *
-     * @return a list of all views which are currently visible and accessible for
-     *         the current logged in user
+     * @return a list of all views which are currently visible and accessible
+     *         for the current logged in user
      */
     private List<DashboardMenuItem> getAccessibleViews() {
         return this.dashboardVaadinViews.stream()
@@ -316,10 +318,11 @@ public final class DashboardMenu extends CustomComponent {
     }
 
     /**
-     * notifies the dashboard that the view has been changed and the button needs to
-     * be re-styled.
+     * notifies the dashboard that the view has been changed and the button
+     * needs to be re-styled.
      *
-     * @param event the post view change event
+     * @param event
+     *            the post view change event
      */
     public void postViewChange(final PostViewChangeEvent event) {
         menuButtons.forEach(button -> button.postViewChange(event));
@@ -328,9 +331,10 @@ public final class DashboardMenu extends CustomComponent {
     /**
      * Returns the dashboard view type by a given view name.
      *
-     * @param viewName the name of the view to retrieve
-     * @return the dashboard view for a given viewname or {@code null} if view with
-     *         given viewname does not exists
+     * @param viewName
+     *            the name of the view to retrieve
+     * @return the dashboard view for a given viewname or {@code null} if view
+     *         with given viewname does not exists
      */
     public DashboardMenuItem getByViewName(final String viewName) {
         final Optional<DashboardMenuItem> findFirst = dashboardVaadinViews.stream()
@@ -346,7 +350,8 @@ public final class DashboardMenu extends CustomComponent {
     /**
      * Is the given view accessible.
      *
-     * @param viewName the view name
+     * @param viewName
+     *            the view name
      * @return <code>true</code> = denied, <code>false</code> = accessible
      */
     public boolean isAccessDenied(final String viewName) {
@@ -387,9 +392,11 @@ public final class DashboardMenu extends CustomComponent {
         private final DashboardMenuItem view;
 
         /**
-         * creates a new button in case of pressed switches to the given {@code view}.
+         * creates a new button in case of pressed switches to the given
+         * {@code view}.
          *
-         * @param view the view to switch to in case the button is pressed
+         * @param view
+         *            the view to switch to in case the button is pressed
          */
         public ValoMenuItemButton(final DashboardMenuItem view) {
             this.view = view;
@@ -406,7 +413,8 @@ public final class DashboardMenu extends CustomComponent {
         /**
          * notifies the button to change his style.
          *
-         * @param event the post view change event
+         * @param event
+         *            the post view change event
          */
         public void postViewChange(final PostViewChangeEvent event) {
             removeStyleName(STYLE_SELECTED);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
@@ -1107,8 +1107,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
 
     private enum ERROR_THRESHOLD_OPTIONS {
 
-        PERCENT("label.errorthreshold.option.percent"),
-        COUNT("label.errorthreshold.option.count");
+        PERCENT("label.errorthreshold.option.percent"), COUNT("label.errorthreshold.option.count");
 
         private final String value;
 
@@ -1117,7 +1116,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
         }
 
         private String getValue(final VaadinMessageSource i18n) {
-            return  i18n.getMessage(value);
+            return i18n.getMessage(value);
         }
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/AuthenticationConfigurationView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/AuthenticationConfigurationView.java
@@ -128,8 +128,8 @@ public class AuthenticationConfigurationView extends BaseConfigurationView
         gridLayout.addComponent(downloadAnonymousCheckBox, 0, 3);
         gridLayout.addComponent(anonymousDownloadAuthenticationConfigurationItem, 1, 3);
 
-        final Link linkToSecurityHelp = SPUIComponentProvider
-                .getHelpLink(i18n, uiProperties.getLinks().getDocumentation().getSecurity());
+        final Link linkToSecurityHelp = SPUIComponentProvider.getHelpLink(i18n,
+                uiProperties.getLinks().getDocumentation().getSecurity());
         gridLayout.addComponent(linkToSecurityHelp, 2, 3);
         gridLayout.setComponentAlignment(linkToSecurityHelp, Alignment.BOTTOM_RIGHT);
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/RolloutConfigurationView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/RolloutConfigurationView.java
@@ -73,8 +73,8 @@ public class RolloutConfigurationView extends BaseConfigurationView
         hLayout.addComponent(approvalCheckbox);
         hLayout.addComponent(approvalConfigurationItem);
 
-        final Link linkToApprovalHelp = SPUIComponentProvider
-                .getHelpLink(i18n, uiProperties.getLinks().getDocumentation().getRollout());
+        final Link linkToApprovalHelp = SPUIComponentProvider.getHelpLink(i18n,
+                uiProperties.getLinks().getDocumentation().getRollout());
         hLayout.addComponent(linkToApprovalHelp);
         hLayout.setComponentAlignment(linkToApprovalHelp, Alignment.BOTTOM_RIGHT);
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/TenantConfigurationDashboardView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/TenantConfigurationDashboardView.java
@@ -153,8 +153,8 @@ public class TenantConfigurationDashboardView extends CustomComponent implements
         undoConfigurationBtn.addClickListener(event -> undoConfiguration());
         hlayout.addComponent(undoConfigurationBtn);
 
-        final Link linkToSystemConfigHelp = SPUIComponentProvider
-                .getHelpLink(i18n, uiProperties.getLinks().getDocumentation().getSystemConfigurationView());
+        final Link linkToSystemConfigHelp = SPUIComponentProvider.getHelpLink(i18n,
+                uiProperties.getLinks().getDocumentation().getSystemConfigurationView());
         hlayout.addComponent(linkToSystemConfigHelp);
 
         return hlayout;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/polling/DurationField.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/polling/DurationField.java
@@ -143,7 +143,7 @@ public class DurationField extends DateField {
      * Sets the duration value
      * 
      * @param duration
-     *            duration, only values <= 23:59:59 are excepted
+     *            duration, only values less then 23:59:59 are excepted
      */
     public void setDuration(@NotNull final Duration duration) {
         if (duration.compareTo(MAXIMUM_DURATION) > 0) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUILabelDefinitions.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUILabelDefinitions.java
@@ -134,7 +134,7 @@ public final class SPUILabelDefinitions {
      */
     public static final String AUTO_ASSIGN_DISTRIBUTION_SET = "autoAssignDistributionSet";
     /**
-     * ASSIGNED DISTRIBUTION Name & Version.
+     * ASSIGNED DISTRIBUTION Name and Version.
      */
     public static final String ASSIGNED_DISTRIBUTION_NAME_VER = "assignedDistNameVersion";
 
@@ -144,7 +144,7 @@ public final class SPUILabelDefinitions {
     public static final String INSTALLED_DISTRIBUTION_ID = "installedDistributionSet.id";
 
     /**
-     * INSTALLED DISTRIBUTION Name & Version.
+     * INSTALLED DISTRIBUTION Name and Version.
      */
     public static final String INSTALLED_DISTRIBUTION_NAME_VER = "installedDistNameVersion";
 

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
       <cron-utils.version>5.0.5</cron-utils.version>
       <jsoup.version>1.8.3</jsoup.version>
       <allure.version>2.7.0</allure.version>
-      <eclipselink.version>2.7.3</eclipselink.version>
+      <eclipselink.version>2.7.4</eclipselink.version>
       <gwtmockito.version>1.1.8</gwtmockito.version>
       <pl.pragmatists.version>1.0.2</pl.pragmatists.version>
       <guava.version>25.0-jre</guava.version>
@@ -303,6 +303,14 @@
       <pluginManagement>
          <plugins>
             <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-javadoc-plugin</artifactId>
+               <configuration>
+                  <doclint>syntax</doclint>
+               </configuration>
+            </plugin>
+
+            <plugin>
                <groupId>com.mycila</groupId>
                <artifactId>license-maven-plugin</artifactId>
                <version>2.11</version>
@@ -313,7 +321,7 @@
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_SIEMENS_18.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_MICROSOFT_18.txt</validHeader>
-                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_18.txt</validHeader>
+                     <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_18.txt</validHeader>
                   </validHeaders>
                   <excludes>
                      <exclude>**/README</exclude>
@@ -490,11 +498,15 @@
          <build>
             <plugins>
                <plugin>
-                  <!-- Use the Nexus Staging plugin as a full replacement for the standard Maven Deploy plugin. See https://github.com/sonatype/nexus-maven-plugins/tree/master/staging/maven-plugin
-                     why this makes sense :-) We can control whether we want to deploy to the Eclipse repo or Maven Central by a combination of the version being a SNAPSHOT
-                     or RELEASE version and property skipNexusStaging=true/false. In any case we can take advantage of the plugin's "deferred deploy" feature which makes sure that
-                     all artifacts of a multi-module project are deployed as a whole at the end of the build process instead of deploying each module's artifacts individually
-                     as part of building the module. -->
+                  <!-- Use the Nexus Staging plugin as a full replacement 
+                     for the standard Maven Deploy plugin. See https://github.com/sonatype/nexus-maven-plugins/tree/master/staging/maven-plugin 
+                     why this makes sense :-) We can control whether we want to deploy to the 
+                     Eclipse repo or Maven Central by a combination of the version being a SNAPSHOT 
+                     or RELEASE version and property skipNexusStaging=true/false. In any case 
+                     we can take advantage of the plugin's "deferred deploy" feature which makes 
+                     sure that all artifacts of a multi-module project are deployed as a whole 
+                     at the end of the build process instead of deploying each module's artifacts 
+                     individually as part of building the module. -->
                   <groupId>org.sonatype.plugins</groupId>
                   <artifactId>nexus-staging-maven-plugin</artifactId>
                   <version>1.6.7</version>


### PR DESCRIPTION
It seems that the maven Javadoc Plugin update has now lint enabled by default. 

In order to have our release build run again I did:

* Reduced lint to syntax check only.
* Fixed many syntax errors in JavaDoc.
* Moved one class that is JPA specific out of the repository API package (i.e. it had JPA JavaDoc dependencies).
* Add JavaDoc check to Circle so that we can see errors in PRs.

While at it I updated EclipseLInk to 2.7.4