### PR TITLE
Increase cronutils version

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/MaintenanceScheduleHelper.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/MaintenanceScheduleHelper.java
@@ -58,7 +58,7 @@ public final class MaintenanceScheduleHelper {
      * @return { @link Optional<ZonedDateTime>} of the next available window. In
      *         case there is none, or there are maintenance window validation
      *         errors, returns empty value.
-     * 
+     *
      */
     // Exception squid:S1166 - if there are validation error(format of cron
     // expression or duration is wrong), we simply return empty value
@@ -69,8 +69,7 @@ public final class MaintenanceScheduleHelper {
             final ExecutionTime scheduleExecutor = ExecutionTime.forCron(getCronFromExpression(cronSchedule));
             final ZonedDateTime now = ZonedDateTime.now(ZoneOffset.of(timezone));
             final ZonedDateTime after = now.minus(convertToISODuration(duration));
-            final ZonedDateTime next = scheduleExecutor.nextExecution(after);
-            return Optional.of(next);
+            return scheduleExecutor.nextExecution(after);
         } catch (final RuntimeException ignored) {
             return Optional.empty();
         }
@@ -85,7 +84,7 @@ public final class MaintenanceScheduleHelper {
      *            year".
      *
      * @return {@link Cron} object, that corresponds to the expression.
-     * 
+     *
      * @throws IllegalArgumentException
      *             if the cron expression doesn't have a valid format.
      */

--- a/pom.xml
+++ b/pom.xml
@@ -163,8 +163,8 @@
       <maven.processor.plugin.version>3.3.3</maven.processor.plugin.version>
       <maven.scm.plugin.version>1.11.1</maven.scm.plugin.version>
 
-      <!-- Misc libraries versions - START -->
-      <cron-utils.version>5.0.5</cron-utils.version>
+      <!-- Misc libraries versions - START -->      
+      <cron-utils.version>9.1.3</cron-utils.version>
       <jsoup.version>1.11.2</jsoup.version>
       <allure.version>2.13.6</allure.version>
       <eclipselink.version>2.7.7</eclipselink.version>


### PR DESCRIPTION
CVE-2020-26238 is fixed with cron-utils 9.1.3

Signed-off-by: Markus Block <markus.block@bosch-si.com>