### PR TITLE
add method to get a single action by externalRef

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -482,6 +482,16 @@ public interface ControllerManagement {
     List<Action> getActiveActionsByExternalRef(@NotNull List<String> externalRefs);
 
     /**
+     * Retrieves an {@link Action} using {@link Action#getExternalRef()}
+     * 
+     * @param externalRef
+     *            of the action. See {@link Action#getExternalRef()}
+     * @return {@link Action} or {@code null} if it does not exist
+     */
+    @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
+    Optional<Action> getActionByExternalRef(@NotEmpty String externalRef);
+
+    /**
      * Delete a single target.
      *
      * @param controllerId

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -266,6 +266,8 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
 
     
     /**
+     * Retrieves an {@link Action} that matches the queried externalRef.
+     * 
      * @param externalRef
      *            of the action. See {@link Action#getExternalRef()}
      * @return the found {@link Action}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/ActionRepository.java
@@ -264,6 +264,14 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction, Long>,
     List<Action> findByExternalRefInAndActive(@Param("externalRefs") List<String> externalRefs,
             @Param("active") boolean active);
 
+    
+    /**
+     * @param externalRef
+     *            of the action. See {@link Action#getExternalRef()}
+     * @return the found {@link Action}
+     */
+    Optional<Action> findByExternalRef(@Param("externalRef") String externalRef);
+
     /**
      * Switches the status of actions from one specific status into another for
      * given actions IDs, active flag and current status

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -1050,6 +1050,11 @@ public class JpaControllerManagement extends JpaActionManagement implements Cont
         actionRepository.updateExternalRef(actionId, externalRef);
     }
 
+    @Override
+    public Optional<Action> getActionByExternalRef(@NotEmpty final String externalRef) {
+        return actionRepository.findByExternalRef(externalRef);
+    }
+
     private void cancelAssignDistributionSetEvent(final JpaTarget target, final Long actionId) {
         afterCommit.afterCommit(() -> eventPublisherHolder.getEventPublisher().publishEvent(
                 new CancelTargetAssignmentEvent(target, actionId, eventPublisherHolder.getApplicationId())));

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
@@ -1384,7 +1384,7 @@ public class ControllerManagementTest extends AbstractJpaIntegrationTest {
         final Optional<Action> foundAction = controllerManagement.getActionByExternalRef(knownExternalRef);
 
         // THEN
-        assertThat(foundAction.isPresent()).isTrue();
+        assertThat(foundAction).isPresent();
         assertThat(foundAction.get().getId()).isEqualTo(actionId);
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
@@ -1366,6 +1366,29 @@ public class ControllerManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
+    @Description("Verify that getting a single action using externalRef works")
+    public void getActionUsingSingleExternalRef() {
+
+        final String knownControllerId = "controllerId";
+        final String knownExternalRef = "externalRefId";
+        final DistributionSet knownDistributionSet = testdataFactory.createDistributionSet();
+
+        // GIVEN
+        testdataFactory.createTarget(knownControllerId);
+        final DistributionSetAssignmentResult assignmentResult = assignDistributionSet(knownDistributionSet.getId(),
+                knownControllerId);
+        final Long actionId = getFirstAssignedActionId(assignmentResult);
+        controllerManagement.updateActionExternalRef(actionId, knownExternalRef);
+        
+        // WHEN
+        final Optional<Action> foundAction = controllerManagement.getActionByExternalRef(knownExternalRef);
+
+        // THEN
+        assertThat(foundAction.isPresent()).isTrue();
+        assertThat(foundAction.get().getId()).isEqualTo(actionId);
+    }
+
+    @Test
     @Description("Verify that a null externalRef cannot be assigned to an action")
     public void externalRefCannotBeNull() {
         assertThatExceptionOfType(ConstraintViolationException.class)


### PR DESCRIPTION
ControllerManagement must provide a method to retrieve an action by its externalRef.

Signed-off-by: Ravindranath Sandeep <Sandeep.Ravindranath@bosch-si.com>