### PR TITLE
Streamline hawkBit logout behaviour (OIDC vs. Credentials) 

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
@@ -234,7 +234,7 @@ class OidcLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
             throws IOException, ServletException {
         if (authentication instanceof OAuth2AuthenticationToken) {
-            this.setTargetUrlParameter(null);
+            this.setTargetUrlParameter("/");
         } else {
             this.setTargetUrlParameter("login");
         }

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
@@ -61,7 +61,9 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
@@ -84,6 +86,14 @@ public class OidcUserManagementAutoConfiguration {
     public OAuth2UserService<OidcUserRequest, OidcUser> oidcUserDetailsService(
             final JwtAuthoritiesExtractor extractor) {
         return new JwtAuthoritiesOidcUserService(extractor);
+    }
+
+    /**
+     * @return the logout success handler for OpenID Connect
+     */
+    @Bean
+    public LogoutSuccessHandler oidcLogoutSuccessHandler() {
+        return new OidcLogoutSuccessHandler();
     }
 
     /**
@@ -211,6 +221,24 @@ class OidcLogoutHandler extends SecurityContextLogoutHandler {
             final RestTemplate restTemplate = new RestTemplate();
             restTemplate.getForEntity(builder.toUriString(), String.class);
         }
+    }
+}
+
+/**
+ * LogoutSuccessHandler that decides where to redirect to after logout, depending on
+ * the previously used auth mechanism
+ */
+class OidcLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException, ServletException {
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            this.setTargetUrlParameter(null);
+        } else {
+            this.setTargetUrlParameter("login");
+        }
+        super.onLogoutSuccess(request, response, authentication);
     }
 }
 

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
@@ -61,9 +61,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
-import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
-import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
@@ -86,16 +84,6 @@ public class OidcUserManagementAutoConfiguration {
     public OAuth2UserService<OidcUserRequest, OidcUser> oidcUserDetailsService(
             final JwtAuthoritiesExtractor extractor) {
         return new JwtAuthoritiesOidcUserService(extractor);
-    }
-
-    /**
-     * @return the logout success handler for OpenID Connect
-     */
-    @Bean
-    public LogoutSuccessHandler oidcLogoutSuccessHandler() {
-        SimpleUrlLogoutSuccessHandler logoutSuccessHandler = new SimpleUrlLogoutSuccessHandler();
-        logoutSuccessHandler.setDefaultTargetUrl("/");
-        return logoutSuccessHandler;
     }
 
     /**


### PR DESCRIPTION
When oidc configurations are set in the properties file, currently the auth provider login screen is shown even when logged in with a basic auth user.

Instead, even when oidc is configured, the user should be redirected to the same login page he previously used to login.  