### PR TITLE
Avoid unnecessary database queries when editing RSQL filter query.

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
@@ -462,6 +462,9 @@ public interface TargetManagement {
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
     Page<Target> findByRsql(@NotNull Pageable pageable, @NotNull String rsqlParam);
 
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    void validateQuery(@NotNull String rsqlParam);
+
     /**
      * Retrieves all target based on {@link TargetFilterQuery}.
      * 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -314,6 +314,11 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
+    public void validateQuery(String rsqlParam){
+        RSQLUtility.parseRsql(rsqlParam);
+    }
+
+    @Override
     public Page<Target> findByRsql(final Pageable pageable, final String targetFilterQuery) {
         return findTargetsBySpec(
                 RSQLUtility.parse(targetFilterQuery, TargetFields.class, virtualPropertyReplacer, database), pageable);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
@@ -149,7 +149,7 @@ public final class RSQLUtility {
         parseRsql(rsql);
     }
 
-    private static Node parseRsql(final String rsql) {
+    public static Node parseRsql(final String rsql) {
         try {
             LOGGER.debug("parsing rsql string {}", rsql);
             final Set<ComparisonOperator> operators = RSQLOperators.defaultOperators();

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlParserValidationOracle.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlParserValidationOracle.java
@@ -34,7 +34,6 @@ import org.eclipse.persistence.exceptions.ConversionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.util.CollectionUtils;
 
@@ -76,7 +75,7 @@ public class RsqlParserValidationOracle implements RsqlValidationOracle {
         context.setSyntaxErrorContext(errorContext);
 
         try {
-            targetManagement.findByRsql(PageRequest.of(0, 1), rsqlQuery);
+            targetManagement.validateQuery(rsqlQuery);
             context.setSyntaxError(false);
             suggestionContext.getSuggestions().addAll(getLogicalOperatorSuggestion(rsqlQuery));
         } catch (final RSQLParameterSyntaxException | RSQLParserException ex) {


### PR DESCRIPTION
This should fix the issue described in https://github.com/eclipse/hawkbit/issues/1023

Summary: To avoid unnecessary database queries when editing/validating RSQL filter query in Target Filter Management, instead of performing `targetRepository.findAll()`, the RSQL string is parsed to check for exceptions, which are evaluated for the sake of validating and generating suggestions.