### PR TITLE
Removed misleading code from RSQLUtility - unused operator '=li='

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
@@ -153,7 +153,6 @@ public final class RSQLUtility {
         try {
             LOGGER.debug("parsing rsql string {}", rsql);
             final Set<ComparisonOperator> operators = RSQLOperators.defaultOperators();
-            operators.add(new ComparisonOperator("=li=", false));
             return new RSQLParser(operators).parse(rsql);
         } catch (final IllegalArgumentException e) {
             throw new RSQLParameterSyntaxException("rsql filter must not be null", e);


### PR DESCRIPTION
This is a fix for https://github.com/eclipse/hawkbit/issues/1029

Summary. The unused RSQL operator is removed from the list of valid operators, as it is not implemented by the RSQL visitor and can only confuse users when valitating the RSQL filter syntax, making them think that this is a valid operator.