### PR TITLE
Reduce log output for entity not found in AmqpAuthenticationMessageHandler

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpAuthenticationMessageHandler.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpAuthenticationMessageHandler.java
@@ -193,6 +193,9 @@ public class AmqpAuthenticationMessageHandler extends BaseAmqpService {
         return artifact;
     }
 
+    // suppress warning, EntityNotFoundException has not to be logged or
+    // rethrown as the exception has no valuable information
+    @SuppressWarnings("squid:S1166")
     private Message handleAuthenticationMessage(final Message message) {
         final DmfDownloadResponse authenticationResponse = new DmfDownloadResponse();
         final DmfTenantSecurityToken secruityToken = convertMessage(message, DmfTenantSecurityToken.class);
@@ -227,7 +230,7 @@ public class AmqpAuthenticationMessageHandler extends BaseAmqpService {
             authenticationResponse.setMessage("Building download URI failed");
         } catch (final EntityNotFoundException e) {
             final String errorMessage = "Artifact for resource " + fileResource + " not found ";
-            LOG.warn(errorMessage);
+            LOG.info(errorMessage);
             authenticationResponse.setResponseCode(HttpStatus.NOT_FOUND.value());
             authenticationResponse.setMessage(errorMessage);
         }

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpAuthenticationMessageHandler.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpAuthenticationMessageHandler.java
@@ -226,8 +226,8 @@ public class AmqpAuthenticationMessageHandler extends BaseAmqpService {
             authenticationResponse.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
             authenticationResponse.setMessage("Building download URI failed");
         } catch (final EntityNotFoundException e) {
-            final String errorMessage = "Artifact for resource " + fileResource + "not found ";
-            LOG.warn(errorMessage, e);
+            final String errorMessage = "Artifact for resource " + fileResource + " not found ";
+            LOG.warn(errorMessage);
             authenticationResponse.setResponseCode(HttpStatus.NOT_FOUND.value());
             authenticationResponse.setMessage(errorMessage);
         }

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpAuthenticationMessageHandlerIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpAuthenticationMessageHandlerIntegrationTest.java
@@ -115,7 +115,7 @@ public class AmqpAuthenticationMessageHandlerIntegrationTest extends AbstractAmq
 
         final Message returnMessage = sendAndReceiveAuthenticationMessage(securityToken);
         verifyResult(returnMessage, HttpStatus.NOT_FOUND,
-                "Artifact for resource FileResource [sha1=null, artifactId=null, filename=null]not found ");
+                "Artifact for resource FileResource [sha1=null, artifactId=null, filename=null] not found ");
 
     }
 
@@ -131,8 +131,8 @@ public class AmqpAuthenticationMessageHandlerIntegrationTest extends AbstractAmq
                 FileResource.createFileResourceBySha1(sha1Hash));
 
         final Message returnMessage = sendAndReceiveAuthenticationMessage(securityToken);
-        verifyResult(returnMessage, HttpStatus.NOT_FOUND,
-                "Artifact for resource FileResource [sha1=" + sha1Hash + ", artifactId=null, filename=null]not found ");
+        verifyResult(returnMessage, HttpStatus.NOT_FOUND, "Artifact for resource FileResource [sha1=" + sha1Hash
+                + ", artifactId=null, filename=null] not found ");
     }
 
     @Test
@@ -144,7 +144,7 @@ public class AmqpAuthenticationMessageHandlerIntegrationTest extends AbstractAmq
 
         final Message returnMessage = sendAndReceiveAuthenticationMessage(securityToken);
         verifyResult(returnMessage, HttpStatus.NOT_FOUND,
-                "Artifact for resource FileResource [sha1=12345, artifactId=null, filename=null]not found ");
+                "Artifact for resource FileResource [sha1=12345, artifactId=null, filename=null] not found ");
 
     }
 
@@ -159,8 +159,8 @@ public class AmqpAuthenticationMessageHandlerIntegrationTest extends AbstractAmq
                 FileResource.createFileResourceBySha1(sha1Hash));
 
         final Message returnMessage = sendAndReceiveAuthenticationMessage(securityToken);
-        verifyResult(returnMessage, HttpStatus.NOT_FOUND,
-                "Artifact for resource FileResource [sha1=" + sha1Hash + ", artifactId=null, filename=null]not found ");
+        verifyResult(returnMessage, HttpStatus.NOT_FOUND, "Artifact for resource FileResource [sha1=" + sha1Hash
+                + ", artifactId=null, filename=null] not found ");
 
     }
 
@@ -176,7 +176,7 @@ public class AmqpAuthenticationMessageHandlerIntegrationTest extends AbstractAmq
 
         final Message returnMessage = sendAndReceiveAuthenticationMessage(securityToken);
         verifyResult(returnMessage, HttpStatus.NOT_FOUND,
-                "Artifact for resource FileResource [sha1=2f532b93ed23b4341a81dc9b1ee8a1c44b5526ab, artifactId=null, filename=null]not found ");
+                "Artifact for resource FileResource [sha1=2f532b93ed23b4341a81dc9b1ee8a1c44b5526ab, artifactId=null, filename=null] not found ");
 
     }
 
@@ -258,7 +258,7 @@ public class AmqpAuthenticationMessageHandlerIntegrationTest extends AbstractAmq
 
         final Message returnMessage = sendAndReceiveAuthenticationMessage(securityToken);
         verifyResult(returnMessage, HttpStatus.NOT_FOUND,
-                "Artifact for resource FileResource [sha1=null, artifactId=null, filename=Test.txt]not found ");
+                "Artifact for resource FileResource [sha1=null, artifactId=null, filename=Test.txt] not found ");
 
     }
 
@@ -274,7 +274,7 @@ public class AmqpAuthenticationMessageHandlerIntegrationTest extends AbstractAmq
 
         final Message returnMessage = sendAndReceiveAuthenticationMessage(securityToken);
         verifyResult(returnMessage, HttpStatus.NOT_FOUND,
-                "Artifact for resource FileResource [sha1=null, artifactId=null, filename=filename0]not found ");
+                "Artifact for resource FileResource [sha1=null, artifactId=null, filename=filename0] not found ");
 
     }
 
@@ -289,7 +289,7 @@ public class AmqpAuthenticationMessageHandlerIntegrationTest extends AbstractAmq
 
         final Message returnMessage = sendAndReceiveAuthenticationMessage(securityToken);
         verifyResult(returnMessage, HttpStatus.NOT_FOUND, "Artifact for resource FileResource [sha1=null, artifactId="
-                + artifacts.get(0).getId() + ", filename=null]not found ");
+                + artifacts.get(0).getId() + ", filename=null] not found ");
 
     }
 
@@ -320,7 +320,7 @@ public class AmqpAuthenticationMessageHandlerIntegrationTest extends AbstractAmq
 
         final Message returnMessage = sendAndReceiveAuthenticationMessage(securityToken);
         verifyResult(returnMessage, HttpStatus.NOT_FOUND,
-                "Artifact for resource FileResource [sha1=null, artifactId=null, filename=null]not found ");
+                "Artifact for resource FileResource [sha1=null, artifactId=null, filename=null] not found ");
 
     }
 
@@ -340,7 +340,7 @@ public class AmqpAuthenticationMessageHandlerIntegrationTest extends AbstractAmq
 
         final Message returnMessage = sendAndReceiveAuthenticationMessage(securityToken);
         verifyResult(returnMessage, HttpStatus.NOT_FOUND,
-                "Artifact for resource FileResource [sha1=null, artifactId=null, filename=null]not found ");
+                "Artifact for resource FileResource [sha1=null, artifactId=null, filename=null] not found ");
 
     }
 


### PR DESCRIPTION
With this PR, the exception won't be printed anymore in case of entity not found in the `AmqpAuthenticationMessageHandler`, as is is not really needed here.

Signed-off-by: Sebastian Firsching <sebastian.firsching@bosch-si.com>