### PR TITLE
add a generic remote event type

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/GenericRemoteEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/GenericRemoteEvent.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.hawkbit.repository.event.remote;
+
+/**
+ * An event that can be generally used to communicate within the microservices
+ * using the internal event bus.
+ */
+public class GenericRemoteEvent extends RemoteTenantAwareEvent {
+
+    private static final long serialVersionUID = 1L;
+    private Class<?> payloadType;
+    private Object payload;
+
+    /**
+     * Default constructor.
+     */
+    public GenericRemoteEvent() {
+        // for serialization libs like jackson
+    }
+
+    /**
+     * constructor
+     * 
+     * @param tenant
+     *            the tenant
+     * @param payloadType
+     *            the class type of the payload
+     * @param payload
+     *            the content of the payload
+     * @param applicationId
+     *            the origin application id
+     */
+    public GenericRemoteEvent(final String tenant, final Class<?> payloadType, final Object payload,
+            final String applicationId) {
+        super(payload, tenant, applicationId);
+        this.payloadType = payloadType;
+        this.payload = payload;
+    }
+
+    /**
+     * Gets the class type of the payload associated with this event
+     * 
+     * @return type of the payload
+     */
+    public Class<?> getPayloadType() {
+        return payloadType;
+    }
+
+    /**
+     * Gets the payload associated with this event
+     * 
+     * @return the payload
+     */
+    public Object getPayload() {
+        return payload;
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/event/EventType.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/event/EventType.java
@@ -17,6 +17,7 @@ import org.eclipse.hawkbit.repository.event.remote.DistributionSetDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.DistributionSetTagDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.DistributionSetTypeDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.DownloadProgressEvent;
+import org.eclipse.hawkbit.repository.event.remote.GenericRemoteEvent;
 import org.eclipse.hawkbit.repository.event.remote.MultiActionEvent;
 import org.eclipse.hawkbit.repository.event.remote.RolloutDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.RolloutGroupDeletedEvent;
@@ -136,6 +137,9 @@ public class EventType {
 
         // deployment event for assignments and /or cancellations
         TYPES.put(38, MultiActionEvent.class);
+        
+        //generic event for internal communication between service nodes.
+        TYPES.put(39, GenericRemoteEvent.class);
     }
 
     private int value;


### PR DESCRIPTION
This event can be used for inter communication between the nodes to
share generic information. It can by providing a payload and payload
type which will be an agreement between the sender and the receiver.

Signed-off-by: Ravindranath Sandeep (INST-IOT/ESW-Imb) <Sandeep.Ravindranath@bosch-si.com>