### PR TITLE
Increase notification visibility time

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUILabelDefinitions.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUILabelDefinitions.java
@@ -16,7 +16,7 @@ public final class SPUILabelDefinitions {
     /**
      * Delay - Notification.
      */
-    public static final int SP_DELAY = 1000;
+    public static final int SP_DELAY = 3000;
 
     /**
      * NAME.


### PR DESCRIPTION
UI notifications are now displayed for 3 seconds. They used to disappear after one second, which is too fast to read long messages. Notifications do not block the UI and can be closed manually so there is no disadvantage in displaying them for a longer time.

Signed-off-by: Stefan Klotz <stefan.klotz@bosch-si.com>