### PR TITLE
increase the value of maximal targets per auto assigment

### DIFF
--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/HawkbitSecurityProperties.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/HawkbitSecurityProperties.java
@@ -259,7 +259,7 @@ public class HawkbitSecurityProperties {
          * Maximum number of targets for an automatic distribution set
          * assignment
          */
-        private int maxTargetsPerAutoAssignment = 5000;
+        private int maxTargetsPerAutoAssignment = 20000;
 
         /**
          * Maximum size of artifacts in bytes. Defaults to 1 GB.


### PR DESCRIPTION
PR contains a higher value of maximal targets per auto assigment.


Signed-off-by: Michael Herdt <Michael.Herdt2@bosch-si.com>