### PR TITLE
Fix empty controller name

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -192,7 +192,9 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
      */
     public JpaTarget(final String controllerId, final String securityToken) {
         this.controllerId = controllerId;
-        setName(controllerId);
+        final String name = controllerId.length() > NAME_MAX_SIZE ? controllerId.substring(0, NAME_MAX_SIZE)
+                : controllerId;
+        setName(name);
         this.securityToken = securityToken;
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -196,7 +196,7 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
         this.securityToken = securityToken;
     }
 
-    private String truncateControllerIdToMaxNameLength(final String controllerId) {
+    private static String truncateControllerIdToMaxNameLength(final String controllerId) {
         return controllerId != null && controllerId.length() > NAME_MAX_SIZE ? controllerId.substring(0, NAME_MAX_SIZE)
                 : controllerId;
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -192,8 +192,9 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
      */
     public JpaTarget(final String controllerId, final String securityToken) {
         this.controllerId = controllerId;
-        final String name = controllerId.length() > NAME_MAX_SIZE ? controllerId.substring(0, NAME_MAX_SIZE)
-                : controllerId;
+        final String name = (controllerId != null && controllerId.length() > NAME_MAX_SIZE
+                ? controllerId.substring(0, NAME_MAX_SIZE)
+                : controllerId);
         setName(name);
         this.securityToken = securityToken;
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -192,11 +192,13 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
      */
     public JpaTarget(final String controllerId, final String securityToken) {
         this.controllerId = controllerId;
-        final String name = (controllerId != null && controllerId.length() > NAME_MAX_SIZE
-                ? controllerId.substring(0, NAME_MAX_SIZE)
-                : controllerId);
-        setName(name);
+        setName(truncateControllerIdToMaxNameLength(controllerId));
         this.securityToken = securityToken;
+    }
+
+    private String truncateControllerIdToMaxNameLength(final String controllerId) {
+        return controllerId != null && controllerId.length() > NAME_MAX_SIZE ? controllerId.substring(0, NAME_MAX_SIZE)
+                : controllerId;
     }
 
     JpaTarget() {

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
@@ -677,11 +677,15 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
 
         final String targetList = JsonBuilder.targets(Arrays.asList(target), false);
 
+        final String expectedTargetName = randomString.substring(0,
+                Math.min(JpaTarget.CONTROLLER_ID_MAX_SIZE, NamedEntity.NAME_MAX_SIZE));
+
         mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).content(targetList)
                 .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated())
                 .andExpect(jsonPath("[0].controllerId", equalTo(randomString)))
-                .andExpect(jsonPath("[0].name", equalTo(randomString.substring(0,
-                        Math.min(JpaTarget.CONTROLLER_ID_MAX_SIZE, NamedEntity.NAME_MAX_SIZE)))));
+                .andExpect(jsonPath("[0].name", equalTo(expectedTargetName)));
+
+        assertThat(targetManagement.getByControllerID(randomString).get().getName()).isEqualTo(expectedTargetName);
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
@@ -672,7 +672,7 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
     @Test
     @Description("Ensures that a target creation with empty name and a controllerId that exceeds the name length limitation is successful and the name gets truncated.")
     public void createTargetWithEmptyNameAndLongControllerId() throws Exception {
-        final String randomString = RandomStringUtils.random(JpaTarget.CONTROLLER_ID_MAX_SIZE);
+        final String randomString = RandomStringUtils.randomAlphanumeric(JpaTarget.CONTROLLER_ID_MAX_SIZE);
 
         final Target target = entityFactory.target().create().controllerId(randomString).build();
 

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 import javax.validation.ConstraintViolationException;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.assertj.core.util.Lists;
 import org.eclipse.hawkbit.exception.SpServerError;
 import org.eclipse.hawkbit.im.authentication.SpPermission;
 import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtActionType;
@@ -676,7 +675,7 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
 
         final Target target = entityFactory.target().create().controllerId(randomString).build();
 
-        final String targetList = JsonBuilder.targets(Lists.list(target), false);
+        final String targetList = JsonBuilder.targets(Arrays.asList(target), false);
 
         mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).content(targetList)
                 .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated())


### PR DESCRIPTION
When no name is provided while creating a target, the controllerId is taken as name. But the length limits for controllerId and name differ. This fix truncates the controllerId when taken as name, as the limit for the controllerId is larger than the one for the name.