### PR TITLE
fix the logic that marks distributionSet as complete

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.jpa.model;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -209,8 +210,12 @@ public class JpaDistributionSetType extends AbstractJpaNamedEntity implements Di
 
     @Override
     public boolean checkComplete(final DistributionSet distributionSet) {
-        return distributionSet.getModules().stream().map(SoftwareModule::getType).collect(Collectors.toList())
-                .containsAll(getMandatoryModuleTypes());
+        List<SoftwareModuleType> smTypes = distributionSet.getModules().stream().map(SoftwareModule::getType)
+                .collect(Collectors.toList());
+        if (smTypes.size() == 0) {
+            return false;
+        }
+        return smTypes.containsAll(getMandatoryModuleTypes());
     }
 
     @Override


### PR DESCRIPTION
DistributionSets without SoftwareModules shall not be marked as
complete, when no Software Module is assigned. 

Further details can be found in [jira ticket MECS-7900](https://products.bosch-si.com/jira/browse/MECS-7900)
