### PR TITLE
Feature fixed timezone

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/AbstractHawkbitUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/AbstractHawkbitUI.java
@@ -16,6 +16,7 @@ import org.eclipse.hawkbit.ui.menu.DashboardMenuItem;
 import org.eclipse.hawkbit.ui.push.EventPushStrategy;
 import org.eclipse.hawkbit.ui.themes.HawkbitTheme;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
+import org.eclipse.hawkbit.ui.utils.SPDateTimeUtil;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
 import org.slf4j.Logger;
@@ -120,6 +121,7 @@ public abstract class AbstractHawkbitUI extends UI implements DetachListener {
         rootLayout.setSizeFull();
 
         HawkbitCommonUtil.initLocalization(this, uiProperties.getLocalization(), i18n);
+        SPDateTimeUtil.initializeFixedTimeZoneProperty(uiProperties.getTimezone().getFixedTimezone());
 
         dashboardMenu.init();
         dashboardMenu.setResponsive(true);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/AbstractHawkbitUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/AbstractHawkbitUI.java
@@ -121,7 +121,7 @@ public abstract class AbstractHawkbitUI extends UI implements DetachListener {
         rootLayout.setSizeFull();
 
         HawkbitCommonUtil.initLocalization(this, uiProperties.getLocalization(), i18n);
-        SPDateTimeUtil.initializeFixedTimeZoneProperty(uiProperties.getTimezone().getFixedTimezone());
+        SPDateTimeUtil.initializeFixedTimeZoneProperty(uiProperties.getTimezone());
 
         dashboardMenu.init();
         dashboardMenu.setResponsive(true);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/AbstractHawkbitUI.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/AbstractHawkbitUI.java
@@ -121,7 +121,7 @@ public abstract class AbstractHawkbitUI extends UI implements DetachListener {
         rootLayout.setSizeFull();
 
         HawkbitCommonUtil.initLocalization(this, uiProperties.getLocalization(), i18n);
-        SPDateTimeUtil.initializeFixedTimeZoneProperty(uiProperties.getTimezone());
+        SPDateTimeUtil.initializeFixedTimeZoneProperty(uiProperties.getFixedTimeZone());
 
         dashboardMenu.init();
         dashboardMenu.setResponsive(true);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
@@ -25,7 +25,7 @@ public class UiProperties implements Serializable {
 
     private boolean gravatar;
 
-    private String timezone;
+    private String fixedTimeZone;
 
     private final Localization localization = new Localization();
 
@@ -45,12 +45,12 @@ public class UiProperties implements Serializable {
         this.gravatar = gravatar;
     }
 
-    public String getTimezone() {
-        return timezone;
+    public String getFixedTimeZone() {
+        return fixedTimeZone;
     }
 
-    public void setTimezone(final String timezone) {
-        this.timezone = timezone;
+    public void setFixedTimeZone(final String fixedTimeZone) {
+        this.fixedTimeZone = fixedTimeZone;
     }
 
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
@@ -9,7 +9,6 @@
 package org.eclipse.hawkbit.ui;
 
 import java.io.Serializable;
-import java.sql.Time;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +50,9 @@ public class UiProperties implements Serializable {
     }
 
 
+    /**
+     * Time zone information
+     */
     public static class Timezone implements Serializable {
         private static final long serialVersionUID = 1L;
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.ui;
 
 import java.io.Serializable;
+import java.sql.Time;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -24,6 +25,8 @@ public class UiProperties implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private boolean gravatar;
+
+    private final Timezone timezone = new Timezone();
 
     private final Localization localization = new Localization();
 
@@ -41,6 +44,28 @@ public class UiProperties implements Serializable {
 
     public void setGravatar(final boolean gravatar) {
         this.gravatar = gravatar;
+    }
+
+    public Timezone getTimezone() {
+        return timezone;
+    }
+
+
+    public static class Timezone implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Provide a static timezone for the UI
+         */
+        private String fixedTimezone = "";
+
+        public String getFixedTimezone() {
+            return fixedTimezone;
+        }
+
+        public void setFixedTimezone(final String fixedTimezone) {
+            this.fixedTimezone = fixedTimezone;
+        }
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/UiProperties.java
@@ -25,7 +25,7 @@ public class UiProperties implements Serializable {
 
     private boolean gravatar;
 
-    private final Timezone timezone = new Timezone();
+    private String timezone;
 
     private final Localization localization = new Localization();
 
@@ -45,30 +45,14 @@ public class UiProperties implements Serializable {
         this.gravatar = gravatar;
     }
 
-    public Timezone getTimezone() {
+    public String getTimezone() {
         return timezone;
     }
 
-
-    /**
-     * Time zone information
-     */
-    public static class Timezone implements Serializable {
-        private static final long serialVersionUID = 1L;
-
-        /**
-         * Provide a static timezone for the UI
-         */
-        private String fixedTimezone = "";
-
-        public String getFixedTimezone() {
-            return fixedTimezone;
-        }
-
-        public void setFixedTimezone(final String fixedTimezone) {
-            this.fixedTimezone = fixedTimezone;
-        }
+    public void setTimezone(final String timezone) {
+        this.timezone = timezone;
     }
+
 
     /**
      * Localization information

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPDateTimeUtil.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPDateTimeUtil.java
@@ -19,6 +19,7 @@ import org.eclipse.hawkbit.repository.model.BaseEntity;
 
 import com.google.common.collect.Maps;
 import com.vaadin.server.WebBrowser;
+import org.springframework.util.StringUtils;
 
 /**
  * Common Util to get date/time related information.
@@ -54,13 +55,14 @@ public final class SPDateTimeUtil {
     }
 
     /**
-     * Get browser time zone.
+     * Get browser time zone or fixed time zone if configured
      *
      * @return TimeZone
      */
     public static TimeZone getBrowserTimeZone() {
 
-        if (!fixedTimeZoneProperty.isEmpty()) {
+
+        if (StringUtils.isEmpty(fixedTimeZoneProperty)) {
             return TimeZone.getTimeZone(fixedTimeZoneProperty);
         }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPDateTimeUtil.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPDateTimeUtil.java
@@ -19,7 +19,6 @@ import org.eclipse.hawkbit.repository.model.BaseEntity;
 
 import com.google.common.collect.Maps;
 import com.vaadin.server.WebBrowser;
-import org.eclipse.hawkbit.ui.UiProperties;
 
 /**
  * Common Util to get date/time related information.
@@ -28,6 +27,7 @@ public final class SPDateTimeUtil {
 
     private static final String DURATION_FORMAT = "y','M','d','H','m','s";
     private static final Map<Integer, CalendarI18N> DURATION_I18N = Maps.newHashMapWithExpectedSize(6);
+    private static String fixedTimeZoneProperty;
 
     static {
         DURATION_I18N.put(0, CalendarI18N.YEAR);
@@ -42,15 +42,26 @@ public final class SPDateTimeUtil {
 
     }
 
+
+    /**
+     * Set fixed UI timezone
+     *
+     * @param fixedTimeZoneProperty
+     *      time zone e.g. Europe/Berlin. If time zone is unknown, it will default to GMT
+     */
+    public static void initializeFixedTimeZoneProperty(String fixedTimeZoneProperty) {
+        SPDateTimeUtil.fixedTimeZoneProperty = fixedTimeZoneProperty;
+    }
+
     /**
      * Get browser time zone.
      *
      * @return TimeZone
      */
-    public static TimeZone getBrowserTimeZone(UiProperties uiProperties) {
+    public static TimeZone getBrowserTimeZone() {
 
-        if (!uiProperties.getTimezone().getFixedTimezone().isEmpty()) {
-            return TimeZone.getTimeZone(uiProperties.getTimezone().getFixedTimezone());
+        if (!fixedTimeZoneProperty.isEmpty()) {
+            return TimeZone.getTimeZone(fixedTimeZoneProperty);
         }
 
         final WebBrowser webBrowser = com.vaadin.server.Page.getCurrent().getWebBrowser();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPDateTimeUtil.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPDateTimeUtil.java
@@ -62,7 +62,7 @@ public final class SPDateTimeUtil {
     public static TimeZone getBrowserTimeZone() {
 
 
-        if (StringUtils.isEmpty(fixedTimeZoneProperty)) {
+        if (!StringUtils.isEmpty(fixedTimeZoneProperty)) {
             return TimeZone.getTimeZone(fixedTimeZoneProperty);
         }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPDateTimeUtil.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPDateTimeUtil.java
@@ -19,6 +19,7 @@ import org.eclipse.hawkbit.repository.model.BaseEntity;
 
 import com.google.common.collect.Maps;
 import com.vaadin.server.WebBrowser;
+import org.eclipse.hawkbit.ui.UiProperties;
 
 /**
  * Common Util to get date/time related information.
@@ -46,7 +47,12 @@ public final class SPDateTimeUtil {
      *
      * @return TimeZone
      */
-    public static TimeZone getBrowserTimeZone() {
+    public static TimeZone getBrowserTimeZone(UiProperties uiProperties) {
+
+        if (!uiProperties.getTimezone().getFixedTimezone().isEmpty()) {
+            return TimeZone.getTimeZone(uiProperties.getTimezone().getFixedTimezone());
+        }
+
         final WebBrowser webBrowser = com.vaadin.server.Page.getCurrent().getWebBrowser();
         final String[] timeZones = TimeZone.getAvailableIDs(webBrowser.getRawTimezoneOffset());
         TimeZone tz = TimeZone.getDefault();


### PR DESCRIPTION
In order to display timestamps in the UI, hawkBit tries to find out the time zone of the client (browser). Therefore, the GMT offset is taken and mapped to a valid time zone. However, since multiple time zones have the same GMT offset, hawkBit may select the wrong time zone.

In such scenarios, it might be off help to fix the time zone to a certain zone, for all clients. Ignoring their reported offset. 

This feature is disabled by default and can be used by setting the following property:

`hawkbit.server.ui.fixedTimeZone=Europe/Berlin`