### PR TITLE
Fix lazy loading Bean Queries in UI

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/details/ArtifactBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/details/ArtifactBeanQuery.java
@@ -19,7 +19,6 @@ import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery;
@@ -94,8 +93,8 @@ public class ArtifactBeanQuery extends AbstractBeanQuery<Artifact> {
     public int size() {
         long size = 0;
         if (baseSwModuleId != null) {
-            firstPagetArtifacts = getArtifactManagement()
-                    .findBySoftwareModule(PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort), baseSwModuleId);
+            firstPagetArtifacts = getArtifactManagement().findBySoftwareModule(
+                    new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), baseSwModuleId);
             size = firstPagetArtifacts.getTotalElements();
         }
         if (size > Integer.MAX_VALUE) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/ManageDistBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/ManageDistBeanQuery.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetFilter;
 import org.eclipse.hawkbit.repository.model.DistributionSetFilter.DistributionSetFilterBuilder;
@@ -22,7 +23,6 @@ import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -120,7 +120,7 @@ public class ManageDistBeanQuery extends AbstractBeanQuery<ProxyDistribution> {
         if (startIndex == 0 && firstPageDistributionSets != null) {
             distBeans = firstPageDistributionSets;
         } else {
-            distBeans = findDistBeans(PageRequest.of(startIndex / count, count, sort));
+            distBeans = findDistBeans(new OffsetBasedPageRequest(startIndex, count, sort));
         }
 
         for (final DistributionSet distributionSet : distBeans) {
@@ -137,7 +137,7 @@ public class ManageDistBeanQuery extends AbstractBeanQuery<ProxyDistribution> {
 
     @Override
     public int size() {
-        firstPageDistributionSets = findDistBeans(PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort));
+        firstPageDistributionSets = findDistBeans(new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort));
         final long size = firstPageDistributionSets.getTotalElements();
 
         if (size > Integer.MAX_VALUE) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CustomTargetBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/CustomTargetBeanQuery.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.ui.common.UserDetailsFormatter;
@@ -27,7 +28,6 @@ import org.eclipse.hawkbit.ui.utils.SPDateTimeUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -89,12 +89,9 @@ public class CustomTargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
         Slice<Target> targetBeans;
         final List<ProxyTarget> proxyTargetBeans = new ArrayList<>();
         if (!StringUtils.isEmpty(filterQuery)) {
-            targetBeans = targetManagement.findByRsql(
-                    PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort),
-                    filterQuery);
+            targetBeans = targetManagement.findByRsql(new OffsetBasedPageRequest(startIndex, count, sort), filterQuery);
         } else {
-            targetBeans = targetManagement
-                    .findAll(PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort));
+            targetBeans = targetManagement.findAll(new OffsetBasedPageRequest(startIndex, count, sort));
         }
 
         for (final Target targ : targetBeans) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterBeanQuery.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
 import org.eclipse.hawkbit.repository.model.Action.ActionType;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
@@ -24,7 +25,6 @@ import org.eclipse.hawkbit.ui.utils.SPDateTimeUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -86,11 +86,10 @@ public class TargetFilterBeanQuery extends AbstractBeanQuery<ProxyTargetFilter> 
         } else if (StringUtils.isEmpty(searchText)) {
             // if no search filters available
             targetFilterQuery = getTargetFilterQueryManagement()
-                    .findAll(PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort));
+                    .findAll(new OffsetBasedPageRequest(startIndex, count, sort));
         } else {
-            targetFilterQuery = getTargetFilterQueryManagement().findByName(
-                    PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort),
-                    searchText);
+            targetFilterQuery = getTargetFilterQueryManagement()
+                    .findByName(new OffsetBasedPageRequest(startIndex, count, sort), searchText);
         }
         for (final TargetFilterQuery tarFilterQuery : targetFilterQuery) {
             final ProxyTargetFilter proxyTarFilter = new ProxyTargetFilter();
@@ -128,10 +127,10 @@ public class TargetFilterBeanQuery extends AbstractBeanQuery<ProxyTargetFilter> 
     public int size() {
         if (StringUtils.isEmpty(searchText)) {
             firstPageTargetFilter = getTargetFilterQueryManagement()
-                    .findAll(PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort));
+                    .findAll(new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort));
         } else {
             firstPageTargetFilter = getTargetFilterQueryManagement()
-                    .findByName(PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort), searchText);
+                    .findByName(new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), searchText);
         }
         final long size = firstPageTargetFilter.getTotalElements();
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionBeanQuery.java
@@ -15,11 +15,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.hawkbit.repository.DeploymentManagement;
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.ui.management.actionhistory.ProxyAction.IsActiveDecoration;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -83,12 +83,12 @@ public class ActionBeanQuery extends AbstractBeanQuery<ProxyAction> {
         if (startIndex == 0) {
             if (firstPageActions == null) {
                 firstPageActions = getDeploymentManagement().findActionsByTarget(currentSelectedConrollerId,
-                        PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort));
+                        new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort));
             }
             actionBeans = firstPageActions;
         } else {
             actionBeans = getDeploymentManagement().findActionsByTarget(currentSelectedConrollerId,
-                    PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort));
+                    new OffsetBasedPageRequest(startIndex, count, sort));
         }
         return createProxyActions(actionBeans);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusBeanQuery.java
@@ -15,11 +15,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.hawkbit.repository.DeploymentManagement;
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery;
@@ -81,8 +81,7 @@ public class ActionStatusBeanQuery extends AbstractBeanQuery<ProxyActionStatus> 
             actionBeans = firstPageActionStates;
         } else {
             actionBeans = getDeploymentManagement().findActionStatusByAction(
-                    PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort),
-                    currentSelectedActionId);
+                    new OffsetBasedPageRequest(startIndex, count, sort), currentSelectedActionId);
         }
         return createProxyActionStates(actionBeans);
     }
@@ -116,8 +115,8 @@ public class ActionStatusBeanQuery extends AbstractBeanQuery<ProxyActionStatus> 
      * .util.List, java.util.List, java.util.List)
      */
     @Override
-    protected void saveBeans(List<ProxyActionStatus> addedBeans, List<ProxyActionStatus> modifiedBeans,
-            List<ProxyActionStatus> removedBeans) {
+    protected void saveBeans(final List<ProxyActionStatus> addedBeans, final List<ProxyActionStatus> modifiedBeans,
+            final List<ProxyActionStatus> removedBeans) {
         // CRUD operations on Target will be done through repository methods
     }
 
@@ -127,7 +126,7 @@ public class ActionStatusBeanQuery extends AbstractBeanQuery<ProxyActionStatus> 
 
         if (currentSelectedActionId != null) {
             firstPageActionStates = getDeploymentManagement().findActionStatusByAction(
-                    PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort), currentSelectedActionId);
+                    new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), currentSelectedActionId);
             size = firstPageActionStates.getTotalElements();
         }
         if (size > Integer.MAX_VALUE) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusMsgBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/actionhistory/ActionStatusMsgBeanQuery.java
@@ -15,11 +15,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.hawkbit.repository.DeploymentManagement;
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.util.StringUtils;
@@ -84,8 +84,7 @@ public class ActionStatusMsgBeanQuery extends AbstractBeanQuery<ProxyMessage> {
             actionBeans = firstPageMessages;
         } else {
             actionBeans = getDeploymentManagement().findMessagesByActionStatusId(
-                    PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort),
-                    currentSelectedActionStatusId);
+                    new OffsetBasedPageRequest(startIndex, count, sort), currentSelectedActionStatusId);
         }
         return createProxyMessages(actionBeans);
     }
@@ -129,7 +128,7 @@ public class ActionStatusMsgBeanQuery extends AbstractBeanQuery<ProxyMessage> {
 
         if (currentSelectedActionStatusId != null) {
             firstPageMessages = getDeploymentManagement().findMessagesByActionStatusId(
-                    PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort), currentSelectedActionStatusId);
+                    new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), currentSelectedActionStatusId);
             size = firstPageMessages.getTotalElements();
         }
         if (size > Integer.MAX_VALUE) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/dstable/DistributionBeanQuery.java
@@ -26,7 +26,6 @@ import org.eclipse.hawkbit.ui.utils.SPDateTimeUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.util.StringUtils;
@@ -148,19 +147,19 @@ public class DistributionBeanQuery extends AbstractBeanQuery<ProxyDistribution> 
 
             firstPageDistributionSets = getDistributionSetManagement()
                     .findByFilterAndAssignedInstalledDsOrderedByLinkTarget(
-                            PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort), distributionSetFilterBuilder,
-                            pinnedTarget.getControllerId());
+                            new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort),
+                            distributionSetFilterBuilder, pinnedTarget.getControllerId());
         } else if (distributionTags.isEmpty() && StringUtils.isEmpty(searchText) && !noTagClicked) {
             // if no search filters available
             firstPageDistributionSets = getDistributionSetManagement()
-                    .findByCompleted(PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort), true);
+                    .findByCompleted(new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), true);
         } else {
             final DistributionSetFilter distributionSetFilter = new DistributionSetFilterBuilder().setIsDeleted(false)
                     .setIsComplete(true).setSearchText(searchText).setSelectDSWithNoTag(noTagClicked)
                     .setTagNames(distributionTags).build();
 
             firstPageDistributionSets = getDistributionSetManagement().findByDistributionSetFilter(
-                    PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort), distributionSetFilter);
+                    new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), distributionSetFilter);
 
         }
         final long size = firstPageDistributionSets.getTotalElements();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetBeanQuery.java
@@ -27,7 +27,6 @@ import org.eclipse.hawkbit.ui.utils.SPDateTimeUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -110,18 +109,15 @@ public class TargetBeanQuery extends AbstractBeanQuery<ProxyTarget> {
         final List<ProxyTarget> proxyTargetBeans = new ArrayList<>();
         if (pinnedDistId != null) {
             targetBeans = getTargetManagement().findByFilterOrderByLinkedDistributionSet(
-                    new OffsetBasedPageRequest(startIndex, SPUIDefinitions.PAGE_SIZE, sort), pinnedDistId,
+                    new OffsetBasedPageRequest(startIndex, count, sort), pinnedDistId,
                     new FilterParams(status, overdueState, searchText, distributionId, noTagClicked, targetTags));
         } else if (null != targetFilterQueryId) {
-            targetBeans = getTargetManagement().findByTargetFilterQuery(
-                    PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort),
-                    targetFilterQueryId);
-        } else if (!isAnyFilterSelected()) {
             targetBeans = getTargetManagement()
-                    .findAll(PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort));
+                    .findByTargetFilterQuery(new OffsetBasedPageRequest(startIndex, count, sort), targetFilterQueryId);
+        } else if (!isAnyFilterSelected()) {
+            targetBeans = getTargetManagement().findAll(new OffsetBasedPageRequest(startIndex, count, sort));
         } else {
-            targetBeans = getTargetManagement().findByFilters(
-                    PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE, SPUIDefinitions.PAGE_SIZE, sort),
+            targetBeans = getTargetManagement().findByFilters(new OffsetBasedPageRequest(startIndex, count, sort),
                     new FilterParams(status, overdueState, searchText, distributionId, noTagClicked, targetTags));
         }
         for (final Target targ : targetBeans) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/DistributionBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/DistributionBeanQuery.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetFilter;
 import org.eclipse.hawkbit.repository.model.DistributionSetFilter.DistributionSetFilterBuilder;
@@ -25,7 +26,6 @@ import org.eclipse.hawkbit.ui.utils.SPDateTimeUtil;
 import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery;
@@ -83,7 +83,7 @@ public class DistributionBeanQuery extends AbstractBeanQuery<ProxyDistribution> 
             distBeans = firstPageDistributionSets;
         } else {
             distBeans = getDistributionSetManagement().findByDistributionSetFilter(
-                    PageRequest.of(startIndex / count, count, sort), distributionSetFilter);
+                    new OffsetBasedPageRequest(startIndex, count, sort), distributionSetFilter);
         }
         return createProxyDistributions(distBeans);
     }
@@ -119,8 +119,8 @@ public class DistributionBeanQuery extends AbstractBeanQuery<ProxyDistribution> 
         final DistributionSetFilter distributionSetFilter = new DistributionSetFilterBuilder().setIsDeleted(false)
                 .setIsComplete(true).build();
 
-        firstPageDistributionSets = getDistributionSetManagement()
-                .findByDistributionSetFilter(PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort), distributionSetFilter);
+        firstPageDistributionSets = getDistributionSetManagement().findByDistributionSetFilter(
+                new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), distributionSetFilter);
         final long size = firstPageDistributionSets.getTotalElements();
         if (size > Integer.MAX_VALUE) {
             return Integer.MAX_VALUE;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rollout/RolloutBeanQuery.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.Rollout;
@@ -21,7 +22,6 @@ import org.eclipse.hawkbit.ui.customrenderers.client.renderers.RolloutRendererDa
 import org.eclipse.hawkbit.ui.rollout.state.RolloutUIState;
 import org.eclipse.hawkbit.ui.utils.HawkbitCommonUtil;
 import org.eclipse.hawkbit.ui.utils.SPDateTimeUtil;
-import org.eclipse.hawkbit.ui.utils.SPUIDefinitions;
 import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -89,8 +89,7 @@ public class RolloutBeanQuery extends AbstractBeanQuery<ProxyRollout> {
     @Override
     protected List<ProxyRollout> loadBeans(final int startIndex, final int count) {
         final Slice<Rollout> rolloutBeans;
-        final PageRequest pageRequest = PageRequest.of(startIndex / SPUIDefinitions.PAGE_SIZE,
-                SPUIDefinitions.PAGE_SIZE, sort);
+        final PageRequest pageRequest = new OffsetBasedPageRequest(startIndex, count, sort);
         if (StringUtils.isEmpty(searchText)) {
             rolloutBeans = getRolloutManagement().findAllWithDetailedStatus(pageRequest, false);
         } else {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgroup/RolloutGroupBeanQuery.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
@@ -30,7 +31,6 @@ import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery;
@@ -105,7 +105,7 @@ public class RolloutGroupBeanQuery extends AbstractBeanQuery<ProxyRolloutGroup> 
                 proxyRolloutGroupsList = firstPageRolloutGroupSets.getContent();
             } else {
                 proxyRolloutGroupsList = getRolloutGroupManagement()
-                        .findByRolloutWithDetailedStatus(PageRequest.of(startIndex / count, count), rolloutId)
+                        .findByRolloutWithDetailedStatus(new OffsetBasedPageRequest(startIndex, count), rolloutId)
                         .getContent();
             }
         }
@@ -156,8 +156,8 @@ public class RolloutGroupBeanQuery extends AbstractBeanQuery<ProxyRolloutGroup> 
         long size = 0;
         if (rolloutId != null) {
             try {
-                firstPageRolloutGroupSets = getRolloutGroupManagement()
-                        .findByRolloutWithDetailedStatus(PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort), rolloutId);
+                firstPageRolloutGroupSets = getRolloutGroupManagement().findByRolloutWithDetailedStatus(
+                        new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), rolloutId);
                 size = firstPageRolloutGroupSets.getTotalElements();
             } catch (final EntityNotFoundException e) {
                 LOG.error("Rollout does not exists. Redirect to Rollouts overview", e);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsBeanQuery.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetsBeanQuery.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.RolloutGroupManagement;
 import org.eclipse.hawkbit.repository.RolloutManagement;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
@@ -29,7 +30,6 @@ import org.eclipse.hawkbit.ui.utils.SpringContextHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.vaadin.addons.lazyquerycontainer.AbstractBeanQuery;
@@ -90,7 +90,7 @@ public class RolloutGroupTargetsBeanQuery extends AbstractBeanQuery<ProxyTarget>
         return rolloutGroup
                 .map(group -> getProxyRolloutGroupTargetsList(
                         getRolloutGroupManagement().findAllTargetsOfRolloutGroupWithActionStatus(
-                                PageRequest.of(startIndex / count, count), group.getId()).getContent()))
+                                new OffsetBasedPageRequest(startIndex, count), group.getId()).getContent()))
                 .orElse(Collections.emptyList());
     }
 
@@ -137,7 +137,7 @@ public class RolloutGroupTargetsBeanQuery extends AbstractBeanQuery<ProxyTarget>
         try {
             firstPageTargetSets = rolloutGroup
                     .map(group -> getRolloutGroupManagement().findAllTargetsOfRolloutGroupWithActionStatus(
-                            PageRequest.of(0, SPUIDefinitions.PAGE_SIZE, sort), group.getId()))
+                            new OffsetBasedPageRequest(0, SPUIDefinitions.PAGE_SIZE, sort), group.getId()))
                     .orElse(null);
 
             size = firstPageTargetSets == null ? 0 : firstPageTargetSets.getTotalElements();


### PR DESCRIPTION
Inconsistent way of defining Pageable in Lazy Bean Queries led to duplicate entries in Tables. This PR unifies Pageable behaviour by using the OffsetBasedPageRequest.