### PR TITLE
Use FilterParanms instead if single method parameters

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/FilterParams.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/FilterParams.java
@@ -8,7 +8,12 @@
  */
 package org.eclipse.hawkbit.repository;
 
+import java.io.Serializable;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import javax.validation.constraints.NotNull;
 
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
@@ -17,32 +22,36 @@ import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
  * Encapsulates a set of filters that may be specified (optionally). Properties
  * that are not specified (e.g. <code>null</code> for simple properties) When
  * applied, these filters are AND-gated.
- *
  */
-public class FilterParams {
+public class FilterParams implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private final Collection<TargetUpdateStatus> filterByStatus;
-    private final Boolean overdueState;
+    private final boolean overdueState;
     private final String filterBySearchText;
     private final Boolean selectTargetWithNoTag;
     private final String[] filterByTagNames;
     private final Long filterByDistributionId;
 
+    private FilterParams(@NotNull Long filterByDistributionId) {
+        this(Collections.emptyList(), null, null, filterByDistributionId, null);
+    }
+
     /**
-     * Constructor.
+     * Constructor for creating filter-objects.
      *
-     * @param filterByInstalledOrAssignedDistributionSetId
-     *            if set, a filter is added for the given
-     *            {@link DistributionSet#getId()}
      * @param filterByStatus
      *            if set, a filter is added for target states included by the
      *            collection
      * @param overdueState
      *            if set, a filter is added for overdued devices
      * @param filterBySearchText
-     *            if set, a filter is added for the given search text
+     *            to find targets having the text anywhere in name or description.
+     * @param filterByInstalledOrAssignedDistributionSetId
+     *            filter by installed or assigned {@link DistributionSet#getId()}
      * @param selectTargetWithNoTag
-     *            if set, tag-filtering is enabled
+     *            flag to select targets with no tag assigned, if set, tag-filtering
+     *            is enabled
      * @param filterByTagNames
      *            if tag-filtering is enabled, a filter is added for the given
      *            tag-names
@@ -50,12 +59,34 @@ public class FilterParams {
     public FilterParams(final Collection<TargetUpdateStatus> filterByStatus, final Boolean overdueState,
             final String filterBySearchText, final Long filterByInstalledOrAssignedDistributionSetId,
             final Boolean selectTargetWithNoTag, final String... filterByTagNames) {
-        this.filterByStatus = filterByStatus;
-        this.overdueState = overdueState;
+        this.filterByStatus = (filterByStatus == null) ? Collections.emptyList() : filterByStatus;
+        this.overdueState = Boolean.TRUE.equals(overdueState);
         this.filterBySearchText = filterBySearchText;
         this.filterByDistributionId = filterByInstalledOrAssignedDistributionSetId;
-        this.selectTargetWithNoTag = selectTargetWithNoTag;
-        this.filterByTagNames = filterByTagNames;
+        this.selectTargetWithNoTag = Boolean.TRUE.equals(selectTargetWithNoTag);
+        this.filterByTagNames = (filterByTagNames == null) ? new String[0] : filterByTagNames;
+    }
+
+    /**
+     * Construct a {@linkplain FilterParams} object for a distribution set
+     *
+     * @param distributionId
+     *            the ID of the distribution set to be filtered for
+     * @return a new {@linkplain FilterParams} entity
+     */
+    public static FilterParams forDistributionSet(Long distributionId) {
+        return new FilterParams(distributionId);
+    }
+
+    /**
+     * Construct a {@linkplain FilterParams} object for a list of tags
+     *
+     * @param tagNames
+     *            tag-names to be filtered
+     * @return a new {@linkplain FilterParams} entity
+     */
+    public static FilterParams forTags(String... tagNames) {
+        return new FilterParams(null, null, null, null, false, tagNames);
     }
 
     /**
@@ -64,8 +95,8 @@ public class FilterParams {
      *
      * @return {@link DistributionSet#getId()} to filter the result
      */
-    public Long getFilterByDistributionId() {
-        return filterByDistributionId;
+    public Optional<Long> getFilterByDistributionId() {
+        return Optional.ofNullable(filterByDistributionId);
     }
 
     /**
@@ -79,26 +110,27 @@ public class FilterParams {
     }
 
     /**
-     * Gets the flag for overdue filter; if set to <code>true</code>, the
-     * overdue filter is activated. Overdued targets a targets that did not
-     * respond during the configured intervals: poll_itvl + overdue_itvl. <br>
-     * If set to <code>null</code> this filter is disabled.
+     * Gets the flag for overdue filter; if set to <code>true</code>, the overdue
+     * filter is activated. Overdued targets a targets that did not respond during
+     * the configured intervals: poll_itvl + overdue_itvl. <br>
+     * The default is {@code false} - no filtering for overdue targets.
      *
-     * @return flag for overdue filter activation
+     * @return {@code true} when overdue filtering should be active, {@code false}
+     *         otherwise.
      */
-    public Boolean getOverdueState() {
+    public boolean isOverdueState() {
         return overdueState;
     }
 
     /**
-     * Gets the search text to filter for. This is used to find targets having
-     * the text anywhere in name or description <br>
+     * Gets the search text to filter for. This is used to find targets having the
+     * text anywhere in name or description <br>
      * If set to <code>null</code> this filter is disabled.
      *
      * @return the search text to filter for
      */
-    public String getFilterBySearchText() {
-        return filterBySearchText;
+    public Optional<String> getFilterBySearchText() {
+        return Optional.ofNullable(filterBySearchText);
     }
 
     /**
@@ -107,17 +139,50 @@ public class FilterParams {
      *
      * @return the flag indicating if tagging filter is used
      */
-    public Boolean getSelectTargetWithNoTag() {
+    public boolean isSelectTargetWithNoTag() {
         return selectTargetWithNoTag;
     }
 
     /**
-     * Gets the tags that are used to filter for. The activation of this filter
-     * is done by {@link #setSelectTargetWithNoTag(Boolean)}.
+     * Gets the tags that are used to filter for. The activation of this filter is
+     * done by {@link #isSelectTargetWithNoTag()}.
      *
-     * @return the tags that are used to filter for
+     * @return the tags that are used to filter for or an empty array if non are
+     *         present
      */
     public String[] getFilterByTagNames() {
         return filterByTagNames;
+    }
+
+    /**
+     * checks if there is a valid filter specified
+     *
+     * @return true if there is no valid filter set
+     */
+    public boolean isEmpty() {
+        return isEmpty(filterByDistributionId);
+    }
+
+    /**
+     * Checks if there is a valid filter set. The filter is empty if no filter
+     * criteria is set.
+     *
+     * @param filterByDistributionId
+     *            {@link DistributionSet#getId()}
+     * @return true if there is no valid filter set.
+     */
+    public boolean isEmpty(final Long filterByDistributionId) {
+        return filterByStatus.isEmpty() || getFilterBySearchText().isPresent() || filterByDistributionId != null
+                || !hasTagsFilterActive();
+    }
+
+    /**
+     * Check if a filter by tag should be applied. Returns also true when tags
+     * should be explicitly ignored.
+     *
+     * @return true when a tag-filter should be applied, false otherwise
+     */
+    public boolean hasTagsFilterActive() {
+        return selectTargetWithNoTag || filterByTagNames.length > 0;
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
@@ -81,35 +81,16 @@ public interface TargetManagement {
     /**
      * Count {@link Target}s for all the given filter parameters.
      *
-     * @param status
-     *            find targets having one of these {@link TargetUpdateStatus}s.
-     *            Set to <code>null</code> in case this is not required.
-     * @param overdueState
-     *            find targets that are overdue (targets that did not respond
-     *            during the configured intervals: poll_itvl + overdue_itvl).
-     *            Set to <code>null</code> in case this is not required.
-     * @param searchText
-     *            to find targets having the text anywhere in name or
-     *            description. Set <code>null</code> in case this is not
-     *            required.
-     * @param installedOrAssignedDistributionSetId
-     *            to find targets having the {@link DistributionSet} as
-     *            installed or assigned. Set to <code>null</code> in case this
-     *            is not required.
-     * @param tagNames
-     *            to find targets which are having any one in this tag names.
-     *            Set <code>null</code> in case this is not required.
-     * @param selectTargetWithNoTag
-     *            flag to select targets with no tag assigned
+     * @param filter
+     *            parameters by which targets should be filtered
      *
      * @return the found number {@link Target}s
      * 
      * @throws EntityNotFoundException
-     *             if distribution set with given ID does not exist
+     *             If no distribution set is found matching the given filter
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
-    long countByFilters(Collection<TargetUpdateStatus> status, Boolean overdueState, String searchText,
-            Long installedOrAssignedDistributionSetId, Boolean selectTargetWithNoTag, String... tagNames);
+    long countByFilters(FilterParams filter);
 
     /**
      * Counts number of targets with given with given distribution set Id

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
@@ -14,11 +14,11 @@ import java.util.List;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.ListJoin;
+import javax.persistence.criteria.MapJoin;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.SetJoin;
-import javax.persistence.criteria.MapJoin;
 import javax.validation.constraints.NotNull;
 
 import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
@@ -237,7 +237,7 @@ public final class TargetSpecifications {
         final SetJoin<JpaTarget, JpaTargetTag> tags = targetRoot.join(JpaTarget_.tags, JoinType.LEFT);
         final Path<String> exp = tags.get(JpaTargetTag_.name);
         if (selectTargetWithNoTag) {
-            if (tagNames != null) {
+            if (tagNames != null && tagNames.length > 0) {
                 return cb.or(exp.isNull(), exp.in(tagNames));
             } else {
                 return exp.isNull();

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFilterTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFilterTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.eclipse.hawkbit.repository.FilterParams;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.model.TargetTag;
+import org.junit.Test;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+@Feature("Component Tests - Repository")
+@Story("Target Filter")
+public class TargetFilterTest extends AbstractJpaIntegrationTest {
+
+    @Test
+    @Description("Tests the UI-filter functions")
+    public void filterShouldNotFindTargetsForNotExistingTag() {
+        assertThat(targetManagement.countByFilters(FilterParams.forTags("X"))).as("Target count is wrong").isEqualTo(0);
+    }
+
+    @Test
+    @Description("Tests the UI-filter functions")
+    public void shouldOnlyFindTaggedTargets() {
+        TargetTag tag = targetTagManagement.create(entityFactory.tag().create().name("TEST-TAG"));
+        Target target1 = targetManagement
+                .create(entityFactory.target().create().controllerId("target-1").name("Name1"));
+        targetManagement.create(entityFactory.target().create().controllerId("target-2").name("Name2"));
+        targetManagement.assignTag(Arrays.asList(target1.getControllerId()), tag.getId());
+
+        assertThat(targetManagement.countByFilters(FilterParams.forTags(tag.getName()))).as("Target count is wrong")
+                .isEqualTo(1);
+    }
+
+    @Test
+    @Description("Tests the UI-filter functions")
+    public void shouldApplyAsSoonAsTagsAreProvided() {
+        FilterParams filter = FilterParams.forTags("1", "2", "3");
+        assertThat(filter.hasTagsFilterActive()).as("Has tags should evaluate to true").isTrue();
+    }
+
+    @Test
+    @Description("Tests the UI-filter functions")
+    public void shouldApplyWhenTagsHaveBeenSelected() {
+        FilterParams filter = new FilterParams(null, null, null, null, true, null);
+        assertThat(filter.hasTagsFilterActive()).as("Has tags should evaluate to true").isTrue();
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementSearchTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementSearchTest.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -184,8 +185,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         new FilterParams(pending, null, null, installedSet.getId(), Boolean.FALSE, new String[0]))
                 .getContent())
                         .as("has number of elements").hasSize(1).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(pending, null, null,
-                                installedSet.getId(), Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(new FilterParams(pending, null,
+                                null, installedSet.getId(), Boolean.FALSE, new String[0]))))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -201,8 +202,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findByFilters(PAGE, new FilterParams(both, null, null, null, Boolean.FALSE, targTagW.getName()))
                 .getContent()).as("has number of elements").hasSize(200)
                         .as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(both, null, null, null,
-                                Boolean.FALSE, targTagW.getName())))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(
+                                new FilterParams(both, null, null, null, Boolean.FALSE, targTagW.getName()))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -217,8 +218,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findByFilters(PAGE, new FilterParams(pending, null, null, null, Boolean.FALSE, targTagW.getName()))
                 .getContent())
                         .as("has number of elements").hasSize(2).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(pending, null, null, null,
-                                Boolean.FALSE, targTagW.getName())))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(
+                                new FilterParams(pending, null, null, null, Boolean.FALSE, targTagW.getName()))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -235,8 +236,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         new FilterParams(pending, null, null, setA.getId(), Boolean.FALSE, targTagW.getName()))
                 .getContent())
                         .as("has number of elements").hasSize(2).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(pending, null, null, setA.getId(),
-                                Boolean.FALSE, targTagW.getName())))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(new FilterParams(pending, null,
+                                null, setA.getId(), Boolean.FALSE, targTagW.getName()))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -253,8 +254,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         new FilterParams(pending, null, "%targ-B%", setA.getId(), Boolean.FALSE, targTagW.getName()))
                 .getContent())
                         .as("has number of elements").hasSize(1).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(pending, null, "%targ-B%",
-                                setA.getId(), Boolean.FALSE, targTagW.getName())))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(new FilterParams(pending, null,
+                                "%targ-B%", setA.getId(), Boolean.FALSE, targTagW.getName()))))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -271,8 +272,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         new FilterParams(pending, null, "%targ-A%", setA.getId(), Boolean.FALSE, new String[0]))
                 .getContent())
                         .as("has number of elements").hasSize(1).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(pending, null, "%targ-A%",
-                                setA.getId(), Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(new FilterParams(pending, null,
+                                "%targ-A%", setA.getId(), Boolean.FALSE, new String[0]))))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -288,8 +289,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findByFilters(PAGE, new FilterParams(pending, null, null, setA.getId(), Boolean.FALSE, new String[0]))
                 .getContent())
                         .as("has number of elements").hasSize(3).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(pending, null, null, setA.getId(),
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(
+                                new FilterParams(pending, null, null, setA.getId(), Boolean.FALSE, new String[0]))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -304,8 +305,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findByFilters(PAGE, new FilterParams(pending, null, null, null, Boolean.FALSE, new String[0]))
                 .getContent())
                         .as("has number of elements").hasSize(3).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(pending, null, null, null,
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(
+                                new FilterParams(pending, null, null, null, Boolean.FALSE, new String[0]))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -322,8 +323,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         new FilterParams(unknown, null, "%targ-B%", null, Boolean.FALSE, targTagW.getName()))
                 .getContent()).as("has number of elements").hasSize(99)
                         .as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(unknown, null, "%targ-B%", null,
-                                Boolean.FALSE, targTagW.getName())))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(
+                                new FilterParams(unknown, null, "%targ-B%", null, Boolean.FALSE, targTagW.getName()))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -338,8 +339,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findByFilters(PAGE, new FilterParams(unknown, null, "%targ-A%", null, Boolean.FALSE, new String[0]))
                 .getContent()).as("has number of elements").hasSize(99)
                         .as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(unknown, null, "%targ-A%", null,
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(
+                                new FilterParams(unknown, null, "%targ-A%", null, Boolean.FALSE, new String[0]))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -356,8 +357,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findByFilters(PAGE, new FilterParams(unknown, null, null, setA.getId(), Boolean.FALSE, new String[0]))
                 .getContent())
                         .as("has number of elements").hasSize(0).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(unknown, null, null, setA.getId(),
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(
+                                new FilterParams(unknown, null, null, setA.getId(), Boolean.FALSE, new String[0]))))
                         .as("and filter query returns the same result")
                         .hasSize(targetManagement.findByRsql(PAGE, query).getContent().size());
     }
@@ -372,8 +373,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 new FilterParams(unknown, null, null, null, Boolean.FALSE, targTagY.getName(), targTagW.getName()))
                 .getContent()).as("has number of elements").hasSize(198)
                         .as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(unknown, null, null, null,
-                                Boolean.FALSE, targTagY.getName(), targTagW.getName())))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(new FilterParams(unknown, null,
+                                null, null, Boolean.FALSE, targTagY.getName(), targTagW.getName()))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -388,8 +389,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findByFilters(PAGE, new FilterParams(unknown, null, null, null, Boolean.FALSE, new String[0]))
                 .getContent()).as("has number of elements").hasSize(397)
                         .as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(unknown, null, null, null,
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(
+                                new FilterParams(unknown, null, null, null, Boolean.FALSE, new String[0]))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -406,8 +407,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findByFilters(PAGE, new FilterParams(unknown, Boolean.TRUE, null, null, Boolean.FALSE, new String[0]))
                 .getContent()).as("has number of elements").hasSize(198)
                         .as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(unknown, Boolean.TRUE, null, null,
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(
+                                new FilterParams(unknown, Boolean.TRUE, null, null, Boolean.FALSE, new String[0]))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -423,8 +424,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         new FilterParams(null, null, "%targ-A%", setA.getId(), Boolean.FALSE, new String[0]))
                 .getContent())
                         .as("has number of elements").hasSize(1).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(null, null, "%targ-A%",
-                                setA.getId(), Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(
+                                new FilterParams(null, null, "%targ-A%", setA.getId(), Boolean.FALSE, new String[0]))))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -439,8 +440,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findByFilters(PAGE, new FilterParams(null, null, null, setA.getId(), Boolean.FALSE, new String[0]))
                 .getContent())
                         .as("has number of elements").hasSize(3).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(null, null, null, setA.getId(),
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(
+                                targetManagement.countByFilters(FilterParams.forDistributionSet(setA.getId()))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -456,8 +457,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         new FilterParams(null, null, "%targ-C%", setA.getId(), Boolean.FALSE, targTagX.getName()))
                 .getContent())
                         .as("has number of elements").hasSize(0).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(null, null, "%targ-C%",
-                                setA.getId(), Boolean.FALSE, targTagX.getName())))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(new FilterParams(null, null,
+                                "%targ-C%", setA.getId(), Boolean.FALSE, targTagX.getName()))))
                         .as("and filter query returns the same result")
                         .hasSize(targetManagement.findByRsql(PAGE, query).getContent().size());
 
@@ -472,8 +473,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         new FilterParams(null, null, "%targ-A%", setA.getId(), Boolean.FALSE, targTagW.getName()))
                 .getContent())
                         .as("has number of elements").hasSize(0).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(null, null, "%targ-A%",
-                                setA.getId(), Boolean.FALSE, targTagW.getName())))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(new FilterParams(null, null,
+                                "%targ-A%", setA.getId(), Boolean.FALSE, targTagW.getName()))))
                         .as("and filter query returns the same result")
                         .hasSize(targetManagement.findByRsql(PAGE, query).getContent().size());
 
@@ -489,8 +490,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         new FilterParams(null, null, "%targ-C%", setA.getId(), Boolean.FALSE, targTagW.getName()))
                 .getContent())
                         .as("has number of elements").hasSize(1).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(null, null, "%targ-C%",
-                                setA.getId(), Boolean.FALSE, targTagW.getName())))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(new FilterParams(null, null,
+                                "%targ-C%", setA.getId(), Boolean.FALSE, targTagW.getName()))))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -501,21 +502,21 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
     private void verifyThat1TargetHasNameAndId(final String name, final String controllerId) {
         assertThat(targetManagement.findByFilters(PAGE, new FilterParams(null, null, name, null, Boolean.FALSE))
                 .getContent()).as("has number of elements").hasSize(1).as("that number is also returned by count query")
-                        .hasSize(Ints
-                                .saturatedCast(targetManagement.countByFilters(null, null, name, null, Boolean.FALSE)));
+                        .hasSize(Ints.saturatedCast(targetManagement
+                                .countByFilters(new FilterParams(null, null, name, null, Boolean.FALSE))));
 
         assertThat(targetManagement.findByFilters(PAGE, new FilterParams(null, null, controllerId, null, Boolean.FALSE))
                 .getContent()).as("has number of elements").hasSize(1).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(
-                                targetManagement.countByFilters(null, null, controllerId, null, Boolean.FALSE)));
+                        .hasSize(Ints.saturatedCast(targetManagement
+                                .countByFilters(new FilterParams(null, null, controllerId, null, Boolean.FALSE))));
     }
 
     @Step
     private void verifyThat1TargetHasAttributeValue(final String value, final String controllerId) {
         assertThat(targetManagement.findByFilters(PAGE, new FilterParams(null, null, value, null, Boolean.FALSE))
                 .getContent()).as("has number of elements").hasSize(1).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(
-                                targetManagement.countByFilters(null, null, value, null, Boolean.FALSE)));
+                        .hasSize(Ints.saturatedCast(targetManagement
+                                .countByFilters(new FilterParams(null, null, value, null, Boolean.FALSE))));
     }
 
     @Step
@@ -527,8 +528,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 new FilterParams(null, null, "%targ-B%", null, Boolean.FALSE, targTagY.getName(), targTagW.getName()))
                 .getContent()).as("has number of elements").hasSize(100)
                         .as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(null, null, "%targ-B%", null,
-                                Boolean.FALSE, targTagY.getName(), targTagW.getName())))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(new FilterParams(null, null,
+                                "%targ-B%", null, Boolean.FALSE, targTagY.getName(), targTagW.getName()))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -549,8 +550,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findByFilters(PAGE, new FilterParams(null, null, null, null, Boolean.FALSE, targTagD.getName()))
                 .getContent()).as("Expected number of results is").hasSize(200)
                         .as("and is expected number of results is equal to ")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(null, null, null, null,
-                                Boolean.FALSE, targTagD.getName())))
+                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(
+                                new FilterParams(null, null, null, null, Boolean.FALSE, targTagD.getName()))))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -735,9 +736,6 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
         toggleTagAssignment(tagABCTargets, tagB);
         toggleTagAssignment(tagABCTargets, tagC);
 
-        assertThat(targetManagement.countByFilters(null, null, null, null, Boolean.FALSE, "X"))
-                .as("Target count is wrong").isEqualTo(0);
-
         // search for targets with tag tagA
         final List<Target> targetWithTagA = new ArrayList<>();
         final List<Target> targetWithTagB = new ArrayList<>();
@@ -765,12 +763,12 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
         checkTargetHasNotTags(tagCTargets, tagA, tagB);
 
         // check again target lists refreshed from DB
-        assertThat(targetManagement.countByFilters(null, null, null, null, Boolean.FALSE, "A"))
-                .as("Target count is wrong").isEqualTo(targetWithTagA.size());
-        assertThat(targetManagement.countByFilters(null, null, null, null, Boolean.FALSE, "B"))
-                .as("Target count is wrong").isEqualTo(targetWithTagB.size());
-        assertThat(targetManagement.countByFilters(null, null, null, null, Boolean.FALSE, "C"))
-                .as("Target count is wrong").isEqualTo(targetWithTagC.size());
+        assertThat(targetManagement.countByFilters(FilterParams.forTags("A"))).as("Target count is wrong")
+                .isEqualTo(targetWithTagA.size());
+        assertThat(targetManagement.countByFilters(FilterParams.forTags("B"))).as("Target count is wrong")
+                .isEqualTo(targetWithTagB.size());
+        assertThat(targetManagement.countByFilters(FilterParams.forTags("C"))).as("Target count is wrong")
+                .isEqualTo(targetWithTagC.size());
     }
 
     @Test

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DistributionSetTable.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.im.authentication.SpPermission;
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.FilterParams;
 import org.eclipse.hawkbit.repository.SoftwareModuleManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetUpdatedEvent;
@@ -384,7 +385,7 @@ public class DistributionSetTable extends AbstractNamedVersionTable<Distribution
         if (sm.getType().getMaxAssignments() < 1) {
             return false;
         }
-        if (targetManagement.countByFilters(null, null, null, ds.getId(), Boolean.FALSE, new String[] {}) > 0) {
+        if (targetManagement.countByFilters(FilterParams.forDistributionSet(ds.getId())) > 0) {
             /* Distribution is already assigned */
             getNotification().displayValidationError(getI18n().getMessage("message.dist.inuse", dsNameAndVersion));
             return false;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBeanQuery.java
@@ -31,7 +31,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery;
 import org.vaadin.addons.lazyquerycontainer.QueryDefinition;
@@ -45,15 +44,11 @@ public class TargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
     private static final long serialVersionUID = -5645680058303167558L;
 
     private Sort sort = new Sort(SPUIDefinitions.TARGET_TABLE_CREATE_AT_SORT_ORDER, "id");
-    private transient Collection<TargetUpdateStatus> status;
-    private transient Boolean overdueState;
-    private String[] targetTags;
-    private Long distributionId;
-    private String searchText;
-    private Boolean noTagClicked;
     private transient TargetManagement targetManagement;
     private transient DeploymentManagement deploymentManagement;
     private transient VaadinMessageSource i18N;
+
+    private FilterParams filter;
     private Long pinnedDistId;
     private Long targetFilterQueryId;
     private ManagementUIState managementUIState;
@@ -76,16 +71,20 @@ public class TargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
         super(definition, queryConfig, sortIds, sortStates);
 
         if (HawkbitCommonUtil.isNotNullOrEmpty(queryConfig)) {
-            status = (Collection<TargetUpdateStatus>) queryConfig.get(SPUIDefinitions.FILTER_BY_STATUS);
-            overdueState = (Boolean) queryConfig.get(SPUIDefinitions.FILTER_BY_OVERDUE_STATE);
-            targetTags = (String[]) queryConfig.get(SPUIDefinitions.FILTER_BY_TAG);
-            noTagClicked = (Boolean) queryConfig.get(SPUIDefinitions.FILTER_BY_NO_TAG);
-            distributionId = (Long) queryConfig.get(SPUIDefinitions.FILTER_BY_DISTRIBUTION);
-            searchText = (String) queryConfig.get(SPUIDefinitions.FILTER_BY_TEXT);
-            targetFilterQueryId = (Long) queryConfig.get(SPUIDefinitions.FILTER_BY_TARGET_FILTER_QUERY);
+            String searchText = (String) queryConfig.get(SPUIDefinitions.FILTER_BY_TEXT);
             if (!StringUtils.isEmpty(searchText)) {
                 searchText = String.format("%%%s%%", searchText);
             }
+
+            filter = new FilterParams(
+                    (Collection<TargetUpdateStatus>) queryConfig.get(SPUIDefinitions.FILTER_BY_STATUS),
+                    (Boolean) queryConfig.get(SPUIDefinitions.FILTER_BY_OVERDUE_STATE), searchText,
+                    (Long) queryConfig.get(SPUIDefinitions.FILTER_BY_DISTRIBUTION),
+                    (Boolean) queryConfig.get(SPUIDefinitions.FILTER_BY_NO_TAG),
+                    (String[]) queryConfig.get(SPUIDefinitions.FILTER_BY_TAG));
+
+            targetFilterQueryId = (Long) queryConfig.get(SPUIDefinitions.FILTER_BY_TARGET_FILTER_QUERY);
+
             pinnedDistId = (Long) queryConfig.get(SPUIDefinitions.ORDER_BY_DISTRIBUTION);
         }
 
@@ -110,19 +109,18 @@ public class TargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
         final List<ProxyTarget> proxyTargetBeans = new ArrayList<>();
         if (pinnedDistId != null) {
             targetBeans = getTargetManagement().findByFilterOrderByLinkedDistributionSet(
-                    new OffsetBasedPageRequest(startIndex, SPUIDefinitions.PAGE_SIZE, sort), pinnedDistId,
-                    new FilterParams(status, overdueState, searchText, distributionId, noTagClicked, targetTags));
+                    new OffsetBasedPageRequest(startIndex, SPUIDefinitions.PAGE_SIZE, sort), pinnedDistId, getFilter());
         } else if (null != targetFilterQueryId) {
             targetBeans = getTargetManagement().findByTargetFilterQuery(
                     PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort),
                     targetFilterQueryId);
-        } else if (!isAnyFilterSelected()) {
+        } else if (filter.isEmpty()) {
             targetBeans = getTargetManagement()
                     .findAll(PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort));
         } else {
             targetBeans = getTargetManagement().findByFilters(
                     PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort),
-                    new FilterParams(status, overdueState, searchText, distributionId, noTagClicked, targetTags));
+                    getFilter());
         }
         for (final Target targ : targetBeans) {
             final ProxyTarget prxyTarget = new ProxyTarget();
@@ -158,15 +156,8 @@ public class TargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
         return proxyTargetBeans;
     }
 
-    private Boolean isTagSelected() {
-        if (targetTags == null && !noTagClicked) {
-            return false;
-        }
-        return true;
-    }
-
-    private boolean isOverdueFilterEnabled() {
-        return Boolean.TRUE.equals(overdueState);
+    private FilterParams getFilter() {
+        return filter;
     }
 
     @Override
@@ -181,11 +172,10 @@ public class TargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
         long size;
         if (null != targetFilterQueryId) {
             size = getTargetManagement().countByTargetFilterQuery(targetFilterQueryId);
-        } else if (!isAnyFilterSelected()) {
+        } else if (filter.isEmpty()) {
             size = totSize;
         } else {
-            size = getTargetManagement().countByFilters(status, overdueState, searchText, distributionId, noTagClicked,
-                    targetTags);
+            size = getTargetManagement().countByFilters(getFilter());
         }
 
         final ManagementUIState tmpManagementUIState = getManagementUIState();
@@ -198,12 +188,6 @@ public class TargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
         }
 
         return (int) size;
-    }
-
-    private boolean isAnyFilterSelected() {
-        final boolean isFilterSelected = isTagSelected() || isOverdueFilterEnabled();
-        return isFilterSelected || !CollectionUtils.isEmpty(status) || distributionId != null
-                || !StringUtils.isEmpty(searchText);
     }
 
     private TargetManagement getTargetManagement() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTable.java
@@ -12,6 +12,7 @@ import static org.eclipse.hawkbit.ui.management.TargetAssignmentOperations.creat
 import static org.eclipse.hawkbit.ui.management.TargetAssignmentOperations.isMaintenanceWindowValid;
 import static org.eclipse.hawkbit.ui.management.TargetAssignmentOperations.saveAllAssignments;
 
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -79,7 +80,6 @@ import org.eclipse.hawkbit.ui.utils.UINotification;
 import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.vaadin.addons.lazyquerycontainer.BeanQueryFactory;
 import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
@@ -808,26 +808,12 @@ public class TargetTable extends AbstractTable<Target> {
         final long size;
         if (query.isPresent()) {
             size = targetManagement.countByTargetFilterQuery(query.get());
-        } else if (noFilterSelected(filterParams.getFilterByStatus(), pinnedDistId,
-                filterParams.getSelectTargetWithNoTag(), filterParams.getFilterByTagNames(),
-                filterParams.getFilterBySearchText())) {
+        } else if (filterParams.isEmpty(pinnedDistId)) {
             size = totalTargetsCount;
         } else {
-            size = targetManagement.countByFilters(filterParams.getFilterByStatus(), filterParams.getOverdueState(),
-                    filterParams.getFilterBySearchText(), filterParams.getFilterByDistributionId(),
-                    filterParams.getSelectTargetWithNoTag(), filterParams.getFilterByTagNames());
+            size = targetManagement.countByFilters(filterParams);
         }
         return size;
-    }
-
-    private static boolean noFilterSelected(final Collection<TargetUpdateStatus> status, final Long distributionId,
-            final Boolean noTagClicked, final String[] targetTags, final String searchText) {
-        return CollectionUtils.isEmpty(status) && distributionId == null && StringUtils.isEmpty(searchText)
-                && !isTagSelected(targetTags, noTagClicked);
-    }
-
-    private static Boolean isTagSelected(final String[] targetTags, final Boolean noTagClicked) {
-        return targetTags == null && !noTagClicked;
     }
 
     private long getTotalTargetsCount() {


### PR DESCRIPTION
Center logic distributed in different places in the FilterParam-class
Avoid use of `null`

Signed-off-by: Peter Vigier <Peter.Vigier@bosch-si.com>