### PR TITLE
Trigger Distribution Set assignment check on updating target config data

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageHandlerServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageHandlerServiceIntegrationTest.java
@@ -924,12 +924,12 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
         assertThat(target).isPresent();
 
         // verify the DS was assigned to the Target
-        final DistributionSet assignedDistributionSet = ((JpaTarget) target.get()).getAssignedDistributionSet();
+        final DistributionSet assignedDistributionSet = target.get().getAssignedDistributionSet();
         assertThat(assignedDsId).isNotNull();
         assertThat(assignedDistributionSet.getId()).isEqualTo(assignedDsId);
 
         // verify that the installed DS was not affected
-        final JpaDistributionSet installedDistributionSet = ((JpaTarget) target.get()).getInstalledDistributionSet();
+        final DistributionSet installedDistributionSet = target.get().getInstalledDistributionSet();
         if (installedDsId == null) {
             assertThat(installedDistributionSet).isNull();
         } else {

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -385,6 +385,9 @@ public interface ControllerManagement {
     Target updateControllerAttributes(@NotEmpty String controllerId, @NotNull Map<String, String> attributes,
             UpdateMode mode);
 
+    @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
+    void triggerDistributionSetAssignmentCheck(String controllerId);
+
     /**
      * Finds {@link Target} based on given controller ID returns found Target
      * without details, i.e. NO {@link Target#getTags()} and

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
@@ -110,7 +110,32 @@ public interface DeploymentManagement {
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_REPOSITORY_AND_UPDATE_TARGET)
     List<DistributionSetAssignmentResult> assignDistributionSets(String initiatedBy,
             @Valid @NotEmpty List<DeploymentRequest> deploymentRequests, String actionMessage);
-            
+
+    /**
+     * Assigns {@link DistributionSet} to {@link Target} according to the
+     * {@link DeploymentRequest}.
+     *
+     * @param target
+     *            target that the DS shall be assigned to
+     * @param deploymentRequest
+     *            information about target-ds-assignment that shall be made
+     * @param actionMessage
+     *            an optional message for the action status
+     *
+     * @return the assignment result
+     *
+     * @throws IncompleteDistributionSetException
+     *             if mandatory {@link SoftwareModuleType} are not assigned as
+     *             defined by the {@link DistributionSetType}.
+     *
+     * @throws EntityNotFoundException
+     *             if either provided {@link DistributionSet} or {@link Target}s
+     *             do not exist
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_REPOSITORY_AND_UPDATE_TARGET)
+    DistributionSetAssignmentResult assignDistributionSet(@Valid Target target,
+            DeploymentRequest deploymentRequest, String actionMessage);
+
                 /**
      * build a {@link DeploymentRequest} for a target distribution set
      * assignment

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
@@ -9,6 +9,9 @@
 package org.eclipse.hawkbit.repository.model;
 
 import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -98,5 +101,15 @@ public interface Target extends NamedEntity {
      *         {@link #getControllerAttributes()}.
      */
     boolean isRequestControllerAttributes();
+
+    Set<TargetTag> getTags();
+
+    Map<String, String> getControllerAttributes();
+
+    DistributionSet getInstalledDistributionSet();
+
+    DistributionSet getAssignedDistributionSet();
+
+    List<TargetMetadata> getMetadata();
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/OfflineDsAssignmentStrategy.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/OfflineDsAssignmentStrategy.java
@@ -83,10 +83,27 @@ public class OfflineDsAssignmentStrategy extends AbstractDsAssignmentStrategy {
     }
 
     @Override
+    void closeActiveActions(Long targetId) {
+        // Not supported by offline case
+    }
+
+    @Override
+    void cancelActiveActions(Long targetId) {
+        // Not supported by offline case
+    }
+
+    @Override
     void setAssignedDistributionSetAndTargetStatus(final JpaDistributionSet set, final List<List<Long>> targetIds,
             final String currentUser) {
         targetIds.forEach(tIds -> targetRepository.setAssignedAndInstalledDistributionSetAndUpdateStatus(
                 TargetUpdateStatus.IN_SYNC, set, System.currentTimeMillis(), currentUser, tIds));
+    }
+
+    @Override
+    void setAssignedDistributionSetAndTargetStatus(DistributionSet dSet, Long targetId, String currentUser) {
+        throw new UnsupportedOperationException(
+                "Method 'setAssignedDistributionSetAndTargetStatus(DistributionSet dSet, Long targetId, String currentUser)'"
+                        + " not supported for Offline Assignment Strategy");
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/OnlineDsAssignmentStrategy.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/OnlineDsAssignmentStrategy.java
@@ -119,6 +119,16 @@ public class OnlineDsAssignmentStrategy extends AbstractDsAssignmentStrategy {
     }
 
     @Override
+    void closeActiveActions(final Long targetId) {
+        closeObsoleteUpdateActions(Collections.singletonList(targetId));
+    }
+
+    @Override
+    void cancelActiveActions(final Long targetId) {
+        overrideObsoleteUpdateActions(Collections.singletonList(targetId));
+    }
+
+    @Override
     void setAssignedDistributionSetAndTargetStatus(final JpaDistributionSet set, final List<List<Long>> targetIds,
             final String currentUser) {
         targetIds.forEach(tIds -> targetRepository.setAssignedDistributionSetAndUpdateStatus(TargetUpdateStatus.PENDING,
@@ -126,10 +136,16 @@ public class OnlineDsAssignmentStrategy extends AbstractDsAssignmentStrategy {
 
     }
 
+    void setAssignedDistributionSetAndTargetStatus(final DistributionSet dSet, final Long targetId, final String currentUser){
+        targetRepository.setAssignedDistributionSetAndUpdateStatus(TargetUpdateStatus.PENDING,
+                (JpaDistributionSet) dSet, System.currentTimeMillis(), currentUser, Collections.singletonList(targetId));
+    }
+
     @Override
     JpaAction createTargetAction(final String initiatedBy, final TargetWithActionType targetWithActionType,
             final List<JpaTarget> targets, final JpaDistributionSet set) {
         final JpaAction result = super.createTargetAction(initiatedBy, targetWithActionType, targets, set);
+
         if (result != null) {
             result.setStatus(Status.RUNNING);
         }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -858,4 +858,10 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
             final RolloutManagement rolloutManagement, final SystemSecurityContext systemSecurityContext) {
         return new RolloutScheduler(systemManagement, rolloutManagement, systemSecurityContext);
     }
+
+    @Bean
+    @ConditionalOnMissingBean
+    TargetFieldExtractor targetFieldsExtractorService(){
+        return new TargetFieldExtractor();
+    }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetFieldData.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetFieldData.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2020 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa;
+
+import org.eclipse.hawkbit.repository.TargetFields;
+import org.eclipse.hawkbit.repository.rsql.VirtualPropertyReplacer;
+import org.eclipse.hawkbit.repository.rsql.VirtualPropertyResolver;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Container object to store and keep the extracted Target field values
+ * to be used by RsqlVisitor in order to compare with Target filters
+ */
+public class TargetFieldData {
+
+    private final List<TargetFieldContent> contentList = new ArrayList<>();
+
+    public void add(TargetFields name, String value) {
+        TargetFieldContent content = new TargetFieldContent(name, value);
+        contentList.add(content);
+    }
+
+    /**
+     * Adds Target's field data to the container
+     *
+     * @param name Target field name
+     * @param subKey Field name subkey (optional), e.g. "attribute.device_type", "device_type" is the subkey
+     * @param value Target field value
+     */
+    public void add(TargetFields name, String subKey, String value) {
+        TargetFieldContent content = new TargetFieldContent(name, subKey, value);
+        contentList.add(content);
+    }
+
+    /**
+     * Checks if an entry with the given key and value exists
+     * @param key Field name
+     * @param value Field value
+     * @return true if the key-value pair exists, otherwise false
+     */
+    public boolean hasEntry(String key, String value){
+        return contentList.stream()
+                .filter(c -> c.fieldName.equalsIgnoreCase(key))
+                .anyMatch(c -> c.fieldValue.equalsIgnoreCase(value));
+    }
+
+    /**
+     * Method to be called by RsqlVisitor
+     * Checks whether the object contains field name and value relation described by the operator
+     * @param selector RSQL selector (key)
+     * @param operator RSQL operator (relation descriptor)
+     * @param value RSQL value
+     * @return true if he object contains field name and value relation described by the operator, otherwise false
+     */
+    public boolean request(String selector, String operator, String value) {
+        return request(selector, operator, Collections.singletonList(value));
+    }
+
+    /**
+     * Method to be called by RsqlVisitor
+     * Checks whether the object contains field name and value relation described by the operator
+     * @param selector RSQL selector (key)
+     * @param operator RSQL operator (relation descriptor)
+     * @param inputValues RSQL value
+     * @return true if he object contains field name and value relation described by the operator, otherwise false
+     */
+    public boolean request(String selector, String operator, List<String> inputValues) {
+
+        VirtualPropertyReplacer propertyReplacer = new VirtualPropertyResolver();
+
+        List<String> values = inputValues.stream()
+                .map(propertyReplacer::replace)
+                .collect(Collectors.toList());
+
+        List<TargetFieldContent> fieldContent = contentList.stream()
+                .filter(c -> selector.equalsIgnoreCase(c.fieldName))
+                .collect(Collectors.toList());
+
+        if("==".equalsIgnoreCase(operator) || "=in=".equalsIgnoreCase(operator)) {
+            return containsAnyOf(fieldContent, values);
+        }
+
+        if("!=".equalsIgnoreCase(operator) || "=out=".equalsIgnoreCase(operator)) {
+            return containsNoneOf(fieldContent, values, withSubKey(selector));
+        }
+
+        if("=gt=".equalsIgnoreCase(operator)) {
+            return valueGreaterThan(fieldContent, values);
+        }
+
+        if("=ge=".equalsIgnoreCase(operator)) {
+            return valueGreaterOrEqualTo(fieldContent, values);
+        }
+
+        if("=lt=".equalsIgnoreCase(operator)) {
+            return valueLessThan(fieldContent, values);
+        }
+
+        if("=le=".equalsIgnoreCase(operator)) {
+            return valueLessOrEqualTo(fieldContent, values);
+        }
+
+        throw new IllegalArgumentException("Unknown operator: {" + operator + "}");
+    }
+
+    private static boolean containsWildCard(String input){
+        return input.contains("*");
+    }
+
+    private static boolean matchWithWildCards(String fieldValue, String inputValue){
+        String modifiedValue = inputValue.replaceAll("\\*", ".*");
+        return Pattern.matches(modifiedValue, fieldValue);
+    }
+
+    private static boolean isEmpty(List<String> input){
+        return input.stream().allMatch(String::isEmpty);
+    }
+
+    private static boolean withSubKey(String key){
+        return key.toLowerCase().startsWith("attribute.") || key.toLowerCase().startsWith("metadata.");
+    }
+
+    private static boolean containsAnyOf(List<TargetFieldContent> fieldValues, List<String> inputValues){
+        // for cases like [tag == ""]
+        if(fieldValues.isEmpty() && isEmpty(inputValues)) {
+            return true;
+        }
+
+        for(TargetFieldContent content : fieldValues){
+            for(String inputValue : inputValues){
+                if(containsWildCard(inputValue) && matchWithWildCards(content.fieldValue, inputValue)){
+                    return true;
+                }
+            }
+
+            if(inputValues.stream().anyMatch(content.fieldValue::equalsIgnoreCase)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsNoneOf(List<TargetFieldContent> fieldValues, List<String> inputValues,
+            boolean withSubKey) {
+        // must not match non-existent fields with subkey like [attribute.noexist != value]
+        // but must match other non-existent fields like [tag != "alpha"]
+        if(fieldValues.isEmpty() && withSubKey) {
+            return false;
+        }
+
+        if(isEmpty(inputValues)) {
+            return true;
+        }
+
+        for(TargetFieldContent content : fieldValues){
+            for(String inputValue : inputValues){
+                if(containsWildCard(inputValue) && matchWithWildCards(content.fieldValue, inputValue)){
+                    return false;
+                }
+            }
+
+            if(inputValues.stream().anyMatch(content.fieldValue::equalsIgnoreCase)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean valueGreaterThan(List<TargetFieldContent> fieldValues, List<String> inputValues){
+        if(fieldValues.isEmpty() || isEmpty(inputValues)) {
+            return false;
+        }
+
+        return fieldValues.get(0).fieldValue.compareToIgnoreCase(inputValues.get(0)) > 0;
+    }
+
+    private static boolean valueGreaterOrEqualTo(List<TargetFieldContent> fieldValues, List<String> inputValues){
+        if(fieldValues.isEmpty() || isEmpty(inputValues)) {
+            return false;
+        }
+
+        return fieldValues.get(0).fieldValue.compareToIgnoreCase(inputValues.get(0)) >= 0;
+    }
+
+    private static boolean valueLessThan(List<TargetFieldContent> fieldValues, List<String> inputValues){
+        if(fieldValues.isEmpty() || isEmpty(inputValues)) {
+            return false;
+        }
+
+        return fieldValues.get(0).fieldValue.compareToIgnoreCase(inputValues.get(0)) < 0;
+    }
+
+    private static boolean valueLessOrEqualTo(List<TargetFieldContent> fieldValues, List<String> inputValues){
+        if(fieldValues.isEmpty() || isEmpty(inputValues)) {
+            return false;
+        }
+
+        return fieldValues.get(0).fieldValue.compareToIgnoreCase(inputValues.get(0)) <= 0;
+    }
+
+    private static class TargetFieldContent{
+
+        protected final String fieldName;
+        protected final String fieldValue;
+
+        public TargetFieldContent(TargetFields fieldName, String value){
+            this(fieldName, "", value);
+        }
+
+        public TargetFieldContent(TargetFields fieldName, String subKey, String value){
+            this.fieldName = (subKey.isEmpty() ? fieldName.name() : (fieldName.name() + "." + subKey)).toLowerCase();
+            this.fieldValue = value.toLowerCase();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TargetFieldContent content = (TargetFieldContent) o;
+            return fieldName.equals(content.fieldName) && fieldValue.equals(content.fieldValue);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fieldName, fieldValue);
+        }
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetFieldExtractor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetFieldExtractor.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2020 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa;
+
+import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.model.TargetMetadata;
+import org.eclipse.hawkbit.repository.model.TargetTag;
+import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.hawkbit.repository.TargetFields;
+
+/**
+ * Service to extract field values from {@link Target}-Object
+ */
+@Service
+public class TargetFieldExtractor {
+
+    private String controllerId;
+    private String name;
+    private String description;
+    private String updateStatus;
+    private String address;
+    private String lastQuery;
+    private List<TargetTag> targetTagList;
+    private List<TargetMetadata> metadata;
+    private Map<String, String> attributes;
+    private DistributionSet assignedDs;
+    private DistributionSet installedDs;
+    private String createdAt;
+    private String lastModifiedAt;
+
+    private static final String EMPTY_STRING = "";
+
+    private TargetFieldData fieldData;
+
+    /**
+     * Method to extract the field values from {@link Target}-Object
+     *
+     * @param   target to extract the data from
+     * @return  {@link TargetFieldData} container with the extracted data
+     */
+    public TargetFieldData extractData(Target target){
+
+        fieldData = new TargetFieldData();
+
+        fetchTargetFieldValues(target);
+
+        fieldData.add(TargetFields.ID, controllerId);
+        fieldData.add(TargetFields.CONTROLLERID, controllerId);
+        fieldData.add(TargetFields.NAME, name);
+        fieldData.add(TargetFields.DESCRIPTION, description);
+        fieldData.add(TargetFields.CREATEDAT, createdAt);
+        fieldData.add(TargetFields.LASTMODIFIEDAT, lastModifiedAt);
+        fieldData.add(TargetFields.UPDATESTATUS, updateStatus);
+        fieldData.add(TargetFields.IPADDRESS, address);
+        fieldData.add(TargetFields.LASTCONTROLLERREQUESTAT, lastQuery);
+
+        addMetadata();
+        addAttributes();
+        addAssignedDsData();
+        addInstalledDsData();
+        addTagData();
+
+        return fieldData;
+    }
+
+    private void fetchTargetFieldValues(Target target){
+        controllerId = target.getControllerId() == null ? EMPTY_STRING : target.getControllerId();
+        name = target.getName() == null ? EMPTY_STRING : target.getName();
+        description = target.getDescription() == null ? EMPTY_STRING : target.getDescription();
+        updateStatus = target.getUpdateStatus() == null ? TargetUpdateStatus.UNKNOWN.name(): target.getUpdateStatus().name();
+        address = target.getAddress() == null ? EMPTY_STRING : target.getAddress().toString();
+        lastQuery = (target.getLastTargetQuery() == null) ? EMPTY_STRING : target.getLastTargetQuery().toString();
+        targetTagList = new ArrayList<>(target.getTags());
+        metadata = target.getMetadata();
+        attributes = target.getControllerAttributes();
+        assignedDs = target.getAssignedDistributionSet();
+        installedDs = target.getInstalledDistributionSet();
+        createdAt = Long.toString(target.getCreatedAt());
+        lastModifiedAt = Long.toString(target.getLastModifiedAt());
+    }
+
+    private void addTagData(){
+        if(targetTagList.isEmpty()) {
+            return;
+        }
+
+        targetTagList.forEach(tag -> fieldData.add(TargetFields.TAG, tag.getName()));
+    }
+
+    private void addAttributes(){
+        attributes.forEach((key, value) -> fieldData.add(TargetFields.ATTRIBUTE, key, value));
+    }
+
+    private void addMetadata(){
+        metadata.forEach(data -> fieldData.add(TargetFields.METADATA, data.getKey(), data.getValue()));
+    }
+
+    private void addAssignedDsData(){
+        if(assignedDs == null) {
+            return;
+        }
+
+        fieldData.add(TargetFields.ASSIGNEDDS, "name", assignedDs.getName());
+        fieldData.add(TargetFields.ASSIGNEDDS, "version", assignedDs.getVersion());
+    }
+
+    private void addInstalledDsData(){
+        if(installedDs == null) {
+            return;
+        }
+
+        fieldData.add(TargetFields.INSTALLEDDS, "name", installedDs.getName());
+        fieldData.add(TargetFields.INSTALLEDDS, "version", installedDs.getVersion());
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -205,6 +205,7 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
         // empty constructor for JPA.
     }
 
+    @Override
     public DistributionSet getAssignedDistributionSet() {
         return assignedDistributionSet;
     }
@@ -214,6 +215,7 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
         return controllerId;
     }
 
+    @Override
     public Set<TargetTag> getTags() {
         if (tags == null) {
             return Collections.emptySet();
@@ -348,10 +350,12 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
         return updateStatus;
     }
 
-    public JpaDistributionSet getInstalledDistributionSet() {
+    @Override
+    public DistributionSet getInstalledDistributionSet() {
         return installedDistributionSet;
     }
 
+    @Override
     public Map<String, String> getControllerAttributes() {
         return controllerAttributes;
     }
@@ -361,6 +365,7 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
         return requestControllerAttributes;
     }
 
+    @Override
     public List<TargetMetadata> getMetadata() {
         if (metadata == null) {
             return Collections.emptyList();

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlMatcher.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlMatcher.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2020 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa.rsql;
+
+import cz.jirutka.rsql.parser.RSQLParser;
+import cz.jirutka.rsql.parser.ast.Node;
+import cz.jirutka.rsql.parser.ast.RSQLVisitor;
+import org.eclipse.hawkbit.repository.jpa.TargetFieldData;
+
+/**
+ * Interface containing one single static method to match {@link TargetFieldData}
+ * with RSQL String
+ */
+public interface RsqlMatcher {
+    /**
+     * Method to match {@link TargetFieldData} with RSQL String
+     * @param rsql RSQL String
+     * @param fieldData Container object with Target's field values
+     * @return true if Target's field values match the given RSQL String, otherwise false
+     */
+    static boolean matches(String rsql, TargetFieldData fieldData){
+
+        Node rootNode = new RSQLParser().parse(rsql.toLowerCase());
+
+        RSQLVisitor<Boolean, TargetFieldData> visitor = new RsqlVisitor();
+
+        return rootNode.accept(visitor, fieldData);
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlVisitor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlVisitor.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2020 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa.rsql;
+
+import cz.jirutka.rsql.parser.ast.AndNode;
+import cz.jirutka.rsql.parser.ast.ComparisonNode;
+import cz.jirutka.rsql.parser.ast.ComparisonOperator;
+import cz.jirutka.rsql.parser.ast.Node;
+import cz.jirutka.rsql.parser.ast.OrNode;
+import cz.jirutka.rsql.parser.ast.RSQLVisitor;
+import org.eclipse.hawkbit.repository.jpa.TargetFieldData;
+
+import java.util.List;
+
+/**
+ *  Implementation of {@link RSQLVisitor}
+ */
+public class RsqlVisitor implements RSQLVisitor<Boolean, TargetFieldData> {
+
+    @Override
+    public Boolean visit(AndNode node, TargetFieldData fieldData) {
+        for(Node child: node.getChildren()){
+            if(!child.accept(this, fieldData)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public Boolean visit(OrNode node, TargetFieldData fieldData) {
+        for(Node child: node.getChildren()){
+            if(child.accept(this, fieldData)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Boolean visit(ComparisonNode node, TargetFieldData fieldData) {
+        String key = node.getSelector();
+        List<String> values = node.getArguments();
+        ComparisonOperator operator = node.getOperator();
+
+        return fieldData.request(key, operator.getSymbol(), values);
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFieldDataTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFieldDataTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2020 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Arrays;
+
+import static org.eclipse.hawkbit.repository.TargetFields.ASSIGNEDDS;
+import static org.eclipse.hawkbit.repository.TargetFields.ATTRIBUTE;
+import static org.eclipse.hawkbit.repository.TargetFields.CONTROLLERID;
+import static org.eclipse.hawkbit.repository.TargetFields.CREATEDAT;
+import static org.eclipse.hawkbit.repository.TargetFields.DESCRIPTION;
+import static org.eclipse.hawkbit.repository.TargetFields.ID;
+import static org.eclipse.hawkbit.repository.TargetFields.INSTALLEDDS;
+import static org.eclipse.hawkbit.repository.TargetFields.IPADDRESS;
+import static org.eclipse.hawkbit.repository.TargetFields.LASTCONTROLLERREQUESTAT;
+import static org.eclipse.hawkbit.repository.TargetFields.LASTMODIFIEDAT;
+import static org.eclipse.hawkbit.repository.TargetFields.METADATA;
+import static org.eclipse.hawkbit.repository.TargetFields.NAME;
+import static org.eclipse.hawkbit.repository.TargetFields.TAG;
+import static org.eclipse.hawkbit.repository.TargetFields.UPDATESTATUS;
+import static org.eclipse.hawkbit.repository.model.TargetUpdateStatus.PENDING;
+import static org.eclipse.hawkbit.repository.model.TargetUpdateStatus.UNKNOWN;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TargetFieldDataTest {
+
+    final static String LOCALHOST = URI.create("http://127.0.0.1").toString();
+
+    final static String EQUAL = "==";
+    final static String NOT_EQUAL = "!=";
+    final static String GREATER = "=gt=";
+    final static String GREATER_EQUAL = "=ge=";
+    final static String LESS = "=lt=";
+    final static String LESS_EQUAL = "=le=";
+    final static String IN = "=in=";
+    final static String OUT = "=out=";
+
+    private TargetFieldData fieldData;
+    private TargetFieldData fieldData2;
+
+    @Before
+    public void setUp() throws InterruptedException {
+
+        fieldData = new TargetFieldData();
+
+        String createdTime = Long.toString(System.currentTimeMillis());
+
+        Thread.sleep(123);
+        String lastModifiedTime = Long.toString(System.currentTimeMillis());
+
+        Thread.sleep(123);
+        String lastRequestTime = Long.toString(System.currentTimeMillis());
+
+        fieldData.add(ID, "012345");
+        fieldData.add(NAME, "targetName1");
+        fieldData.add(DESCRIPTION, "TargetDescription1");
+        fieldData.add(CREATEDAT, createdTime);
+        fieldData.add(LASTMODIFIEDAT, lastModifiedTime);
+        fieldData.add(CONTROLLERID, "012345");
+        fieldData.add(UPDATESTATUS, PENDING.name());
+        fieldData.add(IPADDRESS, LOCALHOST);
+        fieldData.add(ATTRIBUTE, "revision", "1.123");
+        fieldData.add(ATTRIBUTE, "device_type", "dev_test");
+        fieldData.add(ASSIGNEDDS, "name", "AssignedDs");
+        fieldData.add(ASSIGNEDDS, "version", "3.321");
+        fieldData.add(INSTALLEDDS, "name", "InstalledDs");
+        fieldData.add(INSTALLEDDS, "version", "9.876");
+        fieldData.add(TAG, "alpha");
+        fieldData.add(TAG, "beta");
+        fieldData.add(LASTCONTROLLERREQUESTAT, lastRequestTime);
+        fieldData.add(METADATA, "metakey1", "metavalue1");
+        fieldData.add(METADATA, "metakey2", "metavalue2");
+
+        fieldData2 = new TargetFieldData();
+
+        fieldData2.add(ID, "543210");
+        fieldData2.add(NAME, "targetName2");
+        fieldData2.add(DESCRIPTION, "TargetDescription2");
+        fieldData2.add(CONTROLLERID, "543210");
+        fieldData2.add(UPDATESTATUS, UNKNOWN.name());
+        fieldData2.add(IPADDRESS, LOCALHOST);
+    }
+
+    @Test
+    public void test_key_value_condition_on_targetFieldData(){
+
+        assertTrue("Should match id == 012345", fieldData.request(ID.name(), EQUAL, "012345"));
+        assertTrue("Should match id != 543210", fieldData.request(ID.name(), NOT_EQUAL, "543210"));
+        assertFalse("Should not match id < ''", fieldData.request(ID.name(), LESS, ""));
+        assertFalse("Should not match id <= ''", fieldData.request(ID.name(), LESS_EQUAL, ""));
+        assertFalse("Should not match id > ''", fieldData.request(ID.name(), GREATER, ""));
+        assertFalse("Should not match id >= ''", fieldData.request(ID.name(), GREATER_EQUAL, ""));
+        assertTrue("Should match provided array contains ID", fieldData.request(ID.name(), IN, Arrays.asList("abcd", "012345", "95478")));
+        assertTrue("Should match provided array doesn't contain ID", fieldData.request(ID.name(), OUT, Arrays.asList("abcd", "052abc", "95478")));
+        assertTrue("Should match id > 012344", fieldData.request(ID.name(), GREATER, "012344"));
+        assertTrue("Should match id < 012346", fieldData.request(ID.name(), LESS, "012346"));
+        assertTrue("Should match id >= 012345", fieldData.request(ID.name(), GREATER_EQUAL, "012345"));
+        assertTrue("Should match id <= 012345", fieldData.request(ID.name(), LESS_EQUAL, "012345"));
+        assertTrue("Should match id >= 012343", fieldData.request(ID.name(), GREATER_EQUAL, "012343"));
+        assertTrue("Should match id <= 012347", fieldData.request(ID.name(), LESS_EQUAL, "012347"));
+        assertFalse("Should not match id == 012...", fieldData.request(ID.name(), EQUAL, "012..."));
+
+        assertTrue("Should match tag=alpha", fieldData.request(TAG.name(), EQUAL, "alpha"));
+        assertTrue("Should match tag=beta", fieldData.request(TAG.name(), EQUAL, "beta"));
+        assertFalse("Should not match tag=''", fieldData.request(TAG.name(), EQUAL, ""));
+        assertFalse("Should not match tag!=alpha", fieldData.request(TAG.name(), NOT_EQUAL, "alpha"));
+        assertTrue("Should match tag=''", fieldData.request(TAG.name(), NOT_EQUAL, ""));
+
+        assertTrue("Should match attribute == ''", fieldData2.request(ATTRIBUTE.name(), EQUAL, ""));
+        assertFalse("Should not match attribute.attr_name == attr_value", fieldData2.request(ATTRIBUTE.name() + ".attr_name", EQUAL, "attr_value"));
+        assertFalse("Should not match attribute.attr_name != attr_value", fieldData2.request(ATTRIBUTE.name() + ".attr_name", NOT_EQUAL, "attr_value"));
+        assertFalse("Should not match provided array doesn't contain attr_value", fieldData2.request(ATTRIBUTE.name() + ".attr_name", OUT, Arrays.asList("attr_value", "abcdefg")));
+        assertFalse("Should not match provided array contains attr_value", fieldData2.request(ATTRIBUTE.name() + ".attr_name", IN, Arrays.asList("attr_value", "abcdefg")));
+
+        assertTrue("Should match tag == ''", fieldData2.request(TAG.name(), EQUAL, ""));
+        assertTrue("Should match tag != alpha", fieldData2.request(TAG.name(), NOT_EQUAL, "alpha"));
+
+        assertTrue("Should match tag =in= ''", fieldData2.request(TAG.name(), IN, ""));
+        assertTrue("Should match tag =out= provided list", fieldData2.request(TAG.name(), OUT, Arrays.asList("alpha", "beta")));
+
+        assertTrue("Should match id == *23*", fieldData.request(ID.name(), EQUAL, "*23*"));
+        assertTrue("Should match id == 0*23*5", fieldData.request(ID.name(), EQUAL, "0*23*5"));
+        assertTrue("Should match id == *5", fieldData.request(ID.name(), EQUAL, "*5"));
+        assertTrue("Should match id == 0123*", fieldData.request(ID.name(), EQUAL, "0123*"));
+        assertTrue("Should match id == *1*3*4*", fieldData.request(ID.name(), EQUAL, "*1*3*4*"));
+
+        assertFalse("Should not match id != *23*", fieldData.request(ID.name(), NOT_EQUAL, "*23*"));
+        assertFalse("Should not match id != 0*23*5", fieldData.request(ID.name(), NOT_EQUAL, "0*23*5"));
+        assertFalse("Should not match id != *5", fieldData.request(ID.name(), NOT_EQUAL, "*5"));
+        assertFalse("Should not match id != 0123*", fieldData.request(ID.name(), NOT_EQUAL, "0123*"));
+        assertFalse("Should not match id != *1*3*4*", fieldData.request(ID.name(), NOT_EQUAL, "*1*3*4*"));
+
+        assertTrue("Should match id != *32*", fieldData.request(ID.name(), NOT_EQUAL, "*32*"));
+        assertFalse("Should not match id == 5*3", fieldData.request(ID.name(), EQUAL, "5*3"));
+
+        assertTrue("Should match createdAt < current date", fieldData.request(CREATEDAT.name(), LESS, "${now_ts}"));
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFieldExtractorTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFieldExtractorTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2020 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa;
+
+import org.eclipse.hawkbit.repository.UpdateMode;
+import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.DistributionSetAssignmentResult;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.model.TargetTag;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.eclipse.hawkbit.repository.TargetFields.ASSIGNEDDS;
+import static org.eclipse.hawkbit.repository.TargetFields.ATTRIBUTE;
+import static org.eclipse.hawkbit.repository.TargetFields.CONTROLLERID;
+import static org.eclipse.hawkbit.repository.TargetFields.CREATEDAT;
+import static org.eclipse.hawkbit.repository.TargetFields.DESCRIPTION;
+import static org.eclipse.hawkbit.repository.TargetFields.ID;
+import static org.eclipse.hawkbit.repository.TargetFields.INSTALLEDDS;
+import static org.eclipse.hawkbit.repository.TargetFields.IPADDRESS;
+import static org.eclipse.hawkbit.repository.TargetFields.LASTCONTROLLERREQUESTAT;
+import static org.eclipse.hawkbit.repository.TargetFields.LASTMODIFIEDAT;
+import static org.eclipse.hawkbit.repository.TargetFields.METADATA;
+import static org.eclipse.hawkbit.repository.TargetFields.NAME;
+import static org.eclipse.hawkbit.repository.TargetFields.TAG;
+import static org.eclipse.hawkbit.repository.TargetFields.UPDATESTATUS;
+import static org.eclipse.hawkbit.repository.model.TargetUpdateStatus.IN_SYNC;
+import static org.eclipse.hawkbit.repository.model.TargetUpdateStatus.PENDING;
+import static org.eclipse.hawkbit.repository.test.util.TestdataFactory.DEFAULT_VERSION;
+
+import static org.junit.Assert.assertTrue;
+
+public class TargetFieldExtractorTest extends AbstractJpaIntegrationTest {
+
+    private String targetId;
+    private String targetId2;
+
+    @Autowired
+    protected TargetFieldExtractor extractorService;
+
+    @Before
+    public void setUp() {
+
+        Target target = targetManagement.create(entityFactory.target().create()
+                .controllerId("targetId123")
+                .name("targetName123")
+                .description("targetDescription123"));
+
+        targetId = target.getControllerId();
+
+        final DistributionSet assignedDs = testdataFactory.createDistributionSet("AssignedDs");
+        assignDistributionSet(assignedDs.getId(), target.getControllerId(), Action.ActionType.SOFT);
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("revision", "1.11");
+        attributes.put("device_type", "dev_test");
+        controllerManagement.updateControllerAttributes(targetId, attributes, UpdateMode.REPLACE);
+
+
+        createTargetMetadata(targetId, Arrays.asList(
+                entityFactory.generateDsMetadata("metakey_1", "metavalue_1"),
+                entityFactory.generateDsMetadata("metakey_2", "metavalue_2")
+        ));
+
+        controllerManagement.findOrRegisterTargetIfItDoesNotExist(targetId, LOCALHOST);
+
+        final TargetTag tag_alpha = targetTagManagement.create(entityFactory.tag().create().name("alpha"));
+        final TargetTag tag_beta = targetTagManagement.create(entityFactory.tag().create().name("beta"));
+        targetManagement.assignTag(Collections.singletonList(targetId), tag_alpha.getId());
+        targetManagement.assignTag(Collections.singletonList(targetId), tag_beta.getId());
+
+        Target target2 = targetManagement.create(entityFactory.target().create()
+                .controllerId("targetId123_2")
+                .name("targetName123_2")
+                .description("targetDescription123_2"));
+
+        targetId2 = target2.getControllerId();
+
+        final DistributionSet installedDs = testdataFactory.createDistributionSet("InstalledDs");
+        DistributionSetAssignmentResult result = assignDistributionSet(installedDs.getId(), targetId2, Action.ActionType.SOFT);
+
+        addUpdateActionStatus(getFirstAssignedActionId(result), Action.Status.FINISHED);
+    }
+
+
+    private void addUpdateActionStatus(final Long actionId, final Action.Status actionStatus) {
+        controllerManagement.addUpdateActionStatus(entityFactory.actionStatus().create(actionId).status(actionStatus));
+    }
+
+    @Test
+    public void extractFieldsTest() {
+
+        Target testTarget = targetManagement.getByControllerID(targetId).orElseThrow(EntityNotFoundException::new);
+        TargetFieldData fieldData = extractorService.extractData(testTarget);
+
+        Target testTarget2 = targetManagement.getByControllerID(targetId2).orElseThrow(EntityNotFoundException::new);
+        TargetFieldData fieldData2 = extractorService.extractData(testTarget2);
+
+        assertTrue("Should contain 'ID = targetId123'",
+                fieldData.hasEntry(ID.name(), "targetId123"));
+        assertTrue("Should contain 'CONTROLLERID = targetId123'",
+                fieldData.hasEntry(CONTROLLERID.name(), "targetId123"));
+        assertTrue("Should contain 'NAME = targetName123'",
+                fieldData.hasEntry(NAME.name(), "targetName123"));
+        assertTrue("Should contain 'DESCRIPTION = targetDescription123'",
+                fieldData.hasEntry(DESCRIPTION.name(), "targetDescription123"));
+        assertTrue("Should contain 'UPDATESTATUS = PENDING'",
+                fieldData.hasEntry(UPDATESTATUS.name(), PENDING.name()));
+        assertTrue("Should contain 'ASSIGNEDDS.name = AssignedDs'",
+                fieldData.hasEntry(ASSIGNEDDS.name() + ".name", "AssignedDs"));
+        assertTrue("Should contain 'ASSIGNEDDS.version = 1.0'",
+                fieldData.hasEntry(ASSIGNEDDS.name() + ".version", DEFAULT_VERSION));
+        assertTrue("Should contain 'INSTALLEDDS.name = InstalledDs'",
+                fieldData2.hasEntry(INSTALLEDDS.name() + ".name", "InstalledDs"));
+        assertTrue("Should contain 'INSTALLEDDS.version = 1.0'",
+                fieldData2.hasEntry(INSTALLEDDS.name() + ".version", DEFAULT_VERSION));
+        assertTrue("Should contain 'UPDATESTATUS = IN_SYNC'",
+                fieldData2.hasEntry(UPDATESTATUS.name(), IN_SYNC.name()));
+        assertTrue("Should contain 'ATTRIBUTE.revision = 1.11'",
+                fieldData.hasEntry(ATTRIBUTE.name() + ".revision", "1.11"));
+        assertTrue("Should contain 'ATTRIBUTE.device_type = dev_test'",
+                fieldData.hasEntry(ATTRIBUTE.name() + ".device_type", "dev_test"));
+        assertTrue("Should contain METADATA.metakey_1 = metavalue_1",
+                fieldData.hasEntry(METADATA.name() + ".metakey_1", "metavalue_1"));
+        assertTrue("Should contain METADATA.metakey_2 = metavalue_2",
+                fieldData.hasEntry(METADATA.name() + ".metakey_2", "metavalue_2"));
+        assertTrue("Should contain IPADDRESS = http://127.0.0.1",
+                fieldData.hasEntry(IPADDRESS.name() , LOCALHOST.toString()));
+        assertTrue("Should contain TAG = alpha",
+                fieldData.hasEntry(TAG.name(), "alpha"));
+        assertTrue("Should contain TAG = beta",
+                fieldData.hasEntry(TAG.name(), "beta"));
+        assertTrue("Should contain CREATEDAT = [Long value]",
+                fieldData.hasEntry(CREATEDAT.name(), Long.toString(testTarget.getCreatedAt())));
+        assertTrue("Should contain LASTMODIFIEDAT = [Long value]",
+                fieldData.hasEntry(LASTMODIFIEDAT.name(),  Long.toString(testTarget.getLastModifiedAt())));
+        assertTrue("Should contain LASTCONTROLLERREQUESTAT = [Long value]",
+                fieldData.hasEntry(LASTCONTROLLERREQUESTAT.name(),  Long.toString(testTarget.getLastTargetQuery())));
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlMatcherTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlMatcherTest.java
@@ -1,0 +1,463 @@
+/**
+ * Copyright (c) 2020 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa.rsql;
+
+import org.eclipse.hawkbit.repository.jpa.TargetFieldData;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.GregorianCalendar;
+
+import static java.util.Calendar.DECEMBER;
+import static org.eclipse.hawkbit.repository.TargetFields.ASSIGNEDDS;
+import static org.eclipse.hawkbit.repository.TargetFields.ATTRIBUTE;
+import static org.eclipse.hawkbit.repository.TargetFields.CONTROLLERID;
+import static org.eclipse.hawkbit.repository.TargetFields.CREATEDAT;
+import static org.eclipse.hawkbit.repository.TargetFields.DESCRIPTION;
+import static org.eclipse.hawkbit.repository.TargetFields.ID;
+import static org.eclipse.hawkbit.repository.TargetFields.INSTALLEDDS;
+import static org.eclipse.hawkbit.repository.TargetFields.IPADDRESS;
+import static org.eclipse.hawkbit.repository.TargetFields.LASTCONTROLLERREQUESTAT;
+import static org.eclipse.hawkbit.repository.TargetFields.LASTMODIFIEDAT;
+import static org.eclipse.hawkbit.repository.TargetFields.METADATA;
+import static org.eclipse.hawkbit.repository.TargetFields.NAME;
+import static org.eclipse.hawkbit.repository.TargetFields.TAG;
+import static org.eclipse.hawkbit.repository.TargetFields.UPDATESTATUS;
+import static org.eclipse.hawkbit.repository.jpa.rsql.RsqlMatcher.matches;
+import static org.eclipse.hawkbit.repository.model.TargetUpdateStatus.PENDING;
+import static org.eclipse.hawkbit.repository.model.TargetUpdateStatus.UNKNOWN;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RsqlMatcherTest {
+    final static String LOCALHOST = URI.create("http://127.0.0.1").toString();
+
+    final static String idEqualTrue = "id == 012345";
+    final static String idNotEqualTrue = "id != 54321";
+    final static String idNotEqualFalse = "id != 012345";
+    final static String idInTrue = "id =in= (abcd, 9999, 012345, 7456)";
+    final static String idInFalse = "id =in= (abcd, 9999, 7456)";
+    final static String idOutTrue = "id =out= (abcd, 9999, 8546)";
+    final static String idOutFalse = "id =out= (abcd, 9999, 8546, 012345)";
+
+    final static String idWildCardEqualTrue1 = "id == *2345";
+    final static String idWildCardEqualTrue2 = "id == 0*";
+    final static String idWildCardEqualTrue3 = "id == *123*";
+    final static String idWildCardEqualTrue4 = "id == *1*4*";
+    final static String idWildCardEqualTrue5 = "id == 01*45";
+    final static String idWildCardEqualTrue6 = "id == *012345*";
+    final static String idWildCardEqualTrue7= "id == *0*1*2*3*4*5*";
+    final static String idWildCardEqualFalse2 = "id == 0124*5";
+
+    final static String controllerIdEqualTrue = "controllerid == 012345";
+    final static String controllerIdInTrue = "controllerid =in= (abcd, 9999, 012345, 7456)";
+    final static String controllerIdInFalse = "controllerid =in= (abcd, 9999, 7456)";
+    final static String controllerIdOutTrue = "controllerid =out= (abcd, 9999, 8546)";
+    final static String controllerIdOutFalse = "controllerid =out= (abcd, 9999, 8546, 012345)";
+
+    final static String nameEqualTrue1 = "name == targetName1";
+    final static String nameEqualTrue2 = "name == 'targetName1'";
+    final static String nameInTrue = "name =in= (abcd, targetName1, 012345, 7456)";
+    final static String nameInFalse = "name =in= (abcd, 9999, 7456, asdfgh)";
+    final static String nameOutTrue = "name =out= (abcd, 9999, 8546)";
+    final static String nameOutFalse = "name =out= (abcd, 9999, 8546, targetName1, 012345)";
+
+    final static String descEqualTrue1 = "description == TargetDescription1";
+    final static String descEqualTrue2 = "description == \"TargetDescription1\"";
+    final static String descInTrue = "description =in= (abcd, TargetDescription1, 012345, 7456)";
+    final static String descInFalse = "description =in= (abcd, 9999, 7456, asdfgh)";
+    final static String descOutTrue = "description =out= (abcd, 9999, 8546, ghjktrz)";
+    final static String descOutFalse = "description =out= (abcd, 9999, 8546, TargetDescription1, 012345)";
+
+    final static String ipAddressEqualTrue1 = "ipaddress == " + LOCALHOST;
+    final static String ipAddressEqualTrue2 = "ipaddress == '" + LOCALHOST + "'";
+    final static String ipAddressEqualFalse = "ipaddress == \"http:\\\\abcde.123485\"";
+    final static String ipAddressNotEqualTrue = "ipaddress != http:\\\\192.168.0.1";
+    final static String ipAddressNotEqualFalse = "ipaddress != " + LOCALHOST;
+    final static String ipAddressOutTrue = "ipaddress =OUT= (abcd, 9999, 8546, ghjktrz, http:\\\\devolo.com)";
+    final static String ipAddressOutFalse = "ipaddress=oUt= (abcd, 9999, 8546,"+ LOCALHOST + ",InstalledDs, 012345)";
+    final static String ipAddressInTrue = "ipaddress=iN=(abcd, " + LOCALHOST + ", 8546, ghjktrz)";
+    final static String ipAddressInFalse = "ipaddress =In=(abcd, 9874, 8546, ghjktrz)";
+
+    final static String updateStatusEqualTrue1 = "updatestatus == pending";
+    final static String updateStatusEqualTrue2 = "updatestatus == pENdInG";
+    final static String updateStatusEqualFalse = "updatestatus == in_sync";
+    final static String updateStatusInTrue = "updatestatus =IN= (pending, error, abcdefgh123)";
+    final static String updateStatusInFalse = "updatestatus =iN= (in_sync, error, abcdefgh123)";
+    final static String updateStatusOutTrue = "updatestatus =OUT= (finished, error, abcdefgh123)";
+    final static String updateStatusOutFalse = "updatestatus =oUt= (in_sync, pending, error, abcdefgh123)";
+
+    final static String attributeRevisionEqualTrue1 = "attribute.revision == 1.123";
+    final static String attributeRevisionEqualTrue2 = "attribute.revision == \"1.123\"";
+    final static String attributeRevisionEqualFalse = "attribute.revision == \"abcde\"";
+    final static String attributeRevisionNotEqualTrue = "attribute.revision != 6.6.6";
+    final static String attributeRevisionNotEqualFalse = "attribute.revision != 1.123";
+    final static String attributeRevisionOutTrue = "attribute.revision =out= (abcd, 9999, 8546, ghjktrz)";
+    final static String attributeRevisionOutFalse = "attribute.revision =out= (abcd, 9999, 8546, 1.123, 012345)";
+    final static String attributeRevisionInTrue = "attribute.revision =in= (abcd, 1.123, 8546, ghjktrz)";
+    final static String attributeRevisionInFalse = "attribute.revision =in= (abcd, 9874, 8546, ghjktrz)";
+
+    final static String attributeDevTypeEqualTrue1 = "attribute.device_type == dev_test";
+    final static String attributeDevTypeEqualTrue2 = "attribute.device_type == \"dev_test\"";
+    final static String attributeDevTypeEqualFalse1 = "attribute.device_type == \"abcde\"";
+    final static String attributeDevTypeEqualFalse2 = "attribute.keynotexistant == \"abcde\"";
+    final static String attributeDevTypeNotEqualTrue = "attribute.device_type != qwertz";
+    final static String attributeDevTypeNotEqualFalse1 = "attribute.device_type != dev_test";
+    final static String attributeDevTypeNotEqualFalse2 = "attribute.keynotexistant != dev_test";
+    final static String attributeDevTypeOutTrue = "attribute.device_type =OUT= (abcd, 9999, 8546, ghjktrz)";
+    final static String attributeDevTypeOutFalse = "attribute.device_type =oUt= (abcd, 9999, 8546, dev_test, 012345)";
+    final static String attributeDevTypeInTrue = "attribute.device_type =iN= (abcd, dev_test, 8546, ghjktrz)";
+    final static String attributeDevTypeInFalse = "attribute.device_type =In= (abcd, 9874, 8546, ghjktrz)";
+
+    final static String assignedDsNameEqualTrue1 = "assignedds.name == AssignedDs";
+    final static String assignedDsNameEqualTrue2 = "assignedds.name == 'AssignedDs'";
+    final static String assignedDsNameEqualFalse = "assignedds.name == \"abcde\"";
+    final static String assignedDsNameNotEqualTrue = "assignedds.name != asdfg";
+    final static String assignedDsNameNotEqualFalse = "assignedds.name != AssignedDs";
+    final static String assignedDsNameOutTrue = "assignedds.name =OUT= (abcd, 9999, 8546, ghjktrz, InstalledDs)";
+    final static String assignedDsNameOutFalse = "assignedds.name =oUt= (abcd, 9999, 8546, AssignedDs, 012345)";
+    final static String assignedDsNameInTrue = "assignedds.name =iN= (abcd, AssignedDs, 8546, ghjktrz)";
+    final static String assignedDsNameInFalse = "assignedds.name =In= (abcd, 9874, 8546, ghjktrz)";
+
+    final static String installedDsNameEqualTrue1 = "installedds.name == InstalledDs";
+    final static String installedDsNameEqualTrue2 = "installedds.name == 'InstalledDs'";
+    final static String installedDsNameEqualFalse = "installedds.name == \"abcde\"";
+    final static String installedDsNameNotEqualTrue = "installedds.name != asdfg";
+    final static String installedDsNameNotEqualFalse = "installedds.name != InstalledDs";
+    final static String installedDsNameOutTrue = "installedds.name =OUT= (abcd, 9999, 8546, ghjktrz, AssignedDs)";
+    final static String installedDsNameOutFalse = "installedds.name =oUt= (abcd, 9999, 8546, InstalledDs, 012345)";
+    final static String installedDsNameInTrue = "installedds.name =iN= (abcd, InstalledDs, 8546, ghjktrz)";
+    final static String installedDsNameInFalse = "installedds.name =In= (abcd, 9874, 8546, ghjktrz)";
+
+    final static String tagEqualTrue1 = "tag == alpha";
+    final static String tagEqualTrue2 = "tag == beta";
+    final static String tagNotEqualTrue = "tag != nightly";
+    final static String tagNotEqualFalse = "tag != alpha";
+    final static String tagInTrue1 = "tag =in= (asdh, 9999, 012345, 7456, alpha)";
+    final static String tagInTrue2 = "tag =in= (aasdfdg, beta, 012345, 7456)";
+    final static String tagInFalse = "tag =in= (abcd, 9999, asdfg, 7456)";
+    final static String tagOutTrue = "tag =out= (abcd, 9999, 8546, nightly, random123)";
+    final static String tagOutFalse1 = "tag =out= (abcd, alpha, 8546, 012345)";
+    final static String tagOutFalse2 = "tag =out= (abcd, rtzu, beta, 012345)";
+
+    final static String metadata1EqualTrue = "metadata.metakey1 == metavalue1";
+    final static String metadataEqualFalse = "metadata.wrongkey == metavalue1";
+    final static String metadataNotEqualFalse = "metadata.wrongkey != metavalue1";
+    final static String metadata1EqualFalse = "metadata.metakey1 == value";
+    final static String metadata1NotEqualTrue = "metadata.metakey1 != mtvl";
+    final static String metadata1NotEqualFalse = "metadata.metakey1 != metavalue1";
+    final static String metadata1OutTrue = "metadata.metakey1 =out= (abcd, 9999, 8546, ghjktrz)";
+    final static String metadata1OutFalse = "metadata.metakey1 =out= (abcd, 9999, metavalue1, 1.123, 012345)";
+    final static String metadata1InTrue = "metadata.metakey1 =in= (abcd, metavalue1, 8546, ghjktrz)";
+    final static String metadata1InFalse = "metadata.metakey1 =in= (abcd, 9874, 8546, ghjktrz)";
+
+    final static String metadata2EqualTrue = "metadata.metakey2 == metavalue2";
+    final static String metadata2EqualFalse = "metadata.metakey2 == value";
+    final static String metadata2NotEqualTrue = "metadata.metakey2 != mtvl";
+    final static String metadata2NotEqualFalse = "metadata.metakey2 != metavalue2";
+    final static String metadata2OutTrue = "metadata.metakey2 =out= (abcd, 9999, 8546, ghjktrz)";
+    final static String metadata2OutFalse = "metadata.metakey2 =out= (abcd, 9999, metavalue2, 1.123, 012345)";
+    final static String metadata2InTrue = "metadata.metakey2 =in= (abcd, metavalue2, 8546, ghjktrz)";
+    final static String metadata2InFalse = "metadata.metakey2 =in= (abcd, 9874, 8546, ghjktrz)";
+
+    final static String createdAtLessTrue =
+            "createdat =lt= " + new GregorianCalendar(2020, DECEMBER, 1).getTimeInMillis();
+    final static String createdAtLessFalse =
+            "createdat =lt= " + new GregorianCalendar(2010, DECEMBER, 1).getTimeInMillis();
+    final static String createdAtGreaterTrue =
+            "createdat =gt= " + new GregorianCalendar(2014, DECEMBER, 1).getTimeInMillis();
+    final static String createdAtGreaterFalse =
+            "createdat =gt= " + new GregorianCalendar(2020, DECEMBER, 1).getTimeInMillis();
+    final static String createdAtLessEqualTrue =
+            "createdat =le= " + new GregorianCalendar(2020, DECEMBER, 1).getTimeInMillis();
+    final static String createdAtLessEqualFalse =
+            "createdat =le= " + new GregorianCalendar(2014, DECEMBER, 1).getTimeInMillis();
+    final static String createdAtGreaterEqualTrue =
+            "createdat =ge= " + new GregorianCalendar(2010, DECEMBER, 1).getTimeInMillis();
+    final static String createdAtGreaterEqualFalse =
+            "createdat =ge= " + new GregorianCalendar(2016, DECEMBER, 1).getTimeInMillis();
+    final static String createdAtGreaterEqualEqualTrue =
+            "createdat =ge= " + new GregorianCalendar(2015, DECEMBER, 1).getTimeInMillis();
+    final static String createdAtLessEqualEqualTrue =
+            "createdat =le= " + new GregorianCalendar(2015, DECEMBER, 1).getTimeInMillis();
+
+    final static String lastModifiedAtLessTrue =
+            "lastmodifiedat =lt= " + new GregorianCalendar(2020, DECEMBER, 1).getTimeInMillis();
+    final static String lastModifiedAtLessFalse =
+            "lastmodifiedat =lt= " + new GregorianCalendar(2010, DECEMBER, 1).getTimeInMillis();
+    final static String lastModifiedAtGreaterTrue =
+            "lastmodifiedat =gt= " + new GregorianCalendar(2014, DECEMBER, 1).getTimeInMillis();
+    final static String lastModifiedAtGreaterFalse =
+            "lastmodifiedat =gt= " + new GregorianCalendar(2020, DECEMBER, 1).getTimeInMillis();
+    final static String lastModifiedAtLessEqualTrue =
+            "lastmodifiedat =le= " + new GregorianCalendar(2020, DECEMBER, 1).getTimeInMillis();
+    final static String lastModifiedAtLessEqualFalse =
+            "lastmodifiedat =le= " + new GregorianCalendar(2014, DECEMBER, 1).getTimeInMillis();
+    final static String lastModifiedAtGreaterEqualTrue =
+            "lastmodifiedat =ge= " + new GregorianCalendar(2010, DECEMBER, 1).getTimeInMillis();
+    final static String lastModifiedAtGreaterEqualFalse =
+            "lastmodifiedat =ge= " + new GregorianCalendar(2017, DECEMBER, 1).getTimeInMillis();
+    final static String lastModifiedAtGreaterEqualEqualTrue =
+            "lastmodifiedat =ge= " + new GregorianCalendar(2015, DECEMBER, 1).getTimeInMillis();
+    final static String lastModifiedAtLessEqualEqualTrue =
+            "lastmodifiedat =le= " + new GregorianCalendar(2016, DECEMBER, 1).getTimeInMillis();
+
+    final static String lastRequestLessTrue =
+            "lastcontrollerrequestat =lt= " + new GregorianCalendar(2020, DECEMBER, 1).getTimeInMillis();
+    final static String lastRequestLessFalse =
+            "lastcontrollerrequestat =lt= " + new GregorianCalendar(2010, DECEMBER, 1).getTimeInMillis();
+    final static String lastRequestGreaterTrue =
+            "lastcontrollerrequestat =gt= " + new GregorianCalendar(2014, DECEMBER, 1).getTimeInMillis();
+    final static String lastRequestGreaterFalse =
+            "lastcontrollerrequestat =gt= " + new GregorianCalendar(2020, DECEMBER, 1).getTimeInMillis();
+    final static String lastRequestLessEqualTrue =
+            "lastcontrollerrequestat =le= " + new GregorianCalendar(2020, DECEMBER, 1).getTimeInMillis();
+    final static String lastRequestLessEqualFalse =
+            "lastcontrollerrequestat =le= " + new GregorianCalendar(2014, DECEMBER, 1).getTimeInMillis();
+    final static String lastRequestGreaterEqualTrue =
+            "lastcontrollerrequestat =ge= " + new GregorianCalendar(2010, DECEMBER, 1).getTimeInMillis();
+    final static String lastRequestGreaterEqualFalse =
+            "lastcontrollerrequestat =ge= " + new GregorianCalendar(2018, DECEMBER, 1).getTimeInMillis();
+    final static String lastRequestGreaterEqualEqualTrue =
+            "lastcontrollerrequestat =ge= " + new GregorianCalendar(2017, DECEMBER, 1).getTimeInMillis();
+    final static String lastRequestLessEqualEqualTrue =
+            "lastcontrollerrequestat =le= " + new GregorianCalendar(2017, DECEMBER, 1).getTimeInMillis();
+
+    final static String idAndTagTrue = idEqualTrue + " and " + tagInTrue1;
+    final static String idAndTagTrueAndAttributeTrue = idEqualTrue + " and " + tagInTrue1 + " and " + attributeDevTypeInTrue;
+    final static String idAndTagFalse = idEqualTrue + " and " + tagInFalse;
+    final static String attributeOrMetadataTrue = attributeRevisionInTrue + " or " + metadata1EqualFalse;
+    final static String idOrCreatedOrUpdateFalse = idInFalse + " or " + createdAtGreaterFalse + " or " + updateStatusEqualFalse;
+    final static String idAndTagOrLastRequestTrue = "(" + idInFalse + " and " + tagInTrue1 + ")" + " or " + lastRequestGreaterTrue;
+
+    final static String attributeKeyNotExistValueEmptyFalse = "attribute.keynotexistant != \"\"";
+
+    private TargetFieldData fieldData;
+    private TargetFieldData fieldData2;
+
+    @Before
+    public void setUp() {
+
+        fieldData = new TargetFieldData();
+
+        String createdTime = Long.toString(new GregorianCalendar(2015, DECEMBER, 1).getTimeInMillis());
+        String lastModifiedTime = Long.toString(new GregorianCalendar(2016, DECEMBER, 1).getTimeInMillis());
+        String lastRequestTime = Long.toString(new GregorianCalendar(2017, DECEMBER, 1).getTimeInMillis());
+
+        fieldData.add(ID, "012345");
+        fieldData.add(NAME, "targetName1");
+        fieldData.add(DESCRIPTION, "TargetDescription1");
+        fieldData.add(CREATEDAT, createdTime);
+        fieldData.add(LASTMODIFIEDAT, lastModifiedTime);
+        fieldData.add(CONTROLLERID, "012345");
+        fieldData.add(UPDATESTATUS, PENDING.name());
+        fieldData.add(IPADDRESS, LOCALHOST);
+        fieldData.add(ATTRIBUTE, "revision", "1.123");
+        fieldData.add(ATTRIBUTE, "device_type", "dev_test");
+        fieldData.add(ASSIGNEDDS, "name", "AssignedDs");
+        fieldData.add(ASSIGNEDDS, "version", "3.321");
+        fieldData.add(INSTALLEDDS, "name", "InstalledDs");
+        fieldData.add(INSTALLEDDS, "version", "9.876");
+        fieldData.add(TAG, "alpha");
+        fieldData.add(TAG, "beta");
+        fieldData.add(LASTCONTROLLERREQUESTAT, lastRequestTime);
+        fieldData.add(METADATA, "metakey1", "metavalue1");
+        fieldData.add(METADATA, "metakey2", "metavalue2");
+
+        fieldData2 = new TargetFieldData();
+
+        fieldData.add(ID, "123456");
+        fieldData.add(NAME, "targetName2");
+        fieldData.add(DESCRIPTION, "TargetDescription2");
+        fieldData.add(CREATEDAT, createdTime);
+        fieldData.add(LASTMODIFIEDAT, lastModifiedTime);
+        fieldData.add(CONTROLLERID, "123456");
+        fieldData.add(UPDATESTATUS, UNKNOWN.name());
+        fieldData.add(IPADDRESS, LOCALHOST);
+        fieldData.add(ATTRIBUTE, "device_type", "dev_test");
+        fieldData.add(LASTCONTROLLERREQUESTAT, lastRequestTime);
+    }
+
+    @Test
+    public void match_combined_properties(){
+        assertTrue("Should match ID and tag", matches(idAndTagTrue, fieldData));
+        assertTrue("Should match ID and tag and attribute", matches(idAndTagTrueAndAttributeTrue, fieldData));
+        assertFalse("Should not match ID and tag", matches(idAndTagFalse, fieldData));
+        assertTrue("Should match attribute or metadata", matches(attributeOrMetadataTrue, fieldData));
+        assertFalse("Should not match ID or createdat or updatestatus", matches(idOrCreatedOrUpdateFalse, fieldData));
+        assertTrue("Should match ID and tag or lastrequest", matches(idAndTagOrLastRequestTrue, fieldData));
+    }
+
+    @Test
+    public void match_single_properties() {
+
+        assertTrue("Should match ID with wildcard as equal", matches(idWildCardEqualTrue1, fieldData));
+        assertTrue("Should match ID with wildcard as equal", matches(idWildCardEqualTrue2, fieldData));
+        assertTrue("Should match ID with wildcard as equal", matches(idWildCardEqualTrue3, fieldData));
+        assertTrue("Should match ID with wildcard as equal", matches(idWildCardEqualTrue4, fieldData));
+        assertTrue("Should match ID with wildcard as equal", matches(idWildCardEqualTrue5, fieldData));
+        assertTrue("Should match ID with wildcard as equal", matches(idWildCardEqualTrue6, fieldData));
+        assertTrue("Should match ID with wildcard as equal", matches(idWildCardEqualTrue7, fieldData));
+        assertFalse("Should not match ID with wildcard as equal", matches(idWildCardEqualFalse2, fieldData));
+
+        assertTrue("Should match IP address as equal", matches(ipAddressEqualTrue1, fieldData));
+        assertTrue("Should match IP address as equal", matches(ipAddressEqualTrue2, fieldData));
+        assertFalse("Should not match IP address as equal", matches(ipAddressEqualFalse, fieldData));
+        assertTrue("Should match IP address as not equal", matches(ipAddressNotEqualTrue, fieldData));
+        assertFalse("Should not match IP address as not equal", matches(ipAddressNotEqualFalse, fieldData));
+        assertTrue("Should match IP address as not containing", matches(ipAddressOutTrue, fieldData));
+        assertFalse("Should not match IP address as not containing", matches(ipAddressOutFalse, fieldData));
+        assertTrue("Should match IP address as containing", matches(ipAddressInTrue, fieldData));
+        assertFalse("Should not match IP address as containing", matches(ipAddressInFalse, fieldData));
+
+        assertTrue("Should match lastrequestdate less than", matches(lastRequestLessTrue, fieldData));
+        assertFalse("Should not match lastrequestdate less than", matches(lastRequestLessFalse, fieldData));
+        assertTrue("Should match lastrequestdate greater than", matches(lastRequestGreaterTrue, fieldData));
+        assertFalse("Should not match lastrequestdate greater than", matches(lastRequestGreaterFalse, fieldData));
+        assertTrue("Should match lastrequestdate less or equal", matches(lastRequestLessEqualTrue, fieldData));
+        assertFalse("Should not match lastrequestdate less or equal", matches(lastRequestLessEqualFalse, fieldData));
+        assertTrue("Should match lastrequestdate greater or equal", matches(lastRequestGreaterEqualTrue, fieldData));
+        assertFalse("Should not match lastrequestdate greater or equal", matches(lastRequestGreaterEqualFalse, fieldData));
+        assertTrue("Should match lastrequestdate greater or equal", matches(lastRequestGreaterEqualEqualTrue, fieldData));
+        assertTrue("Should match lastrequestdate less or equal", matches(lastRequestLessEqualEqualTrue, fieldData));
+
+        assertTrue("Should match metadata equal", matches(metadata2EqualTrue, fieldData));
+        assertFalse("Should not match metadata equal", matches(metadata2EqualFalse, fieldData));
+        assertTrue("Should match metadata not equal", matches(metadata2NotEqualTrue, fieldData));
+        assertFalse("Should not match metadata not equal", matches(metadata2NotEqualFalse, fieldData));
+        assertTrue("Should match metadata not containing", matches(metadata2OutTrue, fieldData));
+        assertFalse("Should not match metadata not containing", matches(metadata2OutFalse, fieldData));
+        assertTrue("Should match metadata containing", matches(metadata2InTrue, fieldData));
+        assertFalse("Should not match metadata containing", matches(metadata2InFalse, fieldData));
+
+        assertTrue("Should match metadata equal", matches(metadata1EqualTrue, fieldData));
+        assertFalse("Should not match metadata equal", matches(metadataEqualFalse, fieldData));
+        assertFalse("Should not match metadata not equal", matches(metadataNotEqualFalse, fieldData));
+        assertFalse("Should not match metadata equal", matches(metadata1EqualFalse, fieldData));
+        assertTrue("Should match metadata not equal", matches(metadata1NotEqualTrue, fieldData));
+        assertFalse("Should not match metadata not equal", matches(metadata1NotEqualFalse, fieldData));
+        assertTrue("Should match metadata not containing", matches(metadata1OutTrue, fieldData));
+        assertFalse("Should not match metadata not containing", matches(metadata1OutFalse, fieldData));
+        assertTrue("Should match metadata containing", matches(metadata1InTrue, fieldData));
+        assertFalse("Should not match metadata containing", matches(metadata1InFalse, fieldData));
+
+        assertTrue("Should match tag equal", matches(tagEqualTrue1, fieldData));
+        assertTrue("Should match tag equal", matches(tagEqualTrue2, fieldData));
+        assertTrue("Should match tag not equal", matches(tagNotEqualTrue, fieldData));
+        assertFalse("Should not match tag not equal",matches(tagNotEqualFalse, fieldData));
+        assertTrue("Should match tag containing", matches(tagInTrue1, fieldData));
+        assertTrue("Should match tag containing", matches(tagInTrue2, fieldData));
+        assertFalse("Should not match tag containing", matches(tagInFalse, fieldData));
+        assertTrue("Should match tag not containing", matches(tagOutTrue, fieldData));
+        assertFalse("Should not match tag not containing", matches(tagOutFalse1, fieldData));
+        assertFalse("Should not match tag not containing", matches(tagOutFalse2, fieldData));
+
+        assertTrue("Should match AssignedDS name equal", matches(assignedDsNameEqualTrue1, fieldData));
+        assertTrue("Should match AssignedDS name equal", matches(assignedDsNameEqualTrue2, fieldData));
+        assertFalse("Should not match AssignedDS name equal", matches(assignedDsNameEqualFalse, fieldData));
+        assertTrue("Should match AssignedDS name not equal", matches(assignedDsNameNotEqualTrue, fieldData));
+        assertFalse("Should not match AssignedDS name not equal", matches(assignedDsNameNotEqualFalse, fieldData));
+        assertTrue("Should match AssignedDS name not containing", matches(assignedDsNameOutTrue, fieldData));
+        assertFalse("Should not match AssignedDS name not containing", matches(assignedDsNameOutFalse, fieldData));
+        assertTrue("Should match AssignedDS name containing", matches(assignedDsNameInTrue, fieldData));
+        assertFalse("Should not match AssignedDS name containing", matches(assignedDsNameInFalse, fieldData));
+
+        assertTrue("Should match InstalledDS name equal", matches(installedDsNameEqualTrue1, fieldData));
+        assertTrue("Should match InstalledDS name equal", matches(installedDsNameEqualTrue2, fieldData));
+        assertFalse("Should not match InstalledDS name equal", matches(installedDsNameEqualFalse, fieldData));
+        assertTrue("Should match InstalledDS name not equal", matches(installedDsNameNotEqualTrue, fieldData));
+        assertFalse("Should not match InstalledDS name not equal", matches(installedDsNameNotEqualFalse, fieldData));
+        assertTrue("Should match InstalledDS name not containing", matches(installedDsNameOutTrue, fieldData));
+        assertFalse("Should not match InstalledDS name not containing", matches(installedDsNameOutFalse, fieldData));
+        assertTrue("Should match InstalledDS name containing", matches(installedDsNameInTrue, fieldData));
+        assertFalse("Should not match InstalledDS name containing", matches(installedDsNameInFalse, fieldData));
+
+        assertTrue("Should match attribute revision equal", matches(attributeRevisionEqualTrue1, fieldData));
+        assertTrue("Should match attribute revision equal", matches(attributeRevisionEqualTrue2, fieldData));
+        assertFalse("Should not match attribute revision equal", matches(attributeRevisionEqualFalse, fieldData));
+        assertTrue("Should match attribute revision not equal", matches(attributeRevisionNotEqualTrue, fieldData));
+        assertFalse("Should not match attribute revision not equal", matches(attributeRevisionNotEqualFalse, fieldData));
+        assertTrue("Should match attribute revision not containing", matches(attributeRevisionOutTrue, fieldData));
+        assertTrue("Should match attribute revision containing", matches(attributeRevisionInTrue, fieldData));
+        assertFalse("Should not match attribute revision not containing", matches(attributeRevisionOutFalse, fieldData));
+        assertFalse("Should not match attribute revision containing", matches(attributeRevisionInFalse, fieldData));
+
+        assertTrue("Should match attribute device_type equal", matches(attributeDevTypeEqualTrue1, fieldData));
+        assertTrue("Should match attribute device_type equal", matches(attributeDevTypeEqualTrue2, fieldData));
+        assertFalse("Should not match attribute device_type equal", matches(attributeDevTypeEqualFalse1, fieldData));
+        assertFalse("Should not match attribute device_type equal", matches(attributeDevTypeEqualFalse2, fieldData));
+        assertTrue("Should match attribute device_type not equal", matches(attributeDevTypeNotEqualTrue, fieldData));
+        assertFalse("Should not match attribute device_type not equal", matches(attributeDevTypeNotEqualFalse1, fieldData));
+        assertFalse("Should not match attribute device_type not equal", matches(attributeDevTypeNotEqualFalse2, fieldData));
+        assertTrue("Should match attribute device_type not containing", matches(attributeDevTypeOutTrue, fieldData));
+        assertTrue("Should match attribute device_type containing", matches(attributeDevTypeInTrue, fieldData));
+        assertFalse("Should not match attribute device_type not containing", matches(attributeDevTypeOutFalse, fieldData));
+        assertFalse("Should not match attribute device_type containing", matches(attributeDevTypeInFalse, fieldData));
+        assertFalse("Should not match attribute device_type key not existing", matches(attributeKeyNotExistValueEmptyFalse, fieldData2));
+
+        assertTrue("Should match ID equal", matches(idEqualTrue, fieldData));
+        assertTrue("Should match ID not equal", matches(idNotEqualTrue, fieldData));
+        assertFalse("Should not match ID not equal", matches(idNotEqualFalse, fieldData));
+        assertTrue("Should match ID containing", matches(idInTrue, fieldData));
+        assertFalse("Should not match ID containing", matches(idInFalse, fieldData));
+        assertTrue("Should match ID not containing", matches(idOutTrue, fieldData));
+        assertFalse("Should not match ID not containing", matches(idOutFalse, fieldData));
+
+        assertTrue("Should match ControllerID equal", matches(controllerIdEqualTrue, fieldData));
+        assertTrue("Should match ControllerID containing", matches(controllerIdInTrue, fieldData));
+        assertFalse("Should not match ControllerID containing", matches(controllerIdInFalse, fieldData));
+        assertTrue("Should match ControllerID not containing", matches(controllerIdOutTrue, fieldData));
+        assertFalse("Should not match ControllerID not containing", matches(controllerIdOutFalse, fieldData));
+
+        assertTrue("Should match name equal", matches(nameEqualTrue1, fieldData));
+        assertTrue("Should match name equal", matches(nameEqualTrue2, fieldData));
+        assertTrue("Should match name containing", matches(nameInTrue, fieldData));
+        assertFalse("Should not match name containing", matches(nameInFalse, fieldData));
+        assertTrue("Should match name not containing", matches(nameOutTrue, fieldData));
+        assertFalse("Should not match name not containing", matches(nameOutFalse, fieldData));
+
+        assertTrue("Should match description equal", matches(descEqualTrue1, fieldData));
+        assertTrue("Should match description equal", matches(descEqualTrue2, fieldData));
+        assertTrue("Should match description containing", matches(descInTrue, fieldData));
+        assertFalse("Should not match description containing", matches(descInFalse, fieldData));
+        assertTrue("Should match description not containing", matches(descOutTrue, fieldData));
+        assertFalse("Should not match description not containing", matches(descOutFalse, fieldData));
+
+        assertTrue("Should match createdAt less than", matches(createdAtLessTrue, fieldData));
+        assertFalse("Should not match createdAt less than", matches(createdAtLessFalse, fieldData));
+        assertTrue("Should match createdAt greater than", matches(createdAtGreaterTrue, fieldData));
+        assertFalse("Should not match createdAt greater than", matches(createdAtGreaterFalse, fieldData));
+        assertTrue("Should match createdAt less or equal", matches(createdAtLessEqualTrue, fieldData));
+        assertFalse("Should not match createdAt less or equal", matches(createdAtLessEqualFalse, fieldData));
+        assertTrue("Should match createdAt greater or equal", matches(createdAtGreaterEqualTrue, fieldData));
+        assertFalse("Should not match createdAt greater or equal", matches(createdAtGreaterEqualFalse, fieldData));
+        assertTrue("Should match createdAt greater or equal", matches(createdAtGreaterEqualEqualTrue, fieldData));
+        assertTrue("Should match createdAt less or equal", matches(createdAtLessEqualEqualTrue, fieldData));
+
+        assertTrue("Should match modifiedAt less than", matches(lastModifiedAtLessTrue, fieldData));
+        assertFalse("Should not match modifiedAt less than", matches(lastModifiedAtLessFalse, fieldData));
+        assertTrue("Should match modifiedAt greater than", matches(lastModifiedAtGreaterTrue, fieldData));
+        assertFalse("Should not match modifiedAt greater than", matches(lastModifiedAtGreaterFalse, fieldData));
+        assertTrue("Should match modifiedAt less or equal", matches(lastModifiedAtLessEqualTrue, fieldData));
+        assertFalse("Should not match modifiedAt less or equal", matches(lastModifiedAtLessEqualFalse, fieldData));
+        assertTrue("Should match modifiedAt greater or equal", matches(lastModifiedAtGreaterEqualTrue, fieldData));
+        assertFalse("Should not match modifiedAt greater or equal", matches(lastModifiedAtGreaterEqualFalse, fieldData));
+        assertTrue("Should match modifiedAt greater or equal", matches(lastModifiedAtGreaterEqualEqualTrue, fieldData));
+        assertTrue("Should match modifiedAt less or equal", matches(lastModifiedAtLessEqualEqualTrue, fieldData));
+
+        assertTrue("Should match updatestatus equal", matches(updateStatusEqualTrue1, fieldData));
+        assertTrue("Should match updatestatus equal", matches(updateStatusEqualTrue2, fieldData));
+        assertFalse("Should not match updatestatus equal", matches(updateStatusEqualFalse, fieldData));
+        assertTrue("Should match updatestatus containing", matches(updateStatusInTrue, fieldData));
+        assertFalse("Should not match updatestatus containing", matches(updateStatusInFalse, fieldData));
+        assertTrue("Should match updatestatus not containing", matches(updateStatusOutTrue, fieldData));
+        assertFalse("Should not match updatestatus not containing", matches(updateStatusOutFalse, fieldData));
+    }
+}

--- a/hawkbit-rest/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -458,6 +458,9 @@ public class DdiRootController implements DdiRootControllerRestApi {
             @PathVariable("tenant") final String tenant, @PathVariable("controllerId") final String controllerId) {
 
         controllerManagement.updateControllerAttributes(controllerId, configData.getData(), getUpdateMode(configData));
+
+        controllerManagement.triggerDistributionSetAssignmentCheck(controllerId);
+
         return ResponseEntity.ok().build();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,7 @@
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_19.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_MICROSOFT_18.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_DEVOLO_19.txt</validHeader>
+                     <validHeader>licenses/LICENSE_HEADER_TEMPLATE_DEVOLO_20.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_KIWIGRID_19.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_ENAPTER.txt</validHeader>
                   </validHeaders>


### PR DESCRIPTION
This is an attempt to solve the issue described here: https://github.com/eclipse/hawkbit/issues/983

Summary: whenever a target uploads its configuration over REST endpoint '.../configData' a check for Distribution Set assignment is triggered based on existing Target Filters. This makes AutoAssignmentChecker and Scheduler obsolete. The database load is reduced significantly since there is no need to execute the assignment check regularly.

Signed-off-by: Sergey Gerasimov <sergey.gerasimov@devolo.de>