### PR TITLE
Make logout button in dashboard menu context path aware.

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/menu/DashboardMenu.java
@@ -28,6 +28,7 @@ import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.vaadin.server.FontAwesome;
@@ -217,7 +218,7 @@ public final class DashboardMenu extends CustomComponent {
     }
 
     private static String generateLogoutUrl() {
-        final UriComponentsBuilder logout = UriComponentsBuilder.fromPath(LOGOUT_BASE);
+        final UriComponentsBuilder logout = ServletUriComponentsBuilder.fromCurrentContextPath().path(LOGOUT_BASE);
 
         UserDetailsFormatter.getCurrentTenant().ifPresent(tenant -> logout.queryParam("login",
                 UriComponentsBuilder.fromPath(LOGIN_BASE).queryParam("tenant", tenant).build().toUriString()));


### PR DESCRIPTION
Hi,

we tried putting hawkbit behind a reverse proxy using a path prefix (such as `/hawkbit`). Everything on the web frontend works well except the logout process. The logout button was not aware of the `server.servlet.context-path` property and thus, instead of directing the user to `/hawkbit/UI/logout` it directed them to `/UI/logout` resulting in a 404.

This is fixed with this PR.

Signed-off-by: Brandon Schmitt <Brandon.Schmitt@kiwigrid.com>