### PR TITLE
In-memory user management should not ignore user roles configured via Spring

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/InMemoryUserManagementAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/InMemoryUserManagementAutoConfiguration.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.autoconfigure.security;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.hawkbit.im.authentication.MultitenancyIndicator;
 import org.eclipse.hawkbit.im.authentication.PermissionUtils;
@@ -24,6 +25,7 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.authentication.configuration.GlobalAuthenticationConfigurerAdapter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.User.UserBuilder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
@@ -57,8 +59,15 @@ public class InMemoryUserManagementAutoConfiguration extends GlobalAuthenticatio
     UserDetailsService userDetailsService() {
         final InMemoryUserDetailsManager inMemoryUserDetailsManager = new InMemoryUserPrincipalDetailsManager();
         inMemoryUserDetailsManager.setAuthenticationManager(null);
-        inMemoryUserDetailsManager.createUser(new User(securityProperties.getUser().getName(),
-                securityProperties.getUser().getPassword(), PermissionUtils.createAllAuthorityList()));
+        final org.springframework.boot.autoconfigure.security.SecurityProperties.User user = securityProperties
+                .getUser();
+        final UserBuilder userBuilder = User.builder().username(user.getName()).password(user.getPassword())
+                .authorities(PermissionUtils.createAllAuthorityList());
+        final List<String> roles = user.getRoles();
+        if (!roles.isEmpty()) {
+            userBuilder.roles(roles.toArray(new String[roles.size()]));
+        }
+        inMemoryUserDetailsManager.createUser(userBuilder.build());
         return inMemoryUserDetailsManager;
     }
 

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/InMemoryUserManagementAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/InMemoryUserManagementAutoConfiguration.java
@@ -59,8 +59,7 @@ public class InMemoryUserManagementAutoConfiguration extends GlobalAuthenticatio
     UserDetailsService userDetailsService() {
         final InMemoryUserDetailsManager inMemoryUserDetailsManager = new InMemoryUserPrincipalDetailsManager();
         inMemoryUserDetailsManager.setAuthenticationManager(null);
-        final org.springframework.boot.autoconfigure.security.SecurityProperties.User user = securityProperties
-                .getUser();
+        final SecurityProperties.User user = securityProperties.getUser();
         final UserBuilder userBuilder = User.builder().username(user.getName()).password(user.getPassword())
                 .authorities(PermissionUtils.createAllAuthorityList());
         final List<String> roles = user.getRoles();


### PR DESCRIPTION
The in-memory user management of Eclipse hawkBit (org.eclipse.hawkbit.autoconfigure.security.InMemoryUserManagementAutoConfiguration) provisions a technical user based on the Spring Security properties "spring.security.user.name" and "spring.security.user.password". While it assigns the permissions as expected, it ignores the "spring.security.user.roles" configuration property. This pull request delivers a small fix which makes sure that the roles are applied too (if they are configured).

Signed-off-by: Stefan Behl <stefan.behl@bosch-si.com>