### PR TITLE
fix the logic that marks distributionSet as complete

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.jpa.model;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -209,8 +210,12 @@ public class JpaDistributionSetType extends AbstractJpaNamedEntity implements Di
 
     @Override
     public boolean checkComplete(final DistributionSet distributionSet) {
-        return distributionSet.getModules().stream().map(SoftwareModule::getType).collect(Collectors.toList())
-                .containsAll(getMandatoryModuleTypes());
+        List<SoftwareModuleType> smTypes = distributionSet.getModules().stream().map(SoftwareModule::getType)
+                .collect(Collectors.toList());
+        if (smTypes.isEmpty()) {
+            return false;
+        }
+        return smTypes.containsAll(getMandatoryModuleTypes());
     }
 
     @Override


### PR DESCRIPTION
A DistributionSet (DS) can only be assigned to a target, when it is marked as complete.
A DS is marked as complete, when all requirements of the selected DS-Type are fulfilled.
A DS-Type determines which SoftwareModules (SM) of which SM-Type can be (optional) or have to be (required) contained.

When specifying a DS-Type that contains only optional SMs, a DS is marked as complete even without any SM assigned. This shall be changed.

A DS shall be only considered as complete, when:

SMs of the required SM-Types are assigned
At least one SM is assigned, in case all SM-Types are optional