### PR TITLE
Fix xss remained parts

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractMetadataDetailsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractMetadataDetailsLayout.java
@@ -82,7 +82,7 @@ public abstract class AbstractMetadataDetailsLayout extends Table {
 
     private Button customMetadataDetailButton(final String metadataKey) {
         final Button viewIcon = SPUIComponentProvider.getButton(getDetailLinkId(metadataKey), metadataKey,
-                "View " + metadataKey + "  Metadata details", null, false, null, SPUIButtonStyleNoBorder.class);
+                null, null, false, null, SPUIButtonStyleNoBorder.class);
         viewIcon.setData(metadataKey);
         viewIcon.addStyleName(ValoTheme.BUTTON_TINY + " " + ValoTheme.BUTTON_LINK + " " + "on-focus-no-border link"
                 + " " + "text-style");

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractMetadataDetailsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractMetadataDetailsLayout.java
@@ -81,6 +81,7 @@ public abstract class AbstractMetadataDetailsLayout extends Table {
     }
 
     private Button customMetadataDetailButton(final String metadataKey) {
+        //TODO after Vaadin 8 migration: Enable tooltip again, currently it is set to [null] to avoid cross site scripting.
         final Button viewIcon = SPUIComponentProvider.getButton(getDetailLinkId(metadataKey), metadataKey,
                 null, null, false, null, SPUIButtonStyleNoBorder.class);
         viewIcon.setData(metadataKey);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractMetadataDetailsLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractMetadataDetailsLayout.java
@@ -81,7 +81,7 @@ public abstract class AbstractMetadataDetailsLayout extends Table {
     }
 
     private Button customMetadataDetailButton(final String metadataKey) {
-        //TODO after Vaadin 8 migration: Enable tooltip again, currently it is set to [null] to avoid cross site scripting.
+        //After Vaadin 8 migration: Enable tooltip again, currently it is set to [null] to avoid cross site scripting.
         final Button viewIcon = SPUIComponentProvider.getButton(getDetailLinkId(metadataKey), metadataKey,
                 null, null, false, null, SPUIButtonStyleNoBorder.class);
         viewIcon.setData(metadataKey);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
@@ -266,6 +266,7 @@ public class TargetDetails extends AbstractTableDetailsLayout<Target> {
         sortedAttributes.forEach((key, value) -> {
             final HorizontalLayout conAttributeLayout = SPUIComponentProvider.createNameValueLayout(key.concat("  :  "),
                     value == null ? "" : value);
+            //TODO after Vaadin 8 migration: Enable tooltip again, currently it is set to [null] to avoid cross site scripting.
             conAttributeLayout.setDescription(null);
             conAttributeLayout.addStyleName("label-style");
             attributesLayout.addComponent(conAttributeLayout);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
@@ -266,7 +266,7 @@ public class TargetDetails extends AbstractTableDetailsLayout<Target> {
         sortedAttributes.forEach((key, value) -> {
             final HorizontalLayout conAttributeLayout = SPUIComponentProvider.createNameValueLayout(key.concat("  :  "),
                     value == null ? "" : value);
-            conAttributeLayout.setDescription(key.concat("  :  ") + value);
+            conAttributeLayout.setDescription(null);
             conAttributeLayout.addStyleName("label-style");
             attributesLayout.addComponent(conAttributeLayout);
         });

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
@@ -266,7 +266,7 @@ public class TargetDetails extends AbstractTableDetailsLayout<Target> {
         sortedAttributes.forEach((key, value) -> {
             final HorizontalLayout conAttributeLayout = SPUIComponentProvider.createNameValueLayout(key.concat("  :  "),
                     value == null ? "" : value);
-            //TODO after Vaadin 8 migration: Enable tooltip again, currently it is set to [null] to avoid cross site scripting.
+            //After Vaadin 8 migration: Enable tooltip again, currently it is set to [null] to avoid cross site scripting.
             conAttributeLayout.setDescription(null);
             conAttributeLayout.addStyleName("label-style");
             attributesLayout.addComponent(conAttributeLayout);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/filter/TargetFilterQueryButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/filter/TargetFilterQueryButtons.java
@@ -130,6 +130,7 @@ public class TargetFilterQueryButtons extends Table {
         if (id != null) {
             button.setCaption(name);
         }
+        //TODO after Vaadin 8 migration: Enable tooltip again, currently it is set to [null] to avoid cross site scripting.
         button.setDescription(null);
         button.setData(itemId);
         button.addClickListener(event -> customTargetTagFilterButtonClick.processButtonClick(event));

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/filter/TargetFilterQueryButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/filter/TargetFilterQueryButtons.java
@@ -130,7 +130,7 @@ public class TargetFilterQueryButtons extends Table {
         if (id != null) {
             button.setCaption(name);
         }
-        button.setDescription(name);
+        button.setDescription(null);
         button.setData(itemId);
         button.addClickListener(event -> customTargetTagFilterButtonClick.processButtonClick(event));
         return button;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/filter/TargetFilterQueryButtons.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettag/filter/TargetFilterQueryButtons.java
@@ -130,7 +130,7 @@ public class TargetFilterQueryButtons extends Table {
         if (id != null) {
             button.setCaption(name);
         }
-        //TODO after Vaadin 8 migration: Enable tooltip again, currently it is set to [null] to avoid cross site scripting.
+        //After Vaadin 8 migration: Enable tooltip again, currently it is set to [null] to avoid cross site scripting.
         button.setDescription(null);
         button.setData(itemId);
         button.addClickListener(event -> customTargetTagFilterButtonClick.processButtonClick(event));


### PR DESCRIPTION
Through analysis of the SnakeYAML parser vulnerability, some remained Cross Site Scripting relevant tooltips were found. This tooltips were disabled by this pull request, as they are always handled as rendered rich text. It is planned to enable them again after Vaadin 8 migration, as tooltips will provide content type settings.