### PR TITLE
Fixed error message not shown when exceeding filesize

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/AbstractFileTransferHandler.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/AbstractFileTransferHandler.java
@@ -130,10 +130,6 @@ public abstract class AbstractFileTransferHandler implements Serializable {
         interruptUploadAndSetReason(i18n.getMessage("message.no.duplicateFiles"));
     }
 
-    protected void interruptUploadDueToFileSizeExceeded(final long maxSize) {
-        interruptUploadAndSetReason(i18n.getMessage("message.uploadedfile.size.exceeded", maxSize));
-    }
-
     protected void interruptUploadDueToIllegalFilename() {
         interruptUploadAndSetReason(i18n.getMessage("message.uploadedfile.illegalFilename"));
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerStreamVariable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerStreamVariable.java
@@ -90,7 +90,7 @@ public class FileTransferHandlerStreamVariable extends AbstractFileTransferHandl
             publishUploadProgressEvent(fileUploadId, 0, fileSize);
             startTransferToRepositoryThread(inputStream, fileUploadId, mimeType);
         } catch (final IOException e) {
-            LOG.error("Creating piped Stream failed {}.", e);
+            LOG.warn("Creating piped Stream failed {}.", e);
             tryToCloseIOStream(outputStream);
             tryToCloseIOStream(inputStream);
             interruptUploadDueToUploadFailed();
@@ -125,9 +125,7 @@ public class FileTransferHandlerStreamVariable extends AbstractFileTransferHandl
         }
 
         if (event.getBytesReceived() > maxSize || event.getContentLength() > maxSize) {
-            final String maxSizeText = SizeConversionHelper.byteValueToReadableString(maxSize);
-            LOG.debug("User tried to upload more than was allowed ({}).", maxSizeText);
-            interruptUploadDueToFileSizeQuotaExceeded(maxSizeText);
+            interruptUploadDueToFileSizeQuotaExceeded(SizeConversionHelper.byteValueToReadableString(maxSize));
             return;
         }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerStreamVariable.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerStreamVariable.java
@@ -66,10 +66,10 @@ public class FileTransferHandlerStreamVariable extends AbstractFileTransferHandl
         assertStateConsistency(fileUploadId, event.getFileName());
 
         if (RegexCharacterCollection.stringContainsCharacter(event.getFileName(), ILLEGAL_FILENAME_CHARACTERS)) {
-            LOG.info("Filename contains illegal characters {} for upload {}", fileUploadId.getFilename(), fileUploadId);
+            LOG.debug("Filename contains illegal characters {} for upload {}", fileUploadId.getFilename(), fileUploadId);
             interruptUploadDueToIllegalFilename();
         } else if (isFileAlreadyContainedInSoftwareModule(fileUploadId, selectedSoftwareModule)) {
-            LOG.info("File {} already contained in Software Module {}", fileUploadId.getFilename(),
+            LOG.debug("File {} already contained in Software Module {}", fileUploadId.getFilename(),
                     selectedSoftwareModule);
             interruptUploadDueToDuplicateFile();
         }
@@ -94,7 +94,7 @@ public class FileTransferHandlerStreamVariable extends AbstractFileTransferHandl
             tryToCloseIOStream(outputStream);
             tryToCloseIOStream(inputStream);
             interruptUploadDueToUploadFailed();
-            publishUploadFailedAndFinishedEvent(fileUploadId, e);
+            publishUploadFailedAndFinishedEvent(fileUploadId);
             return ByteStreams.nullOutputStream();
         }
         return outputStream;
@@ -126,7 +126,7 @@ public class FileTransferHandlerStreamVariable extends AbstractFileTransferHandl
 
         if (event.getBytesReceived() > maxSize || event.getContentLength() > maxSize) {
             final String maxSizeText = SizeConversionHelper.byteValueToReadableString(maxSize);
-            LOG.error("User tried to upload more than was allowed ({}).", maxSizeText);
+            LOG.debug("User tried to upload more than was allowed ({}).", maxSizeText);
             interruptUploadDueToFileSizeQuotaExceeded(maxSizeText);
             return;
         }
@@ -159,7 +159,8 @@ public class FileTransferHandlerStreamVariable extends AbstractFileTransferHandl
         if (!isUploadInterrupted()) {
             interruptUploadDueToUploadFailed();
         }
-        publishUploadFailedAndFinishedEvent(fileUploadId, event.getException());
+        LOG.debug("Streaming of file {} failed due to following exception: {}", fileUploadId, event.getException());
+        publishUploadFailedAndFinishedEvent(fileUploadId);
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerVaadinUpload.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerVaadinUpload.java
@@ -83,7 +83,6 @@ public class FileTransferHandlerVaadinUpload extends AbstractFileTransferHandler
             interruptUploadDueToDuplicateFile();
             event.getUpload().interruptUpload();
         } else {
-            LOG.debug("Uploading file {}", fileUploadId);
             publishUploadStarted(fileUploadId);
 
             if (RegexCharacterCollection.stringContainsCharacter(event.getFilename(), ILLEGAL_FILENAME_CHARACTERS)) {
@@ -131,7 +130,7 @@ public class FileTransferHandlerVaadinUpload extends AbstractFileTransferHandler
             publishUploadProgressEvent(fileUploadId, 0, 0);
             startTransferToRepositoryThread(inputStream, fileUploadId, mimeType);
         } catch (final IOException e) {
-            LOG.error("Creating piped Stream failed {}.", e);
+            LOG.warn("Creating piped Stream failed {}.", e);
             tryToCloseIOStream(outputStream);
             tryToCloseIOStream(inputStream);
             interruptUploadDueToUploadFailed();
@@ -154,9 +153,7 @@ public class FileTransferHandlerVaadinUpload extends AbstractFileTransferHandler
         }
 
         if (readBytes > maxSize || contentLength > maxSize) {
-            final String maxSizeText = SizeConversionHelper.byteValueToReadableString(maxSize);
-            LOG.debug("User tried to upload more than was allowed ({}).", maxSizeText);
-            interruptUploadDueToFileSizeQuotaExceeded(maxSizeText);
+            interruptUploadDueToFileSizeQuotaExceeded(SizeConversionHelper.byteValueToReadableString(maxSize));
             return;
         }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerVaadinUpload.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerVaadinUpload.java
@@ -16,6 +16,7 @@ import java.util.concurrent.locks.Lock;
 
 import org.eclipse.hawkbit.repository.ArtifactManagement;
 import org.eclipse.hawkbit.repository.RegexCharacterCollection;
+import org.eclipse.hawkbit.repository.SizeConversionHelper;
 import org.eclipse.hawkbit.repository.SoftwareModuleManagement;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
@@ -147,14 +148,15 @@ public class FileTransferHandlerVaadinUpload extends AbstractFileTransferHandler
      */
     @Override
     public void updateProgress(final long readBytes, final long contentLength) {
-        if (readBytes > maxSize || contentLength > maxSize) {
-            LOG.error("User tried to upload more than was allowed ({}).", maxSize);
-            interruptUploadDueToFileSizeExceeded(maxSize);
+        if (isUploadInterrupted()) {
+            publishUploadFailedAndFinishedEvent(fileUploadId);
             return;
         }
-        if (isUploadInterrupted()) {
-            // Upload interruption is delayed maybe another event is fired
-            // before
+
+        if (readBytes > maxSize || contentLength > maxSize) {
+            final String maxSizeText = SizeConversionHelper.byteValueToReadableString(maxSize);
+            LOG.error("User tried to upload more than was allowed ({}).", maxSizeText);
+            interruptUploadDueToFileSizeQuotaExceeded(maxSizeText);
             return;
         }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerVaadinUpload.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/upload/FileTransferHandlerVaadinUpload.java
@@ -83,16 +83,16 @@ public class FileTransferHandlerVaadinUpload extends AbstractFileTransferHandler
             interruptUploadDueToDuplicateFile();
             event.getUpload().interruptUpload();
         } else {
-            LOG.info("Uploading file {}", fileUploadId);
+            LOG.debug("Uploading file {}", fileUploadId);
             publishUploadStarted(fileUploadId);
 
             if (RegexCharacterCollection.stringContainsCharacter(event.getFilename(), ILLEGAL_FILENAME_CHARACTERS)) {
-                LOG.info("Filename contains illegal characters {} for upload {}", fileUploadId.getFilename(),
+                LOG.debug("Filename contains illegal characters {} for upload {}", fileUploadId.getFilename(),
                         fileUploadId);
                 interruptUploadDueToIllegalFilename();
                 event.getUpload().interruptUpload();
             } else if (isFileAlreadyContainedInSoftwareModule(fileUploadId, softwareModule)) {
-                LOG.info("File {} already contained in Software Module {}", fileUploadId.getFilename(), softwareModule);
+                LOG.debug("File {} already contained in Software Module {}", fileUploadId.getFilename(), softwareModule);
                 interruptUploadDueToDuplicateFile();
                 event.getUpload().interruptUpload();
             }
@@ -135,7 +135,7 @@ public class FileTransferHandlerVaadinUpload extends AbstractFileTransferHandler
             tryToCloseIOStream(outputStream);
             tryToCloseIOStream(inputStream);
             interruptUploadDueToUploadFailed();
-            publishUploadFailedAndFinishedEvent(fileUploadId, e);
+            publishUploadFailedAndFinishedEvent(fileUploadId);
             return ByteStreams.nullOutputStream();
         }
         return outputStream;
@@ -155,7 +155,7 @@ public class FileTransferHandlerVaadinUpload extends AbstractFileTransferHandler
 
         if (readBytes > maxSize || contentLength > maxSize) {
             final String maxSizeText = SizeConversionHelper.byteValueToReadableString(maxSize);
-            LOG.error("User tried to upload more than was allowed ({}).", maxSizeText);
+            LOG.debug("User tried to upload more than was allowed ({}).", maxSizeText);
             interruptUploadDueToFileSizeQuotaExceeded(maxSizeText);
             return;
         }
@@ -202,7 +202,8 @@ public class FileTransferHandlerVaadinUpload extends AbstractFileTransferHandler
         if (!isUploadInterrupted()) {
             interruptUploadDueToUploadFailed();
         }
-        publishUploadFailedAndFinishedEvent(fileUploadId, event.getReason());
+        LOG.debug("Upload of file {} failed due to following exception: {}", fileUploadId, event.getReason());
+        publishUploadFailedAndFinishedEvent(fileUploadId);
     }
 
     @Override

--- a/hawkbit-ui/src/main/resources/messages.properties
+++ b/hawkbit-ui/src/main/resources/messages.properties
@@ -469,7 +469,6 @@ message.upload.failed = Upload failed
 message.upload.assignmentQuota = Max assignments per software module exceeded
 message.upload.fileSizeQuota = Maximum artifact size ({0}) exceeded
 message.upload.storageQuota = Storage quota exceeded, {0} left
-message.uploadedfile.size.exceeded = File size exceeded. Allowed size {0} bytes
 message.uploadedfile.illegalFilename = Filename contains illegal characters
 message.artifact.deleted = Artifact with file {0} deleted successfully
 


### PR DESCRIPTION
This fixes a problem when trying to upload a file that exceeds the max allowed file size of spring. The upload was rejected, but this was not visible in the UI. It just showed the progress bar but did not do anything.

With this PR it will notify the UI properly and provide a message why the upload failed.