### PR TITLE
added missing JsonIgnoreProperties annotation for DDI Api model classes

### DIFF
--- a/hawkbit-rest/hawkbit-ddi-api/pom.xml
+++ b/hawkbit-rest/hawkbit-ddi-api/pom.xml
@@ -59,5 +59,10 @@
          <artifactId>assertj-core</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>com.google.guava</groupId>
+         <artifactId>guava</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 </project>

--- a/hawkbit-rest/hawkbit-ddi-api/pom.xml
+++ b/hawkbit-rest/hawkbit-ddi-api/pom.xml
@@ -10,15 +10,15 @@
 -->
 
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-     <groupId>org.eclipse.hawkbit</groupId>
-     <artifactId>hawkbit-rest-parent</artifactId>
-     <version>0.3.0-SNAPSHOT</version>
-  </parent>
-  <artifactId>hawkbit-ddi-api</artifactId>
-  <name>hawkBit :: REST :: DDI API</name>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <modelVersion>4.0.0</modelVersion>
+   <parent>
+      <groupId>org.eclipse.hawkbit</groupId>
+      <artifactId>hawkbit-rest-parent</artifactId>
+      <version>0.3.0-SNAPSHOT</version>
+   </parent>
+   <artifactId>hawkbit-ddi-api</artifactId>
+   <name>hawkBit :: REST :: DDI API</name>
 
    <dependencies>
       <dependency>
@@ -36,6 +36,28 @@
       <dependency>
          <groupId>javax.validation</groupId>
          <artifactId>validation-api</artifactId>
+      </dependency>
+
+      <!-- TEST -->
+      <dependency>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-databind</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.qameta.allure</groupId>
+         <artifactId>allure-junit4</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.assertj</groupId>
+         <artifactId>assertj-core</artifactId>
+         <scope>test</scope>
       </dependency>
    </dependencies>
 </project>

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistory.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistory.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.eclipse.hawkbit.ddi.rest.api.DdiRootControllerRestApi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * {@link DdiActionFeedback}.
  */
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({ "status", "messages" })
 public class DdiActionHistory {
 

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifact.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifact.java
@@ -12,12 +12,14 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.hateoas.ResourceSupport;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Download information for all artifacts related to a specific {@link DdiChunk}
  * .
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiArtifact extends ResourceSupport {
 
     @NotNull

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHash.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHash.java
@@ -8,15 +8,15 @@
  */
 package org.eclipse.hawkbit.ddi.json.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Hashes for given Artifact.
- *
- *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiArtifactHash {
 
     @JsonProperty
@@ -40,11 +40,11 @@ public class DdiArtifactHash {
      * Public constructor.
      *
      * @param sha1
-     *            sha1 hash of the artifact
+     *         sha1 hash of the artifact
      * @param md5
-     *            md5 hash of the artifact
+     *         md5 hash of the artifact
      * @param sha256
-     *            sha256 hash of the artifact
+     *         sha256 hash of the artifact
      */
     public DdiArtifactHash(final String sha1, final String md5, final String sha256) {
         this.sha1 = sha1;

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiCancel.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiCancel.java
@@ -10,7 +10,9 @@ package org.eclipse.hawkbit.ddi.json.model;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Cancel action to be provided to the target.
@@ -31,7 +33,9 @@ public class DdiCancel {
      * @param cancelAction
      *            the action
      */
-    public DdiCancel(final String id, final DdiCancelActionToStop cancelAction) {
+    @JsonCreator
+    public DdiCancel(@JsonProperty("id") final String id,
+            @JsonProperty("cancelAction") final DdiCancelActionToStop cancelAction) {
         this.id = id;
         this.cancelAction = cancelAction;
     }

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiCancel.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiCancel.java
@@ -10,9 +10,12 @@ package org.eclipse.hawkbit.ddi.json.model;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * Cancel action to be provided to the target.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiCancel {
 
     private final String id;

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelActionToStop.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelActionToStop.java
@@ -10,7 +10,9 @@ package org.eclipse.hawkbit.ddi.json.model;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * The action that has to be stopped by the target.
@@ -25,9 +27,10 @@ public class DdiCancelActionToStop {
      * Parameterized constructor.
      *
      * @param stopId
-     *            ID of the action to be stoppedW
+     *            ID of the action to be stopped
      */
-    public DdiCancelActionToStop(final String stopId) {
+    @JsonCreator
+    public DdiCancelActionToStop(@JsonProperty("stopId") final String stopId) {
         this.stopId = stopId;
     }
 

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelActionToStop.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelActionToStop.java
@@ -10,9 +10,12 @@ package org.eclipse.hawkbit.ddi.json.model;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * The action that has to be stopped by the target.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiCancelActionToStop {
 
     @NotNull

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiChunk.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiChunk.java
@@ -13,12 +13,14 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Deployment chunks.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiChunk {
 
     @JsonProperty("part")

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigData.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigData.java
@@ -13,11 +13,13 @@ import java.util.Map;
 import javax.validation.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Feedback channel for ConfigData action.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiConfigData extends DdiActionFeedback {
 
     @NotEmpty

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeployment.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeployment.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -21,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Detailed update action information.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiDeployment {
 
     private HandlingType download;

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBase.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBase.java
@@ -12,6 +12,7 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.hateoas.ResourceSupport;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -19,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * Update action resource.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({ "id", "deployment", "actionHistory" })
 public class DdiDeploymentBase extends ResourceSupport {
 

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadata.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadata.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.ddi.json.model;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -27,7 +28,8 @@ public class DdiMetadata {
     @NotNull
     private final String value;
 
-    public DdiMetadata(final String key, final String value) {
+    @JsonCreator
+    public DdiMetadata(@JsonProperty("key") final String key, @JsonProperty("value")final String value) {
         this.key = key;
         this.value = value;
     }

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadata.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadata.java
@@ -10,12 +10,14 @@ package org.eclipse.hawkbit.ddi.json.model;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Additional metadata to be provided for the target/device.
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiMetadata {
     @JsonProperty
     @NotNull

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiProgress.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiProgress.java
@@ -11,12 +11,14 @@ package org.eclipse.hawkbit.ddi.json.model;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Action fulfillment progress by means of gives the achieved amount of maximal
  * of possible levels.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiProgress {
 
     @NotNull

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiResult.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiResult.java
@@ -12,6 +12,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -19,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Result information of the action progress which can by an intermediate or
  * final update.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiResult {
 
     @NotNull

--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiStatus.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiStatus.java
@@ -15,12 +15,14 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Details status information concerning the action processing.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiStatus {
 
     @NotNull

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedbackTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedbackTest.java
@@ -17,6 +17,7 @@ import org.assertj.core.util.Lists;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -24,7 +25,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiActionFeedback'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiActionFeedbackTest {
 
@@ -61,7 +62,7 @@ public class DdiActionFeedbackTest {
         assertThat(ddiActionFeedback.getTime()).matches("20190809T121314");
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiActionFeedback = "{\"id\": [1],\"time\":\"20190809T121314\",\"status\":{\"execution\":\"closed\",\"result\":null,\"details\":[]}}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedbackTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedbackTest.java
@@ -1,0 +1,63 @@
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiActionFeedback'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiActionFeedbackTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        Long id = 123L;
+        String time = "20190809T121314";
+        DdiStatus ddiStatus = new DdiStatus(DdiStatus.ExecutionStatus.CLOSED, null, Lists.emptyList());
+        DdiActionFeedback ddiActionFeedback = new DdiActionFeedback(id, time, ddiStatus);
+
+        // Test
+        String serializedDdiActionFeedback = mapper.writeValueAsString(ddiActionFeedback);
+        DdiActionFeedback deserializedDdiActionFeedback = mapper.readValue(serializedDdiActionFeedback,
+                DdiActionFeedback.class);
+
+        assertThat(serializedDdiActionFeedback).contains(id.toString(), time);
+        assertThat(deserializedDdiActionFeedback.getId()).isEqualTo(id);
+        assertThat(deserializedDdiActionFeedback.getTime()).isEqualTo(time);
+        assertThat(deserializedDdiActionFeedback.getStatus().toString()).isEqualTo(ddiStatus.toString());
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiActionFeedback = "{\"id\":1, \"time\":\"20190809T121314\", \"status\":{\"execution\":\"closed\", \"result\":null, \"details\":[]}, \"unknownProperty\": \"test\"}";
+
+        // Test
+        DdiActionFeedback ddiActionFeedback = mapper.readValue(serializedDdiActionFeedback, DdiActionFeedback.class);
+
+        assertThat(ddiActionFeedback.getId()).isEqualTo(1L);
+        assertThat(ddiActionFeedback.getTime()).matches("20190809T121314");
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiActionFeedback = "{\"id\": [1],\"time\":\"20190809T121314\",\"status\":{\"execution\":\"closed\",\"result\":null,\"details\":[]}}";
+
+        // Test
+        mapper.readValue(serializedDdiActionFeedback, DdiActionFeedback.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedbackTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedbackTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -32,6 +33,7 @@ public class DdiActionFeedbackTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         Long id = 123L;
@@ -51,6 +53,7 @@ public class DdiActionFeedbackTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiActionFeedback = "{\"id\":1, \"time\":\"20190809T121314\", \"status\":{\"execution\":\"closed\", \"result\":null, \"details\":[]}, \"unknownProperty\": \"test\"}";
@@ -63,6 +66,7 @@ public class DdiActionFeedbackTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiActionFeedback = "{\"id\": [1],\"time\":\"20190809T121314\",\"status\":{\"execution\":\"closed\",\"result\":null,\"details\":[]}}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedbackTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedbackTest.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
 package org.eclipse.hawkbit.ddi.json.model;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistoryTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistoryTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -33,6 +34,7 @@ public class DdiActionHistoryTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         String actionStatus = "TestAction";
@@ -49,6 +51,7 @@ public class DdiActionHistoryTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiActionHistory = "{\"status\":\"SomeAction\", \"messages\":[\"Some message\"], \"unknownProperty\": \"test\"}";
@@ -60,6 +63,7 @@ public class DdiActionHistoryTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiActionFeedback = "{\"status\": [SomeAction], \"messages\": [\"Some message\"]}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistoryTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistoryTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -25,7 +26,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiActionHistory'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiActionHistoryTest {
 
@@ -58,7 +59,7 @@ public class DdiActionHistoryTest {
         assertThat(ddiActionHistory.toString()).contains("SomeAction", "Some message");
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiActionFeedback = "{\"status\": [SomeAction], \"messages\": [\"Some message\"]}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistoryTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistoryTest.java
@@ -1,0 +1,60 @@
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiActionHistory'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiActionHistoryTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        String actionStatus = "TestAction";
+        List<String> messages = Arrays.asList("Action status message 1", "Action status message 2");
+        DdiActionHistory ddiActionHistory = new DdiActionHistory(actionStatus, messages);
+
+        // Test
+        String serializedDdiActionHistory = mapper.writeValueAsString(ddiActionHistory);
+        DdiActionHistory deserializedDdiActionHistory = mapper.readValue(serializedDdiActionHistory,
+                DdiActionHistory.class);
+
+        assertThat(serializedDdiActionHistory).contains(actionStatus, messages.get(0), messages.get(1));
+        assertThat(deserializedDdiActionHistory.toString()).contains(actionStatus, messages.get(0), messages.get(1));
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiActionHistory = "{\"status\":\"SomeAction\", \"messages\":[\"Some message\"], \"unknownProperty\": \"test\"}";
+
+        // Test
+        DdiActionHistory ddiActionHistory = mapper.readValue(serializedDdiActionHistory, DdiActionHistory.class);
+
+        assertThat(ddiActionHistory.toString()).contains("SomeAction", "Some message");
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiActionFeedback = "{\"status\": [SomeAction], \"messages\": [\"Some message\"]}";
+
+        // Test
+        mapper.readValue(serializedDdiActionFeedback, DdiActionHistory.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistoryTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistoryTest.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
 package org.eclipse.hawkbit.ddi.json.model;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHashTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHashTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -23,7 +24,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiArtifactHash'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiArtifactHashTest {
 
@@ -61,7 +62,7 @@ public class DdiArtifactHashTest {
         assertThat(ddiArtifact.getSha256()).isEqualTo("789");
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiArtifact = "{\"sha1\": [123], \"md5\": 456, \"sha256\": \"789\"";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHashTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHashTest.java
@@ -1,0 +1,64 @@
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiArtifact'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiArtifactHashTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        String sha1Hash = "11111";
+        String md5Hash = "22222";
+        String sha256Hash = "33333";
+        DdiArtifactHash DdiArtifact = new DdiArtifactHash(sha1Hash, md5Hash, sha256Hash);
+
+        // Test
+        String serializedDdiArtifact = mapper.writeValueAsString(DdiArtifact);
+        DdiArtifactHash deserializedDdiArtifact = mapper.readValue(serializedDdiArtifact,
+                DdiArtifactHash.class);
+
+        assertThat(serializedDdiArtifact).contains(sha1Hash, md5Hash, sha256Hash);
+        assertThat(deserializedDdiArtifact.getSha1()).isEqualTo(sha1Hash);
+        assertThat(deserializedDdiArtifact.getMd5()).isEqualTo(md5Hash);
+        assertThat(deserializedDdiArtifact.getSha256()).isEqualTo(sha256Hash);
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiArtifact = "{\"sha1\": \"123\", \"md5\": \"456\",  \"sha256\": \"789\", \"unknownProperty\": \"test\"}";
+
+        // Test
+        DdiArtifactHash DdiArtifact = mapper.readValue(serializedDdiArtifact, DdiArtifactHash.class);
+
+        assertThat(DdiArtifact.getSha1()).isEqualTo("123");
+        assertThat(DdiArtifact.getMd5()).isEqualTo("456");
+        assertThat(DdiArtifact.getSha256()).isEqualTo("789");
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiArtifact = "{\"sha1\": [123], \"md5\": 456, \"sha256\": \"789\"";
+
+        // Test
+        mapper.readValue(serializedDdiArtifact, DdiArtifactHash.class);
+    }
+
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHashTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHashTest.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
 package org.eclipse.hawkbit.ddi.json.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,7 +21,7 @@ import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
 /**
- * Test serializability of DDI api model 'DdiArtifact'
+ * Test serializability of DDI api model 'DdiArtifactHash'
  */
 @Feature("Model Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
@@ -45,11 +54,11 @@ public class DdiArtifactHashTest {
         String serializedDdiArtifact = "{\"sha1\": \"123\", \"md5\": \"456\",  \"sha256\": \"789\", \"unknownProperty\": \"test\"}";
 
         // Test
-        DdiArtifactHash DdiArtifact = mapper.readValue(serializedDdiArtifact, DdiArtifactHash.class);
+        DdiArtifactHash ddiArtifact = mapper.readValue(serializedDdiArtifact, DdiArtifactHash.class);
 
-        assertThat(DdiArtifact.getSha1()).isEqualTo("123");
-        assertThat(DdiArtifact.getMd5()).isEqualTo("456");
-        assertThat(DdiArtifact.getSha256()).isEqualTo("789");
+        assertThat(ddiArtifact.getSha1()).isEqualTo("123");
+        assertThat(ddiArtifact.getMd5()).isEqualTo("456");
+        assertThat(ddiArtifact.getSha256()).isEqualTo("789");
     }
 
     @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHashTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHashTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -31,6 +32,7 @@ public class DdiArtifactHashTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         String sha1Hash = "11111";
@@ -50,6 +52,7 @@ public class DdiArtifactHashTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiArtifact = "{\"sha1\": \"123\", \"md5\": \"456\",  \"sha256\": \"789\", \"unknownProperty\": \"test\"}";
@@ -63,6 +66,7 @@ public class DdiArtifactHashTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiArtifact = "{\"sha1\": [123], \"md5\": 456, \"sha256\": \"789\"";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactTest.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
 package org.eclipse.hawkbit.ddi.json.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,7 +72,7 @@ public class DdiArtifactTest {
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiArtifact = "{\"filename\": [\"test.file\"],\"hashes\":{\"sha1\":\"123\",\"md5\":\"456\",\"sha256\":\"789\"},\"size\":111,\"links\":[]}";
-        
+
         // Test
         mapper.readValue(serializedDdiArtifact, DdiArtifact.class);
     }

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactTest.java
@@ -1,0 +1,70 @@
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiArtifact'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiArtifactTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        String filename = "testfile.txt";
+        DdiArtifactHash hashes = new DdiArtifactHash("123", "456", "789");
+        Long size = 12345L;
+
+        DdiArtifact ddiArtifact = new DdiArtifact();
+        ddiArtifact.setFilename(filename);
+        ddiArtifact.setHashes(hashes);
+        ddiArtifact.setSize(size);
+
+        // Test
+        String serializedDdiArtifact = mapper.writeValueAsString(ddiArtifact);
+        DdiArtifact deserializedDdiArtifact = mapper.readValue(serializedDdiArtifact, DdiArtifact.class);
+
+        assertThat(serializedDdiArtifact).contains(filename, "12345");
+        assertThat(deserializedDdiArtifact.getFilename()).isEqualTo(filename);
+        assertThat(deserializedDdiArtifact.getSize()).isEqualTo(size);
+        assertThat(deserializedDdiArtifact.getHashes().getSha1()).isEqualTo(hashes.getSha1());
+        assertThat(deserializedDdiArtifact.getHashes().getMd5()).isEqualTo(hashes.getMd5());
+        assertThat(deserializedDdiArtifact.getHashes().getSha256()).isEqualTo(hashes.getSha256());
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiArtifact = "{\"filename\":\"test.file\",\"hashes\":{\"sha1\":\"123\",\"md5\":\"456\",\"sha256\":\"789\"},\"size\":111,\"links\":[],\"unknownProperty\": \"test\"}";
+
+        // Test
+        DdiArtifact ddiArtifact = mapper.readValue(serializedDdiArtifact, DdiArtifact.class);
+
+        assertThat(ddiArtifact.getFilename()).isEqualTo("test.file");
+        assertThat(ddiArtifact.getSize()).isEqualTo(111);
+        assertThat(ddiArtifact.getHashes().getSha1()).isEqualTo("123");
+        assertThat(ddiArtifact.getHashes().getMd5()).isEqualTo("456");
+        assertThat(ddiArtifact.getHashes().getSha256()).isEqualTo("789");
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiArtifact = "{\"filename\": [\"test.file\"],\"hashes\":{\"sha1\":\"123\",\"md5\":\"456\",\"sha256\":\"789\"},\"size\":111,\"links\":[]}";
+        
+        // Test
+        mapper.readValue(serializedDdiArtifact, DdiArtifact.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -23,7 +24,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiArtifact'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiArtifactTest {
 
@@ -68,7 +69,7 @@ public class DdiArtifactTest {
         assertThat(ddiArtifact.getHashes().getSha256()).isEqualTo("789");
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiArtifact = "{\"filename\": [\"test.file\"],\"hashes\":{\"sha1\":\"123\",\"md5\":\"456\",\"sha256\":\"789\"},\"size\":111,\"links\":[]}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -31,6 +32,7 @@ public class DdiArtifactTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         String filename = "testfile.txt";
@@ -55,6 +57,7 @@ public class DdiArtifactTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiArtifact = "{\"filename\":\"test.file\",\"hashes\":{\"sha1\":\"123\",\"md5\":\"456\",\"sha256\":\"789\"},\"size\":111,\"links\":[],\"unknownProperty\": \"test\"}";
@@ -70,6 +73,7 @@ public class DdiArtifactTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiArtifact = "{\"filename\": [\"test.file\"],\"hashes\":{\"sha1\":\"123\",\"md5\":\"456\",\"sha256\":\"789\"},\"size\":111,\"links\":[]}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelActionToStopTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelActionToStopTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -31,6 +32,7 @@ public class DdiCancelActionToStopTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         String stopId = "1234";
@@ -45,6 +47,7 @@ public class DdiCancelActionToStopTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiCancelActionToStop = "{\"stopId\":\"12345\",\"unknownProperty\":\"test\"}";
@@ -57,6 +60,7 @@ public class DdiCancelActionToStopTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiCancelActionToStop = "{\"stopId\": [\"12345\"]}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelActionToStopTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelActionToStopTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -23,7 +24,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiCancelActionToStop'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiCancelActionToStopTest {
 
@@ -55,7 +56,7 @@ public class DdiCancelActionToStopTest {
         assertThat(ddiCancelActionToStop.getStopId()).contains("12345");
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiCancelActionToStop = "{\"stopId\": [\"12345\"]}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelActionToStopTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelActionToStopTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiCancelActionToStop'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiCancelActionToStopTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        String stopId = "1234";
+        DdiCancelActionToStop ddiCancelActionToStop = new DdiCancelActionToStop(stopId);
+        // Test
+        String serializedDdiCancelActionToStop = mapper.writeValueAsString(ddiCancelActionToStop);
+        DdiCancelActionToStop deserializedDdiCancelActionToStop = mapper.readValue(serializedDdiCancelActionToStop,
+                DdiCancelActionToStop.class);
+
+        assertThat(serializedDdiCancelActionToStop).contains(stopId);
+        assertThat(deserializedDdiCancelActionToStop.getStopId()).isEqualTo(stopId);
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiCancelActionToStop = "{\"stopId\":\"12345\",\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiCancelActionToStop ddiCancelActionToStop = mapper.readValue(serializedDdiCancelActionToStop,
+                DdiCancelActionToStop.class);
+
+        assertThat(ddiCancelActionToStop.getStopId()).contains("12345");
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiCancelActionToStop = "{\"stopId\": [\"12345\"]}";
+
+        // Test
+        mapper.readValue(serializedDdiCancelActionToStop, DdiCancelActionToStop.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiArtifact'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiCancelTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        String ddiCancelId = "1234";
+        DdiCancelActionToStop ddiCancelActionToStop = new DdiCancelActionToStop("1234");
+        DdiCancel ddiCancel = new DdiCancel(ddiCancelId, ddiCancelActionToStop);
+
+        // Test
+        String serializedDdiCancel = mapper.writeValueAsString(ddiCancel);
+        DdiCancel deserializedDdiCancel = mapper.readValue(serializedDdiCancel, DdiCancel.class);
+
+        assertThat(serializedDdiCancel).contains(ddiCancelId, ddiCancelActionToStop.getStopId());
+        assertThat(deserializedDdiCancel.getId()).isEqualTo(ddiCancelId);
+        assertThat(deserializedDdiCancel.getCancelAction().getStopId()).isEqualTo(ddiCancelActionToStop.getStopId());
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiCancel = "{\"id\":\"1234\",\"cancelAction\":{\"stopId\":\"1234\"}, \"unknownProperty\": \"test\"}";
+
+        // Test
+        DdiCancel ddiCancel = mapper.readValue(serializedDdiCancel, DdiCancel.class);
+
+        assertThat(ddiCancel.getId()).isEqualTo("1234");
+        assertThat(ddiCancel.getCancelAction().getStopId()).matches("1234");
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiCancel = "{\"id\":[\"1234\"],\"cancelAction\":{\"stopId\":\"1234\"}}";
+
+        // Test
+        mapper.readValue(serializedDdiCancel, DdiCancel.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -31,6 +32,7 @@ public class DdiCancelTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         String ddiCancelId = "1234";
@@ -47,6 +49,7 @@ public class DdiCancelTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiCancel = "{\"id\":\"1234\",\"cancelAction\":{\"stopId\":\"1234\"}, \"unknownProperty\": \"test\"}";
@@ -59,6 +62,7 @@ public class DdiCancelTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiCancel = "{\"id\":[\"1234\"],\"cancelAction\":{\"stopId\":\"1234\"}}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiCancelTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -23,7 +24,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiArtifact'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiCancelTest {
 
@@ -57,7 +58,7 @@ public class DdiCancelTest {
         assertThat(ddiCancel.getCancelAction().getStopId()).matches("1234");
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiCancel = "{\"id\":[\"1234\"],\"cancelAction\":{\"stopId\":\"1234\"}}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiChunkTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiChunkTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -33,6 +34,7 @@ public class DdiChunkTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         String part = "1234";
@@ -53,6 +55,7 @@ public class DdiChunkTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiChunk = "{\"part\":\"1234\",\"version\":\"1.0\",\"name\":\"Dummy-Artifact\",\"artifacts\":[],\"unknownProperty\":\"test\"}";
@@ -67,6 +70,7 @@ public class DdiChunkTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiChunk = "{\"part\":[\"1234\"],\"version\":\"1.0\",\"name\":\"Dummy-Artifact\",\"artifacts\":[]}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiChunkTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiChunkTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiChunk'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiChunkTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        String part = "1234";
+        String version = "1.0";
+        String name = "Dummy-Artifact";
+        List<DdiArtifact> dummyArtifacts = Collections.emptyList();
+        DdiChunk ddiChunk = new DdiChunk(part, version, name, dummyArtifacts, null);
+
+        // Test
+        String serializedDdiChunk = mapper.writeValueAsString(ddiChunk);
+        DdiChunk deserializedDdiChunk = mapper.readValue(serializedDdiChunk, DdiChunk.class);
+
+        assertThat(serializedDdiChunk).contains(part, version, name);
+        assertThat(deserializedDdiChunk.getPart()).isEqualTo(part);
+        assertThat(deserializedDdiChunk.getVersion()).isEqualTo(version);
+        assertThat(deserializedDdiChunk.getName()).isEqualTo(name);
+        assertThat(deserializedDdiChunk.getArtifacts().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiChunk = "{\"part\":\"1234\",\"version\":\"1.0\",\"name\":\"Dummy-Artifact\",\"artifacts\":[],\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiChunk ddiChunk = mapper.readValue(serializedDdiChunk, DdiChunk.class);
+
+        assertThat(ddiChunk.getPart()).isEqualTo("1234");
+        assertThat(ddiChunk.getVersion()).isEqualTo("1.0");
+        assertThat(ddiChunk.getName()).isEqualTo("Artifact");
+        assertThat(ddiChunk.getArtifacts().size()).isEqualTo(0);
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiChunk = "{\"part\":[\"1234\"],\"version\":\"1.0\",\"name\":\"Dummy-Artifact\",\"artifacts\":[]}";
+
+        // Test
+        mapper.readValue(serializedDdiChunk, DdiChunk.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiChunkTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiChunkTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -25,7 +26,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiChunk'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiChunkTest {
 
@@ -65,7 +66,7 @@ public class DdiChunkTest {
         assertThat(ddiChunk.getArtifacts().size()).isEqualTo(0);
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiChunk = "{\"part\":[\"1234\"],\"version\":\"1.0\",\"name\":\"Dummy-Artifact\",\"artifacts\":[]}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiChunkTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiChunkTest.java
@@ -61,7 +61,7 @@ public class DdiChunkTest {
 
         assertThat(ddiChunk.getPart()).isEqualTo("1234");
         assertThat(ddiChunk.getVersion()).isEqualTo("1.0");
-        assertThat(ddiChunk.getName()).isEqualTo("Artifact");
+        assertThat(ddiChunk.getName()).isEqualTo("Dummy-Artifact");
         assertThat(ddiChunk.getArtifacts().size()).isEqualTo(0);
     }
 

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigDataTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigDataTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -33,6 +34,7 @@ public class DdiConfigDataTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         Long id = 123L;
@@ -59,6 +61,7 @@ public class DdiConfigDataTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiConfigData = "{\"id\":123,\"time\":\"20190809T121314\","
@@ -76,6 +79,7 @@ public class DdiConfigDataTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiConfigData = "{\"id\":[123],\"time\":\"20190809T121314\","

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigDataTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigDataTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiConfigData'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiConfigDataTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        Long id = 123L;
+        String time = "20190809T121314";
+        DdiStatus ddiStatus = new DdiStatus(DdiStatus.ExecutionStatus.CLOSED,
+                new DdiResult(DdiResult.FinalResult.SUCCESS, null), null);
+        Map<String, String> data = new HashMap<>();
+        data.put("test", "data");
+        DdiConfigData ddiConfigData = new DdiConfigData(id, time, ddiStatus, data, DdiUpdateMode.REPLACE);
+
+        // Test
+        String serializedDdiConfigData = mapper.writeValueAsString(ddiConfigData);
+        DdiConfigData deserializedDdiConfigData = mapper.readValue(serializedDdiConfigData, DdiConfigData.class);
+
+        assertThat(serializedDdiConfigData).contains(id.toString(), time, ddiStatus.getExecution().getName(),
+                ddiStatus.getResult().getFinished().getName(), "test", "data");
+        assertThat(deserializedDdiConfigData.getId()).isEqualTo(id);
+        assertThat(deserializedDdiConfigData.getTime()).isEqualTo(time);
+        assertThat(deserializedDdiConfigData.getStatus().getExecution()).isEqualTo(DdiStatus.ExecutionStatus.CLOSED);
+        assertThat(deserializedDdiConfigData.getStatus().getResult().getFinished()).isEqualTo(
+                DdiResult.FinalResult.SUCCESS);
+        assertThat(deserializedDdiConfigData.getMode()).isEqualTo(DdiUpdateMode.REPLACE);
+
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiConfigData = "{\"id\":123,\"time\":\"20190809T121314\","
+                + "\"status\":{\"execution\":\"closed\",\"result\":{\"finished\":\"success\",\"progress\":null},"
+                + "\"details\":[]},\"data\":{\"test\":\"data\"},\"mode\":\"replace\",\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiConfigData ddiConfigData = mapper.readValue(serializedDdiConfigData, DdiConfigData.class);
+
+        assertThat(ddiConfigData.getId()).isEqualTo(123);
+        assertThat(ddiConfigData.getTime()).isEqualTo("20190809T121314");
+        assertThat(ddiConfigData.getStatus().getExecution()).isEqualTo(DdiStatus.ExecutionStatus.CLOSED);
+        assertThat(ddiConfigData.getStatus().getResult().getFinished()).isEqualTo(DdiResult.FinalResult.SUCCESS);
+        assertThat(ddiConfigData.getMode()).isEqualTo(DdiUpdateMode.REPLACE);
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiConfigData = "{\"id\":[123],\"time\":\"20190809T121314\","
+                + "\"status\":{\"execution\":\"closed\",\"result\":{\"finished\":\"success\",\"progress\":null},"
+                + "\"details\":[]},\"data\":{\"test\":\"data\"},\"mode\":\"replace\",\"unknownProperty\":\"test\"}";
+
+        // Test
+        mapper.readValue(serializedDdiConfigData, DdiConfigData.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigDataTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigDataTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -25,7 +26,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiConfigData'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiConfigDataTest {
 
@@ -74,7 +75,7 @@ public class DdiConfigDataTest {
         assertThat(ddiConfigData.getMode()).isEqualTo(DdiUpdateMode.REPLACE);
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiConfigData = "{\"id\":[123],\"time\":\"20190809T121314\","

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -31,6 +32,7 @@ public class DdiConfigTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         DdiPolling ddiPolling = new DdiPolling("10");
@@ -45,6 +47,7 @@ public class DdiConfigTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiConfig = "{\"polling\":{\"sleep\":\"123\"},\"unknownProperty\":\"test\"}";
@@ -56,6 +59,7 @@ public class DdiConfigTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiConfig = "{\"polling\":{\"sleep\":[\"10\"]}}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -23,7 +24,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiConfig'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiConfigTest {
 
@@ -54,7 +55,7 @@ public class DdiConfigTest {
         assertThat(ddiConfig.getPolling().getSleep()).isEqualTo("123");
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiConfig = "{\"polling\":{\"sleep\":[\"10\"]}}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiConfigTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiConfig'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiConfigTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        DdiPolling ddiPolling = new DdiPolling("10");
+        DdiConfig ddiConfig = new DdiConfig(ddiPolling);
+
+        // Test
+        String serializedDdiConfig = mapper.writeValueAsString(ddiConfig);
+        DdiConfig deserializedDdiConfig = mapper.readValue(serializedDdiConfig, DdiConfig.class);
+
+        assertThat(serializedDdiConfig).contains("10");
+        assertThat(deserializedDdiConfig.getPolling().getSleep()).isEqualTo("10");
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiConfig = "{\"polling\":{\"sleep\":\"123\"},\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiConfig ddiConfig = mapper.readValue(serializedDdiConfig, DdiConfig.class);
+
+        assertThat(ddiConfig.getPolling().getSleep()).isEqualTo("123");
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiConfig = "{\"polling\":{\"sleep\":[\"10\"]}}";
+
+        // Test
+        mapper.readValue(serializedDdiConfig, DdiConfig.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiControllerBaseTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiControllerBaseTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiControllerBase'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiControllerBaseTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        // Setup
+        DdiPolling ddiPolling = new DdiPolling("10");
+        DdiConfig ddiConfig = new DdiConfig(ddiPolling);
+        DdiControllerBase ddiControllerBase = new DdiControllerBase(ddiConfig);
+
+        // Test
+        String serializedDdiControllerBase = mapper.writeValueAsString(ddiControllerBase);
+        DdiControllerBase deserializedDdiControllerBase = mapper.readValue(serializedDdiControllerBase,
+                DdiControllerBase.class);
+
+        assertThat(serializedDdiControllerBase).contains(ddiPolling.getSleep());
+        assertThat(deserializedDdiControllerBase.getConfig().getPolling().getSleep()).isEqualTo(ddiPolling.getSleep());
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiControllerBase = "{\"config\":{\"polling\":{\"sleep\":\"123\"}},\"links\":[],\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiControllerBase ddiControllerBase = mapper.readValue(serializedDdiControllerBase, DdiControllerBase.class);
+
+        assertThat(ddiControllerBase.getConfig().getPolling().getSleep()).isEqualTo("123");
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiControllerBase = "{\"config\":{\"polling\":{\"sleep\":[\"123\"]}},\"links\":[],\"unknownProperty\":\"test\"}";
+
+        // Test
+        mapper.readValue(serializedDdiControllerBase, DdiControllerBase.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiControllerBaseTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiControllerBaseTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -31,6 +32,7 @@ public class DdiControllerBaseTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         // Setup
@@ -48,6 +50,7 @@ public class DdiControllerBaseTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiControllerBase = "{\"config\":{\"polling\":{\"sleep\":\"123\"}},\"links\":[],\"unknownProperty\":\"test\"}";
@@ -59,6 +62,7 @@ public class DdiControllerBaseTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiControllerBase = "{\"config\":{\"polling\":{\"sleep\":[\"123\"]}},\"links\":[],\"unknownProperty\":\"test\"}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiControllerBaseTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiControllerBaseTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -23,7 +24,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiControllerBase'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiControllerBaseTest {
 
@@ -57,7 +58,7 @@ public class DdiControllerBaseTest {
         assertThat(ddiControllerBase.getConfig().getPolling().getSleep()).isEqualTo("123");
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiControllerBase = "{\"config\":{\"polling\":{\"sleep\":[\"123\"]}},\"links\":[],\"unknownProperty\":\"test\"}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBaseTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBaseTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -36,6 +37,7 @@ public class DdiDeploymentBaseTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         String id = "1234";
@@ -60,6 +62,7 @@ public class DdiDeploymentBaseTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiDeploymentBase = "{\"id\":\"1234\",\"deployment\":{\"download\":\"forced\","
@@ -77,6 +80,7 @@ public class DdiDeploymentBaseTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiDeploymentBase = "{\"id\":[\"1234\"],\"deployment\":{\"download\":\"forced\","

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBaseTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBaseTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.hawkbit.ddi.json.model.DdiDeployment.DdiMaintenanceWindowStatus.AVAILABLE;
+import static org.eclipse.hawkbit.ddi.json.model.DdiDeployment.HandlingType.ATTEMPT;
+import static org.eclipse.hawkbit.ddi.json.model.DdiDeployment.HandlingType.FORCED;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiDeploymentBase'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiDeploymentBaseTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        String id = "1234";
+        DdiDeployment ddiDeployment = new DdiDeployment(FORCED, ATTEMPT, Collections.emptyList(), AVAILABLE);
+        String actionStatus = "TestAction";
+        DdiActionHistory ddiActionHistory = new DdiActionHistory(actionStatus,
+                Arrays.asList("Action status message 1", "Action status message 2"));
+        DdiDeploymentBase ddiDeploymentBase = new DdiDeploymentBase(id, ddiDeployment, ddiActionHistory);
+
+        // Test
+        String serializedDdiDeploymentBase = mapper.writeValueAsString(ddiDeploymentBase);
+        DdiDeploymentBase deserializedDdiDeploymentBase = mapper.readValue(serializedDdiDeploymentBase,
+                DdiDeploymentBase.class);
+
+        assertThat(serializedDdiDeploymentBase).contains(id, FORCED.getName(), ATTEMPT.getName(), AVAILABLE.getStatus(),
+                actionStatus);
+        assertThat(deserializedDdiDeploymentBase.getDeployment().getDownload()).isEqualTo(ddiDeployment.getDownload());
+        assertThat(deserializedDdiDeploymentBase.getDeployment().getUpdate()).isEqualTo(ddiDeployment.getUpdate());
+        assertThat(deserializedDdiDeploymentBase.getDeployment().getMaintenanceWindow()).isEqualTo(
+                ddiDeployment.getMaintenanceWindow());
+        assertThat(deserializedDdiDeploymentBase.getActionHistory().toString()).isEqualTo(ddiActionHistory.toString());
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiDeploymentBase = "{\"id\":\"1234\",\"deployment\":{\"download\":\"forced\","
+                + "\"update\":\"attempt\",\"maintenanceWindow\":\"available\",\"chunks\":[]},"
+                + "\"actionHistory\":{\"status\":\"TestAction\",\"messages\":[\"Action status message 1\","
+                + "\"Action status message 2\"]},\"links\":[],\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiDeploymentBase ddiDeploymentBase = mapper.readValue(serializedDdiDeploymentBase, DdiDeploymentBase.class);
+
+        assertThat(ddiDeploymentBase.getDeployment().getDownload().getName()).isEqualTo(FORCED.getName());
+        assertThat(ddiDeploymentBase.getDeployment().getUpdate().getName()).isEqualTo(ATTEMPT.getName());
+        assertThat(ddiDeploymentBase.getDeployment().getMaintenanceWindow().getStatus()).isEqualTo(
+                AVAILABLE.getStatus());
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiDeploymentBase = "{\"id\":[\"1234\"],\"deployment\":{\"download\":\"forced\","
+                + "\"update\":\"attempt\",\"maintenanceWindow\":\"available\",\"chunks\":[]},"
+                + "\"actionHistory\":{\"status\":\"TestAction\",\"messages\":[\"Action status message 1\","
+                + "\"Action status message 2\"]},\"links\":[]}";
+
+        // Test
+        mapper.readValue(serializedDdiDeploymentBase, DdiDeploymentBase.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBaseTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBaseTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -28,7 +29,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiDeploymentBase'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiDeploymentBaseTest {
 
@@ -75,7 +76,7 @@ public class DdiDeploymentBaseTest {
                 AVAILABLE.getStatus());
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiDeploymentBase = "{\"id\":[\"1234\"],\"deployment\":{\"download\":\"forced\","

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.hawkbit.ddi.json.model.DdiDeployment.DdiMaintenanceWindowStatus.AVAILABLE;
+import static org.eclipse.hawkbit.ddi.json.model.DdiDeployment.HandlingType.ATTEMPT;
+import static org.eclipse.hawkbit.ddi.json.model.DdiDeployment.HandlingType.FORCED;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiDeployment'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiDeploymentTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        DdiDeployment ddiDeployment = new DdiDeployment(FORCED, ATTEMPT, Collections.emptyList(), AVAILABLE);
+
+        // Test
+        String serializedDdiDeployment = mapper.writeValueAsString(ddiDeployment);
+        DdiDeployment deserializedDdiDeployment = mapper.readValue(serializedDdiDeployment, DdiDeployment.class);
+
+        assertThat(serializedDdiDeployment).contains(ddiDeployment.getDownload().getName(),
+                ddiDeployment.getMaintenanceWindow().getStatus());
+        assertThat(deserializedDdiDeployment.getDownload().getName()).isEqualTo(ddiDeployment.getDownload().getName());
+        assertThat(deserializedDdiDeployment.getUpdate().getName()).isEqualTo(ddiDeployment.getUpdate().getName());
+        assertThat(deserializedDdiDeployment.getMaintenanceWindow().getStatus()).isEqualTo(
+                ddiDeployment.getMaintenanceWindow().getStatus());
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiDeployment = "{\"download\":\"forced\",\"update\":\"attempt\", "
+                + "\"maintenanceWindow\":\"available\",\"chunks\":[],\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiDeployment ddiDeployment = mapper.readValue(serializedDdiDeployment, DdiDeployment.class);
+
+        assertThat(ddiDeployment.getDownload().getName()).isEqualTo(FORCED.getName());
+        assertThat(ddiDeployment.getUpdate().getName()).isEqualTo(ATTEMPT.getName());
+        assertThat(ddiDeployment.getMaintenanceWindow().getStatus()).isEqualTo(AVAILABLE.getStatus());
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiDeployment = "{\"download\":[\"forced\"],\"update\":\"attempt\", "
+                + "\"maintenanceWindow\":\"available\",\"chunks\":[]}";
+
+        // Test
+        mapper.readValue(serializedDdiDeployment, DdiDeployment.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -27,7 +28,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiDeployment'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiDeploymentTest {
 
@@ -64,7 +65,7 @@ public class DdiDeploymentTest {
         assertThat(ddiDeployment.getMaintenanceWindow().getStatus()).isEqualTo(AVAILABLE.getStatus());
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiDeployment = "{\"download\":[\"forced\"],\"update\":\"attempt\", "

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -35,6 +36,7 @@ public class DdiDeploymentTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         DdiDeployment ddiDeployment = new DdiDeployment(FORCED, ATTEMPT, Collections.emptyList(), AVAILABLE);
@@ -52,6 +54,7 @@ public class DdiDeploymentTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiDeployment = "{\"download\":\"forced\",\"update\":\"attempt\", "
@@ -66,6 +69,7 @@ public class DdiDeploymentTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiDeployment = "{\"download\":[\"forced\"],\"update\":\"attempt\", "

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadataTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadataTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiMetadata'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiMetadataTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        String key = "testKey";
+        String value = "testValue";
+        DdiMetadata ddiMetadata = new DdiMetadata(key, value);
+
+        // Test
+        String serializedDdiMetadata = mapper.writeValueAsString(ddiMetadata);
+        DdiMetadata deserializedDdiMetadata = mapper.readValue(serializedDdiMetadata, DdiMetadata.class);
+
+        assertThat(serializedDdiMetadata).contains(key, value);
+        assertThat(deserializedDdiMetadata.getKey()).isEqualTo(ddiMetadata.getKey());
+        assertThat(deserializedDdiMetadata.getValue()).isEqualTo(ddiMetadata.getValue());
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiMetadata = "{\"key\":\"testKey\",\"value\":\"testValue\",\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiMetadata ddiMetadata = mapper.readValue(serializedDdiMetadata, DdiMetadata.class);
+
+        assertThat(ddiMetadata.getKey()).isEqualTo("testKey");
+        assertThat(ddiMetadata.getValue()).isEqualTo("testValue");
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiMetadata = "{\"key\":[\"testKey\"],\"value\":\"testValue\"}";
+
+        // Test
+        mapper.readValue(serializedDdiMetadata, DdiMetadata.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadataTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadataTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -23,7 +24,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiMetadata'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiMetadataTest {
 
@@ -57,7 +58,7 @@ public class DdiMetadataTest {
         assertThat(ddiMetadata.getValue()).isEqualTo("testValue");
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiMetadata = "{\"key\":[\"testKey\"],\"value\":\"testValue\"}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadataTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadataTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -31,6 +32,7 @@ public class DdiMetadataTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         String key = "testKey";
@@ -47,6 +49,7 @@ public class DdiMetadataTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiMetadata = "{\"key\":\"testKey\",\"value\":\"testValue\",\"unknownProperty\":\"test\"}";
@@ -59,6 +62,7 @@ public class DdiMetadataTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiMetadata = "{\"key\":[\"testKey\"],\"value\":\"testValue\"}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiPollingTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiPollingTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -23,7 +24,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiPolling'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiPollingTest {
 
@@ -53,7 +54,7 @@ public class DdiPollingTest {
         assertThat(ddiPolling.getSleep()).isEqualTo("10");
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiPolling = "{\"sleep\":[\"10\"]}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiPollingTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiPollingTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiPolling'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiPollingTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        DdiPolling ddiPolling = new DdiPolling("10");
+
+        // Test
+        String serializedDdiPolling = mapper.writeValueAsString(ddiPolling);
+        DdiPolling deserializedDdiPolling = mapper.readValue(serializedDdiPolling, DdiPolling.class);
+
+        assertThat(serializedDdiPolling).contains(ddiPolling.getSleep());
+        assertThat(deserializedDdiPolling.getSleep()).isEqualTo(ddiPolling.getSleep());
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiPolling = "{\"sleep\":\"10\",\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiPolling ddiPolling = mapper.readValue(serializedDdiPolling, DdiPolling.class);
+
+        assertThat(ddiPolling.getSleep()).isEqualTo("10");
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiPolling = "{\"sleep\":[\"10\"]}";
+
+        // Test
+        mapper.readValue(serializedDdiPolling, DdiPolling.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiPollingTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiPollingTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -31,6 +32,7 @@ public class DdiPollingTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         DdiPolling ddiPolling = new DdiPolling("10");
@@ -44,6 +46,7 @@ public class DdiPollingTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiPolling = "{\"sleep\":\"10\",\"unknownProperty\":\"test\"}";
@@ -55,6 +58,7 @@ public class DdiPollingTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiPolling = "{\"sleep\":[\"10\"]}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiProgressTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiProgressTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -23,7 +24,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiProgress'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiProgressTest {
 
@@ -55,7 +56,7 @@ public class DdiProgressTest {
         assertThat(ddiProgress.getOf()).isEqualTo(100);
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiProgress = "{\"cnt\":[30],\"of\":100}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiProgressTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiProgressTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiProgress'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiProgressTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        DdiProgress ddiProgress = new DdiProgress(30, 100);
+
+        // Test
+        String serializedDdiProgress = mapper.writeValueAsString(ddiProgress);
+        DdiProgress deserializedDdiProgress = mapper.readValue(serializedDdiProgress, DdiProgress.class);
+
+        assertThat(serializedDdiProgress).contains(ddiProgress.getCnt().toString(), ddiProgress.getOf().toString());
+        assertThat(deserializedDdiProgress.getCnt()).isEqualTo(ddiProgress.getCnt());
+        assertThat(deserializedDdiProgress.getOf()).isEqualTo(ddiProgress.getOf());
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiProgress = "{\"cnt\":30,\"of\":100,\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiProgress ddiProgress = mapper.readValue(serializedDdiProgress, DdiProgress.class);
+
+        assertThat(ddiProgress.getCnt()).isEqualTo(30);
+        assertThat(ddiProgress.getOf()).isEqualTo(100);
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiProgress = "{\"cnt\":[30],\"of\":100}";
+
+        // Test
+        mapper.readValue(serializedDdiProgress, DdiProgress.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiProgressTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiProgressTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -31,6 +32,7 @@ public class DdiProgressTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         DdiProgress ddiProgress = new DdiProgress(30, 100);
@@ -45,6 +47,7 @@ public class DdiProgressTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiProgress = "{\"cnt\":30,\"of\":100,\"unknownProperty\":\"test\"}";
@@ -57,6 +60,7 @@ public class DdiProgressTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiProgress = "{\"cnt\":[30],\"of\":100}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiResultTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiResultTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.hawkbit.ddi.json.model.DdiResult.FinalResult.NONE;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiResult'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiResultTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        DdiProgress ddiProgress = new DdiProgress(30, 100);
+        DdiResult ddiResult = new DdiResult(NONE, ddiProgress);
+
+        // Test
+        String serializedDdiResult = mapper.writeValueAsString(ddiResult);
+        DdiResult deserializedDdiResult = mapper.readValue(serializedDdiResult, DdiResult.class);
+
+        assertThat(serializedDdiResult).contains(NONE.getName(), ddiProgress.getCnt().toString(),
+                ddiProgress.getOf().toString());
+        assertThat(deserializedDdiResult.getFinished()).isEqualTo(ddiResult.getFinished());
+        assertThat(deserializedDdiResult.getProgress().getCnt()).isEqualTo(ddiProgress.getCnt());
+        assertThat(deserializedDdiResult.getProgress().getOf()).isEqualTo(ddiProgress.getOf());
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiResult = "{\"finished\":\"none\",\"progress\":{\"cnt\":30,\"of\":100},\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiResult ddiResult = mapper.readValue(serializedDdiResult, DdiResult.class);
+
+        assertThat(ddiResult.getFinished()).isEqualTo(NONE);
+        assertThat(ddiResult.getProgress().getCnt()).isEqualTo(30);
+        assertThat(ddiResult.getProgress().getOf()).isEqualTo(100);
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiResult = "{\"finished\":[\"none\"],\"progress\":{\"cnt\":30,\"of\":100}}";
+
+        // Test
+        mapper.readValue(serializedDdiResult, DdiResult.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiResultTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiResultTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -24,7 +25,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiResult'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiResultTest {
 
@@ -60,7 +61,7 @@ public class DdiResultTest {
         assertThat(ddiResult.getProgress().getOf()).isEqualTo(100);
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiResult = "{\"finished\":[\"none\"],\"progress\":{\"cnt\":30,\"of\":100}}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiResultTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiResultTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -32,6 +33,7 @@ public class DdiResultTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         DdiProgress ddiProgress = new DdiProgress(30, 100);
@@ -49,6 +51,7 @@ public class DdiResultTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiResult = "{\"finished\":\"none\",\"progress\":{\"cnt\":30,\"of\":100},\"unknownProperty\":\"test\"}";
@@ -62,6 +65,7 @@ public class DdiResultTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiResult = "{\"finished\":[\"none\"],\"progress\":{\"cnt\":30,\"of\":100}}";

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiStatusTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiStatusTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.hawkbit.ddi.json.model.DdiResult.FinalResult.NONE;
+import static org.eclipse.hawkbit.ddi.json.model.DdiStatus.ExecutionStatus.PROCEEDING;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Test serializability of DDI api model 'DdiStatus'
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class DdiStatusTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerializeAndDeserializeObject() throws IOException {
+        // Setup
+        DdiProgress ddiProgress = new DdiProgress(30, 100);
+        DdiResult ddiResult = new DdiResult(NONE, ddiProgress);
+        DdiStatus ddiStatus = new DdiStatus(PROCEEDING, ddiResult, Collections.emptyList());
+
+        // Test
+        String serializedDdiStatus = mapper.writeValueAsString(ddiStatus);
+        DdiStatus deserializedDdiStatus = mapper.readValue(serializedDdiStatus, DdiStatus.class);
+
+        assertThat(serializedDdiStatus).contains(ddiStatus.getExecution().getName(), ddiResult.getFinished().getName(),
+                ddiResult.getProgress().getCnt().toString(), ddiResult.getProgress().getOf().toString());
+        assertThat(deserializedDdiStatus.getExecution()).isEqualTo(ddiStatus.getExecution());
+        assertThat(deserializedDdiStatus.getResult().getFinished()).isEqualTo(ddiStatus.getResult().getFinished());
+        assertThat(deserializedDdiStatus.getResult().getProgress().getCnt()).isEqualTo(
+                ddiStatus.getResult().getProgress().getCnt());
+        assertThat(deserializedDdiStatus.getResult().getProgress().getOf()).isEqualTo(
+                ddiStatus.getResult().getProgress().getOf());
+    }
+
+    @Test
+    public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
+        // Setup
+        String serializedDdiStatus = "{\"execution\":\"proceeding\",\"result\":{\"finished\":\"none\","
+                + "\"progress\":{\"cnt\":30,\"of\":100}},\"details\":[],\"unknownProperty\":\"test\"}";
+
+        // Test
+        DdiStatus ddiStatus = mapper.readValue(serializedDdiStatus, DdiStatus.class);
+
+        assertThat(ddiStatus.getExecution()).isEqualTo(PROCEEDING);
+        assertThat(ddiStatus.getResult().getFinished()).isEqualTo(NONE);
+        assertThat(ddiStatus.getResult().getProgress().getCnt()).isEqualTo(30);
+        assertThat(ddiStatus.getResult().getProgress().getOf()).isEqualTo(100);
+    }
+
+    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+        // Setup
+        String serializedDdiStatus = "{\"execution\":[\"proceeding\"],\"result\":{\"finished\":\"none\","
+                + "\"progress\":{\"cnt\":30,\"of\":100}},\"details\":[]}";
+
+        // Test
+        mapper.readValue(serializedDdiStatus, DdiStatus.class);
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiStatusTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiStatusTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -26,7 +27,7 @@ import io.qameta.allure.Story;
 /**
  * Test serializability of DDI api model 'DdiStatus'
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class DdiStatusTest {
 
@@ -68,7 +69,7 @@ public class DdiStatusTest {
         assertThat(ddiStatus.getResult().getProgress().getOf()).isEqualTo(100);
     }
 
-    @Test(expected = com.fasterxml.jackson.databind.exc.MismatchedInputException.class)
+    @Test(expected = MismatchedInputException.class)
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiStatus = "{\"execution\":[\"proceeding\"],\"result\":{\"finished\":\"none\","

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiStatusTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiStatusTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -34,6 +35,7 @@ public class DdiStatusTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
+    @Description("Verify the correct serialization and deserialization of the model")
     public void shouldSerializeAndDeserializeObject() throws IOException {
         // Setup
         DdiProgress ddiProgress = new DdiProgress(30, 100);
@@ -55,6 +57,7 @@ public class DdiStatusTest {
     }
 
     @Test
+    @Description("Verify the correct deserialization of a model with a additional unknown property")
     public void shouldDeserializeObjectWithUnknownProperty() throws IOException {
         // Setup
         String serializedDdiStatus = "{\"execution\":\"proceeding\",\"result\":{\"finished\":\"none\","
@@ -70,6 +73,7 @@ public class DdiStatusTest {
     }
 
     @Test(expected = MismatchedInputException.class)
+    @Description("Verify that deserialization fails for known properties with a wrong datatype")
     public void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         String serializedDdiStatus = "{\"execution\":[\"proceeding\"],\"result\":{\"finished\":\"none\","

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/JsonIgnorePropertiesAnnotationTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/JsonIgnorePropertiesAnnotationTest.java
@@ -19,17 +19,20 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.ClassPath;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
 /**
  * Check DDI api model classes for '@JsonIgnoreProperties' annotation
  */
-@Feature("Model Tests - Direct Device Integration API")
+@Feature("Unit Tests - Direct Device Integration API")
 @Story("Serializability of DDI api Models")
 public class JsonIgnorePropertiesAnnotationTest {
 
     @Test
+    @Description(
+            "This test verifies that all model classes within the 'org.eclipse.hawkbit.ddi.json.model' package are annotated with '@JsonIgnoreProperties(ignoreUnknown = true)'")
     public void shouldCheckAnnotationsForAllModelClasses() throws IOException {
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
         String packageName = this.getClass().getPackage().getName();

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/JsonIgnorePropertiesAnnotationTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/JsonIgnorePropertiesAnnotationTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.ddi.json.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.ClassPath;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Check DDI api model classes for '@JsonIgnoreProperties' annotation
+ */
+@Feature("Model Tests - Direct Device Integration API")
+@Story("Serializability of DDI api Models")
+public class JsonIgnorePropertiesAnnotationTest {
+
+    @Test
+    public void shouldCheckAnnotationsForAllModelClasses() throws IOException {
+        final ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        String packageName = this.getClass().getPackage().getName();
+
+        ImmutableSet<ClassPath.ClassInfo> topLevelClasses = ClassPath.from(loader).getTopLevelClasses(packageName);
+        for (ClassPath.ClassInfo classInfo : topLevelClasses) {
+            Class<?> modelClass = classInfo.load();
+            if (modelClass.getSimpleName().contains("Test") || modelClass.isEnum()) {
+                continue;
+            }
+            JsonIgnoreProperties annotation = modelClass.getAnnotation(JsonIgnoreProperties.class);
+            assertThat(annotation).isNotNull();
+            assertThat(annotation.ignoreUnknown()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
Added JsonIgnoreProperties annotation to DDI Api model classes to ignore unknown properties on deserialisation

Signed-off-by: Robert Sing <Robert.Sing@bosch-si.com>