### PR TITLE
RabbitMQ listener properties

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/resources/hawkbit-dmf-defaults.properties
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/resources/hawkbit-dmf-defaults.properties
@@ -8,9 +8,9 @@
 #
 
 ## DMF RabbitMQ configuration - START
-spring.rabbitmq.listener.prefetch=10
-spring.rabbitmq.listener.concurrency=3
-spring.rabbitmq.listener.max-concurrency=10
+spring.rabbitmq.listener.simple.prefetch=10
+spring.rabbitmq.listener.simple.concurrency=3
+spring.rabbitmq.listener.simple.max-concurrency=10
 spring.rabbitmq.requested-heartbeat=60
 
 hawkbit.dmf.rabbitmq.declaration-retries=10000

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/resources/hawkbit-dmf-defaults.properties
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/resources/hawkbit-dmf-defaults.properties
@@ -8,8 +8,8 @@
 #
 
 ## DMF RabbitMQ configuration - START
-spring.rabbitmq.listener.simple.prefetch=10
-spring.rabbitmq.listener.simple.concurrency=3
+spring.rabbitmq.listener.simple.prefetch=250
+spring.rabbitmq.listener.simple.concurrency=1
 spring.rabbitmq.listener.simple.max-concurrency=10
 spring.rabbitmq.requested-heartbeat=60
 


### PR DESCRIPTION
Since Spring AMQP version 2 the listener properties' names changed depending on the container that is used, e.g.  spring.rabbitmq.listener.simple.<key> when using SimpleMessageListenerContainer. 
For the prefetch property also the default value has changed to 250, which is set here explicitly to that value to stay stable in case of further changes. 
The concurrency's min and max values are set from 1 (initial default) to 10 to avoid uncontrollably concurrency adjusting when the workload is increasing. 