### PR TITLE
Default sort order for targets and rollouts (ref #764)

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBeanQuery.java
@@ -44,7 +44,7 @@ public class TargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
 
     private static final long serialVersionUID = -5645680058303167558L;
 
-    private Sort sort = new Sort(SPUIDefinitions.TARGET_TABLE_CREATE_AT_SORT_ORDER, "id");
+    private Sort sort = new Sort(SPUIDefinitions.TARGET_TABLE_LASTMODIFIED_AT_SORT_ORDER, "lastModifiedAt");
     private transient Collection<TargetUpdateStatus> status;
     private transient Boolean overdueState;
     private String[] targetTags;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
@@ -43,7 +43,7 @@ public class RolloutBeanQuery extends AbstractBeanQuery<ProxyRollout> {
 
     private final String searchText;
 
-    private Sort sort = new Sort(Direction.ASC, "id");
+    private Sort sort = new Sort(Direction.DESC, "lastModifiedAt");
 
     private transient RolloutManagement rolloutManagement;
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIDefinitions.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIDefinitions.java
@@ -346,7 +346,6 @@ public final class SPUIDefinitions {
     /**
      * Sort order of column - created at in target table.
      */
-    public static final Direction TARGET_TABLE_CREATE_AT_SORT_ORDER = Direction.ASC;
     public static final Direction TARGET_TABLE_LASTMODIFIED_AT_SORT_ORDER = Direction.DESC;
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIDefinitions.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/SPUIDefinitions.java
@@ -347,6 +347,7 @@ public final class SPUIDefinitions {
      * Sort order of column - created at in target table.
      */
     public static final Direction TARGET_TABLE_CREATE_AT_SORT_ORDER = Direction.ASC;
+    public static final Direction TARGET_TABLE_LASTMODIFIED_AT_SORT_ORDER = Direction.DESC;
 
     /**
      * BUTTON- STATUS.


### PR DESCRIPTION
The default sort order has been change in order to show the newest
targets and rollouts are always on the top.

Signed-off-by: Anbazhakan Subramaniam <Anbazhakan.Subramaniam@in.bosch.com>