### PR TITLE
Added config setting for attribute search.

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/tenancy/configuration/TenantConfigurationProperties.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/tenancy/configuration/TenantConfigurationProperties.java
@@ -122,6 +122,11 @@ public class TenantConfigurationProperties {
         public static final String ROLLOUT_APPROVAL_ENABLED = "rollout.approval.enabled";
 
         /**
+         * Option setting for text search in target attributes
+         */
+        public static final String TARGET_SEARCH_ATTRIBUTES_ENABLED = "target.search.attributes.enabled";
+
+        /**
          * Repository on autoclose mode instead of canceling in case of new DS
          * assignment over active actions.
          */

--- a/hawkbit-repository/hawkbit-repository-core/src/main/resources/hawkbit-repository-defaults.properties
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/resources/hawkbit-repository-defaults.properties
@@ -77,6 +77,11 @@ hawkbit.server.tenant.configuration.rollout-approval-enabled.defaultValue=false
 hawkbit.server.tenant.configuration.rollout-approval-enabled.dataType=java.lang.Boolean
 hawkbit.server.tenant.configuration.rollout-approval-enabled.validator=org.eclipse.hawkbit.tenancy.configuration.validator.TenantConfigurationBooleanValidator
 
+hawkbit.server.tenant.configuration.target-search-attributes-enabled.keyName=target.search.attributes.enabled
+hawkbit.server.tenant.configuration.target-search-attributes-enabled.defaultValue=true
+hawkbit.server.tenant.configuration.target-search-attributes-enabled.dataType=java.lang.Boolean
+hawkbit.server.tenant.configuration.target-search-attributes-enabled.validator=org.eclipse.hawkbit.tenancy.configuration.validator.TenantConfigurationBooleanValidator
+
 hawkbit.server.tenant.configuration.action-cleanup-enabled.keyName=action.cleanup.enabled
 hawkbit.server.tenant.configuration.action-cleanup-enabled.defaultValue=false
 hawkbit.server.tenant.configuration.action-cleanup-enabled.dataType=java.lang.Boolean

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -510,11 +510,11 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
             final TargetTagRepository targetTagRepository, final NoCountPagingRepository criteriaNoCountDao,
             final EventPublisherHolder eventPublisherHolder, final TenantAware tenantAware,
             final AfterTransactionCommitExecutor afterCommit, final VirtualPropertyReplacer virtualPropertyReplacer,
-            final JpaProperties properties) {
+            final JpaProperties properties, TenantConfigurationManagement tenantConfigurationManagement) {
         return new JpaTargetManagement(entityManager, quotaManagement, targetRepository, targetMetadataRepository,
                 rolloutGroupRepository, distributionSetRepository, targetFilterQueryRepository, targetTagRepository,
                 criteriaNoCountDao, eventPublisherHolder, tenantAware, afterCommit, virtualPropertyReplacer,
-                properties.getDatabase());
+                properties.getDatabase(), tenantConfigurationManagement);
     }
 
     /**

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TenantResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TenantResourceDocumentationTest.java
@@ -54,6 +54,8 @@ public class TenantResourceDocumentationTest extends AbstractApiRestDocumentatio
     protected static final Map<String, String> CONFIG_ITEM_DESCRIPTIONS = new HashMap<>();
 
     static {
+        CONFIG_ITEM_DESCRIPTIONS.put(TenantConfigurationKey.TARGET_SEARCH_ATTRIBUTES_ENABLED,
+                "if target text search should include target attributes");
         CONFIG_ITEM_DESCRIPTIONS.put(TenantConfigurationKey.AUTHENTICATION_MODE_GATEWAY_SECURITY_TOKEN_ENABLED,
                 "if the authentication mode 'gateway security token' is enabled.");
         CONFIG_ITEM_DESCRIPTIONS.put(TenantConfigurationKey.AUTHENTICATION_MODE_GATEWAY_SECURITY_TOKEN_KEY,

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/TargetSearchConfigurationView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/TargetSearchConfigurationView.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2020 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.ui.tenantconfiguration;
+
+import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.ui.UiProperties;
+import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
+import org.eclipse.hawkbit.ui.tenantconfiguration.search.TargetSearchConfigurationItem;
+import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
+import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
+
+import com.vaadin.data.Property;
+import com.vaadin.ui.CheckBox;
+import com.vaadin.ui.GridLayout;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.Panel;
+import com.vaadin.ui.VerticalLayout;
+
+/**
+ * Provides configuration for target search option
+ * to include/exclude target attributes for the search.
+ */
+public class TargetSearchConfigurationView extends BaseConfigurationView
+        implements Property.ValueChangeListener, ConfigurationItem.ConfigurationItemChangeListener {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TargetSearchConfigurationItem targetSearchConfigurationItem;
+    private final VaadinMessageSource i18n;
+    private final UiProperties uiProperties;
+    private CheckBox attributeSearchCheckbox;
+
+    TargetSearchConfigurationView(final VaadinMessageSource i18n,
+                                  final TenantConfigurationManagement tenantConfigurationManagement, final UiProperties uiProperties) {
+        this.i18n = i18n;
+        this.uiProperties = uiProperties;
+        this.targetSearchConfigurationItem = new TargetSearchConfigurationItem(tenantConfigurationManagement, i18n);
+        this.init();
+    }
+
+    private void init() {
+
+        final Panel rootPanel = new Panel();
+        rootPanel.setSizeFull();
+
+        rootPanel.addStyleName("config-panel");
+
+        final VerticalLayout vLayout = new VerticalLayout();
+        vLayout.setMargin(true);
+        vLayout.setSizeFull();
+
+        final Label header = new Label(i18n.getMessage("configuration.targetsearch.title"));
+        header.addStyleName("config-panel-header");
+        vLayout.addComponent(header);
+
+        final GridLayout gridLayout = new GridLayout(3, 1);
+        gridLayout.setSpacing(true);
+        gridLayout.setImmediate(true);
+        gridLayout.setColumnExpandRatio(1, 1.0F);
+        gridLayout.setSizeFull();
+
+        attributeSearchCheckbox = SPUIComponentProvider.getCheckBox("", "", null, false, "");
+        attributeSearchCheckbox.setId(UIComponentIdProvider.TARGET_SEARCH_ATTRIBUTES);
+        attributeSearchCheckbox.setValue(targetSearchConfigurationItem.isConfigEnabled());
+        attributeSearchCheckbox.addValueChangeListener(this);
+        targetSearchConfigurationItem.addChangeListener(this);
+        gridLayout.addComponent(attributeSearchCheckbox, 0, 0);
+        gridLayout.addComponent(targetSearchConfigurationItem, 1, 0);
+        
+        vLayout.addComponent(gridLayout);
+        rootPanel.setContent(vLayout);
+        setCompositionRoot(rootPanel);
+    }
+
+    @Override
+    public void save() {
+        this.targetSearchConfigurationItem.save();
+    }
+
+    @Override
+    public void undo() {
+        this.targetSearchConfigurationItem.undo();
+        this.attributeSearchCheckbox.setValue(targetSearchConfigurationItem.isConfigEnabled());
+    }
+
+    @Override
+    public void valueChange(final Property.ValueChangeEvent event) {
+        if (attributeSearchCheckbox.equals(event.getProperty())) {
+            if (attributeSearchCheckbox.getValue()) {
+                targetSearchConfigurationItem.configEnable();
+            } else {
+                targetSearchConfigurationItem.configDisable();
+            }
+            notifyConfigurationChanged();
+        }
+    }
+
+    @Override
+    public void configurationHasChanged() {
+        notifyConfigurationChanged();
+    }
+}

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/TenantConfigurationDashboardView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/TenantConfigurationDashboardView.java
@@ -64,6 +64,8 @@ public class TenantConfigurationDashboardView extends CustomComponent implements
 
     private final RolloutConfigurationView rolloutConfigurationView;
 
+    private final TargetSearchConfigurationView targetSearchConfigurationView;
+
     private final VaadinMessageSource i18n;
 
     private final UiProperties uiProperties;
@@ -80,11 +82,13 @@ public class TenantConfigurationDashboardView extends CustomComponent implements
 
     @Autowired
     TenantConfigurationDashboardView(final VaadinMessageSource i18n, final UiProperties uiProperties,
-            final UINotification uINotification, final SystemManagement systemManagement,
-            final DistributionSetTypeManagement distributionSetTypeManagement,
-            final TenantConfigurationManagement tenantConfigurationManagement,
-            final SecurityTokenGenerator securityTokenGenerator,
-            final ControllerPollProperties controllerPollProperties, final SpPermissionChecker permChecker) {
+                                     final UINotification uINotification, final SystemManagement systemManagement,
+                                     final DistributionSetTypeManagement distributionSetTypeManagement,
+                                     final TenantConfigurationManagement tenantConfigurationManagement,
+                                     final SecurityTokenGenerator securityTokenGenerator,
+                                     final ControllerPollProperties controllerPollProperties,
+                                     final SpPermissionChecker permChecker)
+    {
         this.defaultDistributionSetTypeLayout = new DefaultDistributionSetTypeLayout(systemManagement,
                 distributionSetTypeManagement, i18n, permChecker);
         this.authenticationConfigurationView = new AuthenticationConfigurationView(i18n, tenantConfigurationManagement,
@@ -94,6 +98,7 @@ public class TenantConfigurationDashboardView extends CustomComponent implements
         this.repositoryConfigurationView = new RepositoryConfigurationView(i18n, tenantConfigurationManagement,
                 uiProperties);
         this.rolloutConfigurationView = new RolloutConfigurationView(i18n, tenantConfigurationManagement, uiProperties);
+        this.targetSearchConfigurationView = new TargetSearchConfigurationView(i18n, tenantConfigurationManagement, uiProperties);
 
         this.i18n = i18n;
         this.uiProperties = uiProperties;
@@ -111,6 +116,7 @@ public class TenantConfigurationDashboardView extends CustomComponent implements
         configurationViews.add(repositoryConfigurationView);
         configurationViews.add(rolloutConfigurationView);
         configurationViews.add(authenticationConfigurationView);
+        configurationViews.add(targetSearchConfigurationView);
         configurationViews.add(pollingConfigurationView);
         if (customConfigurationViews != null) {
             configurationViews.addAll(

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/search/TargetSearchConfigurationItem.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/search/TargetSearchConfigurationItem.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2020 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.ui.tenantconfiguration.search;
+
+import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.ui.tenantconfiguration.generic.AbstractBooleanTenantConfigurationItem;
+import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.*;
+
+public class TargetSearchConfigurationItem extends AbstractBooleanTenantConfigurationItem {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TargetSearchConfigurationItem.class);
+
+    private boolean configurationEnabled;
+    private boolean configurationEnabledChange;
+
+    public TargetSearchConfigurationItem(TenantConfigurationManagement tenantConfigurationManagement, VaadinMessageSource i18n) {
+        super(TenantConfigurationKey.TARGET_SEARCH_ATTRIBUTES_ENABLED, tenantConfigurationManagement, i18n);
+
+        super.init("configuration.targetsearch.attributes.label");
+        this.configurationEnabled = isConfigEnabled();
+    }
+
+    @Override
+    public void configEnable() {
+        if (!configurationEnabled) {
+            configurationEnabledChange = true;
+        }
+        configurationEnabled = true;
+    }
+
+    @Override
+    public void configDisable() {
+        if (configurationEnabled) {
+            configurationEnabledChange = true;
+        }
+        configurationEnabled = false;
+    }
+
+    @Override
+    public void save() {
+        if (!configurationEnabledChange) {
+            return;
+        }
+        getTenantConfigurationManagement().addOrUpdateConfiguration(getConfigurationKey(), configurationEnabled);
+    }
+
+    @Override
+    public void undo() {
+        configurationEnabledChange = false;
+        configurationEnabled = getTenantConfigurationManagement()
+                .getConfigurationValue(getConfigurationKey(), Boolean.class).getValue();
+    }
+}

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UIComponentIdProvider.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UIComponentIdProvider.java
@@ -1291,6 +1291,12 @@ public final class UIComponentIdProvider {
     public static final String ROLLOUT_APPROVAL_ENABLED_CHECKBOX = "rollout.approve.enabled.checkbox";
 
     /**
+     * Configuration checkbox for
+     * {@link TenantConfigurationKey#TARGET_SEARCH_ATTRIBUTES_ENABLED}
+     */
+    public static final String TARGET_SEARCH_ATTRIBUTES = "target.search.attributes.checkbox";
+
+    /**
      * Id of the rollout approval remark field
      */
     public static final String ROLLOUT_APPROVAL_REMARK_FIELD_ID = "rollout.approve.remark";

--- a/hawkbit-ui/src/main/resources/messages.properties
+++ b/hawkbit-ui/src/main/resources/messages.properties
@@ -570,6 +570,8 @@ configuration.polling.overduetime=Polling Overdue Time
 configuration.polling.custom.value=use a custom value
 configuration.rollout.title=Rollout Configuration
 configuration.rollout.approval.label=Approve rollout before it can be started
+configuration.targetsearch.title = Target Search Options
+configuration.targetsearch.attributes.label = Search in target attributes
 
 #Calendar
 calendar.year=year

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,7 @@
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_19.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_MICROSOFT_18.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_DEVOLO_19.txt</validHeader>
+                     <validHeader>licenses/LICENSE_HEADER_TEMPLATE_DEVOLO_20.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_KIWIGRID_19.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_ENAPTER.txt</validHeader>
                   </validHeaders>


### PR DESCRIPTION
Currently, when running a target search by text, the target attributes are also subject to search. This slows down the search significantly if there is a large number of targets and their attributes. It is also not needed when searching by target ID. So I've added a configuration option in the configuration dashboard to exclude the target attributes to reduce the database load and speed up the search.