### PR TITLE
Change loglevel to debug for rolloutgroup status messages

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -785,7 +785,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
                     .getBean(finishCondition.getBeanName(), RolloutGroupConditionEvaluator.class)
                     .eval(rollout, rolloutGroup, rolloutGroup.getSuccessConditionExp());
             if (isFinished) {
-                LOGGER.info("Rolloutgroup {} is finished, starting next group", rolloutGroup);
+                LOGGER.debug("Rolloutgroup {} is finished, starting next group", rolloutGroup);
                 executeRolloutGroupSuccessAction(rollout, rolloutGroup);
             } else {
                 LOGGER.debug("Rolloutgroup {} is still running", rolloutGroup);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/StartNextGroupRolloutGroupSuccessAction.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/StartNextGroupRolloutGroupSuccessAction.java
@@ -65,7 +65,7 @@ public class StartNextGroupRolloutGroupSuccessAction implements RolloutGroupActi
             // get all next scheduled groups and set them in state running
             rolloutGroupRepository.setStatusForCildren(RolloutGroupStatus.RUNNING, rolloutGroup);
         } else {
-            logger.info("No actions to start for next rolloutgroup of parent {} {}", rolloutGroup.getId(),
+            logger.debug("No actions to start for next rolloutgroup of parent {} {}", rolloutGroup.getId(),
                     rolloutGroup.getName());
             // nothing for next group, just finish the group, this can happen
             // e.g. if targets has been deleted after the group has been


### PR DESCRIPTION
This PR modifies the log level of log messages about the status of rollout groups from info to debug as a proposed solution for issue #846.

The affected log messages are written every 2 seconds for every rollout group that has fulfilled its success condition, but is not finished yet.