### PR TITLE
Auto-Assignment link missing in Target Filter view (caused by NPE in TargetFilterTable)

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterBeanQuery.java
@@ -105,8 +105,8 @@ public class TargetFilterBeanQuery extends AbstractBeanQuery<ProxyTargetFilter> 
             final DistributionSet distributionSet = tarFilterQuery.getAutoAssignDistributionSet();
             if (distributionSet != null) {
                 proxyTarFilter.setAutoAssignDistributionSet(new ProxyDistribution(distributionSet));
-                // for backwards compatibility reasons we need to apply a
-                // fallback to ActionType.FORCED
+                // we need to apply a fallback since the action type field has
+                // been added belatedly (and might be null for older filters)
                 final ActionType autoAssignActionType = tarFilterQuery.getAutoAssignActionType();
                 proxyTarFilter.setAutoAssignActionType(
                         autoAssignActionType != null ? autoAssignActionType : ActionType.FORCED);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterBeanQuery.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
+import org.eclipse.hawkbit.repository.model.Action.ActionType;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.eclipse.hawkbit.ui.common.UserDetailsFormatter;
@@ -104,8 +105,11 @@ public class TargetFilterBeanQuery extends AbstractBeanQuery<ProxyTargetFilter> 
             final DistributionSet distributionSet = tarFilterQuery.getAutoAssignDistributionSet();
             if (distributionSet != null) {
                 proxyTarFilter.setAutoAssignDistributionSet(new ProxyDistribution(distributionSet));
-                proxyTarFilter.setAutoAssignActionType(tarFilterQuery.getAutoAssignActionType());
+                final ActionType autoAssignActionType = tarFilterQuery.getAutoAssignActionType();
+                proxyTarFilter.setAutoAssignActionType(
+                        autoAssignActionType != null ? autoAssignActionType : ActionType.FORCED);
             }
+
             proxyTargetFilter.add(proxyTarFilter);
         }
         return proxyTargetFilter;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterBeanQuery.java
@@ -105,6 +105,8 @@ public class TargetFilterBeanQuery extends AbstractBeanQuery<ProxyTargetFilter> 
             final DistributionSet distributionSet = tarFilterQuery.getAutoAssignDistributionSet();
             if (distributionSet != null) {
                 proxyTarFilter.setAutoAssignDistributionSet(new ProxyDistribution(distributionSet));
+                // for backwards compatibility reasons we need to apply a
+                // fallback to ActionType.FORCED
                 final ActionType autoAssignActionType = tarFilterQuery.getAutoAssignActionType();
                 proxyTarFilter.setAutoAssignActionType(
                         autoAssignActionType != null ? autoAssignActionType : ActionType.FORCED);


### PR DESCRIPTION
For target filter queries having a Auto-Assignment distribution set assigned, the link Auto-Assignment link is missing.

This issue is caused by a NullPointerException in TargetFilterTable:
java.lang.NullPointerException: null
  at o.e.h.u.f.TargetFilterTable.customFilterDistributionSetButton(TargetFilterTable.java:252)
  [...]
  at c.v.u.Table.parseItemIdToCells(Table.java:2327)
  [...]
  at c.v.s.c.UidlRequestHandler.synchronizedHandleRequest(UidlRequestHandler.java:90)

This pull request provides a fix which applies a fallback to ActionType.FORCED if there is no action type in the corresponding database record.

This issue is probably a side effect of [PR 789](https://github.com/eclipse/hawkbit/pull/789).

Signed-off-by: Stefan Behl <stefan.behl@bosch-si.com>