### PR TITLE
Add fix for Download-Only deployment type on DDI-API

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
@@ -143,6 +143,13 @@ public interface Action extends TenantAwareBaseEntity {
     }
 
     /**
+     * @return true when action is downloadonly, false otherwise
+     */
+    default boolean isDownloadOnly() {
+        return ActionType.DOWNLOAD_ONLY == getActionType();
+    }
+
+    /**
      * Action status as reported by the controller.
      *
      * Be aware that JPA is persisting the ordinal number of the enum by means

--- a/hawkbit-rest/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -313,12 +313,11 @@ public class DdiRootController implements DdiRootControllerRestApi {
         return ResponseEntity.notFound().build();
     }
 
-    private HandlingType calculateDownloadType(final Action action) {
+    private static HandlingType calculateDownloadType(final Action action) {
         if (action.isDownloadOnly() || action.isForce()) {
             return HandlingType.FORCED;
-        } else {
-            return HandlingType.ATTEMPT;
         }
+        return HandlingType.ATTEMPT;
     }
 
     private static DdiMaintenanceWindowStatus calculateMaintenanceWindow(final Action action) {

--- a/hawkbit-rest/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -294,7 +294,7 @@ public class DdiRootController implements DdiRootControllerRestApi {
             final DdiActionHistory actionHistory = actionHistoryMsgs.isEmpty() ? null
                     : new DdiActionHistory(action.getStatus().name(), actionHistoryMsgs);
 
-            final HandlingType downloadType = action.isForce() ? HandlingType.FORCED : HandlingType.ATTEMPT;
+            final HandlingType downloadType = calculateDownloadType(action);
             final HandlingType updateType = calculateUpdateType(action, downloadType);
 
             final DdiMaintenanceWindowStatus maintenanceWindow = calculateMaintenanceWindow(action);
@@ -311,6 +311,14 @@ public class DdiRootController implements DdiRootControllerRestApi {
         }
 
         return ResponseEntity.notFound().build();
+    }
+
+    private HandlingType calculateDownloadType(final Action action) {
+        if (action.isDownloadOnly() || action.isForce()) {
+            return HandlingType.FORCED;
+        } else {
+            return HandlingType.ATTEMPT;
+        }
     }
 
     private static DdiMaintenanceWindowStatus calculateMaintenanceWindow(final Action action) {

--- a/hawkbit-rest/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -302,7 +302,7 @@ public class DdiRootController implements DdiRootControllerRestApi {
             final DdiDeploymentBase base = new DdiDeploymentBase(Long.toString(action.getId()),
                     new DdiDeployment(downloadType, updateType, chunks, maintenanceWindow), actionHistory);
 
-            LOG.debug("Found an active UpdateAction for target {}. returning deyploment: {}", controllerId, base);
+            LOG.debug("Found an active UpdateAction for target {}. returning deployment: {}", controllerId, base);
 
             controllerManagement.registerRetrieved(action.getId(), RepositoryConstants.SERVER_MESSAGE_PREFIX
                     + "Target retrieved update action and should start now the download.");
@@ -322,7 +322,9 @@ public class DdiRootController implements DdiRootControllerRestApi {
     }
 
     private static HandlingType calculateUpdateType(final Action action, final HandlingType downloadType) {
-        if (action.hasMaintenanceSchedule()) {
+        if (action.isDownloadOnly()) {
+            return HandlingType.SKIP;
+        } else if (action.hasMaintenanceSchedule()) {
             return action.isMaintenanceWindowAvailable() ? downloadType : HandlingType.SKIP;
         }
         return downloadType;

--- a/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiDeploymentBaseTest.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiDeploymentBaseTest.java
@@ -541,7 +541,7 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
     }
 
     @Test
-    @Description("Attempt/soft deployment to a controller. Checks if the resource response payload for a given deployment is as expected.")
+    @Description("Test download-only (forced + skip) deployment to a controller. Checks if the resource response payload for a given deployment is as expected.")
     public void deploymentDownloadOnlyAction () throws Exception {
         // Prepare test data
         final DistributionSet ds = testdataFactory.createDistributionSet("", true);

--- a/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiDeploymentBaseTest.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiDeploymentBaseTest.java
@@ -84,7 +84,6 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
                 .getContent().get(0);
 
         // get deployment base
-        // get deployment base
         mvc.perform(get("/{tenant}/controller/v1/{target}/deploymentBase/" + uaction.getId(),
                 tenantAware.getCurrentTenant(), target.getControllerId()).accept(DdiRestConstants.MEDIA_TYPE_CBOR))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
@@ -608,7 +607,7 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(jsonPath("$.id", equalTo(String.valueOf(action.getId()))))
-                .andExpect(jsonPath("$.deployment.download", equalTo("attempt")))
+                .andExpect(jsonPath("$.deployment.download", equalTo("forced")))
                 .andExpect(jsonPath("$.deployment.update", equalTo("skip")))
                 .andExpect(jsonPath("$.deployment.chunks[?(@.part=='jvm')].name",
                         contains(ds.findFirstModuleByType(runtimeType).get().getName())))

--- a/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiDeploymentBaseTest.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiDeploymentBaseTest.java
@@ -550,7 +550,7 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         final String visibleMetadataOsValue = "withValue";
 
         final int artifactSize = 5 * 1024;
-        final byte random[] = RandomUtils.nextBytes(artifactSize);
+        final byte[] random = RandomUtils.nextBytes(artifactSize);
         final Artifact artifact = artifactManagement.create(
                 new ArtifactUpload(new ByteArrayInputStream(random), getOsModule(ds), "test1", false, artifactSize));
         final Artifact artifactSignature = artifactManagement.create(new ArtifactUpload(
@@ -575,7 +575,7 @@ public class DdiDeploymentBaseTest extends AbstractDDiApiIntegrationTest {
         final Action action = deploymentManagement.findActiveActionsByTarget(PAGE, savedTarget.getControllerId())
                 .getContent().get(0);
         assertThat(deploymentManagement.countActionsAll()).isEqualTo(1);
-        saved = assignDistributionSet(ds2, saved).getAssignedEntity();
+        assignDistributionSet(ds2, saved).getAssignedEntity();
         assertThat(deploymentManagement.findActiveActionsByTarget(PAGE, savedTarget.getControllerId())).hasSize(2);
         assertThat(deploymentManagement.countActionsAll()).isEqualTo(2);
 


### PR DESCRIPTION
For action type _Download Only_ it doesn't make sense to send `deployment.download = attempt, deployment.update = attempt` since the device shall only download the artefact not install it.

Therefore, the response should look like the following:
`deployment.download = forced, deployment.update = skip`

Since this feature is quite new, I hope breaking the API here is acceptable? However, I feel the current behaviour is not what one would expect.

Feedback welcome!

PS: I fixed some typos along the way

Signed-off-by: Jeroen Laverman <jeroen.laverman@bosch-si.com>