### PR TITLE
Deployment View broken with Access Denied error

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractDistributionSetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractDistributionSetDetails.java
@@ -45,25 +45,18 @@ public abstract class AbstractDistributionSetDetails
 
     private static final long serialVersionUID = 1L;
 
-    private final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout;
-
-    private final DistributionSetMetadataDetailsLayout dsMetadataTable;
-
-    private final UINotification uiNotification;
-
     private final transient DistributionSetManagement distributionSetManagement;
+    private final transient TenantConfigurationManagement tenantConfigurationManagement;
+    private final transient SystemSecurityContext systemSecurityContext;
 
+    private final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout;
+    private final DistributionSetMetadataDetailsLayout dsMetadataTable;
+    private final UINotification uiNotification;
     private final DsMetadataPopupLayout dsMetadataPopupLayout;
-
     private final DistributionTagToken distributionTagToken;
-
     private final SoftwareModuleDetailsTable softwareModuleDetailsTable;
 
-    private final transient TenantConfigurationManagement tenantConfigurationManagement;
-
     private VerticalLayout softwareModuleTab;
-
-    private final SystemSecurityContext systemSecurityContext;
 
     protected AbstractDistributionSetDetails(final VaadinMessageSource i18n, final UIEventBus eventBus,
             final SpPermissionChecker permissionChecker, final ManagementUIState managementUIState,

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractDistributionSetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractDistributionSetDetails.java
@@ -14,6 +14,7 @@ import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.DistributionSetTagManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.tagdetails.DistributionTagToken;
@@ -62,6 +63,8 @@ public abstract class AbstractDistributionSetDetails
 
     private VerticalLayout softwareModuleTab;
 
+    private final SystemSecurityContext systemSecurityContext;
+
     protected AbstractDistributionSetDetails(final VaadinMessageSource i18n, final UIEventBus eventBus,
             final SpPermissionChecker permissionChecker, final ManagementUIState managementUIState,
             final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout,
@@ -69,7 +72,8 @@ public abstract class AbstractDistributionSetDetails
             final DsMetadataPopupLayout dsMetadataPopupLayout, final UINotification uiNotification,
             final DistributionSetTagManagement distributionSetTagManagement,
             final SoftwareModuleDetailsTable softwareModuleDetailsTable,
-            final TenantConfigurationManagement tenantConfigurationManagement) {
+            final TenantConfigurationManagement tenantConfigurationManagement,
+            final SystemSecurityContext systemSecurityContext) {
         super(i18n, eventBus, permissionChecker, managementUIState);
         this.distributionAddUpdateWindowLayout = distributionAddUpdateWindowLayout;
         this.uiNotification = uiNotification;
@@ -79,6 +83,7 @@ public abstract class AbstractDistributionSetDetails
                 managementUIState, distributionSetTagManagement, distributionSetManagement);
         this.softwareModuleDetailsTable = softwareModuleDetailsTable;
         this.tenantConfigurationManagement = tenantConfigurationManagement;
+        this.systemSecurityContext = systemSecurityContext;
 
         dsMetadataTable = new DistributionSetMetadataDetailsLayout(i18n, distributionSetManagement,
                 dsMetadataPopupLayout);
@@ -192,8 +197,8 @@ public abstract class AbstractDistributionSetDetails
     }
 
     private boolean isMultiAssignmentEnabled() {
-        return tenantConfigurationManagement
-                .getConfigurationValue(TenantConfigurationKey.MULTI_ASSIGNMENTS_ENABLED, Boolean.class).getValue();
+        return systemSecurityContext.runAsSystem(() -> tenantConfigurationManagement
+                .getConfigurationValue(TenantConfigurationKey.MULTI_ASSIGNMENTS_ENABLED, Boolean.class).getValue());
     }
 
     private String getMigrationRequiredValue(final Boolean isMigrationRequired) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/DistributionsView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/DistributionsView.java
@@ -22,6 +22,7 @@ import org.eclipse.hawkbit.repository.SoftwareModuleTypeManagement;
 import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.ui.AbstractHawkbitUI;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent;
@@ -104,7 +105,7 @@ public class DistributionsView extends AbstractNotificationView implements Brows
             final ArtifactUploadState artifactUploadState, final SystemManagement systemManagement,
             final ArtifactManagement artifactManagement, final NotificationUnreadButton notificationUnreadButton,
             final DistributionsViewMenuItem distributionsViewMenuItem,
-            final TenantConfigurationManagement configManagement) {
+            final TenantConfigurationManagement configManagement, final SystemSecurityContext systemSecurityContext) {
         super(eventBus, notificationUnreadButton);
         this.permChecker = permChecker;
         this.i18n = i18n;
@@ -119,7 +120,7 @@ public class DistributionsView extends AbstractNotificationView implements Brows
         this.distributionTableLayout = new DistributionSetTableLayout(i18n, eventBus, permChecker, manageDistUIState,
                 softwareModuleManagement, distributionSetManagement, distributionSetTypeManagement, targetManagement,
                 entityFactory, uiNotification, distributionSetTagManagement, distributionsViewClientCriterion,
-                systemManagement, configManagement);
+                systemManagement, configManagement, systemSecurityContext);
         this.softwareModuleTableLayout = new SwModuleTableLayout(i18n, uiNotification, eventBus,
                 softwareModuleManagement, softwareModuleTypeManagement, entityFactory, manageDistUIState, permChecker,
                 distributionsViewClientCriterion, artifactUploadState, artifactManagement);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetDetails.java
@@ -15,6 +15,7 @@ import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.DistributionSetTagManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent;
 import org.eclipse.hawkbit.ui.artifacts.event.SoftwareModuleEvent.SoftwareModuleEventType;
@@ -59,12 +60,13 @@ public class DistributionSetDetails extends AbstractDistributionSetDetails {
             final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout,
             final DistributionSetManagement distributionSetManagement, final UINotification uiNotification,
             final DistributionSetTagManagement distributionSetTagManagement,
-            final DsMetadataPopupLayout dsMetadataPopupLayout, final TenantConfigurationManagement configManagement) {
+            final DsMetadataPopupLayout dsMetadataPopupLayout, final TenantConfigurationManagement configManagement,
+            final SystemSecurityContext systemSecurityContext) {
         super(i18n, eventBus, permissionChecker, managementUIState, distributionAddUpdateWindowLayout,
                 distributionSetManagement, dsMetadataPopupLayout, uiNotification, distributionSetTagManagement,
                 createSoftwareModuleDetailsTable(i18n, permissionChecker, distributionSetManagement, eventBus,
                         manageDistUIState, uiNotification),
-                configManagement);
+                configManagement, systemSecurityContext);
         this.manageDistUIState = manageDistUIState;
 
         tfqDetailsTable = new TargetFilterQueryDetailsTable(i18n);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTableLayout.java
@@ -16,6 +16,7 @@ import org.eclipse.hawkbit.repository.SoftwareModuleManagement;
 import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.table.AbstractTableLayout;
 import org.eclipse.hawkbit.ui.dd.criteria.DistributionsViewClientCriterion;
@@ -42,7 +43,8 @@ public class DistributionSetTableLayout extends AbstractTableLayout<Distribution
             final EntityFactory entityFactory, final UINotification uiNotification,
             final DistributionSetTagManagement distributionSetTagManagement,
             final DistributionsViewClientCriterion distributionsViewClientCriterion,
-            final SystemManagement systemManagement, final TenantConfigurationManagement configManagement) {
+            final SystemManagement systemManagement, final TenantConfigurationManagement configManagement,
+            final SystemSecurityContext systemSecurityContext) {
 
         this.distributionSetTable = new DistributionSetTable(eventBus, i18n, uiNotification, permissionChecker,
                 manageDistUIState, distributionSetManagement, softwareManagement, distributionsViewClientCriterion,
@@ -50,7 +52,7 @@ public class DistributionSetTableLayout extends AbstractTableLayout<Distribution
 
         final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout = new DistributionAddUpdateWindowLayout(
                 i18n, uiNotification, eventBus, distributionSetManagement, distributionSetTypeManagement,
-                systemManagement, entityFactory, distributionSetTable, configManagement);
+                systemManagement, entityFactory, distributionSetTable, configManagement, systemSecurityContext);
 
         final DsMetadataPopupLayout popupLayout = new DsMetadataPopupLayout(i18n, uiNotification, eventBus,
                 distributionSetManagement, entityFactory, permissionChecker);
@@ -61,7 +63,7 @@ public class DistributionSetTableLayout extends AbstractTableLayout<Distribution
                 distributionSetTable,
                 new DistributionSetDetails(i18n, eventBus, permissionChecker, manageDistUIState, null,
                         distributionAddUpdateWindowLayout, distributionSetManagement, uiNotification,
-                        distributionSetTagManagement, popupLayout, configManagement));
+                        distributionSetTagManagement, popupLayout, configManagement, systemSecurityContext));
     }
 
     public DistributionSetTable getDistributionSetTable() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/DeploymentView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/DeploymentView.java
@@ -23,6 +23,7 @@ import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TargetTagManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.ui.AbstractHawkbitUI;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.UiProperties;
@@ -128,7 +129,7 @@ public class DeploymentView extends AbstractNotificationView implements BrowserW
             final TargetTagManagement targetTagManagement,
             final DistributionSetTagManagement distributionSetTagManagement,
             final TargetFilterQueryManagement targetFilterQueryManagement, final SystemManagement systemManagement,
-            final TenantConfigurationManagement configManagement,
+            final TenantConfigurationManagement configManagement, final SystemSecurityContext systemSecurityContext,
             final NotificationUnreadButton notificationUnreadButton,
             final DeploymentViewMenuItem deploymentViewMenuItem, @Qualifier("uiExecutor") final Executor uiExecutor) {
         super(eventBus, notificationUnreadButton);
@@ -149,7 +150,7 @@ public class DeploymentView extends AbstractNotificationView implements BrowserW
                     targetFilterQueryManagement, targetTagManagement);
             final TargetTable targetTable = new TargetTable(eventBus, i18n, uiNotification, targetManagement,
                     managementUIState, permChecker, managementViewClientCriterion, distributionSetManagement,
-                    targetTagManagement, deploymentManagement, configManagement, uiProperties);
+                    targetTagManagement, deploymentManagement, configManagement, systemSecurityContext, uiProperties);
             this.countMessageLabel = new CountMessageLabel(eventBus, targetManagement, i18n, managementUIState,
                     targetTable);
 
@@ -177,7 +178,7 @@ public class DeploymentView extends AbstractNotificationView implements BrowserW
             this.distributionTableLayout = new DistributionTableLayout(i18n, eventBus, permChecker, managementUIState,
                     distributionSetManagement, distributionSetTypeManagement, managementViewClientCriterion,
                     entityFactory, uiNotification, distributionSetTagManagement, targetTagManagement, systemManagement,
-                    targetManagement, deploymentManagement, configManagement, uiProperties);
+                    targetManagement, deploymentManagement, configManagement, systemSecurityContext, uiProperties);
         } else {
             this.distributionTagLayout = null;
             this.distributionTableLayout = null;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
@@ -68,6 +68,7 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
     private final transient SystemManagement systemManagement;
     private final transient EntityFactory entityFactory;
     private final transient TenantConfigurationManagement tenantConfigurationManagement;
+    private final transient SystemSecurityContext systemSecurityContext;
 
     private final DistributionSetTable distributionSetTable;
 
@@ -78,8 +79,6 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
     private ComboBox distsetTypeNameComboBox;
 
     private FormLayout formLayout;
-
-    private final SystemSecurityContext systemSecurityContext;
 
     /**
      * Constructor for DistributionAddUpdateWindowLayout

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionAddUpdateWindowLayout.java
@@ -20,6 +20,7 @@ import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.TenantMetaData;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
 import org.eclipse.hawkbit.ui.common.CommonDialogWindow;
 import org.eclipse.hawkbit.ui.common.CommonDialogWindow.SaveDialogCloseListener;
@@ -78,6 +79,8 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
 
     private FormLayout formLayout;
 
+    private final SystemSecurityContext systemSecurityContext;
+
     /**
      * Constructor for DistributionAddUpdateWindowLayout
      * 
@@ -104,7 +107,8 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
             final UIEventBus eventBus, final DistributionSetManagement distributionSetManagement,
             final DistributionSetTypeManagement distributionSetTypeManagement, final SystemManagement systemManagement,
             final EntityFactory entityFactory, final DistributionSetTable distributionSetTable,
-            final TenantConfigurationManagement tenantConfigurationManagement) {
+            final TenantConfigurationManagement tenantConfigurationManagement,
+            final SystemSecurityContext systemSecurityContext) {
         this.i18n = i18n;
         this.notificationMessage = notificationMessage;
         this.eventBus = eventBus;
@@ -114,6 +118,7 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
         this.entityFactory = entityFactory;
         this.distributionSetTable = distributionSetTable;
         this.tenantConfigurationManagement = tenantConfigurationManagement;
+        this.systemSecurityContext = systemSecurityContext;
         createRequiredComponents();
         buildLayout();
     }
@@ -294,8 +299,8 @@ public class DistributionAddUpdateWindowLayout extends CustomComponent {
     }
 
     private boolean isMultiAssignmentEnabled() {
-        return tenantConfigurationManagement.getConfigurationValue(TenantConfigurationKey.MULTI_ASSIGNMENTS_ENABLED,
-                Boolean.class).getValue();
+        return systemSecurityContext.runAsSystem(() -> tenantConfigurationManagement
+                .getConfigurationValue(TenantConfigurationKey.MULTI_ASSIGNMENTS_ENABLED, Boolean.class).getValue());
     }
 
     private void populateValuesOfDistribution(final Long editDistId) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionDetails.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.ui.management.dstable;
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.DistributionSetTagManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.detailslayout.AbstractDistributionSetDetails;
 import org.eclipse.hawkbit.ui.common.detailslayout.SoftwareModuleDetailsTable;
@@ -33,11 +34,12 @@ public class DistributionDetails extends AbstractDistributionSetDetails {
             final DsMetadataPopupLayout dsMetadataPopupLayout, final UINotification uiNotification,
             final DistributionSetTagManagement distributionSetTagManagement,
             final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout,
-            final TenantConfigurationManagement tenantConfigurationManagement) {
+            final TenantConfigurationManagement tenantConfigurationManagement,
+            final SystemSecurityContext systemSecurityContext) {
         super(i18n, eventBus, permissionChecker, managementUIState, distributionAddUpdateWindowLayout,
                 distributionSetManagement, dsMetadataPopupLayout, uiNotification, distributionSetTagManagement,
                 createSoftwareModuleDetailsTable(i18n, permissionChecker, uiNotification),
-                tenantConfigurationManagement);
+                tenantConfigurationManagement, systemSecurityContext);
         restoreState();
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTableLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionTableLayout.java
@@ -17,6 +17,7 @@ import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TargetTagManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.table.AbstractTableLayout;
@@ -44,11 +45,12 @@ public class DistributionTableLayout extends AbstractTableLayout<DistributionTab
             final UINotification notification, final DistributionSetTagManagement distributionSetTagManagement,
             final TargetTagManagement targetTagManagement, final SystemManagement systemManagement,
             final TargetManagement targetManagement, final DeploymentManagement deploymentManagement,
-            final TenantConfigurationManagement configManagement, final UiProperties uiProperties) {
+            final TenantConfigurationManagement configManagement, final SystemSecurityContext systemSecurityContext,
+            final UiProperties uiProperties) {
 
         final DistributionAddUpdateWindowLayout distributionAddUpdateWindowLayout = new DistributionAddUpdateWindowLayout(
                 i18n, notification, eventBus, distributionSetManagement, distributionSetTypeManagement,
-                systemManagement, entityFactory, null, configManagement);
+                systemManagement, entityFactory, null, configManagement, systemSecurityContext);
 
         final DsMetadataPopupLayout dsMetadataPopupLayout = new DsMetadataPopupLayout(i18n, notification, eventBus,
                 distributionSetManagement, entityFactory, permissionChecker);
@@ -61,7 +63,7 @@ public class DistributionTableLayout extends AbstractTableLayout<DistributionTab
                 distributionTable,
                 new DistributionDetails(i18n, eventBus, permissionChecker, managementUIState, distributionSetManagement,
                         dsMetadataPopupLayout, notification, distributionSetTagManagement,
-                        distributionAddUpdateWindowLayout, configManagement));
+                        distributionAddUpdateWindowLayout, configManagement, systemSecurityContext));
     }
 
     public DistributionTable getDistributionTable() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
@@ -111,42 +111,27 @@ import com.vaadin.ui.themes.ValoTheme;
 public class TargetTable extends AbstractTable<Target> {
 
     private static final long serialVersionUID = 1L;
-
     private static final Logger LOG = LoggerFactory.getLogger(TargetTable.class);
-
     private static final String TARGET_PINNED = "targetPinned";
-
     private static final int PROPERTY_DEPT = 3;
-
     private static final String MESSAGE_ASSIGN_TARGET_TO_MULTIPLE_DISTRIBUTIONS = "message.confirm.assign.multiple.entities.multiple.distributions";
 
     private final transient TargetManagement targetManagement;
-
     private final transient DistributionSetManagement distributionSetManagement;
-
     private final transient TargetTagManagement tagManagement;
-
     private final transient DeploymentManagement deploymentManagement;
-
     private final transient TenantConfigurationManagement configManagement;
+    private final transient SystemSecurityContext systemSecurityContext;
 
     private final ManagementViewClientCriterion managementViewClientCriterion;
-
     private final ManagementUIState managementUIState;
-
-    private Button targetPinnedBtn;
-
-    private boolean targetPinned;
-
     private final UiProperties uiProperties;
-
-    private ConfirmationDialog confirmDialog;
-
     private final ActionTypeOptionGroupAssignmentLayout actionTypeOptionGroupLayout;
-
     private final MaintenanceWindowLayout maintenanceWindowLayout;
 
-    private final SystemSecurityContext systemSecurityContext;
+    private Button targetPinnedBtn;
+    private boolean targetPinned;
+    private ConfirmationDialog confirmDialog;
 
     public TargetTable(final UIEventBus eventBus, final VaadinMessageSource i18n, final UINotification notification,
             final TargetManagement targetManagement, final ManagementUIState managementUIState,

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
@@ -41,7 +41,8 @@ import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 import org.eclipse.hawkbit.repository.model.TargetTagAssignmentResult;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
-import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
+import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.ConfirmationDialog;
@@ -145,12 +146,14 @@ public class TargetTable extends AbstractTable<Target> {
 
     private final MaintenanceWindowLayout maintenanceWindowLayout;
 
+    private final SystemSecurityContext systemSecurityContext;
+
     public TargetTable(final UIEventBus eventBus, final VaadinMessageSource i18n, final UINotification notification,
             final TargetManagement targetManagement, final ManagementUIState managementUIState,
             final SpPermissionChecker permChecker, final ManagementViewClientCriterion managementViewClientCriterion,
             final DistributionSetManagement distributionSetManagement, final TargetTagManagement tagManagement,
             final DeploymentManagement deploymentManagement, final TenantConfigurationManagement configManagement,
-            final UiProperties uiProperties) {
+            final SystemSecurityContext systemSecurityContext, final UiProperties uiProperties) {
         super(eventBus, i18n, notification, permChecker);
         this.targetManagement = targetManagement;
         this.managementViewClientCriterion = managementViewClientCriterion;
@@ -162,6 +165,7 @@ public class TargetTable extends AbstractTable<Target> {
         this.uiProperties = uiProperties;
         this.actionTypeOptionGroupLayout = new ActionTypeOptionGroupAssignmentLayout(i18n);
         this.maintenanceWindowLayout = new MaintenanceWindowLayout(i18n);
+        this.systemSecurityContext = systemSecurityContext;
 
         setItemDescriptionGenerator(new AssignInstalledDSTooltipGenerator());
         addNewContainerDS();
@@ -892,7 +896,7 @@ public class TargetTable extends AbstractTable<Target> {
         if (ids.isEmpty()) {
             return Collections.emptySet();
         }
-        if (isMultiAssignmentsEnabled()) {
+        if (isMultiAssignmentEnabled()) {
             return new HashSet<>(ids);
         }
         return Collections.singleton(ids.iterator().next());
@@ -982,11 +986,9 @@ public class TargetTable extends AbstractTable<Target> {
         return "";
     }
 
-    private boolean isMultiAssignmentsEnabled() {
-        return configManagement
-                .getConfigurationValue(TenantConfigurationProperties.TenantConfigurationKey.MULTI_ASSIGNMENTS_ENABLED,
-                        Boolean.class)
-                .getValue();
+    private boolean isMultiAssignmentEnabled() {
+        return systemSecurityContext.runAsSystem(() -> configManagement
+                .getConfigurationValue(TenantConfigurationKey.MULTI_ASSIGNMENTS_ENABLED, Boolean.class).getValue());
     }
 
 }


### PR DESCRIPTION
The Deployment View is currently broken if the user does not have the SYSTEM_USER permission. In this case, the notification box in the bottom right corner displays an "Access denied" error. Internally this is caused by the following AccessDeniedException:

org.springframework.security.access.AccessDeniedException: Access is denied at org.springframework.security.access.vote.AffirmativeBased.decide(AffirmativeBased.java:84) at org.springframework.security.access.intercept.AbstractSecurityInterceptor.beforeInvocation(AbstractSecurityInterceptor.java:233) at org.springframework.security.access.intercept.aopalliance.MethodSecurityInterceptor.invoke(MethodSecurityInterceptor.java:65) at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) at org.springframework.retry.annotation.AnnotationAwareRetryOperationsInterceptor.invoke(AnnotationAwareRetryOperationsInterceptor.java:156) at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) at org.springframework.aop.aspectj.AspectJAfterThrowingAdvice.invoke(AspectJAfterThrowingAdvice.java:62) at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:93) at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:688) at org.eclipse.hawkbit.repository.jpa.JpaTenantConfigurationManagement$$EnhancerBySpringCGLIB$$2f954398.getConfigurationValue(<generated>) at org.eclipse.hawkbit.ui.common.detailslayout.AbstractDistributionSetDetails.isMultiAssignmentEnabled(AbstractDistributionSetDetails.java:196)

This pull request provides a fix for this misbehavior.

Signed-off-by: Stefan Behl <stefan.behl@bosch-si.com>