### PR TITLE
Add x-content-type-options header to fileStreamingUtil

### DIFF
--- a/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/FileStreamingUtil.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/FileStreamingUtil.java
@@ -131,6 +131,7 @@ public final class FileStreamingUtil {
         response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + filename);
         response.setHeader(HttpHeaders.ETAG, etag);
         response.setHeader(HttpHeaders.ACCEPT_RANGES, "bytes");
+        response.setHeader(com.google.common.net.HttpHeaders.X_CONTENT_TYPE_OPTIONS, "nosniff");
         if (lastModified > 0) {
             response.setDateHeader(HttpHeaders.LAST_MODIFIED, lastModified);
         }

--- a/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/FileStreamingUtil.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/FileStreamingUtil.java
@@ -131,6 +131,9 @@ public final class FileStreamingUtil {
         response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + filename);
         response.setHeader(HttpHeaders.ETAG, etag);
         response.setHeader(HttpHeaders.ACCEPT_RANGES, "bytes");
+        // set the x-content-type options header to prevent browsers from doing
+        // MIME-sniffing when downloading an artifact, as this could cause a
+        // security vulnerability
         response.setHeader(com.google.common.net.HttpHeaders.X_CONTENT_TYPE_OPTIONS, "nosniff");
         if (lastModified > 0) {
             response.setDateHeader(HttpHeaders.LAST_MODIFIED, lastModified);


### PR DESCRIPTION
This pull request adds the x-content-type-options HTTP header to artifact downloads.
Signed-off-by: Sebastian Firsching <sebastian.firsching@bosch-si.com>