### PR TITLE
Fix treshold column headers

### DIFF
--- a/hawkbit-ui/src/main/resources/messages.properties
+++ b/hawkbit-ui/src/main/resources/messages.properties
@@ -627,7 +627,7 @@ header.detail.status = Detail status
 
 header.rolloutgroup.installed.percentage = % Finished
 header.rolloutgroup.threshold.error = % Error threshold
-header.rolloutgroup.threshold = Trigger threshold
+header.rolloutgroup.threshold = % Trigger threshold
 header.rolloutgroup.target.date = Date and time
 header.rolloutgroup.target.message = Messages
 rollout.group.label.target.truncated = {0} targets has been truncated in the list due the target size limit of {1}

--- a/hawkbit-ui/src/main/resources/messages.properties
+++ b/hawkbit-ui/src/main/resources/messages.properties
@@ -626,7 +626,7 @@ header.numberofgroups = Groups
 header.detail.status = Detail status
 
 header.rolloutgroup.installed.percentage = % Finished
-header.rolloutgroup.threshold.error = Error threshold
+header.rolloutgroup.threshold.error = % Error threshold
 header.rolloutgroup.threshold = Trigger threshold
 header.rolloutgroup.target.date = Date and time
 header.rolloutgroup.target.message = Messages


### PR DESCRIPTION
This pull request provides small adaptations in the threshold column headers inside the Rollout view to provide a better understanding of the column values, as they contain percentage values instead of absolute ones. 