### PR TITLE
Metadata UI permissions

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SmMetaDataAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SmMetaDataAddUpdateWindowLayout.java
@@ -8,11 +8,13 @@
  */
 package org.eclipse.hawkbit.ui.artifacts.smtable;
 
+import java.util.function.BooleanSupplier;
+
 import org.eclipse.hawkbit.ui.common.detailslayout.MetaDataAddUpdateWindowLayout;
 import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
 
 import com.vaadin.ui.CheckBox;
-import com.vaadin.ui.ComponentContainer;
+import com.vaadin.ui.VerticalLayout;
 
 /**
  * Class for sm metadata add/update window layout.
@@ -24,23 +26,28 @@ public class SmMetaDataAddUpdateWindowLayout extends MetaDataAddUpdateWindowLayo
      * Constructor for AbstractTagWindowLayout
      * 
      * @param i18n
-     *            I18N
+     *            VaadinMessageSource
+     * @param hasMetadataChangePermission
+     *            checks the permission allowing to change metadata entities
      */
-    public SmMetaDataAddUpdateWindowLayout(final VaadinMessageSource i18n) {
-        super(i18n);
+    public SmMetaDataAddUpdateWindowLayout(final VaadinMessageSource i18n,
+            final BooleanSupplier hasMetadataChangePermission) {
+        super(i18n, hasMetadataChangePermission);
 
         this.isVisibleForTarget = metaDataComponentBuilder.createVisibleForTargetsField(binder);
     }
 
-    /**
-     * @return form layout checkbox container for software module
-     */
     @Override
-    public ComponentContainer getRootComponent() {
-        final ComponentContainer formLayout = super.getRootComponent();
+    protected VerticalLayout getMetadataAddUpdateLayout() {
+        final VerticalLayout addUpdateLayout = super.getMetadataAddUpdateLayout();
+        addUpdateLayout.addComponent(isVisibleForTarget);
 
-        formLayout.addComponent(isVisibleForTarget);
+        return addUpdateLayout;
+    }
 
-        return formLayout;
+    @Override
+    protected void disableMetadataInputComponents() {
+        super.disableMetadataInputComponents();
+        isVisibleForTarget.setEnabled(false);
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SmMetaDataWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/artifacts/smtable/SmMetaDataWindowLayout.java
@@ -67,9 +67,10 @@ public class SmMetaDataWindowLayout extends AbstractMetaDataWindowLayout<Long> {
         this.entityFactory = entityFactory;
 
         this.smMetaDataWindowGrid = new MetaDataWindowGrid<>(i18n, eventBus, permChecker, uiNotification,
-                new SmMetaDataDataProvider(smManagement), this::deleteMetaData);
+                new SmMetaDataDataProvider(smManagement), this::hasMetadataChangePermission, this::deleteMetaData);
 
-        this.smMetaDataAddUpdateWindowLayout = new SmMetaDataAddUpdateWindowLayout(i18n);
+        this.smMetaDataAddUpdateWindowLayout = new SmMetaDataAddUpdateWindowLayout(i18n,
+                this::hasMetadataChangePermission);
         this.addSmMetaDataWindowController = new AddMetaDataWindowController(i18n, uiNotification,
                 smMetaDataAddUpdateWindowLayout, this::createMetaData, this::isDuplicate);
         this.updateSmMetaDataWindowController = new UpdateMetaDataWindowController(i18n, uiNotification,

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractMetaDataWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/AbstractMetaDataWindowLayout.java
@@ -38,6 +38,7 @@ public abstract class AbstractMetaDataWindowLayout<F> extends HorizontalLayout {
     protected final VaadinMessageSource i18n;
     protected final transient UIEventBus eventBus;
     protected final UINotification uiNotification;
+    protected final SpPermissionChecker permChecker;
 
     private final MetadataWindowGridHeader metadataWindowGridHeader;
 
@@ -62,9 +63,23 @@ public abstract class AbstractMetaDataWindowLayout<F> extends HorizontalLayout {
         this.i18n = i18n;
         this.eventBus = eventBus;
         this.uiNotification = uiNotification;
+        this.permChecker = permChecker;
 
         this.metadataWindowGridHeader = new MetadataWindowGridHeader(i18n, permChecker, eventBus,
-                this::showAddMetaDataLayout);
+                this::hasMetadataChangePermission, this::showAddMetaDataLayout);
+    }
+
+    // can be overriden in child classes for entity-specific permission
+    protected boolean hasMetadataChangePermission() {
+        return permChecker.hasUpdateRepositoryPermission();
+    }
+
+    private void showAddMetaDataLayout() {
+        getMetaDataWindowGrid().deselectAll();
+        getAddMetaDataWindowController().populateWithData(null);
+        saveCallback.accept(getAddMetaDataWindowController().getSaveDialogCloseListener());
+
+        resetSaveButton();
     }
 
     protected MetaData createMetaData(final ProxyMetaData entity) {
@@ -128,14 +143,6 @@ public abstract class AbstractMetaDataWindowLayout<F> extends HorizontalLayout {
     protected abstract String getEntityType();
 
     protected abstract void doDeleteMetaDataByKey(final String metaDataKey);
-
-    private void showAddMetaDataLayout() {
-        getMetaDataWindowGrid().deselectAll();
-        getAddMetaDataWindowController().populateWithData(null);
-        saveCallback.accept(getAddMetaDataWindowController().getSaveDialogCloseListener());
-
-        resetSaveButton();
-    }
 
     /**
      * @return add meta data window controller

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/DistributionSetDetailsHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/DistributionSetDetailsHeader.java
@@ -34,17 +34,17 @@ public class DistributionSetDetailsHeader extends AbstractDetailsHeader<ProxyDis
      * Constructor for DistributionSetDetailsHeader
      *
      * @param i18n
-     *          VaadinMessageSource
+     *            VaadinMessageSource
      * @param permChecker
-     *          SpPermissionChecker
+     *            SpPermissionChecker
      * @param eventBus
-     *          UIEventBus
+     *            UIEventBus
      * @param uiNotification
-     *          UINotification
+     *            UINotification
      * @param dsWindowBuilder
-     *          DsWindowBuilder
+     *            DsWindowBuilder
      * @param dsMetaDataWindowBuilder
-     *          DsMetaDataWindowBuilder
+     *            DsMetaDataWindowBuilder
      */
     public DistributionSetDetailsHeader(final VaadinMessageSource i18n, final SpPermissionChecker permChecker,
             final UIEventBus eventBus, final UINotification uiNotification, final DsWindowBuilder dsWindowBuilder,
@@ -70,11 +70,6 @@ public class DistributionSetDetailsHeader extends AbstractDetailsHeader<ProxyDis
     @Override
     protected String getMasterEntityName(final ProxyDistributionSet masterEntity) {
         return masterEntity.getNameVersion();
-    }
-
-    @Override
-    protected boolean hasEditPermission() {
-        return permChecker.hasUpdateRepositoryPermission();
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/MetaDataAddUpdateWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/MetaDataAddUpdateWindowLayout.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.hawkbit.ui.common.detailslayout;
 
+import java.util.function.BooleanSupplier;
+
 import org.eclipse.hawkbit.ui.common.AbstractEntityWindowLayout;
 import org.eclipse.hawkbit.ui.common.data.proxies.ProxyMetaData;
 import org.eclipse.hawkbit.ui.utils.VaadinMessageSource;
@@ -21,6 +23,7 @@ import com.vaadin.ui.VerticalLayout;
  * Class for metadata add/update window layout.
  */
 public class MetaDataAddUpdateWindowLayout extends AbstractEntityWindowLayout<ProxyMetaData> {
+    private final BooleanSupplier hasMetadataChangePermission;
     protected final MetaDataAddUpdateWindowLayoutComponentBuilder metaDataComponentBuilder;
 
     private final TextField metadataKey;
@@ -30,11 +33,15 @@ public class MetaDataAddUpdateWindowLayout extends AbstractEntityWindowLayout<Pr
      * Constructor for AbstractTagWindowLayout
      * 
      * @param i18n
-     *            I18N
+     *            VaadinMessageSource
+     * @param hasMetadataChangePermission
+     *            checks the permission allowing to change metadata entities
      */
-    public MetaDataAddUpdateWindowLayout(final VaadinMessageSource i18n) {
+    public MetaDataAddUpdateWindowLayout(final VaadinMessageSource i18n,
+            final BooleanSupplier hasMetadataChangePermission) {
         super();
 
+        this.hasMetadataChangePermission = hasMetadataChangePermission;
         this.metaDataComponentBuilder = new MetaDataAddUpdateWindowLayoutComponentBuilder(i18n);
 
         this.metadataKey = metaDataComponentBuilder.createKeyField(binder);
@@ -43,6 +50,16 @@ public class MetaDataAddUpdateWindowLayout extends AbstractEntityWindowLayout<Pr
 
     @Override
     public ComponentContainer getRootComponent() {
+        final VerticalLayout addUpdateLayout = getMetadataAddUpdateLayout();
+
+        if (!hasMetadataChangePermission.getAsBoolean()) {
+            disableMetadataInputComponents();
+        }
+
+        return addUpdateLayout;
+    }
+
+    protected VerticalLayout getMetadataAddUpdateLayout() {
         final VerticalLayout addUpdateLayout = new VerticalLayout();
         addUpdateLayout.setSpacing(true);
         addUpdateLayout.setMargin(false);
@@ -57,11 +74,18 @@ public class MetaDataAddUpdateWindowLayout extends AbstractEntityWindowLayout<Pr
         return addUpdateLayout;
     }
 
+    protected void disableMetadataInputComponents() {
+        metadataKey.setEnabled(false);
+        metadataValue.setEnabled(false);
+    }
+
     /**
      * Enable meta data key
      */
     public void enableMetadataKey() {
-        metadataKey.setEnabled(true);
+        if (hasMetadataChangePermission.getAsBoolean()) {
+            metadataKey.setEnabled(true);
+        }
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/MetaDataWindowGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/MetaDataWindowGrid.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.ui.common.detailslayout;
 
 import java.util.Collection;
+import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
@@ -38,6 +39,7 @@ public class MetaDataWindowGrid<F> extends AbstractGrid<ProxyMetaData, F> implem
     public static final String META_DATA_VALUE_ID = "metaDataValue";
     public static final String META_DATA_DELETE_BUTTON_ID = "metaDataDeleteButton";
 
+    private final transient BooleanSupplier hasMetadataChangePermission;
     private final transient DeleteSupport<ProxyMetaData> metaDataDeleteSupport;
 
     /**
@@ -52,17 +54,20 @@ public class MetaDataWindowGrid<F> extends AbstractGrid<ProxyMetaData, F> implem
      * @param notification
      *            UINotification
      * @param dataProvider
-     *            AbstractMetaDataDataProvider for filter support
+     *            provides entity-specific metadata entities
+     * @param hasMetadataChangePermission
+     *            checks the permission allowing to change metadata entities
      * @param itemsDeletionCallback
-     *            Grid item deletion Call back for event listener
+     *            callback method to delete metadata entities
      *
      */
     public MetaDataWindowGrid(final VaadinMessageSource i18n, final UIEventBus eventBus,
             final SpPermissionChecker permissionChecker, final UINotification notification,
-            final AbstractMetaDataDataProvider<?, F> dataProvider,
+            final AbstractMetaDataDataProvider<?, F> dataProvider, final BooleanSupplier hasMetadataChangePermission,
             final Predicate<Collection<ProxyMetaData>> itemsDeletionCallback) {
         super(i18n, eventBus, permissionChecker);
 
+        this.hasMetadataChangePermission = hasMetadataChangePermission;
         this.metaDataDeleteSupport = new DeleteSupport<>(this, i18n, notification, "caption.metadata",
                 "caption.metadata.plur", ProxyMetaData::getKey, itemsDeletionCallback,
                 UIComponentIdProvider.METADATA_DELETE_CONFIRMATION_DIALOG);
@@ -79,7 +84,7 @@ public class MetaDataWindowGrid<F> extends AbstractGrid<ProxyMetaData, F> implem
 
     @Override
     public String getGridId() {
-        return UIComponentIdProvider.METDATA_WINDOW_TABLE_ID;
+        return UIComponentIdProvider.METADATA_WINDOW_TABLE_ID;
     }
 
     @Override
@@ -91,7 +96,7 @@ public class MetaDataWindowGrid<F> extends AbstractGrid<ProxyMetaData, F> implem
                 .setCaption(i18n.getMessage("header.value")).setHidden(true).setHidable(true);
 
         GridComponentBuilder.addDeleteColumn(this, i18n, META_DATA_DELETE_BUTTON_ID, metaDataDeleteSupport,
-                UIComponentIdProvider.META_DATA_DELET_ICON, e -> permissionChecker.hasDeleteRepositoryPermission());
+                UIComponentIdProvider.META_DATA_DELET_ICON, e -> hasMetadataChangePermission.getAsBoolean());
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/MetadataDetailsGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/MetadataDetailsGrid.java
@@ -83,7 +83,7 @@ public class MetadataDetailsGrid<F> extends AbstractGrid<ProxyMetaData, F> imple
 
     @Override
     public String getGridId() {
-        return typePrefix + "." + UIComponentIdProvider.METDATA_DETAILS_TABLE_ID;
+        return typePrefix + "." + UIComponentIdProvider.METADATA_DETAILS_TABLE_ID;
     }
 
     @Override

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/MetadataWindowGridHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/MetadataWindowGridHeader.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.hawkbit.ui.common.detailslayout;
 
+import java.util.function.BooleanSupplier;
+
 import org.eclipse.hawkbit.ui.SpPermissionChecker;
 import org.eclipse.hawkbit.ui.common.grid.header.AbstractGridHeader;
 import org.eclipse.hawkbit.ui.common.grid.header.support.AddHeaderSupport;
@@ -35,15 +37,18 @@ public class MetadataWindowGridHeader extends AbstractGridHeader {
      *            SpPermissionChecker
      * @param eventBus
      *            UIEventBus
+     * @param hasMetadataChangePermission
+     *            checks the permission allowing to change metadata entities
      * @param addNewItemCallback
-     *            Runnable
+     *            callback method to add new metadata entities
      */
     public MetadataWindowGridHeader(final VaadinMessageSource i18n, final SpPermissionChecker permChecker,
-            final UIEventBus eventBus, final Runnable addNewItemCallback) {
+            final UIEventBus eventBus, final BooleanSupplier hasMetadataChangePermission,
+            final Runnable addNewItemCallback) {
         super(i18n, permChecker, eventBus);
 
-        if (permChecker.hasCreateRepositoryPermission()) {
-            this.addHeaderSupport = new AddHeaderSupport(i18n, UIComponentIdProvider.METADTA_ADD_ICON_ID,
+        if (hasMetadataChangePermission.getAsBoolean()) {
+            this.addHeaderSupport = new AddHeaderSupport(i18n, UIComponentIdProvider.METADATA_ADD_ICON_ID,
                     addNewItemCallback, () -> false);
         } else {
             this.addHeaderSupport = null;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/SoftwareModuleDetailsHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/detailslayout/SoftwareModuleDetailsHeader.java
@@ -96,11 +96,6 @@ public class SoftwareModuleDetailsHeader extends AbstractDetailsHeader<ProxySoft
     }
 
     @Override
-    protected boolean hasEditPermission() {
-        return permChecker.hasUpdateRepositoryPermission();
-    }
-
-    @Override
     protected String getEditIconId() {
         return UIComponentIdProvider.UPLOAD_SW_MODULE_EDIT_BUTTON;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/header/AbstractDetailsHeader.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/header/AbstractDetailsHeader.java
@@ -21,7 +21,7 @@ import org.vaadin.spring.events.EventBus.UIEventBus;
  * Header for entity details with edit and metadata support.
  *
  * @param <T>
- *          Generic type
+ *            Generic type
  */
 public abstract class AbstractDetailsHeader<T> extends AbstractMasterAwareGridHeader<T> {
     private static final long serialVersionUID = 1L;
@@ -37,13 +37,13 @@ public abstract class AbstractDetailsHeader<T> extends AbstractMasterAwareGridHe
      * Constructor for AbstractDetailsHeader
      *
      * @param i18n
-     *          VaadinMessageSource
+     *            VaadinMessageSource
      * @param permChecker
-     *          SpPermissionChecker
+     *            SpPermissionChecker
      * @param eventBus
-     *          UIEventBus
+     *            UIEventBus
      * @param uiNotification
-     *          UINotification
+     *            UINotification
      */
     public AbstractDetailsHeader(final VaadinMessageSource i18n, final SpPermissionChecker permChecker,
             final UIEventBus eventBus, final UINotification uiNotification) {
@@ -53,17 +53,29 @@ public abstract class AbstractDetailsHeader<T> extends AbstractMasterAwareGridHe
 
         if (hasEditPermission()) {
             this.editDetailsHeaderSupport = new EditDetailsHeaderSupport(i18n, getEditIconId(), this::onEdit);
+        } else {
+            this.editDetailsHeaderSupport = null;
+        }
+
+        if (hasMetadataReadPermission()) {
             this.metaDataDetailsHeaderSupport = new MetaDataDetailsHeaderSupport(i18n, getMetaDataIconId(),
                     this::showMetaData);
         } else {
-            this.editDetailsHeaderSupport = null;
             this.metaDataDetailsHeaderSupport = null;
         }
 
         addHeaderSupports(Arrays.asList(editDetailsHeaderSupport, metaDataDetailsHeaderSupport));
     }
 
-    protected abstract boolean hasEditPermission();
+    // can be overriden in child classes for entity-specific permission
+    protected boolean hasEditPermission() {
+        return permChecker.hasUpdateRepositoryPermission();
+    }
+
+    // can be overriden in child classes for entity-specific permission
+    protected boolean hasMetadataReadPermission() {
+        return permChecker.hasReadRepositoryPermission();
+    }
 
     protected abstract String getEditIconId();
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/header/support/AddHeaderSupport.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/grid/header/support/AddHeaderSupport.java
@@ -35,13 +35,13 @@ public class AddHeaderSupport implements HeaderSupport {
      * Constructor for AddHeaderSupport
      *
      * @param i18n
-     *          AddHeaderSupport
+     *            VaadinMessageSource
      * @param addIconId
-     *          Add icon id
+     *            Add icon id
      * @param addItemCallback
-     *          Runnable
+     *            callback method to add new entities
      * @param maximizedStateSupplier
-     *          BooleanSupplier
+     *            provides the max/min state of the grid
      */
     public AddHeaderSupport(final VaadinMessageSource i18n, final String addIconId, final Runnable addItemCallback,
             final BooleanSupplier maximizedStateSupplier) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DsMetaDataWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/distributions/dstable/DsMetaDataWindowLayout.java
@@ -69,9 +69,9 @@ public class DsMetaDataWindowLayout extends AbstractMetaDataWindowLayout<Long> {
         this.entityFactory = entityFactory;
 
         this.dsMetaDataWindowGrid = new MetaDataWindowGrid<>(i18n, eventBus, permChecker, uiNotification,
-                new DsMetaDataDataProvider(dsManagement), this::deleteMetaData);
+                new DsMetaDataDataProvider(dsManagement), this::hasMetadataChangePermission, this::deleteMetaData);
 
-        this.metaDataAddUpdateWindowLayout = new MetaDataAddUpdateWindowLayout(i18n);
+        this.metaDataAddUpdateWindowLayout = new MetaDataAddUpdateWindowLayout(i18n, this::hasMetadataChangePermission);
         this.addDsMetaDataWindowController = new AddMetaDataWindowController(i18n, uiNotification,
                 metaDataAddUpdateWindowLayout, this::createMetaData, this::isDuplicate);
         this.updateDsMetaDataWindowController = new UpdateMetaDataWindowController(i18n, uiNotification,

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetDetails.java
@@ -87,7 +87,7 @@ public class TargetDetails extends AbstractGridDetailsLayout<ProxyTarget> {
                 new SimpleEntry<>(i18n.getMessage("caption.tags.tab"), getTargetTagToken().getTagPanel()),
                 new SimpleEntry<>(i18n.getMessage("caption.logs.tab"), logDetails)));
 
-        if (permissionChecker.hasCreateRepositoryPermission()) {
+        if (permissionChecker.hasReadRepositoryPermission()) {
             this.targetMetadataGrid = new MetadataDetailsGrid<>(i18n, eventBus,
                     UIComponentIdProvider.TARGET_TYPE_PREFIX, this::showMetadataDetails,
                     new TargetMetaDataDataProvider(targetManagement));

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetMetaDataWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetMetaDataWindowLayout.java
@@ -70,9 +70,10 @@ public class TargetMetaDataWindowLayout extends AbstractMetaDataWindowLayout<Str
         this.entityFactory = entityFactory;
 
         this.targetMetaDataWindowGrid = new MetaDataWindowGrid<>(i18n, eventBus, permChecker, uiNotification,
-                new TargetMetaDataDataProvider(targetManagement), this::deleteMetaData);
+                new TargetMetaDataDataProvider(targetManagement), this::hasMetadataChangePermission,
+                this::deleteMetaData);
 
-        this.metaDataAddUpdateWindowLayout = new MetaDataAddUpdateWindowLayout(i18n);
+        this.metaDataAddUpdateWindowLayout = new MetaDataAddUpdateWindowLayout(i18n, this::hasMetadataChangePermission);
         this.addTargetMetaDataWindowController = new AddMetaDataWindowController(i18n, uiNotification,
                 metaDataAddUpdateWindowLayout, this::createMetaData, this::isDuplicate);
         this.updateTargetMetaDataWindowController = new UpdateMetaDataWindowController(i18n, uiNotification,

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UIComponentIdProvider.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UIComponentIdProvider.java
@@ -1244,15 +1244,15 @@ public final class UIComponentIdProvider {
     /**
      * Metadata add icon id.
      */
-    public static final String METADTA_ADD_ICON_ID = "metadata.add.icon.id";
+    public static final String METADATA_ADD_ICON_ID = "metadata.add.icon.id";
     /**
      * Metadata details table id.
      */
-    public static final String METDATA_DETAILS_TABLE_ID = "metadata.details.table.id";
+    public static final String METADATA_DETAILS_TABLE_ID = "metadata.details.table.id";
     /**
      * Metadata window table id.
      */
-    public static final String METDATA_WINDOW_TABLE_ID = "metadata.window.table.id";
+    public static final String METADATA_WINDOW_TABLE_ID = "metadata.window.table.id";
 
     /**
      * Distribution set table - Manage metadata id.


### PR DESCRIPTION
Restructuring of UI permissions required for reading/changing the metadata according to management permissions definitions. Previously Metadata was not visible under Target Details in Deployment View du to wrongly configured "Create Repository" permission instead of "Read repository". Additionally for creating/deleting the metadata entries "Update Repository" permission are used that corresponds to the Management layer.