### PR TITLE
OpenID Connect support

### DIFF
--- a/docs/content/concepts/authentication.md
+++ b/docs/content/concepts/authentication.md
@@ -70,4 +70,5 @@ Authentication is provided by _RabbitMQ_ [vhost and user credentials](https://ww
 
 ## Management UI
 - Login Dialog
+- OpenID Connect
 

--- a/docs/content/concepts/authorization.md
+++ b/docs/content/concepts/authorization.md
@@ -7,7 +7,7 @@ weight: 52
 Authorization is handled separately for _Direct Device Integration (DDI) API_ and _Device Management Federation (DMF) API_ (where successful authentication includes full authorization) and _Management API_ and _UI_ which is based on Spring security [authorities](https://github.com/eclipse/hawkbit/blob/master/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java).
 <!--more-->
 
-However, keep in mind that hawkBit does not offer an off the shelf authentication provider to leverage these permissions and the underlying multi user/tenant capabilities of hawkBit. Check out [Spring security documentation](http://projects.spring.io/spring-security/) for further information. In hawkBit [SecurityAutoConfiguration](https://github.com/eclipse/hawkbit/blob/master/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityAutoConfiguration.java) is a good starting point for integration.
+However, keep in mind that hawkBit does not offer an off the shelf authentication provider to leverage these permissions and the underlying multi user/tenant capabilities of hawkBit but it supports authentication providers offering an OpenID Connect interface. Check out [Spring security documentation](http://projects.spring.io/spring-security/) for further information. In hawkBit [SecurityAutoConfiguration](https://github.com/eclipse/hawkbit/blob/master/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityAutoConfiguration.java) is a good starting point for integration.
 
 The default implementation is single user/tenant with basic auth and the logged in user is provided with all permissions. Additionally, the application properties may be configured for multiple static users; see [Multiple Users](#multiple-users) for details.
 
@@ -40,6 +40,18 @@ An example configuration is given below.
     hawkbit.server.im.users[1].permissions=READ_TARGET,UPDATE_TARGET,CREATE_TARGET,DELETE_TARGET
 
 A permissions value of `ALL` will provide that user with all possible permissions. Passwords need to be specified with the used password encoder in brackets. In this example, `noop` is used as the plaintext encoder. For production use, it is recommended to use a hash function designed for passwords such as *bcrypt*. See this [blog post](https://spring.io/blog/2017/11/01/spring-security-5-0-0-rc1-released#password-storage-format) for more information on password encoders in Spring Security.
+
+### OpenID Connect
+hawkbit supports authentication providers which use the OpenID Connect standard, an authentication layer built on top of the OAuth 2.0 protocol.
+An example configuration is given below.
+
+    spring.security.oauth2.client.registration.oidc.client-id=clientID
+    spring.security.oauth2.client.registration.oidc.client-secret=oidc-client-secret
+    spring.security.oauth2.client.provider.oidc.issuer-uri=https://oidc-provider/issuer-uri
+    spring.security.oauth2.client.provider.oidc.authorization-uri=https://oidc-provider/authorization-uri
+    spring.security.oauth2.client.provider.oidc.token-uri=https://oidc-provider/token-uri
+    spring.security.oauth2.client.provider.oidc.user-info-uri=https://oidc-provider/user-info-uri
+    spring.security.oauth2.client.provider.oidc.jwk-set-uri=https://oidc-provider/jwk-set-uri
 
 ### Delivered Permissions
 - READ_/UPDATE_/CREATE_/DELETE_TARGETS for:

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2019 Kiwigrid GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.autoconfigure.security;
 
 import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
+import org.eclipse.hawkbit.im.authentication.UserAuthenticationFilter;
 import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,26 +18,31 @@ import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConf
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.web.authentication.*;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.util.CollectionUtils;
@@ -44,7 +50,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import javax.servlet.ServletException;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -69,12 +75,8 @@ public class OidcUserManagementAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean
-    public OAuth2UserService<OidcUserRequest, OidcUser> oidcUserDetailsService() {
-        final SimpleAuthorityMapper authorityMapper = new SimpleAuthorityMapper();
-        authorityMapper.setPrefix("");
-        authorityMapper.setConvertToUpperCase(true);
-
-        return new JwtAuthoritiesOidcUserService(authorityMapper);
+    public OAuth2UserService<OidcUserRequest, OidcUser> oidcUserDetailsService(JwtAuthoritiesExtractor extractor) {
+        return new JwtAuthoritiesOidcUserService(extractor);
     }
 
     /**
@@ -94,6 +96,28 @@ public class OidcUserManagementAutoConfiguration {
     public LogoutHandler oidcLogoutHandler() {
         return new OidcLogoutHandler();
     }
+
+    /**
+     * @return a jwt authorities extractor which interprets the roles of a user as their authorities.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public JwtAuthoritiesExtractor jwtAuthoritiesExtractor() {
+        final SimpleAuthorityMapper authorityMapper = new SimpleAuthorityMapper();
+        authorityMapper.setPrefix("");
+        authorityMapper.setConvertToUpperCase(true);
+
+        return new JwtAuthoritiesExtractor(authorityMapper);
+    }
+
+    /**
+     * @return an authentication filter for using OAuth2 Bearer Tokens.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public OidcBearerTokenAuthenticationFilter oidcBearerTokenAuthenticationFilter() {
+        return new OidcBearerTokenAuthenticationFilter();
+    }
 }
 
 /**
@@ -101,26 +125,26 @@ public class OidcUserManagementAutoConfiguration {
  */
 class JwtAuthoritiesOidcUserService extends OidcUserService {
 
-    private static final OAuth2Error INVALID_REQUEST = new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST);
+    private final JwtAuthoritiesExtractor authoritiesExtractor;
 
-    private final GrantedAuthoritiesMapper authoritiesMapper;
-
-    JwtAuthoritiesOidcUserService(GrantedAuthoritiesMapper authoritiesMapper) {
+    JwtAuthoritiesOidcUserService(JwtAuthoritiesExtractor authoritiesExtractor) {
         super();
 
-        this.authoritiesMapper = authoritiesMapper;
+        this.authoritiesExtractor = authoritiesExtractor;
     }
 
     @Override
     public OidcUser loadUser(OidcUserRequest userRequest) {
         OidcUser user = super.loadUser(userRequest);
+        ClientRegistration clientRegistration = userRequest.getClientRegistration();
 
-        Set<GrantedAuthority> authorities = new LinkedHashSet<>(extractAuthorities(userRequest));
+        Set<GrantedAuthority> authorities = new LinkedHashSet<>(authoritiesExtractor.extract(clientRegistration,
+                userRequest.getAccessToken().getTokenValue()));
         if (authorities.isEmpty()) {
             return user;
         }
 
-        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint()
+        String userNameAttributeName = clientRegistration.getProviderDetails().getUserInfoEndpoint()
                 .getUserNameAttributeName();
         OidcUser oidcUser;
         if (StringUtils.hasText(userNameAttributeName)) {
@@ -130,43 +154,6 @@ class JwtAuthoritiesOidcUserService extends OidcUserService {
             oidcUser = new DefaultOidcUser(authorities, userRequest.getIdToken(), user.getUserInfo());
         }
         return oidcUser;
-    }
-
-    private Collection<? extends GrantedAuthority> extractAuthorities(OidcUserRequest userRequest) {
-
-        Jwt token;
-        try {
-            // Token is already verified by spring security
-            JwtDecoder jwtDecoder = new NimbusJwtDecoderJwkSupport(
-                    userRequest.getClientRegistration().getProviderDetails().getJwkSetUri());
-            token = jwtDecoder.decode(userRequest.getAccessToken().getTokenValue());
-        } catch (JwtException e) {
-            throw new OAuth2AuthenticationException(INVALID_REQUEST, e);
-        }
-
-        @SuppressWarnings("unchecked")
-        Map<String, Object> resourceMap = (Map<String, Object>) token.getClaims().get("resource_access");
-        String clientId = userRequest.getClientRegistration().getClientId();
-
-        @SuppressWarnings("unchecked")
-        Map<String, Map<String, Object>> clientResource = (Map<String, Map<String, Object>>) resourceMap.get(clientId);
-        if (CollectionUtils.isEmpty(clientResource)) {
-            return Collections.emptyList();
-        }
-
-        @SuppressWarnings("unchecked")
-        List<String> roles = (List<String>) clientResource.get("roles");
-        if (CollectionUtils.isEmpty(roles)) {
-            return Collections.emptyList();
-        }
-
-        Collection<? extends GrantedAuthority> authorities = AuthorityUtils
-                .createAuthorityList(roles.toArray(new String[0]));
-        if (authoritiesMapper != null) {
-            authorities = authoritiesMapper.mapAuthorities(authorities);
-        }
-
-        return authorities;
     }
 }
 
@@ -184,10 +171,10 @@ class OidcAuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSu
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
             Authentication authentication) throws ServletException, IOException {
-        if (authentication instanceof OAuth2AuthenticationToken) {
+        if (authentication instanceof AbstractAuthenticationToken) {
             final String defaultTenant = "DEFAULT";
 
-            OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+            AbstractAuthenticationToken token = (AbstractAuthenticationToken) authentication;
             token.setDetails(new TenantAwareAuthenticationDetails(defaultTenant, false));
 
             systemSecurityContext.runAsSystemAsTenant(systemManagement::getTenantMetadata, defaultTenant);
@@ -217,5 +204,123 @@ class OidcLogoutHandler extends SecurityContextLogoutHandler {
             RestTemplate restTemplate = new RestTemplate();
             restTemplate.getForEntity(builder.toUriString(), String.class);
         }
+    }
+}
+
+/**
+ * Utility class to extract authorities out of the jwt. It interprets the user's role as their authorities.
+ */
+class JwtAuthoritiesExtractor {
+
+    private final GrantedAuthoritiesMapper authoritiesMapper;
+
+    private static final OAuth2Error INVALID_REQUEST = new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST);
+
+    JwtAuthoritiesExtractor(GrantedAuthoritiesMapper authoritiesMapper) {
+        super();
+
+        this.authoritiesMapper = authoritiesMapper;
+    }
+
+    Collection<? extends GrantedAuthority> extract(ClientRegistration clientRegistration,
+                                                                      String tokenValue) {
+        Jwt token;
+        try {
+            // Token is already verified by spring security
+            JwtDecoder jwtDecoder = new NimbusJwtDecoderJwkSupport(
+                    clientRegistration.getProviderDetails().getJwkSetUri());
+            token = jwtDecoder.decode(tokenValue);
+        } catch (JwtException e) {
+            throw new OAuth2AuthenticationException(INVALID_REQUEST, e);
+        }
+
+        return extract(clientRegistration.getClientId(), token.getClaims());
+    }
+
+    Collection<? extends GrantedAuthority> extract(String clientId, Map<String, Object> claims) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resourceMap = (Map<String, Object>) claims.get("resource_access");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Map<String, Object>> clientResource = (Map<String, Map<String, Object>>) resourceMap.get(clientId);
+        if (CollectionUtils.isEmpty(clientResource)) {
+            return Collections.emptyList();
+        }
+
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) clientResource.get("roles");
+        if (CollectionUtils.isEmpty(roles)) {
+            return Collections.emptyList();
+        }
+
+        Collection<? extends GrantedAuthority> authorities = AuthorityUtils
+                .createAuthorityList(roles.toArray(new String[0]));
+        if (authoritiesMapper != null) {
+            authorities = authoritiesMapper.mapAuthorities(authorities);
+        }
+
+        return authorities;
+    }
+}
+
+class OidcBearerTokenAuthenticationFilter implements UserAuthenticationFilter, Filter {
+
+    @Autowired
+    private JwtAuthoritiesExtractor authoritiesExtractor;
+
+    @Autowired
+    private SystemManagement systemManagement;
+
+    @Autowired
+    private SystemSecurityContext systemSecurityContext;
+
+    private ClientRegistration clientRegistration;
+
+    void setClientRegistration(ClientRegistration clientRegistration) {
+        this.clientRegistration = clientRegistration;
+    }
+
+    @Override
+    public void init(final FilterConfig filterConfig) {
+    }
+
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
+            throws IOException, ServletException {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof JwtAuthenticationToken) {
+            final String defaultTenant = "DEFAULT";
+
+            JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) authentication;
+            Jwt jwt = jwtAuthenticationToken.getToken();
+            OidcIdToken idToken = new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(),
+                    jwt.getClaims());
+            OidcUserInfo userInfo = new OidcUserInfo(jwt.getClaims());
+
+            Collection<? extends GrantedAuthority> authorities = authoritiesExtractor.extract(
+                    clientRegistration.getClientId(), jwt.getClaims());
+
+            if (authorities.isEmpty()) {
+                ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN);
+                return;
+            }
+
+            DefaultOidcUser user = new DefaultOidcUser(authorities, idToken, userInfo);
+
+            OAuth2AuthenticationToken oAuth2AuthenticationToken = new OAuth2AuthenticationToken(
+                    user, authorities, clientRegistration.getRegistrationId());
+
+            oAuth2AuthenticationToken.setDetails(new TenantAwareAuthenticationDetails(defaultTenant, false));
+
+            systemSecurityContext.runAsSystemAsTenant(systemManagement::getTenantMetadata, defaultTenant);
+            SecurityContextHolder.getContext().setAuthentication(oAuth2AuthenticationToken);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
     }
 }

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 Kiwigrid GmbH and others.
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2019 Kiwigrid GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.autoconfigure.security;
+
+import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
+import org.eclipse.hawkbit.repository.SystemManagement;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
+
+@Configuration
+@Conditional(value = ClientsConfiguredCondition.class)
+public class OidcUserManagementAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OAuth2UserService<OidcUserRequest, OidcUser> oidcUserDetailsService() {
+        final SimpleAuthorityMapper authorityMapper = new SimpleAuthorityMapper();
+        authorityMapper.setPrefix("");
+        authorityMapper.setConvertToUpperCase(true);
+
+        return new JwtAuthoritiesOidcUserService(authorityMapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AuthenticationSuccessHandler oidcAuthenticationSuccessHandler() {
+        return new OidcAuthenticationSuccessHandler();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public LogoutHandler oidcLogoutHandler() {
+        return new OidcLogoutHandler();
+    }
+}
+
+/**
+ * Extended {@link OidcUserService} supporting JWT containing authorities
+ */
+class JwtAuthoritiesOidcUserService extends OidcUserService {
+
+    private final OAuth2Error INVALID_REQUEST = new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST);
+
+    private final GrantedAuthoritiesMapper authoritiesMapper;
+
+    public JwtAuthoritiesOidcUserService(GrantedAuthoritiesMapper authoritiesMapper) {
+        super();
+
+        this.authoritiesMapper = authoritiesMapper;
+    }
+
+    @Override
+    public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+        OidcUser user = super.loadUser(userRequest);
+
+        Set<GrantedAuthority> authorities = new LinkedHashSet<>(extractAuthorities(userRequest));
+        if (authorities.isEmpty()) {
+            return user;
+        }
+
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint()
+                .getUserNameAttributeName();
+        OidcUser oidcUser;
+        if (StringUtils.hasText(userNameAttributeName)) {
+            oidcUser = new DefaultOidcUser(authorities, userRequest.getIdToken(), user.getUserInfo(),
+                    userNameAttributeName);
+        } else {
+            oidcUser = new DefaultOidcUser(authorities, userRequest.getIdToken(), user.getUserInfo());
+        }
+        return oidcUser;
+    }
+
+    private Collection<? extends GrantedAuthority> extractAuthorities(OidcUserRequest userRequest) {
+
+        Jwt token;
+        try {
+            // Token is already verified by spring security
+            JwtDecoder jwtDecoder = new NimbusJwtDecoderJwkSupport(
+                    userRequest.getClientRegistration().getProviderDetails().getJwkSetUri());
+            token = jwtDecoder.decode(userRequest.getAccessToken().getTokenValue());
+        } catch (JwtException e) {
+            throw new OAuth2AuthenticationException(INVALID_REQUEST, e);
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resourceMap = (Map<String, Object>) token.getClaims().get("resource_access");
+        String clientId = userRequest.getClientRegistration().getClientId();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Map<String, Object>> clientResource = (Map<String, Map<String, Object>>) resourceMap.get(clientId);
+        if (CollectionUtils.isEmpty(clientResource)) {
+            return Collections.emptyList();
+        }
+
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) clientResource.get("roles");
+        if (CollectionUtils.isEmpty(roles)) {
+            return Collections.emptyList();
+        }
+
+        Collection<? extends GrantedAuthority> authorities = AuthorityUtils
+                .createAuthorityList(roles.toArray(new String[0]));
+        if (authoritiesMapper != null) {
+            authorities = authoritiesMapper.mapAuthorities(authorities);
+        }
+
+        return authorities;
+    }
+}
+
+/**
+ * OpenID Connect Authentication Success Handler which load tenant data
+ */
+class OidcAuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+    @Autowired
+    private SystemManagement systemManagement;
+
+    @Autowired
+    private SystemSecurityContext systemSecurityContext;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication) throws ServletException, IOException {
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            final String defaultTenant = "DEFAULT";
+
+            OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+            token.setDetails(new TenantAwareAuthenticationDetails(defaultTenant, false));
+
+            systemSecurityContext.runAsSystemAsTenant(systemManagement::getTenantMetadata, defaultTenant);
+        }
+
+        super.onAuthenticationSuccess(request, response, authentication);
+    }
+}
+
+/**
+ * LogoutHandler to invalidate OpenID Connect tokens
+ */
+class OidcLogoutHandler extends SecurityContextLogoutHandler {
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        super.logout(request, response, authentication);
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof OidcUser) {
+            OidcUser user = (OidcUser) authentication.getPrincipal();
+            String endSessionEndpoint = user.getIssuer() + "/protocol/openid-connect/logout";
+
+            UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(endSessionEndpoint)
+                    .queryParam("id_token_hint", user.getIdToken().getTokenValue());
+
+            RestTemplate restTemplate = new RestTemplate();
+            restTemplate.getForEntity(builder.toUriString(), String.class);
+        }
+    }
+}

--- a/hawkbit-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/hawkbit-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -13,5 +13,6 @@ org.eclipse.hawkbit.autoconfigure.scheduling.AsyncConfigurerAutoConfiguration,\
 org.eclipse.hawkbit.autoconfigure.scheduling.ExecutorAutoConfiguration,\
 org.eclipse.hawkbit.autoconfigure.security.SecurityAutoConfiguration,\
 org.eclipse.hawkbit.autoconfigure.security.InMemoryUserManagementAutoConfiguration,\
+org.eclipse.hawkbit.autoconfigure.security.OidcUserManagementAutoConfiguration,\
 org.eclipse.hawkbit.autoconfigure.web.WebMvcAutoConfiguration,\
 org.eclipse.hawkbit.autoconfigure.PropertyHostnameResolverAutoConfiguration

--- a/hawkbit-security-core/pom.xml
+++ b/hawkbit-security-core/pom.xml
@@ -49,6 +49,10 @@
       </dependency>
       <dependency>
          <groupId>org.springframework.security</groupId>
+         <artifactId>spring-security-oauth2-resource-server</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework.security</groupId>
          <artifactId>spring-security-oauth2-jose</artifactId>
       </dependency>
       <dependency>

--- a/hawkbit-security-core/pom.xml
+++ b/hawkbit-security-core/pom.xml
@@ -44,6 +44,14 @@
          <artifactId>spring-security-core</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.springframework.security</groupId>
+         <artifactId>spring-security-oauth2-client</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework.security</groupId>
+         <artifactId>spring-security-oauth2-jose</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.springframework.boot</groupId>
          <artifactId>spring-boot</artifactId>
       </dependency>

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SpringSecurityAuditorAware.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SpringSecurityAuditorAware.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 /**
  * Auditor class that allows BaseEntitys to insert current logged in user for
@@ -37,6 +38,9 @@ public class SpringSecurityAuditorAware implements AuditorAware<String> {
     private static String getCurrentAuditor(final Authentication authentication) {
         if (authentication.getPrincipal() instanceof UserDetails) {
             return ((UserDetails) authentication.getPrincipal()).getUsername();
+        }
+        if (authentication.getPrincipal() instanceof OidcUser) {
+            return ((OidcUser) authentication.getPrincipal()).getPreferredUsername();
         }
         return authentication.getPrincipal().toString();
     }

--- a/hawkbit-ui/pom.xml
+++ b/hawkbit-ui/pom.xml
@@ -201,6 +201,14 @@
          <groupId>org.springframework.security</groupId>
          <artifactId>spring-security-web</artifactId>
       </dependency>
+      <dependency>
+         <groupId>org.springframework.security</groupId>
+         <artifactId>spring-security-oauth2-client</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework.security</groupId>
+         <artifactId>spring-security-oauth2-jose</artifactId>
+      </dependency>
 
       <dependency>
          <groupId>com.vaadin</groupId>

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/UserDetailsFormatter.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/UserDetailsFormatter.java
@@ -12,14 +12,18 @@ import java.util.Collections;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
 import org.eclipse.hawkbit.im.authentication.UserPrincipal;
 import org.eclipse.hawkbit.repository.model.BaseEntity;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 
 import com.vaadin.server.VaadinService;
@@ -187,7 +191,20 @@ public final class UserDetailsFormatter {
     public static UserDetails getCurrentUser() {
         final SecurityContext context = (SecurityContext) VaadinService.getCurrentRequest().getWrappedSession()
                 .getAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
-        return (UserDetails) context.getAuthentication().getPrincipal();
+        Authentication authentication = context.getAuthentication();
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
+            Object details = authentication.getDetails();
+            String tenant = "DEFAULT";
+            if (details instanceof TenantAwareAuthenticationDetails) {
+                tenant = ((TenantAwareAuthenticationDetails) details).getTenant();
+            }
+            return new UserPrincipal(oidcUser.getPreferredUsername(), "***", oidcUser.getGivenName(),
+                    oidcUser.getFamilyName(), oidcUser.getPreferredUsername(), oidcUser.getEmail(), tenant,
+                    oidcUser.getAuthorities());
+        } else {
+            return (UserDetails) authentication.getPrincipal();
+        }
     }
 
     private static String trimAndFormatDetail(final String formatString, final int expectedDetailLength) {

--- a/licenses/LICENSE_HEADER_TEMPLATE_KIWIGRID_19.txt
+++ b/licenses/LICENSE_HEADER_TEMPLATE_KIWIGRID_19.txt
@@ -1,0 +1,6 @@
+Copyright (c) 2019 Kiwigrid GmbH and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html

--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,7 @@
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_MICROSOFT_18.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_18.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_DEVOLO_19.txt</validHeader>
+                     <validHeader>licenses/LICENSE_HEADER_TEMPLATE_KIWIGRID_19.txt</validHeader>
                   </validHeaders>
                   <excludes>
                      <exclude>**/banner.txt</exclude>


### PR DESCRIPTION
This pull request adds support for authentication providers implenting the [OpenID Connect](https://openid.net/connect/) interface. It uses the Spring Security 5 features for OAuth2 respectively OpenID Connect.

The default configuration has not changed, thus the single user/tenant with basic auth is still the default method.