### PR TITLE
Java 11 support for hawkBit

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/pom.xml
+++ b/hawkbit-repository/hawkbit-repository-jpa/pom.xml
@@ -129,7 +129,7 @@
                   <!--  
                         Required for Java 11 since plugin uses older version (4.8.21) 
                         which suffer from NPE while weaving. We require at least 4.8.48
-                        see: https://github.com/classgraph/classgraph/issues/370 
+                        see: https://github.com/ethlo/eclipselink-maven-plugin/issues/31 
                   -->
                   <groupId>io.github.classgraph</groupId>
                   <artifactId>classgraph</artifactId>

--- a/hawkbit-repository/hawkbit-repository-jpa/pom.xml
+++ b/hawkbit-repository/hawkbit-repository-jpa/pom.xml
@@ -20,10 +20,9 @@
    <name>hawkBit :: Repository :: JPA Implementation</name>
 
    <properties>
-      <javassist.version>3.20.0-GA</javassist.version>
-      <jaxb.api.version>2.3.0</jaxb.api.version>
-      <javax.annotation.version>1.3.1</javax.annotation.version>
       <apt.source.dir>${project.build.directory}/generated-sources/apt/</apt.source.dir>
+      <classgraph.version>4.8.90</classgraph.version>
+      <eclipselink.maven.plugin.version>2.7.5.1</eclipselink.maven.plugin.version>
    </properties>
 
    <dependencies>
@@ -97,7 +96,7 @@
          <plugin>
             <groupId>com.ethlo.persistence.tools</groupId>
             <artifactId>eclipselink-maven-plugin</artifactId>
-            <version>2.7.1.1</version>
+            <version>${eclipselink.maven.plugin.version}</version>
             <executions>
                <execution>
                   <id>modelgen</id>
@@ -118,25 +117,24 @@
             </configuration>
             <dependencies>
                <dependency>
-                  <groupId>javax.xml.bind</groupId>
-                  <artifactId>jaxb-api</artifactId>
-                  <version>${jaxb.api.version}</version>
-               </dependency>
-               <dependency>
+                  <!-- 
+                      Required for Java 11 since plugin version is build on
+                      EclipseLink 2.7.5 (which doesn't have latest fixes for Java 11) 
+                   -->
                   <groupId>org.eclipse.persistence</groupId>
                   <artifactId>org.eclipse.persistence.jpa</artifactId>
                   <version>${eclipselink.version}</version>
                </dependency>
                <dependency>
-                  <groupId>org.javassist</groupId>
-                  <artifactId>javassist</artifactId>
-                  <version>${javassist.version}</version>
-               </dependency>
-               <dependency>
-                  <groupId>javax.annotation</groupId>
-                  <artifactId>javax.annotation-api</artifactId>
-                  <version>${javax.annotation.version}</version>
-               </dependency>
+                  <!--  
+                        Required for Java 11 since plugin uses older version (4.8.21) 
+                        which suffer from NPE while weaving. We require at least 4.8.48
+                        see: https://github.com/classgraph/classgraph/issues/370 
+                  -->
+                  <groupId>io.github.classgraph</groupId>
+                  <artifactId>classgraph</artifactId>
+                  <version>${classgraph.version}</version>
+                </dependency>
             </dependencies>
          </plugin>
          <plugin>

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -16,7 +16,6 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -161,7 +160,7 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
     @MapKeyColumn(name = "attribute_key", nullable = false, length = Target.CONTROLLER_ATTRIBUTE_KEY_SIZE)
     @CollectionTable(name = "sp_target_attributes", joinColumns = {
             @JoinColumn(name = "target_id", nullable = false, updatable = false) }, foreignKey = @ForeignKey(value = ConstraintMode.CONSTRAINT, name = "fk_targ_attrib_target"))
-    private final Map<String, String> controllerAttributes = Collections.synchronizedMap(new HashMap<String, String>());
+    private Map<String, String> controllerAttributes;
 
     // set default request controller attributes to true, because we want to
     // request them the first

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,11 @@
    </repositories>
 
    <properties>
+            
       <java.version>1.8</java.version>
+      <!--       Developer preview         -->
+      <!-- <java.version>11</java.version> -->
+
       <spring.boot.version>2.1.4.RELEASE</spring.boot.version>
       <spring.cloud.version>Greenwich.RELEASE</spring.cloud.version>
 
@@ -162,8 +166,8 @@
       <!-- Misc libraries versions - START -->
       <cron-utils.version>5.0.5</cron-utils.version>
       <jsoup.version>1.11.2</jsoup.version>
-      <allure.version>2.7.0</allure.version>
-      <eclipselink.version>2.7.3</eclipselink.version>
+      <allure.version>2.13.6</allure.version>
+      <eclipselink.version>2.7.7</eclipselink.version>
       <gwtmockito.version>1.1.8</gwtmockito.version>
       <guava.version>25.0-jre</guava.version>
       <javax.el-api.version>2.2.4</javax.el-api.version>


### PR DESCRIPTION
Changes allow to bump Java source level from `8` to `11` passing all tests on JDK 11. 
However I do not enforce the switch to Java 11 yet (cf. [Java 11 roadmap](https://github.com/eclipse/hawkbit/issues/955)).

Main changes:

* Latest stable EclipseLink version fixing invalid JPA type serialization
* Fixed compiler and JPA spec violation which is enforced since Java 9 (cf. [JDK-8157181](https://bugs.openjdk.java.net/browse/JDK-8157181))
* Fixed NPE in `eclipselink-maven-plugin` while parsing JPA annotations