### PR TITLE
adapted constructors of TargetTagCreatedEvent and TargetTagUpdatedEvent

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetTagDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetTagDeletedEvent.java
@@ -9,13 +9,14 @@
 package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.RemoteEntityEvent;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 
 /**
  * Defines the remote event of delete a {@link TargetTag}.
  *
  */
-public class TargetTagDeletedEvent extends RemoteIdEvent implements EntityDeletedEvent {
+public class TargetTagDeletedEvent extends RemoteEntityEvent<TargetTag> implements EntityDeletedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RemoteEntityEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RemoteEntityEvent.java
@@ -51,6 +51,23 @@ public class RemoteEntityEvent<E extends TenantAwareBaseEntity> extends RemoteId
         this.entity = baseEntity;
     }
 
+    /**
+     * Constructor for json serialization.
+     *
+     * @param tenant
+     *            the tenant
+     * @param entityId
+     *            the entity id
+     * @param entityClass
+     *            the entity class
+     * @param applicationId
+     *            the origin application id
+     */
+    public RemoteEntityEvent(final Long entityId, final String tenant, final String entityClass,
+            final String applicationId) {
+        super(entityId, tenant, entityClass, applicationId);
+    }
+
     @JsonIgnore
     public E getEntity() {
         if (entity == null) {

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagCreatedEvent.java
@@ -9,13 +9,14 @@
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.RemoteIdEvent;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 
 /**
  * Defines the remote event for the creation of a new {@link TargetTag}.
  *
  */
-public class TargetTagCreatedEvent extends RemoteEntityEvent<TargetTag> implements EntityCreatedEvent {
+public class TargetTagCreatedEvent extends RemoteIdEvent implements EntityCreatedEvent {
 
     private static final long serialVersionUID = 1L;
 
@@ -27,14 +28,20 @@ public class TargetTagCreatedEvent extends RemoteEntityEvent<TargetTag> implemen
     }
 
     /**
-     * Constructor.
-     * 
-     * @param tag
-     *            the tag which is deleted
+     * Constructor for json serialization.
+     *
+     * @param tenant
+     *            the tenant
+     * @param entityId
+     *            the entity id
+     * @param entityClass
+     *            the entity class
      * @param applicationId
      *            the origin application id
      */
-    public TargetTagCreatedEvent(final TargetTag tag, final String applicationId) {
-        super(tag, applicationId);
+    public TargetTagCreatedEvent(final String tenant, final Long entityId, final String entityClass,
+            final String applicationId) {
+        super(entityId, tenant, entityClass, applicationId);
     }
+
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagCreatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagCreatedEvent.java
@@ -9,14 +9,13 @@
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityCreatedEvent;
-import org.eclipse.hawkbit.repository.event.remote.RemoteIdEvent;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 
 /**
  * Defines the remote event for the creation of a new {@link TargetTag}.
  *
  */
-public class TargetTagCreatedEvent extends RemoteIdEvent implements EntityCreatedEvent {
+public class TargetTagCreatedEvent extends RemoteEntityEvent<TargetTag> implements EntityCreatedEvent {
 
     private static final long serialVersionUID = 1L;
 
@@ -25,6 +24,18 @@ public class TargetTagCreatedEvent extends RemoteIdEvent implements EntityCreate
      */
     public TargetTagCreatedEvent() {
         // for serialization libs like jackson
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param tag
+     *            the tag which is deleted
+     * @param applicationId
+     *            the origin application id
+     */
+    public TargetTagCreatedEvent(final TargetTag tag, final String applicationId) {
+        super(tag, applicationId);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagUpdatedEvent.java
@@ -9,13 +9,14 @@
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityUpdatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.RemoteIdEvent;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 
 /**
  * Defines the remote event for updating a {@link TargetTag}.
  *
  */
-public class TargetTagUpdatedEvent extends RemoteEntityEvent<TargetTag> implements EntityUpdatedEvent {
+public class TargetTagUpdatedEvent extends RemoteIdEvent implements EntityUpdatedEvent {
 
     private static final long serialVersionUID = 1L;
 
@@ -27,14 +28,19 @@ public class TargetTagUpdatedEvent extends RemoteEntityEvent<TargetTag> implemen
     }
 
     /**
-     * Constructor.
-     * 
-     * @param tag
-     *            the tag which is updated
+     * Constructor for json serialization.
+     *
+     * @param tenant
+     *            the tenant
+     * @param entityId
+     *            the entity id
+     * @param entityClass
+     *            the entity class
      * @param applicationId
      *            the origin application id
      */
-    public TargetTagUpdatedEvent(final TargetTag tag, final String applicationId) {
-        super(tag, applicationId);
+    public TargetTagUpdatedEvent(final String tenant, final Long entityId, final String entityClass,
+            final String applicationId) {
+        super(entityId, tenant, entityClass, applicationId);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/TargetTagUpdatedEvent.java
@@ -9,14 +9,13 @@
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityUpdatedEvent;
-import org.eclipse.hawkbit.repository.event.remote.RemoteIdEvent;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 
 /**
  * Defines the remote event for updating a {@link TargetTag}.
  *
  */
-public class TargetTagUpdatedEvent extends RemoteIdEvent implements EntityUpdatedEvent {
+public class TargetTagUpdatedEvent extends RemoteEntityEvent<TargetTag> implements EntityUpdatedEvent {
 
     private static final long serialVersionUID = 1L;
 
@@ -25,6 +24,18 @@ public class TargetTagUpdatedEvent extends RemoteIdEvent implements EntityUpdate
      */
     public TargetTagUpdatedEvent() {
         // for serialization libs like jackson
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param tag
+     *            the tag which is updated
+     * @param applicationId
+     *            the origin application id
+     */
+    public TargetTagUpdatedEvent(final TargetTag tag, final String applicationId) {
+        super(tag, applicationId);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetTag.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetTag.java
@@ -72,16 +72,14 @@ public class JpaTargetTag extends JpaTag implements TargetTag, EventAwareEntity 
     @Override
     public void fireCreateEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher()
-                .publishEvent(new TargetTagCreatedEvent(getTenant(), getId(), getClass().getName(),
-                        EventPublisherHolder.getInstance().getApplicationId()));
+                .publishEvent(new TargetTagCreatedEvent(this, EventPublisherHolder.getInstance().getApplicationId()));
 
     }
 
     @Override
     public void fireUpdateEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher()
-                .publishEvent(new TargetTagUpdatedEvent(getTenant(), getId(), getClass().getName(),
-                        EventPublisherHolder.getInstance().getApplicationId()));
+                .publishEvent(new TargetTagUpdatedEvent(this, EventPublisherHolder.getInstance().getApplicationId()));
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetTag.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetTag.java
@@ -72,14 +72,16 @@ public class JpaTargetTag extends JpaTag implements TargetTag, EventAwareEntity 
     @Override
     public void fireCreateEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher()
-                .publishEvent(new TargetTagCreatedEvent(this, EventPublisherHolder.getInstance().getApplicationId()));
+                .publishEvent(new TargetTagCreatedEvent(getTenant(), getId(), getClass().getName(),
+                        EventPublisherHolder.getInstance().getApplicationId()));
 
     }
 
     @Override
     public void fireUpdateEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher()
-                .publishEvent(new TargetTagUpdatedEvent(this, EventPublisherHolder.getInstance().getApplicationId()));
+                .publishEvent(new TargetTagUpdatedEvent(getTenant(), getId(), getClass().getName(),
+                        EventPublisherHolder.getInstance().getApplicationId()));
     }
 
     @Override


### PR DESCRIPTION
The constructors of `TargetTagCreatedEvent` and `TargetTagUpdatedEvent` are inconsistent with the `TargetTagDeletedEvent`.
I adapted to the constructors for conformity

Signed-off-by: Ahmed Sayed <ahmed.sayed@bosch-si.com>