### PR TITLE
 Add license header for Bosch.IO 2020

### DIFF
--- a/docs/content/guides/runhawkbit.md
+++ b/docs/content/guides/runhawkbit.md
@@ -21,7 +21,7 @@ This guide describes a target architecture that is more like one that you will e
 - [RabbitMQ](https://www.rabbitmq.com) for DMF communication.
 - For testing and demonstration purposes we will also use:
 - [hawkBit Device Simulator](https://github.com/eclipse/hawkbit-examples/tree/master/hawkbit-device-simulator).
-- [hawkBit Management API example client](https://github.com/eclipse/hawkbit-examples/tree/master/hawkbit-mgmt-api-client).
+- [hawkBit Management API example client](https://github.com/eclipse/hawkbit-examples/tree/master/hawkbit-example-mgmt-feign-client).
 
 ## Prerequisites
 

--- a/licenses/LICENSE_HEADER_TEMPLATE_BOSCH_20.txt
+++ b/licenses/LICENSE_HEADER_TEMPLATE_BOSCH_20.txt
@@ -1,0 +1,6 @@
+Copyright (c) 2020 Bosch.IO GmbH and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html

--- a/pom.xml
+++ b/pom.xml
@@ -319,13 +319,14 @@
                <artifactId>license-maven-plugin</artifactId>
                <version>2.11</version>
                <configuration>
-                  <header>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_19.txt</header>
+                  <header>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_20.txt</header>
                   <validHeaders>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_SIEMENS.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_SIEMENS_18.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH.txt</validHeader>
-                     <validHeader>licenses/LICENSE_HEADER_TEMPLATE_MICROSOFT_18.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_18.txt</validHeader>
+                     <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_19.txt</validHeader>
+                     <validHeader>licenses/LICENSE_HEADER_TEMPLATE_MICROSOFT_18.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_DEVOLO_19.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_KIWIGRID_19.txt</validHeader>
                   </validHeaders>


### PR DESCRIPTION
Adds a new license header template for Bosch.IO and fixes a broken link