### PR TITLE
Create index on "last_modified_at" column in "sp_target" table.

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -78,7 +78,7 @@ import org.slf4j.LoggerFactory;
         @Index(name = "sp_idx_target_01", columnList = "tenant,name,assigned_distribution_set"),
         @Index(name = "sp_idx_target_03", columnList = "tenant,controller_id,assigned_distribution_set"),
         @Index(name = "sp_idx_target_04", columnList = "tenant,created_at"),
-        @Index(name = "sp_idx_target_05", columnList = "last_modified_at"),
+        @Index(name = "sp_idx_target_05", columnList = "tenant,last_modified_at"),
         @Index(name = "sp_idx_target_prim", columnList = "tenant,id") }, uniqueConstraints = @UniqueConstraint(columnNames = {
                 "controller_id", "tenant" }, name = "uk_tenant_controller_id"))
 // exception squid:S2160 - BaseEntity equals/hashcode is handling correctly for

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -78,6 +78,7 @@ import org.slf4j.LoggerFactory;
         @Index(name = "sp_idx_target_01", columnList = "tenant,name,assigned_distribution_set"),
         @Index(name = "sp_idx_target_03", columnList = "tenant,controller_id,assigned_distribution_set"),
         @Index(name = "sp_idx_target_04", columnList = "tenant,created_at"),
+        @Index(name = "sp_idx_target_05", columnList = "last_modified_at"),
         @Index(name = "sp_idx_target_prim", columnList = "tenant,id") }, uniqueConstraints = @UniqueConstraint(columnNames = {
                 "controller_id", "tenant" }, name = "uk_tenant_controller_id"))
 // exception squid:S2160 - BaseEntity equals/hashcode is handling correctly for

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_17__add_index_target_modified___DB2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_17__add_index_target_modified___DB2.sql
@@ -1,0 +1,1 @@
+CREATE INDEX sp_idx_target_05 ON sp_target (last_modified_at);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_17__add_index_target_modified___DB2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_17__add_index_target_modified___DB2.sql
@@ -1,1 +1,1 @@
-CREATE INDEX sp_idx_target_05 ON sp_target (last_modified_at);
+CREATE INDEX sp_idx_target_05 ON sp_target (tenant, last_modified_at);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_17__add_index_target_modified___H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_17__add_index_target_modified___H2.sql
@@ -1,0 +1,1 @@
+CREATE INDEX sp_idx_target_05 ON sp_target (last_modified_at);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_17__add_index_target_modified___H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_17__add_index_target_modified___H2.sql
@@ -1,1 +1,1 @@
-CREATE INDEX sp_idx_target_05 ON sp_target (last_modified_at);
+CREATE INDEX sp_idx_target_05 ON sp_target (tenant, last_modified_at);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_17__add_index_target_modified___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_17__add_index_target_modified___MYSQL.sql
@@ -1,0 +1,1 @@
+CREATE INDEX sp_idx_target_05 ON sp_target (last_modified_at);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_17__add_index_target_modified___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_17__add_index_target_modified___MYSQL.sql
@@ -1,1 +1,1 @@
-CREATE INDEX sp_idx_target_05 ON sp_target (last_modified_at);
+CREATE INDEX sp_idx_target_05 ON sp_target (tenant, last_modified_at);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_17__add_index_target_modified___POSTGRESQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_17__add_index_target_modified___POSTGRESQL.sql
@@ -1,0 +1,3 @@
+CREATE INDEX sp_idx_target_05
+ON sp_target
+USING BTREE (last_modified_at);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_17__add_index_target_modified___POSTGRESQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_17__add_index_target_modified___POSTGRESQL.sql
@@ -1,3 +1,3 @@
 CREATE INDEX sp_idx_target_05
 ON sp_target
-USING BTREE (last_modified_at);
+USING BTREE (tenant, last_modified_at);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_17__add_index_target_modified___SQL_SERVER.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_17__add_index_target_modified___SQL_SERVER.sql
@@ -1,0 +1,1 @@
+CREATE INDEX sp_idx_target_05 ON sp_target (last_modified_at);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_17__add_index_target_modified___SQL_SERVER.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_17__add_index_target_modified___SQL_SERVER.sql
@@ -1,1 +1,1 @@
-CREATE INDEX sp_idx_target_05 ON sp_target (last_modified_at);
+CREATE INDEX sp_idx_target_05 ON sp_target (tenant, last_modified_at);


### PR DESCRIPTION
Indexing the column `last_modified_at` in `sp_target` table should improve database performance, since the default ordering behaviour in the "Deployment View" is `ORDER BY "last_modified_at"`