### PR TITLE
Re-arranged the notification to indication user of already assigned ds

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/TargetAssignmentOperations.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/TargetAssignmentOperations.java
@@ -124,15 +124,17 @@ public final class TargetAssignmentOperations {
                 notification
                         .displaySuccess(i18n.getMessage("message.target.assignment", assignmentResult.getAssigned()));
             }
-            if (assignmentResult.getAlreadyAssigned() > 0) {
-                notification.displaySuccess(
-                        i18n.getMessage("message.target.alreadyAssigned", assignmentResult.getAlreadyAssigned()));
-            }
 
             final Set<Long> targetIds = targets.stream().map(Target::getId).collect(Collectors.toSet());
             refreshPinnedDetails(dsIds, targetIds, managementUIState, eventBus, eventSource);
 
             notification.displaySuccess(i18n.getMessage("message.target.ds.assign.success"));
+
+            if (assignmentResult.getAlreadyAssigned() > 0) {
+                notification.displaySuccess(
+                        i18n.getMessage("message.target.alreadyAssigned", assignmentResult.getAlreadyAssigned()));
+            }
+
             eventBus.publish(eventSource, SaveActionWindowEvent.SAVED_ASSIGNMENTS);
         } catch (final MultiAssignmentIsNotEnabledException e) {
             notification.displayValidationError(i18n.getMessage("message.target.ds.multiassign.error"));


### PR DESCRIPTION
Signed-off-by: Shruthi Manavalli Ramanna <shruthimanavalli.ramanna@bosch-si.com>

Provide feedback for the user when he tries to assign an already assigned DistributionSet to a target.
As a result, the existing notification is moved afterthe "successfully saved" notification for evaluation.
