### PR TITLE
Change constructor visibility of JpaTargetTagManagement to public

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetTagManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetTagManagement.java
@@ -54,8 +54,9 @@ public class JpaTargetTagManagement implements TargetTagManagement {
     private final VirtualPropertyReplacer virtualPropertyReplacer;
     private final Database database;
 
-    JpaTargetTagManagement(final TargetTagRepository targetTagRepository, final TargetRepository targetRepository,
-            final VirtualPropertyReplacer virtualPropertyReplacer, final Database database) {
+    public JpaTargetTagManagement(final TargetTagRepository targetTagRepository,
+            final TargetRepository targetRepository, final VirtualPropertyReplacer virtualPropertyReplacer,
+            final Database database) {
         this.targetTagRepository = targetTagRepository;
         this.targetRepository = targetRepository;
         this.virtualPropertyReplacer = virtualPropertyReplacer;


### PR DESCRIPTION
We need the constructor to be public if JpaTargetTagManagement needs to be created anywhere else other than the current place at which it is defined as bean.

Signed-off-by: Ravindranath Sandeep (INST-IOT/ESW-Imb) <Sandeep.Ravindranath@bosch-si.com>