### PR TITLE
JDK 11 build support for hawkBit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
       <!-- Misc libraries versions - START -->
       <cron-utils.version>5.0.5</cron-utils.version>
       <jsoup.version>1.11.2</jsoup.version>
-      <allure.version>2.7.0</allure.version>
+      <allure.version>2.13.6</allure.version>
       <eclipselink.version>2.7.3</eclipselink.version>
       <gwtmockito.version>1.1.8</gwtmockito.version>
       <guava.version>25.0-jre</guava.version>


### PR DESCRIPTION
This is the final missing piece to build hawkBit (source level 8) on JDK 11 without test failures  