### PR TITLE
Reduced DMF logging level in BaseAmqpService to debug

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/BaseAmqpService.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/BaseAmqpService.java
@@ -90,7 +90,7 @@ public class BaseAmqpService {
     }
 
     protected static final void logAndThrowMessageError(final Message message, final String error) {
-        LOGGER.warn("Warning! \"{}\" reported by message: {}", error, message);
+        LOGGER.debug("Warning! \"{}\" reported by message: {}", error, message);
         throw new AmqpRejectAndDontRequeueException(error);
     }
 


### PR DESCRIPTION
To reduce the amount of log messages the level is reduced to debug. Due to the thrown exception in the next line the error is still visible in the logs.
Signed-off-by: Alexander Dobler <alexander.dobler3@bosch-si.com>