### PR TITLE
Improve request rejected exception handling

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityAutoConfiguration.java
@@ -15,13 +15,18 @@ import org.eclipse.hawkbit.security.SecurityContextTenantAware;
 import org.eclipse.hawkbit.security.SecurityTokenGenerator;
 import org.eclipse.hawkbit.security.SpringSecurityAuditorAware;
 import org.eclipse.hawkbit.security.SystemSecurityContext;
+import org.eclipse.hawkbit.security.aop.FilterChainProxyAdvice;
 import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.web.firewall.HttpFirewall;
+import org.springframework.security.web.firewall.RequestRejectedException;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for security.
@@ -80,6 +85,24 @@ public class SecurityAutoConfiguration {
     @ConditionalOnMissingBean
     public SecurityTokenGenerator securityTokenGenerator() {
         return new SecurityTokenGenerator();
+    }
+
+    /**
+     * @return {@link FilterChainProxyAdvice} to handle {@link RequestRejectedException}
+     */
+    @Bean
+    public FilterChainProxyAdvice strictHttpFirewallAdvice() {
+        return new FilterChainProxyAdvice();
+    }
+
+    /**
+     * Set {@link StrictHttpFirewall} to be the default firewall
+     * @return {@link HttpFirewall}
+     */
+    @Bean
+    @Primary
+    public HttpFirewall httpFirewall(){
+        return new StrictHttpFirewall();
     }
 
 }

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/exception/SpServerError.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/exception/SpServerError.java
@@ -232,7 +232,12 @@ public enum SpServerError {
      * invalid.
      */
     SP_AUTO_ASSIGN_DISTRIBUTION_SET_INVALID("hawkbit.server.error.repo.invalidAutoAssignDistributionSet",
-            "The given distribution set for auto-assignment is invalid: it is either incomplete (i.e. mandatory modules are missing) or soft deleted");
+            "The given distribution set for auto-assignment is invalid: it is either incomplete (i.e. mandatory modules are missing) or soft deleted"),
+
+    /**
+     * Error message informing that the current request url contains malicious characters
+     */
+    SP_MALICIOUS_URL_STRING("hawkbit.server.error.rest.maliciousUrl", "The given url contains malicious characters");
 
     private final String key;
     private final String message;

--- a/hawkbit-http-security/pom.xml
+++ b/hawkbit-http-security/pom.xml
@@ -56,6 +56,10 @@
          <artifactId>allure-junit4</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.aspectj</groupId>
+         <artifactId>aspectjrt</artifactId>
+      </dependency>
    </dependencies>
 
 </project>

--- a/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/aop/FilterChainProxyAdvice.java
+++ b/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/aop/FilterChainProxyAdvice.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.security.aop;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.eclipse.hawkbit.exception.SpServerError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.firewall.RequestRejectedException;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
+
+/**
+ * Workaround for issue
+ * https://github.com/spring-projects/spring-security/issues/5007
+ *
+ * Advice class for the {@link FilterChainProxy} to handle the
+ * {@link RequestRejectedException} thrown by the {@link StrictHttpFirewall} and
+ * logged by Jetty/Tomcat.
+ *
+ * Using AspectJ advice around the {@link FilterChainProxy} makes it possible to
+ * directly return the error code through the ServletResponse (2nd argument in
+ * the doFilter() method). It is not possible to advise Jetty or Tomcat because
+ * they are not managed by Spring.
+ * 
+ * Results in an error code 400 BAD_REQUEST instead of the (default) 500.
+ */
+@Aspect
+public class FilterChainProxyAdvice {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FilterChainProxyAdvice.class);
+    /**
+     * Creates an advice for the {@link FilterChainProxy} doFilter method to
+     * catch the {@link RequestRejectedException} thrown by the
+     * {@link StrictHttpFirewall} and sends a 400 BAD REQUEST response
+     *
+     * @param pjp
+     *            the {@link ProceedingJoinPoint} around the {@link FilterChainProxy}.doFilter() method
+     */
+    @Around("execution(public void org.springframework.security.web.FilterChainProxy.doFilter("
+            + "javax.servlet.ServletRequest, javax.servlet.ServletResponse, javax.servlet.FilterChain))")
+    @SuppressWarnings("squid:S1166") // Exception should not be (fully) logged nor rethrown
+    public void handleRequestRejectedExceptionInFilterChainProxy(final ProceedingJoinPoint pjp) throws Throwable {
+        try {
+            pjp.proceed();
+        } catch (RequestRejectedException exception) {
+            LOG.debug("Caught a RequestRejectedException with reason phrase: [{}], sending response error BAD_REQUEST",
+                    exception.getMessage());
+            sendBadRequestResponse((HttpServletRequest) pjp.getArgs()[0], (HttpServletResponse) pjp.getArgs()[1]);
+        }
+    }
+
+    private static void sendBadRequestResponse(final HttpServletRequest request, final HttpServletResponse response)
+            throws IOException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(constructResponseBody(request));
+    }
+
+    private static String constructResponseBody(final HttpServletRequest request) {
+        return String.format("{\"message\":\"%s\", \"path\": \"%s\"}",
+                SpServerError.SP_MALICIOUS_URL_STRING.getMessage(), request.getRequestURI());
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-test/pom.xml
+++ b/hawkbit-repository/hawkbit-repository-test/pom.xml
@@ -92,6 +92,7 @@
       <dependency>
          <groupId>org.springframework.boot</groupId>
          <artifactId>spring-boot-starter-test</artifactId>
+         <scope>compile</scope>
       </dependency>
       <dependency>
          <groupId>org.springframework.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -755,6 +755,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>${spring.boot.version}</version>
+            <scope>test</scope>
             <exclusions>
                <exclusion>
                   <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
The default behavior of the StrictHttpFirewall results in a 500 internal server error when a request url contains potentially malicious strings. This Exception shoulld instead be caught and translated into a 400 BAD REQUEST response.