### PR TITLE
New service which is responsible for execution of TargetFiterQueries

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
@@ -239,7 +239,7 @@ public abstract class AbstractAmqpServiceIntegrationTest extends AbstractAmqpInt
     }
 
     protected void assertAllTargetsCount(final long expectedTargetsCount) {
-        assertThat(targetManagement.count()).isEqualTo(expectedTargetsCount);
+        assertThat(targetQueryExecutionManagement.count()).isEqualTo(expectedTargetsCount);
     }
 
     protected Message assertReplyMessageHeader(final EventTopic eventTopic, final String controllerId) {

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetFilterQueryManagement.java
@@ -288,5 +288,5 @@ public interface TargetFilterQueryManagement {
      * @throws EntityNotFoundException
      *             when the filter couldn't be found
      */
-    TargetFilterQuery getById(Long targetFilterQueryId);
+    TargetFilterQuery getById(long targetFilterQueryId);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetFilterQueryManagement.java
@@ -277,4 +277,16 @@ public interface TargetFilterQueryManagement {
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_TARGET)
     TargetFilterQuery updateAutoAssignDSWithActionType(long queryId, Long dsId, ActionType actionType);
+
+    /**
+     * Get a {@linkplain TargetFilterQuery} by it's ID
+     *
+     * @param targetFilterQueryId
+     *            the ID of the filter
+     * @return the persistent {@linkplain TargetFilterQuery}
+     *
+     * @throws EntityNotFoundException
+     *             when the filter couldn't be found
+     */
+    TargetFilterQuery getById(Long targetFilterQueryId);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetQueryExecutionManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetQueryExecutionManagement.java
@@ -25,13 +25,11 @@ import org.springframework.security.access.prepost.PreAuthorize;
  * This interface is the central point which is responsible to execute queries
  * and return update-targets for Hawkbit.
  *
- * By design it should be as minimal as possible in order to make it easy to
- * plug-in different sources of {@linkplain Target Targets}.
- *
- * For any use-case specific query use the query-/count-methods which limit the
- * result to a predefined set of IDs.
- *
- * @param <T> The concrete type of the target implementation
+ * By design it only contains generic filter methods so given query parameters
+ * can be used in a more universal, model independent manner. Thus domain
+ * specific querying e.g. {@code findByFilterAndDistributionSet(...)} should
+ * rather be expressed within the query syntax, or by providing a pre-select
+ * with the {@code inIdList} parameter, than by introducing (new) named methods.
  */
 public interface TargetQueryExecutionManagement {
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetQueryExecutionManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetQueryExecutionManagement.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository;
+
+import java.util.Collection;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+import org.eclipse.hawkbit.im.authentication.SpPermission;
+import org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * This interface is the central point which is responsible to execute queries
+ * and return update-targets for Hawkbit.
+ *
+ * By design it should be as minimal as possible in order to make it easy to
+ * plug-in different sources of {@linkplain Target Targets}.
+ *
+ * For any use-case specific query use the query-/count-methods which limit the
+ * result to a predefined set of IDs.
+ *
+ * @param <T> The concrete type of the target implementation
+ */
+public interface TargetQueryExecutionManagement {
+
+    /**
+     * Retrieves all targets.
+     *
+     * @param pageable
+     *            pagination parameter
+     * @return the found {@link Target}s
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    Page<Target> findAll(@NotNull Pageable pageable);
+
+    /**
+     * Query targets
+     *
+     * @param pageable
+     *            pagination parameter
+     * @param query
+     *            in RSQL notation
+     *
+     * @return the found {@linkplain Target}s, never {@code null}
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    Page<Target> findByQuery(@NotNull Pageable pageable, @NotEmpty String query);
+
+    /**
+     * Query targets and limit the result to be in the provided ID-list
+     *
+     * @param pageable
+     *            pagination parameter
+     * @param query
+     *            in RSQL notation
+     * @param inIdList
+     *            Limit the result to the provided IDs ("... AND controllerId in
+     *            [id, ...]")
+     *
+     * @return the found {@linkplain Target}s, never {@code null}
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    Page<Target> findByQuery(@NotNull Pageable pageable, @NotEmpty String query, Collection<String> inIdList);
+
+    /**
+     * Count with a {@linkplain TargetFilterQuery#getQuery()}
+     *
+     * @param query
+     *            filter definition in RSQL syntax
+     * @return the found number {@linkplain Target}s
+     */
+    @PreAuthorize(SpPermission.SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    long countByQuery(@NotEmpty String query);
+
+    /**
+     * Count with a {@linkplain TargetFilterQuery#getQuery()}
+     *
+     * @param query
+     *            filter definition in RSQL syntax
+     * @param inIdList
+     *            Limit the result to the provided IDs ("... AND controllerId in
+     *            [id, ...]")
+     * @return the found number {@linkplain Target}s
+     */
+    @PreAuthorize(SpPermission.SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    long countByQuery(@NotEmpty String query, @NotNull Collection<String> inIdList);
+
+    /**
+     * Counts all {@linkplain Target}s in the repository
+     *
+     * @return number of {@linkplain Target}s
+     */
+    @PreAuthorize(SpPermission.SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    long count();
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
@@ -197,6 +197,12 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     }
 
     @Override
+    public TargetFilterQuery getById(final Long targetFilterQueryId) {
+        return get(targetFilterQueryId)
+                .orElseThrow(() -> new EntityNotFoundException(TargetFilterQuery.class, targetFilterQueryId));
+    }
+
+    @Override
     @Transactional
     public TargetFilterQuery update(final TargetFilterQueryUpdate u) {
         final GenericTargetFilterQueryUpdate update = (GenericTargetFilterQueryUpdate) u;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
@@ -197,7 +197,7 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     }
 
     @Override
-    public TargetFilterQuery getById(final Long targetFilterQueryId) {
+    public TargetFilterQuery getById(final long targetFilterQueryId) {
         return get(targetFilterQueryId)
                 .orElseThrow(() -> new EntityNotFoundException(TargetFilterQuery.class, targetFilterQueryId));
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetQueryExecutionManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetQueryExecutionManagement.java
@@ -27,18 +27,26 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.orm.jpa.vendor.Database;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * Provides a source of
  * {@linkplain org.eclipse.hawkbit.repository.model.Target}s based on Hawkbit's
  * internal device-management.
  */
+@Validated
 @Transactional(readOnly = true)
 public class JpaTargetQueryExecutionManagement implements TargetQueryExecutionManagement {
     private final VirtualPropertyReplacer virtualPropertyReplacer;
     private final Database database;
     private final TargetRepository targetRepository;
 
+    /**
+     * Creates a {@linkplain JpaTargetQueryExecutionManagement}
+     * @param targetRepository the target repo
+     * @param virtualPropertyReplacer the virtual property replacer
+     * @param database the database
+     */
     public JpaTargetQueryExecutionManagement(final TargetRepository targetRepository,
             final VirtualPropertyReplacer virtualPropertyReplacer, final Database database) {
         this.virtualPropertyReplacer = virtualPropertyReplacer;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetQueryExecutionManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetQueryExecutionManagement.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+import org.eclipse.hawkbit.repository.TargetFields;
+import org.eclipse.hawkbit.repository.TargetQueryExecutionManagement;
+import org.eclipse.hawkbit.repository.jpa.model.JpaTarget;
+import org.eclipse.hawkbit.repository.jpa.rsql.RSQLUtility;
+import org.eclipse.hawkbit.repository.jpa.specifications.TargetSpecifications;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.rsql.VirtualPropertyReplacer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Provides a source of
+ * {@linkplain org.eclipse.hawkbit.repository.model.Target}s based on Hawkbit's
+ * internal device-management.
+ */
+@Transactional(readOnly = true)
+public class JpaTargetQueryExecutionManagement implements TargetQueryExecutionManagement {
+    private final VirtualPropertyReplacer virtualPropertyReplacer;
+    private final Database database;
+    private final TargetRepository targetRepository;
+
+    public JpaTargetQueryExecutionManagement(final TargetRepository targetRepository,
+            final VirtualPropertyReplacer virtualPropertyReplacer, final Database database) {
+        this.virtualPropertyReplacer = virtualPropertyReplacer;
+        this.database = database;
+        this.targetRepository = targetRepository;
+    }
+
+    @Override
+    public Page<Target> findAll(@NotNull final Pageable pageable) {
+        return convertPage(targetRepository.findAll(pageable));
+    }
+
+    @Override
+    public Page<Target> findByQuery(final Pageable pageable, @NotEmpty final String query) {
+        return convertPage(targetRepository.findAll(toSpec(query), pageable));
+    }
+
+    @Override
+    public Page<Target> findByQuery(@NotNull final Pageable pageable, @NotEmpty final String query,
+            @NotNull final Collection<String> inIdList) {
+        if (inIdList.isEmpty()) {
+            return Page.empty();
+        }
+        final Specification<JpaTarget> spec = toSpec(query, inIdList);
+        return convertPage(targetRepository.findAll(spec, pageable));
+    }
+
+    private static Page<Target> convertPage(final Page<? extends Target> result) {
+        return new PageImpl<>(Collections.unmodifiableList(result.getContent()), result.getPageable(),
+                result.getTotalElements());
+    }
+
+    @Override
+    public long countByQuery(@NotEmpty final String query) {
+        return targetRepository.count((root, q, cb) -> {
+            q.distinct(true);
+            return toSpec(query).toPredicate(root, q, cb);
+        });
+    }
+
+    @Override
+    public long countByQuery(@NotEmpty final String query, @NotNull final Collection<String> inIdList) {
+        return inIdList.isEmpty() ? 0L : targetRepository.count((root, q, cb) -> {
+            q.distinct(true);
+            return toSpec(query, inIdList).toPredicate(root, q, cb);
+        });
+    }
+
+    @Override
+    public long count() {
+        return targetRepository.count();
+    }
+
+    private Specification<JpaTarget> toSpec(final String query, final Collection<String> inIdList) {
+        return toSpec(query).and(TargetSpecifications.hasControllerId(inIdList));
+    }
+
+    private Specification<JpaTarget> toSpec(final String query) {
+        return RSQLUtility.parse(query, TargetFields.class, virtualPropertyReplacer, database);
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
@@ -182,7 +182,7 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
      * @return controller-ids which do have the specified {@linkplain DistributionSet} installed.
      */
     @Query("SELECT t.controllerId FROM JpaTarget t where t.installedDistributionSet.id = :dsId")
-    Set<String> findControllerIdsByInstalledDistributionSet(Long dsId);
+    Set<String> findControllerIdsByInstalledDistributionSet(@Param("dsId") Long dsId);
 
     /**
      * Finds all targets that have defined {@link DistributionSet} assigned.
@@ -202,7 +202,7 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
      * @return a list of controller-ids which do have the specified {@linkplain DistributionSet} assigned.
      */
     @Query("SELECT t.controllerId FROM JpaTarget t where t.assignedDistributionSet.id = :dsId")
-    Set<String> findControllerIdsByAssignedDistributionSet(Long dsId);
+    Set<String> findControllerIdsByAssignedDistributionSet(@Param("dsId") Long dsId);
 
     /**
      * Finds all target-controller IDs that have a {@link DistributionSet}
@@ -214,8 +214,8 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
      * @return a list of target controller-IDs
      */
     @Query("SELECT t.controllerId FROM JpaTarget  t where t.controllerId not in ("
-            + "SELECT t.controllerId FROM JpaTarget t JOIN t.actions a where a.distributionSet.id = :setId)")
-    Set<String> findByNoActionWithDistributionSetExisits(Long setId);
+            + "SELECT t.controllerId FROM JpaTarget t JOIN t.actions a where a.distributionSet.id = :dsId)")
+    Set<String> findByNoActionWithDistributionSetExisits(@Param("dsId") Long dsId);
 
     /**
      * retrieves {@link Target}s where

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.persistence.EntityManager;
 
@@ -128,6 +129,16 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
     Page<JpaTarget> findByTag(Pageable page, @Param("tag") Long tagId);
 
     /**
+     * Finds {@link Target} IDs by assigned {@link Tag}.
+     *
+     * @param tagId
+     *            to be found
+     * @return all controller IDs of found targets
+     */
+    @Query(value = "SELECT t.controllerId FROM JpaTarget t JOIN t.tags tt WHERE tt.id = :tag")
+    Set<String> findControllerIdsByTag(@Param("tag") Long tagId);
+
+    /**
      * Finds all {@link Target}s based on given {@link Target#getControllerId()}
      * list and assigned {@link Tag#getName()}.
      *
@@ -166,6 +177,14 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
     Page<Target> findByInstalledDistributionSetId(Pageable pageable, Long setID);
 
     /**
+     * Select controllerIds which do have a ceratain {@linkplain DistributionSet} installed
+     * @param dsId the id of a {@linkplain DistributionSet}
+     * @return controller-ids which do have the specified {@linkplain DistributionSet} installed.
+     */
+    @Query("SELECT t.controllerId FROM JpaTarget t where t.installedDistributionSet.id = :dsId")
+    Set<String> findControllerIdsByInstalledDistributionSet(Long dsId);
+
+    /**
      * Finds all targets that have defined {@link DistributionSet} assigned.
      * 
      * @param pageable
@@ -178,10 +197,31 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
     Page<Target> findByAssignedDistributionSetId(Pageable pageable, Long setID);
 
     /**
+     * Select controllerIds which do have a ceratain {@linkplain DistributionSet} assigned
+     * @param dsId the id of the {@linkplain DistributionSet}
+     * @return a list of controller-ids which do have the specified {@linkplain DistributionSet} assigned.
+     */
+    @Query("SELECT t.controllerId FROM JpaTarget t where t.assignedDistributionSet.id = :dsId")
+    Set<String> findControllerIdsByAssignedDistributionSet(Long dsId);
+
+    /**
+     * Finds all target-controller IDs that have a {@link DistributionSet}
+     * <em>not</em> assigned in either action
+     *
+     * @param setId
+     *            is the ID of the {@linkplain DistributionSet} to filter for.
+     *
+     * @return a list of target controller-IDs
+     */
+    @Query("SELECT t.controllerId FROM JpaTarget  t where t.controllerId not in ("
+            + "SELECT t.controllerId FROM JpaTarget t JOIN t.actions a where a.distributionSet.id = :setId)")
+    Set<String> findByNoActionWithDistributionSetExisits(Long setId);
+
+    /**
      * retrieves {@link Target}s where
      * {@link JpaTarget#isRequestControllerAttributes()}.
      * 
-     * @param pageReq
+     * @param pageable
      *            page parameter
      *
      * @return the found {@link Target}s

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignChecker.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignChecker.java
@@ -170,8 +170,8 @@ public class AutoAssignChecker {
      */
     private List<TargetWithActionType> getTargetsWithActionType(final String targetFilterQuery, final Long dsId,
             final ActionType type, final int count) {
-        final Page<Target> targets = targetManagement.findByTargetFilterQueryAndNonDS(PageRequest.of(0, count), dsId,
-                targetFilterQuery);
+        final Page<Target> targets = targetManagement
+                .findByNoActionWithDistributionSetExistsAndQuery(PageRequest.of(0, count), dsId, targetFilterQuery);
         // the action type is set to FORCED per default (when not explicitly
         // specified)
         final ActionType autoAssignActionType = type == null ? ActionType.FORCED : type;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlParserValidationOracle.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlParserValidationOracle.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.repository.TargetFields;
-import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.TargetQueryExecutionManagement;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterSyntaxException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterUnsupportedFieldException;
 import org.eclipse.hawkbit.repository.jpa.rsql.ParseExceptionWrapper.TokenWrapper;
@@ -33,7 +33,6 @@ import org.eclipse.hawkbit.repository.rsql.ValidationOracleContext;
 import org.eclipse.persistence.exceptions.ConversionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.util.CollectionUtils;
@@ -61,8 +60,15 @@ public class RsqlParserValidationOracle implements RsqlValidationOracle {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RsqlParserValidationOracle.class);
 
-    @Autowired
-    private TargetManagement targetManagement;
+    private final TargetQueryExecutionManagement targetQueryExecutionManagement;
+
+    /**
+     * Create a new query-validator.
+     * @param targetQueryExecutionManagement the executor for the query
+     */
+    public RsqlParserValidationOracle(final TargetQueryExecutionManagement targetQueryExecutionManagement) {
+        this.targetQueryExecutionManagement = targetQueryExecutionManagement;
+    }
 
     @Override
     public ValidationOracleContext suggest(final String rsqlQuery, final int cursorPosition) {
@@ -76,7 +82,7 @@ public class RsqlParserValidationOracle implements RsqlValidationOracle {
         context.setSyntaxErrorContext(errorContext);
 
         try {
-            targetManagement.findByRsql(PageRequest.of(0, 1), rsqlQuery);
+            targetQueryExecutionManagement.findByQuery(PageRequest.of(0, 1), rsqlQuery);
             context.setSyntaxError(false);
             suggestionContext.getSuggestions().addAll(getLogicalOperatorSuggestion(rsqlQuery));
         } catch (final RSQLParameterSyntaxException | RSQLParserException ex) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
@@ -14,11 +14,11 @@ import java.util.List;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.ListJoin;
+import javax.persistence.criteria.MapJoin;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.SetJoin;
-import javax.persistence.criteria.MapJoin;
 import javax.validation.constraints.NotNull;
 
 import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
@@ -215,6 +215,17 @@ public final class TargetSpecifications {
     }
 
     /**
+     * Limit the result to all target in the provided controller-id list.
+     *
+     * @param controllerIds
+     *            list of controller-IDs
+     * @return the {@link Specification}
+     */
+    public static Specification<JpaTarget> hasControllerId(final Collection<String> controllerIds) {
+        return (targetRoot, query, cb) -> targetRoot.get(JpaTarget_.controllerId).in(controllerIds);
+    }
+
+    /**
      * {@link Specification} for retrieving {@link Target}s by "has no tag
      * names"or "has at least on of the given tag names".
      *
@@ -245,20 +256,6 @@ public final class TargetSpecifications {
         } else {
             return exp.in(tagNames);
         }
-    }
-
-    /**
-     * {@link Specification} for retrieving {@link Target}s by assigned
-     * distribution set.
-     *
-     * @param distributionSetId
-     *            the ID of the distribution set which must be assigned
-     * @return the {@link Target} {@link Specification}
-     */
-    public static Specification<JpaTarget> hasAssignedDistributionSet(final Long distributionSetId) {
-        return (targetRoot, query, cb) -> cb.equal(
-                targetRoot.<JpaDistributionSet> get(JpaTarget_.assignedDistributionSet).get(JpaDistributionSet_.id),
-                distributionSetId);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
@@ -602,7 +602,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         // verify that one Action for each assignDistributionSet
         assertThat(actionRepository.findAll(PAGE).getNumberOfElements()).as("wrong size of actions").isEqualTo(20);
 
-        final Iterable<Target> allFoundTargets = targetManagement.findAll(PAGE).getContent();
+        final Iterable<Target> allFoundTargets = targetQueryExecutionManagement.findAll(PAGE).getContent();
 
         // get final updated version of targets
         savedDeployedTargets = targetManagement.getByControllerID(
@@ -920,13 +920,13 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
                     Collections.singletonList("blabla alles gut"));
         }
 
-        assertThat(targetManagement.count()).as("size of targets is wrong").isNotZero();
+        assertThat(targetQueryExecutionManagement.count()).as("size of targets is wrong").isNotZero();
         assertThat(actionStatusRepository.count()).as("size of action status is wrong").isNotZero();
 
         targetManagement.delete(deploymentResult.getUndeployedTargetIDs());
         targetManagement.delete(deploymentResult.getDeployedTargetIDs());
 
-        assertThat(targetManagement.count()).as("size of targets should be zero").isZero();
+        assertThat(targetQueryExecutionManagement.count()).as("size of targets should be zero").isZero();
         assertThat(actionStatusRepository.count()).as("size of action status is wrong").isZero();
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementSearchTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementSearchTest.java
@@ -188,7 +188,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 installedSet.getId(), Boolean.FALSE, new String[0])))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
 
     }
 
@@ -205,7 +205,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, targTagW.getName())))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
     }
 
     @Step
@@ -221,7 +221,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, targTagW.getName())))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
     }
 
     @Step
@@ -239,7 +239,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, targTagW.getName())))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
     }
 
     @Step
@@ -257,7 +257,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 setA.getId(), Boolean.FALSE, targTagW.getName())))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
     }
 
     @Step
@@ -275,7 +275,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 setA.getId(), Boolean.FALSE, new String[0])))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
     }
 
     @Step
@@ -292,7 +292,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, new String[0])))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
     }
 
     @Step
@@ -308,7 +308,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, new String[0])))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
     }
 
     @Step
@@ -326,7 +326,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, targTagW.getName())))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
     }
 
     @Step
@@ -342,7 +342,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, new String[0])))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
 
     }
 
@@ -359,7 +359,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         .hasSize(Ints.saturatedCast(targetManagement.countByFilters(unknown, null, null, setA.getId(),
                                 Boolean.FALSE, new String[0])))
                         .as("and filter query returns the same result")
-                        .hasSize(targetManagement.findByRsql(PAGE, query).getContent().size());
+                        .hasSize(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent().size());
     }
 
     @Step
@@ -376,7 +376,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, targTagY.getName(), targTagW.getName())))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
     }
 
     @Step
@@ -392,7 +392,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, new String[0])))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
 
     }
 
@@ -410,7 +410,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, new String[0])))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
     }
 
     @Step
@@ -427,7 +427,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 setA.getId(), Boolean.FALSE, new String[0])))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
 
     }
 
@@ -443,7 +443,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, new String[0])))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
 
     }
 
@@ -459,7 +459,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         .hasSize(Ints.saturatedCast(targetManagement.countByFilters(null, null, "%targ-C%",
                                 setA.getId(), Boolean.FALSE, targTagX.getName())))
                         .as("and filter query returns the same result")
-                        .hasSize(targetManagement.findByRsql(PAGE, query).getContent().size());
+                        .hasSize(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent().size());
 
     }
 
@@ -475,7 +475,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                         .hasSize(Ints.saturatedCast(targetManagement.countByFilters(null, null, "%targ-A%",
                                 setA.getId(), Boolean.FALSE, targTagW.getName())))
                         .as("and filter query returns the same result")
-                        .hasSize(targetManagement.findByRsql(PAGE, query).getContent().size());
+                        .hasSize(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent().size());
 
     }
 
@@ -493,7 +493,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 setA.getId(), Boolean.FALSE, targTagW.getName())))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
 
     }
 
@@ -531,7 +531,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, targTagY.getName(), targTagW.getName())))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
 
     }
 
@@ -553,7 +553,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                                 Boolean.FALSE, targTagD.getName())))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
-                        .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
+                        .containsAll(targetQueryExecutionManagement.findByQuery(PAGE, query).getContent());
 
     }
 
@@ -562,9 +562,9 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
         assertThat(targetManagement.findByFilters(PAGE, new FilterParams(null, null, null, null, null, new String[0]))
                 .getContent()).as("Overall we expect that many targets in the repository").hasSize(400)
                         .as("which is also reflected by repository count")
-                        .hasSize(Ints.saturatedCast(targetManagement.count()))
+                        .hasSize(Ints.saturatedCast(targetQueryExecutionManagement.count()))
                         .as("which is also reflected by call without specification")
-                        .containsAll(targetManagement.findAll(PAGE).getContent());
+                        .containsAll(targetQueryExecutionManagement.findAll(PAGE).getContent());
 
     }
 
@@ -672,6 +672,10 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .as("Contains the assigned targets").containsAll(assignedtargets)
                 .as("and that means the following expected amount").hasSize(10);
 
+        assertThat(targetRepository.findControllerIdsByAssignedDistributionSet(assignedSet.getId()))
+                .as("Should find the assinged targets")
+                .containsAll(assignedtargets.stream().map(Target::getControllerId).collect(Collectors.toList()));
+
     }
 
     @Test
@@ -686,7 +690,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
         assignDistributionSet(assignedSet, assignedTargets);
 
         final List<Target> result = targetManagement
-                .findByTargetFilterQueryAndNonDS(PAGE, assignedSet.getId(), tfq.getQuery()).getContent();
+                .findByNoActionWithDistributionSetExistsAndQuery(PAGE, assignedSet.getId(), tfq.getQuery())
+                .getContent();
         assertThat(result).as("count of targets").hasSize(unassignedTargets.size()).as("contains all targets")
                 .containsAll(unassignedTargets);
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetQueryExecutionManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetQueryExecutionManagementTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa;
+
+import java.util.Collections;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.hawkbit.repository.TargetQueryExecutionManagement;
+import org.eclipse.hawkbit.repository.jpa.model.JpaTargetMetadata;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+@Feature("Component Tests - Repository")
+@Story("Target Query Execution")
+public class TargetQueryExecutionManagementTest extends AbstractJpaIntegrationTest {
+
+    @Autowired
+    protected TargetQueryExecutionManagement sut;
+
+    @Test
+    @Description("Test that RSQL filter finds targets with metadata and/or controllerId.")
+    public void findTargetsByRsqlWithMetadata() {
+        final String controllerId1 = "target1";
+        final String controllerId2 = "target2";
+        createTargetWithMetadata(controllerId1, 2);
+        createTargetWithMetadata(controllerId2, 2);
+
+        final String rsqlAndControllerIdFilter = "id==target1 and metadata.key1==target1-value1";
+        final String rsqlAndControllerIdWithWrongKeyFilter = "id==* and metadata.unknown==value1";
+        final String rsqlAndControllerIdNotEqualFilter = "id==* and metadata.key2!=target1-value2";
+        final String rsqlOrControllerIdFilter = "id==target1 or metadata.key1==*value1";
+        final String rsqlOrControllerIdWithWrongKeyFilter = "id==target2 or metadata.unknown==value1";
+        final String rsqlOrControllerIdNotEqualFilter = "id==target1 or metadata.key1!=target1-value1";
+
+        Assertions.assertThat(targetQueryExecutionManagement.count()).as("Total targets").isEqualTo(2);
+        validateFoundTargetsByRsql(rsqlAndControllerIdFilter, controllerId1);
+        validateFoundTargetsByRsql(rsqlAndControllerIdWithWrongKeyFilter);
+        validateFoundTargetsByRsql(rsqlAndControllerIdNotEqualFilter, controllerId2);
+        validateFoundTargetsByRsql(rsqlOrControllerIdFilter, controllerId1, controllerId2);
+        validateFoundTargetsByRsql(rsqlOrControllerIdWithWrongKeyFilter, controllerId2);
+        validateFoundTargetsByRsql(rsqlOrControllerIdNotEqualFilter, controllerId1, controllerId2);
+    }
+
+    private void validateFoundTargetsByRsql(final String rsqlFilter, final String... controllerIds) {
+        final Page<? extends Target> foundTargetsByMetadataAndControllerId = targetQueryExecutionManagement
+                .findByQuery(PAGE, rsqlFilter);
+
+        Assertions.assertThat(foundTargetsByMetadataAndControllerId.getTotalElements())
+                .as("Targets count in RSQL filter is wrong").isEqualTo(controllerIds.length);
+        Assertions.assertThat(foundTargetsByMetadataAndControllerId.getContent().stream().map(Target::getControllerId))
+                .as("Targets found by RSQL filter have wrong controller ids").containsExactlyInAnyOrder(controllerIds);
+    }
+
+    private Target createTargetWithMetadata(final String controllerId, final int count) {
+        final Target target = testdataFactory.createTarget(controllerId);
+
+        for (int index = 1; index <= count; index++) {
+            insertTargetMetadata("key" + index, controllerId + "-value" + index, target);
+        }
+        return target;
+    }
+
+    private void insertTargetMetadata(final String knownKey, final String knownValue, final Target target) {
+        final JpaTargetMetadata metadata = new JpaTargetMetadata(knownKey, knownValue, target);
+        targetManagement.createMetaData(target.getControllerId(), Collections.singletonList(metadata));
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autocleanup/AutoActionCleanupTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autocleanup/AutoActionCleanupTest.java
@@ -97,7 +97,7 @@ public class AutoActionCleanupTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verifies that canceled and failed actions are cleaned up.")
-    public void canceledAndFailedActionsAreCleanedUp() throws Exception{
+    public void canceledAndFailedActionsAreCleanedUp(){
 
         // cleanup config for this test case
         setupCleanupConfiguration(true, 0, Action.Status.CANCELED, Action.Status.ERROR);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autocleanup/AutoActionCleanupTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autocleanup/AutoActionCleanupTest.java
@@ -97,7 +97,7 @@ public class AutoActionCleanupTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verifies that canceled and failed actions are cleaned up.")
-    public void canceledAndFailedActionsAreCleanedUp() {
+    public void canceledAndFailedActionsAreCleanedUp() throws Exception{
 
         // cleanup config for this test case
         setupCleanupConfiguration(true, 0, Action.Status.CANCELED, Action.Status.ERROR);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
@@ -209,7 +209,7 @@ public class RSQLTargetFieldTest extends AbstractJpaIntegrationTest {
     }
 
     private void assertRSQLQuery(final String rsqlParam, final long expcetedTargets) {
-        final Page<Target> findTargetPage = targetManagement.findByRsql(PAGE, rsqlParam);
+        final Page<Target> findTargetPage = targetQueryExecutionManagement.findByQuery(PAGE, rsqlParam);
         final long countTargetsAll = findTargetPage.getTotalElements();
         assertThat(findTargetPage).isNotNull();
         assertThat(countTargetsAll).isEqualTo(expcetedTargets);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/tenancy/MultiTenancyEntityTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/tenancy/MultiTenancyEntityTest.java
@@ -72,7 +72,7 @@ public class MultiTenancyEntityTest extends AbstractJpaIntegrationTest {
         createTargetForTenant(controllerAnotherTenant, anotherTenant);
 
         // find all targets for current tenant "mytenant"
-        final Slice<Target> findTargetsAll = targetManagement.findAll(PAGE);
+        final Slice<Target> findTargetsAll = targetQueryExecutionManagement.findAll(PAGE);
         // no target has been created for "mytenant"
         assertThat(findTargetsAll).hasSize(0);
 
@@ -174,7 +174,7 @@ public class MultiTenancyEntityTest extends AbstractJpaIntegrationTest {
     }
 
     private Slice<Target> findTargetsForTenant(final String tenant) throws Exception {
-        return runAsTenant(tenant, () -> targetManagement.findAll(PAGE));
+        return runAsTenant(tenant, () -> targetQueryExecutionManagement.findAll(PAGE));
     }
 
     private void deleteTargetsForTenant(final String tenant, final Collection<Long> targetIds) throws Exception {

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/AbstractIntegrationTest.java
@@ -41,6 +41,7 @@ import org.eclipse.hawkbit.repository.SoftwareModuleTypeManagement;
 import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.TargetQueryExecutionManagement;
 import org.eclipse.hawkbit.repository.TargetTagManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.repository.model.Action;
@@ -147,6 +148,9 @@ public abstract class AbstractIntegrationTest {
 
     @Autowired
     protected TargetTagManagement targetTagManagement;
+
+    @Autowired
+    protected TargetQueryExecutionManagement targetQueryExecutionManagement;
 
     @Autowired
     protected DistributionSetTagManagement distributionSetTagManagement;

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResource.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResource.java
@@ -187,7 +187,7 @@ public class MgmtDistributionSetResource implements MgmtDistributionSetRestApi {
         final Pageable pageable = new OffsetBasedPageRequest(sanitizedOffsetParam, sanitizedLimitParam, sorting);
         final Page<Target> targetsAssignedDS;
         if (rsqlParam != null) {
-            targetsAssignedDS = this.targetManagement.findByAssignedDistributionSetAndRsql(pageable, distributionSetId,
+            targetsAssignedDS = this.targetManagement.findByAssignedDistributionSetAndQuery(pageable, distributionSetId,
                     rsqlParam);
         } else {
             targetsAssignedDS = this.targetManagement.findByAssignedDistributionSet(pageable, distributionSetId);
@@ -215,7 +215,7 @@ public class MgmtDistributionSetResource implements MgmtDistributionSetRestApi {
         final Pageable pageable = new OffsetBasedPageRequest(sanitizedOffsetParam, sanitizedLimitParam, sorting);
         final Page<Target> targetsInstalledDS;
         if (rsqlParam != null) {
-            targetsInstalledDS = this.targetManagement.findByInstalledDistributionSetAndRsql(pageable,
+            targetsInstalledDS = this.targetManagement.findByInstalledDistributionSetAndQuery(pageable,
                     distributionSetId, rsqlParam);
         } else {
             targetsInstalledDS = this.targetManagement.findByInstalledDistributionSet(pageable, distributionSetId);

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTagResource.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTagResource.java
@@ -155,7 +155,7 @@ public class MgmtTargetTagResource implements MgmtTargetTagRestApi {
             findTargetsAll = targetManagement.findByTag(pageable, targetTagId);
 
         } else {
-            findTargetsAll = targetManagement.findByRsqlAndTag(pageable, rsqlParam, targetTagId);
+            findTargetsAll = targetManagement.findByQueryAndTag(pageable, rsqlParam, targetTagId);
         }
 
         final Long countTargetsAll = findTargetsAll.getTotalElements();

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
@@ -674,7 +674,7 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
                 .perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isBadRequest()).andReturn();
 
-        assertThat(targetManagement.count()).isEqualTo(0);
+        assertThat(targetQueryExecutionManagement.count()).isEqualTo(0);
 
         // verify response json exception message
         final ExceptionInfo exceptionInfo = ResourceUtility
@@ -693,7 +693,7 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isBadRequest()).andReturn();
 
-        assertThat(targetManagement.count()).isEqualTo(0);
+        assertThat(targetQueryExecutionManagement.count()).isEqualTo(0);
 
         // verify response json exception message
         final ExceptionInfo exceptionInfo = ResourceUtility
@@ -710,7 +710,7 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isBadRequest()).andReturn();
 
-        assertThat(targetManagement.count()).isEqualTo(0);
+        assertThat(targetQueryExecutionManagement.count()).isEqualTo(0);
 
         // verify response json exception message
         final ExceptionInfo exceptionInfo = ResourceUtility
@@ -729,7 +729,7 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
                 .content(JsonBuilder.targets(Arrays.asList(test1), true)).contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isBadRequest()).andReturn();
 
-        assertThat(targetManagement.count()).isEqualTo(0);
+        assertThat(targetQueryExecutionManagement.count()).isEqualTo(0);
 
         // verify response json exception message
         final ExceptionInfo exceptionInfo = ResourceUtility
@@ -810,9 +810,9 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
                 .contentType(MediaType.APPLICATION_JSON)).andDo(MockMvcResultPrinter.print())
                 .andExpect(status().is2xxSuccessful());
 
-        final Slice<Target> findTargetsAll = targetManagement.findAll(PageRequest.of(0, 100));
+        final Slice<Target> findTargetsAll = targetQueryExecutionManagement.findAll(PageRequest.of(0, 100));
         final Target target = findTargetsAll.getContent().get(0);
-        assertThat(targetManagement.count()).isEqualTo(1);
+        assertThat(targetQueryExecutionManagement.count()).isEqualTo(1);
         assertThat(target.getControllerId()).isEqualTo(knownControllerId);
         assertThat(target.getName()).isEqualTo(knownName);
         assertThat(target.getDescription()).isEqualTo(knownDescription);
@@ -838,7 +838,7 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
                 .andExpect(status().is(HttpStatus.CONFLICT.value())).andReturn();
 
         // verify only one entry
-        assertThat(targetManagement.count()).isEqualTo(1);
+        assertThat(targetQueryExecutionManagement.count()).isEqualTo(1);
 
         // verify response json exception message
         final ExceptionInfo exceptionInfo = ResourceUtility

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTagResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTagResourceTest.java
@@ -242,7 +242,7 @@ public class MgmtTargetTagResourceTest extends AbstractManagementApiIntegrationT
 
         result = toggle(tag, targets);
 
-        updated = targetManagement.findAll(PAGE).getContent();
+        updated = targetQueryExecutionManagement.findAll(PAGE).getContent();
 
         result.andExpect(applyTargetEntityMatcherOnArrayResult(updated.get(0), "unassignedTargets"))
                 .andExpect(applyTargetEntityMatcherOnArrayResult(updated.get(1), "unassignedTargets"));

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CustomTargetBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CustomTargetBeanQuery.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.TargetQueryExecutionManagement;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.ui.common.UserDetailsFormatter;
 import org.eclipse.hawkbit.ui.components.ProxyTarget;
@@ -44,7 +44,8 @@ public class CustomTargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
 
     private static final long serialVersionUID = 6490445732785388071L;
     private Sort sort = new Sort(Direction.ASC, "id");
-    private transient TargetManagement targetManagement;
+    private transient TargetQueryExecutionManagement targetQueryExecutionManagement;
+
     private FilterManagementUIState filterManagementUIState;
     private transient VaadinMessageSource i18N;
     private String filterQuery;
@@ -86,14 +87,14 @@ public class CustomTargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
 
     @Override
     protected List<ProxyTarget> loadBeans(final int startIndex, final int count) {
-        Slice<Target> targetBeans;
+        final Slice<Target> targetBeans;
         final List<ProxyTarget> proxyTargetBeans = new ArrayList<>();
         if (!StringUtils.isEmpty(filterQuery)) {
-            targetBeans = targetManagement.findByRsql(
+            targetBeans = getTargetQueryExecutionManagement().findByQuery(
                     PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort),
                     filterQuery);
         } else {
-            targetBeans = targetManagement
+            targetBeans = getTargetQueryExecutionManagement()
                     .findAll(PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort));
         }
 
@@ -130,7 +131,7 @@ public class CustomTargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
     public int size() {
         long size = 0;
         if (!StringUtils.isEmpty(filterQuery)) {
-            size = getTargetManagement().countByRsql(filterQuery);
+            size = getTargetQueryExecutionManagement().countByQuery(filterQuery);
         }
         getFilterManagementUIState().setTargetsCountAll(size);
         if (size > SPUIDefinitions.MAX_TABLE_ENTRIES) {
@@ -142,11 +143,11 @@ public class CustomTargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
         return (int) size;
     }
 
-    private TargetManagement getTargetManagement() {
-        if (targetManagement == null) {
-            targetManagement = SpringContextHelper.getBean(TargetManagement.class);
+    private TargetQueryExecutionManagement getTargetQueryExecutionManagement() {
+        if (targetQueryExecutionManagement == null) {
+            targetQueryExecutionManagement = SpringContextHelper.getBean(TargetQueryExecutionManagement.class);
         }
-        return targetManagement;
+        return targetQueryExecutionManagement;
     }
 
     private FilterManagementUIState getFilterManagementUIState() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/DistributionSetSelectWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/DistributionSetSelectWindow.java
@@ -249,7 +249,7 @@ public class DistributionSetSelectWindow implements CommonDialogWindow.SaveDialo
             layout.setMargin(true);
             setContent(layout);
 
-            final Long targetsCount = targetManagement.countByRsqlAndNonDS(distributionSetId,
+            final Long targetsCount = targetManagement.countByNotAssignedDistributionSetAndQuery(distributionSetId,
                     targetFilterQuery.getQuery());
             Label mainTextLabel;
             if (targetsCount == 0) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/DeploymentView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/DeploymentView.java
@@ -21,6 +21,7 @@ import org.eclipse.hawkbit.repository.EntityFactory;
 import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.TargetQueryExecutionManagement;
 import org.eclipse.hawkbit.repository.TargetTagManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.security.SystemSecurityContext;
@@ -124,8 +125,8 @@ public class DeploymentView extends AbstractNotificationView implements BrowserW
             final DeploymentManagement deploymentManagement, final DistributionTableFilters distFilterParameters,
             final DistributionSetManagement distributionSetManagement,
             final DistributionSetTypeManagement distributionSetTypeManagement, final TargetManagement targetManagement,
-            final EntityFactory entityFactory, final UiProperties uiProperties,
-            final ManagementViewClientCriterion managementViewClientCriterion,
+            final TargetQueryExecutionManagement targetQueryExecutionManagement, final EntityFactory entityFactory,
+            final UiProperties uiProperties, final ManagementViewClientCriterion managementViewClientCriterion,
             final TargetTagManagement targetTagManagement,
             final DistributionSetTagManagement distributionSetTagManagement,
             final TargetFilterQueryManagement targetFilterQueryManagement, final SystemManagement systemManagement,
@@ -149,8 +150,9 @@ public class DeploymentView extends AbstractNotificationView implements BrowserW
                     managementViewClientCriterion, permChecker, eventBus, uiNotification, entityFactory,
                     targetFilterQueryManagement, targetTagManagement);
             final TargetTable targetTable = new TargetTable(eventBus, i18n, uiNotification, targetManagement,
-                    managementUIState, permChecker, managementViewClientCriterion, distributionSetManagement,
-                    targetTagManagement, deploymentManagement, configManagement, systemSecurityContext, uiProperties);
+                    targetFilterQueryManagement, targetQueryExecutionManagement, managementUIState, permChecker,
+                    managementViewClientCriterion, distributionSetManagement, targetTagManagement, deploymentManagement,
+                   configManagement, systemSecurityContext, uiProperties);
             this.countMessageLabel = new CountMessageLabel(eventBus, targetManagement, i18n, managementUIState,
                     targetTable);
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetTableLayout.java
@@ -46,10 +46,10 @@ public class TargetTableLayout extends AbstractTableLayout<TargetTable> {
         final TargetMetadataPopupLayout targetMetadataPopupLayout = new TargetMetadataPopupLayout(i18n, uiNotification,
                 eventBus, targetManagement, entityFactory, permissionChecker);
         this.eventBus = eventBus;
-        TargetDetails targetDetails = new TargetDetails(i18n, eventBus, permissionChecker, managementUIState, uiNotification,
-                tagManagement, targetManagement, targetMetadataPopupLayout, deploymentManagement, entityFactory,
-                targetTable);
-        TargetTableHeader targetTableHeader = new TargetTableHeader(i18n, permissionChecker, eventBus, uiNotification,
+        final TargetDetails targetDetails = new TargetDetails(i18n, eventBus, permissionChecker, managementUIState,
+                uiNotification, tagManagement, targetManagement, targetMetadataPopupLayout, deploymentManagement,
+                entityFactory, targetTable);
+        final TargetTableHeader targetTableHeader = new TargetTableHeader(i18n, permissionChecker, eventBus, uiNotification,
                 managementUIState, managementViewClientCriterion, targetManagement, deploymentManagement, uiProperties,
                 entityFactory, uiNotification, tagManagement, distributionSetManagement, uiExecutor, targetTable);
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/RolloutView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/RolloutView.java
@@ -18,7 +18,7 @@ import org.eclipse.hawkbit.repository.QuotaManagement;
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
-import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.TargetQueryExecutionManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.ui.AbstractHawkbitUI;
@@ -71,15 +71,16 @@ public class RolloutView extends VerticalLayout implements View {
     @Autowired
     RolloutView(final SpPermissionChecker permissionChecker, final RolloutUIState rolloutUIState,
             final UIEventBus eventBus, final RolloutManagement rolloutManagement,
-            final RolloutGroupManagement rolloutGroupManagement, final TargetManagement targetManagement,
+            final RolloutGroupManagement rolloutGroupManagement,
             final UINotification uiNotification, final UiProperties uiProperties, final EntityFactory entityFactory,
             final VaadinMessageSource i18n, final TargetFilterQueryManagement targetFilterQueryManagement,
+            final TargetQueryExecutionManagement targetQueryExecutionManagement,
             final QuotaManagement quotaManagement, final TenantConfigurationManagement tenantConfigManagement) {
         this.permChecker = permissionChecker;
         this.rolloutManagement = rolloutManagement;
         this.rolloutListView = new RolloutListView(permissionChecker, rolloutUIState, eventBus, rolloutManagement,
-                targetManagement, uiNotification, uiProperties, entityFactory, i18n, targetFilterQueryManagement,
-                rolloutGroupManagement, quotaManagement, tenantConfigManagement);
+                uiNotification, uiProperties, entityFactory, i18n, targetFilterQueryManagement,
+                targetQueryExecutionManagement, rolloutGroupManagement, quotaManagement, tenantConfigManagement);
         this.rolloutGroupsListView = new RolloutGroupsListView(i18n, eventBus, rolloutGroupManagement, rolloutUIState,
                 permissionChecker);
         this.rolloutGroupTargetsListView = new RolloutGroupTargetsListView(eventBus, i18n, rolloutUIState);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/AddUpdateRolloutWindowLayout.java
@@ -21,7 +21,7 @@ import org.eclipse.hawkbit.repository.QuotaManagement;
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
-import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.TargetQueryExecutionManagement;
 import org.eclipse.hawkbit.repository.builder.RolloutCreate;
 import org.eclipse.hawkbit.repository.builder.RolloutGroupCreate;
 import org.eclipse.hawkbit.repository.builder.RolloutUpdate;
@@ -122,9 +122,9 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
 
     private final transient QuotaManagement quotaManagement;
 
-    private final transient TargetManagement targetManagement;
-
     private final transient TargetFilterQueryManagement targetFilterQueryManagement;
+
+    private final transient TargetQueryExecutionManagement targetQueryExecutionManagement;
 
     private final UINotification uiNotification;
 
@@ -185,23 +185,24 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
     private final NullValidator nullValidator = new NullValidator(null, false);
 
     @SuppressWarnings("squid:S00107")
-    AddUpdateRolloutWindowLayout(final RolloutManagement rolloutManagement, final TargetManagement targetManagement,
+    AddUpdateRolloutWindowLayout(final RolloutManagement rolloutManagement,
             final UINotification uiNotification, final UiProperties uiProperties, final EntityFactory entityFactory,
             final VaadinMessageSource i18n, final UIEventBus eventBus,
             final TargetFilterQueryManagement targetFilterQueryManagement,
+            final TargetQueryExecutionManagement targetQueryExecutionManagement,
             final RolloutGroupManagement rolloutGroupManagement, final QuotaManagement quotaManagement) {
         actionTypeOptionGroupLayout = new ActionTypeOptionGroupAssignmentLayout(i18n);
         autoStartOptionGroupLayout = new AutoStartOptionGroupLayout(i18n);
         this.rolloutManagement = rolloutManagement;
         this.rolloutGroupManagement = rolloutGroupManagement;
         this.quotaManagement = quotaManagement;
-        this.targetManagement = targetManagement;
         this.uiNotification = uiNotification;
         this.uiProperties = uiProperties;
         this.entityFactory = entityFactory;
         this.i18n = i18n;
         this.eventBus = eventBus;
         this.targetFilterQueryManagement = targetFilterQueryManagement;
+        this.targetQueryExecutionManagement = targetQueryExecutionManagement;
 
         defineGroupsLayout = new DefineGroupsLayout(i18n, entityFactory, rolloutManagement, targetFilterQueryManagement,
                 rolloutGroupManagement, quotaManagement);
@@ -785,7 +786,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
             groupsLegendLayout.populateTotalTargets(null);
             defineGroupsLayout.setTargetFilter(null);
         } else {
-            totalTargetsCount = targetManagement.countByRsql(filterQueryString);
+            totalTargetsCount = targetQueryExecutionManagement.countByQuery(filterQueryString);
             groupsLegendLayout.populateTotalTargets(totalTargetsCount);
             defineGroupsLayout.setTargetFilter(filterQueryString);
         }
@@ -1014,7 +1015,7 @@ public class AddUpdateRolloutWindowLayout extends GridLayout {
             groupsDefinitionTabs.setSelectedTab(1);
 
             window.clearOriginalValues();
-            totalTargetsCount = targetManagement.countByRsql(rollout.getTargetFilterQuery());
+            totalTargetsCount = targetQueryExecutionManagement.countByQuery(rollout.getTargetFilterQuery());
             groupsLegendLayout.populateTotalTargets(totalTargetsCount);
         } else {
             editRolloutEnabled = true;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListGrid.java
@@ -24,7 +24,7 @@ import org.eclipse.hawkbit.repository.QuotaManagement;
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
-import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.TargetQueryExecutionManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.repository.model.Action.ActionType;
 import org.eclipse.hawkbit.repository.model.Rollout;
@@ -160,17 +160,18 @@ public class RolloutListGrid extends AbstractGrid<LazyQueryContainer> {
     RolloutListGrid(final VaadinMessageSource i18n, final UIEventBus eventBus,
             final RolloutManagement rolloutManagement, final UINotification uiNotification,
             final RolloutUIState rolloutUIState, final SpPermissionChecker permissionChecker,
-            final TargetManagement targetManagement, final EntityFactory entityFactory, final UiProperties uiProperties,
+            final EntityFactory entityFactory, final UiProperties uiProperties,
             final TargetFilterQueryManagement targetFilterQueryManagement,
+            final TargetQueryExecutionManagement targetQueryExecutionManagement,
             final RolloutGroupManagement rolloutGroupManagement, final QuotaManagement quotaManagement,
             final TenantConfigurationManagement tenantConfigManagement) {
         super(i18n, eventBus, permissionChecker);
         this.rolloutManagement = rolloutManagement;
         this.rolloutGroupManagement = rolloutGroupManagement;
         this.tenantConfigManagement = tenantConfigManagement;
-        this.addUpdateRolloutWindow = new AddUpdateRolloutWindowLayout(rolloutManagement, targetManagement,
+        this.addUpdateRolloutWindow = new AddUpdateRolloutWindowLayout(rolloutManagement,
                 uiNotification, uiProperties, entityFactory, i18n, eventBus, targetFilterQueryManagement,
-                rolloutGroupManagement, quotaManagement);
+                targetQueryExecutionManagement, rolloutGroupManagement, quotaManagement);
         this.uiNotification = uiNotification;
         this.rolloutUIState = rolloutUIState;
         alignGenerator = new AlignCellStyleGenerator(null, centerAlignedColumns, null);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListHeader.java
@@ -13,7 +13,7 @@ import org.eclipse.hawkbit.repository.QuotaManagement;
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
-import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.TargetQueryExecutionManagement;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.UiProperties;
 import org.eclipse.hawkbit.ui.common.builder.LabelBuilder;
@@ -43,16 +43,16 @@ public class RolloutListHeader extends AbstractGridHeader {
     private final AddUpdateRolloutWindowLayout addUpdateRolloutWindow;
 
     RolloutListHeader(final SpPermissionChecker permissionChecker, final RolloutUIState rolloutUIState,
-            final UIEventBus eventBus, final RolloutManagement rolloutManagement,
-            final TargetManagement targetManagement, final UINotification uiNotification,
+            final UIEventBus eventBus, final RolloutManagement rolloutManagement, final UINotification uiNotification,
             final UiProperties uiProperties, final EntityFactory entityFactory, final VaadinMessageSource i18n,
             final TargetFilterQueryManagement targetFilterQueryManagement,
+            final TargetQueryExecutionManagement targetQueryExecutionManagement,
             final RolloutGroupManagement rolloutGroupManagement, final QuotaManagement quotaManagement) {
         super(permissionChecker, rolloutUIState, i18n);
         this.eventBus = eventBus;
-        this.addUpdateRolloutWindow = new AddUpdateRolloutWindowLayout(rolloutManagement, targetManagement,
+        this.addUpdateRolloutWindow = new AddUpdateRolloutWindowLayout(rolloutManagement,
                 uiNotification, uiProperties, entityFactory, i18n, eventBus, targetFilterQueryManagement,
-                rolloutGroupManagement, quotaManagement);
+                targetQueryExecutionManagement, rolloutGroupManagement, quotaManagement);
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutListView.java
@@ -13,7 +13,7 @@ import org.eclipse.hawkbit.repository.QuotaManagement;
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
-import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.TargetQueryExecutionManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.UiProperties;
@@ -35,11 +35,11 @@ public class RolloutListView extends AbstractGridComponentLayout {
 
     private final transient RolloutManagement rolloutManagement;
     private final transient RolloutGroupManagement rolloutGroupManagement;
-    private final transient TargetManagement targetManagement;
     private final transient EntityFactory entityFactory;
     private final transient TargetFilterQueryManagement targetFilterQueryManagement;
     private final transient QuotaManagement quotaManagement;
     private final transient TenantConfigurationManagement tenantConfigManagement;
+    private final transient TargetQueryExecutionManagement targetQueryExecutionManagement;
 
     private final SpPermissionChecker permissionChecker;
     private final RolloutUIState rolloutUIState;
@@ -48,9 +48,10 @@ public class RolloutListView extends AbstractGridComponentLayout {
 
     public RolloutListView(final SpPermissionChecker permissionChecker, final RolloutUIState rolloutUIState,
             final UIEventBus eventBus, final RolloutManagement rolloutManagement,
-            final TargetManagement targetManagement, final UINotification uiNotification,
+            final UINotification uiNotification,
             final UiProperties uiProperties, final EntityFactory entityFactory, final VaadinMessageSource i18n,
             final TargetFilterQueryManagement targetFilterQueryManagement,
+            final TargetQueryExecutionManagement targetQueryExecutionManagement,
             final RolloutGroupManagement rolloutGroupManagement, final QuotaManagement quotaManagement,
             final TenantConfigurationManagement tenantConfigManagement) {
         super(i18n, eventBus);
@@ -59,11 +60,11 @@ public class RolloutListView extends AbstractGridComponentLayout {
         this.rolloutManagement = rolloutManagement;
         this.rolloutGroupManagement = rolloutGroupManagement;
         this.quotaManagement = quotaManagement;
-        this.targetManagement = targetManagement;
         this.uiNotification = uiNotification;
         this.uiProperties = uiProperties;
         this.entityFactory = entityFactory;
         this.targetFilterQueryManagement = targetFilterQueryManagement;
+        this.targetQueryExecutionManagement = targetQueryExecutionManagement;
         this.tenantConfigManagement = tenantConfigManagement;
 
         init();
@@ -77,15 +78,15 @@ public class RolloutListView extends AbstractGridComponentLayout {
     @Override
     public AbstractOrderedLayout createGridHeader() {
         return new RolloutListHeader(permissionChecker, rolloutUIState, getEventBus(), rolloutManagement,
-                targetManagement, uiNotification, uiProperties, entityFactory, getI18n(), targetFilterQueryManagement,
-                rolloutGroupManagement, quotaManagement);
+                uiNotification, uiProperties, entityFactory, getI18n(), targetFilterQueryManagement,
+                targetQueryExecutionManagement, rolloutGroupManagement, quotaManagement);
     }
 
     @Override
     public AbstractGrid<LazyQueryContainer> createGrid() {
         return new RolloutListGrid(getI18n(), getEventBus(), rolloutManagement, uiNotification, rolloutUIState,
-                permissionChecker, targetManagement, entityFactory, uiProperties, targetFilterQueryManagement,
-                rolloutGroupManagement, quotaManagement, tenantConfigManagement);
+                permissionChecker, entityFactory, uiProperties, targetFilterQueryManagement,
+                targetQueryExecutionManagement, rolloutGroupManagement, quotaManagement, tenantConfigManagement);
     }
 
 }


### PR DESCRIPTION
The intention of this change is to have one place where external search engines can be plugged into hawkbit (like other device-management systems or also search-related DBs like elastic search or Solr.

Next steps will be to enable different kind of TargetFilterQuery implementations which will enable to leverage the extended capabilities of the different search engines up to the UI and the user.

Signed-off-by: Peter Vigier <Peter.Vigier@bosch-si.com>