### PR TITLE
Added AWS SDK version to ensure versions are used matching hawkbit-extension CQs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
       <java.version>1.8</java.version>
       <spring.boot.version>2.1.3.RELEASE</spring.boot.version>
       <spring.cloud.version>Greenwich.RELEASE</spring.cloud.version>
+      <aws-java-sdk.version>1.11.392</aws-java-sdk.version>
 
       <snapshotDependencyAllowed>true</snapshotDependencyAllowed>
 
@@ -829,6 +830,27 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${awaitility.version}</version>
+         </dependency>
+         <!-- Hawkbit Extensions -->
+         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws-java-sdk.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${aws-java-sdk.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-kms</artifactId>
+            <version>${aws-java-sdk.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>jmespath-java</artifactId>
+            <version>${aws-java-sdk.version}</version>
          </dependency>
       </dependencies>
    </dependencyManagement>


### PR DESCRIPTION
When the hawkbit-extension for S3 was used, different versions of the Amazon SDK libraries where resolved by maven. The versions did not match the ones defined in the extensions pom and therefore did not match the CQs anymore.

This was caused by dependencyManagment definitions for the AWS SDK versions in the spring-boot-starter-parent pom that get precedence over definitions in the included s3 extension.

It can be solved by referencing the needed version directly in hawkbit-parent. To avoid setting the version twice in the hawkbit-parent and the hawkbit-extensions a property was used that can be reused by the extension.