### PR TITLE
Fix NPE issues in RSQLUtility

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtilityTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtilityTest.java
@@ -239,7 +239,9 @@ public class RSQLUtilityTest {
         when(baseSoftwareModuleRootMock.get(anyString())).thenReturn(baseSoftwareModuleRootMock);
         when(baseSoftwareModuleRootMock.getJavaType()).thenReturn((Class) SoftwareModule.class);
 
-        when(subqueryRootMock.get(anyString())).thenReturn(mock(Path.class));
+        final Path pathMock = mock(Path.class);
+        when(pathMock.get(anyString())).thenReturn(pathMock);
+        when(subqueryRootMock.get(anyString())).thenReturn(pathMock);
 
         when(criteriaBuilderMock.and(any(), any())).thenReturn(mock(Predicate.class));
 


### PR DESCRIPTION
This adds a check to ensure the field path of a RSQL query is not null, otherwise throw an exception that can be used to display an error.