### PR TITLE
Fix: undo checkbox for rollout configuration.

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/RolloutConfigurationView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/RolloutConfigurationView.java
@@ -93,6 +93,7 @@ public class RolloutConfigurationView extends BaseConfigurationView
     @Override
     public void undo() {
         this.approvalConfigurationItem.undo();
+        this.approvalCheckbox.setValue(approvalConfigurationItem.isConfigEnabled());
     }
 
     @Override


### PR DESCRIPTION
The "undo" button wasn't working for Rollout Configuration setting checkbox. It is fixed now.