### PR TITLE
Add spring exception handler for FileStreamingFailedException

### DIFF
--- a/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/exception/ResponseExceptionHandler.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/exception/ResponseExceptionHandler.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.hawkbit.exception.AbstractServerRtException;
 import org.eclipse.hawkbit.exception.SpServerError;
 import org.eclipse.hawkbit.rest.json.model.ExceptionInfo;
+import org.eclipse.hawkbit.rest.util.FileStreamingFailedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -115,6 +116,28 @@ public class ResponseExceptionHandler {
             responseStatus = DEFAULT_RESPONSE_STATUS;
         }
         return new ResponseEntity<>(response, responseStatus);
+    }
+
+    /**
+     * Method for handling exception of type
+     * {@link FileStreamingFailedException} which is thrown in case the
+     * streaming of a file failed due to an internal server error. As the
+     * streaming of the file has already begun, no JSON response but only the
+     * ResponseStatus 500 is returned. Called by the Spring-Framework for
+     * exception handling.
+     *
+     * @param request
+     *            the Http request
+     * @param ex
+     *            the exception which occurred
+     * @return the entity to be responded containing the response status 500
+     */
+    @ExceptionHandler(FileStreamingFailedException.class)
+    public ResponseEntity<Object> handleFileStreamingFailedException(final HttpServletRequest request,
+            final Exception ex) {
+        logRequest(request, ex);
+        LOG.warn("File streaming failed: {}", ex.getMessage());
+        return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     /**


### PR DESCRIPTION
This pull request adds a new exception handler for FileStreamingException that will be called by Spring-Framework. As the file streaming has already begun in case the FileStreamingException occurs, a Json response can't be returned. This is the reason why the FileStreamingException needs its own exception handler.

Signed-off-by: Sebastian Firsching <sebastian.firsching@bosch-si.com>