### PR TITLE
Show Controller ID within target, filter and rollouts view

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/builder/GridComponentBuilder.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/builder/GridComponentBuilder.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.ui.common.data.proxies.ProxyIdentifiableEntity;
 import org.eclipse.hawkbit.ui.common.data.proxies.ProxyNamedEntity;
+import org.eclipse.hawkbit.ui.common.data.proxies.ProxyTarget;
 import org.eclipse.hawkbit.ui.common.grid.support.DeleteSupport;
 import org.eclipse.hawkbit.ui.utils.SPUIStyleDefinitions;
 import org.eclipse.hawkbit.ui.utils.UIMessageIdProvider;
@@ -118,6 +119,22 @@ public final class GridComponentBuilder {
     public static <E extends ProxyNamedEntity> Column<E, String> addNameColumn(final Grid<E> grid,
             final VaadinMessageSource i18n, final String columnId) {
         return addColumn(i18n, grid, E::getName, "header.name", columnId, 100D);
+    }
+
+    /**
+     * Add controllerId column to grid
+     *
+     * @param grid
+     *            to add the column to
+     * @param i18n
+     *            message source for internationalization
+     * @param columnId
+     *            column ID
+     * @return the created column
+     */
+    public static Column<ProxyTarget, String> addControllerIdColumn(final Grid<ProxyTarget> grid,
+            final VaadinMessageSource i18n, final String columnId) {
+        return addColumn(i18n, grid, ProxyTarget::getControllerId, "header.controllerId", columnId, 100D);
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/builder/GridComponentBuilder.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/builder/GridComponentBuilder.java
@@ -41,6 +41,8 @@ import com.vaadin.ui.themes.ValoTheme;
  * Builder class for grid components
  */
 public final class GridComponentBuilder {
+    public static final double DEFAULT_MIN_WIDTH = 100D;
+
     public static final String CREATED_BY_ID = "createdBy";
     public static final String CREATED_DATE_ID = "createdDate";
     public static final String MODIFIED_BY_ID = "modifiedBy";
@@ -118,7 +120,7 @@ public final class GridComponentBuilder {
      */
     public static <E extends ProxyNamedEntity> Column<E, String> addNameColumn(final Grid<E> grid,
             final VaadinMessageSource i18n, final String columnId) {
-        return addColumn(i18n, grid, E::getName, "header.name", columnId, 100D);
+        return addColumn(i18n, grid, E::getName, "header.name", columnId, DEFAULT_MIN_WIDTH);
     }
 
     /**
@@ -134,7 +136,7 @@ public final class GridComponentBuilder {
      */
     public static Column<ProxyTarget, String> addControllerIdColumn(final Grid<ProxyTarget> grid,
             final VaadinMessageSource i18n, final String columnId) {
-        return addColumn(i18n, grid, ProxyTarget::getControllerId, "header.controllerId", columnId, 100D);
+        return addColumn(i18n, grid, ProxyTarget::getControllerId, "header.controllerId", columnId, DEFAULT_MIN_WIDTH);
     }
 
     /**
@@ -152,7 +154,7 @@ public final class GridComponentBuilder {
      */
     public static <E extends ProxyNamedEntity> Column<E, String> addDescriptionColumn(final Grid<E> grid,
             final VaadinMessageSource i18n, final String columnId) {
-        return addColumn(i18n, grid, E::getDescription, "header.description", columnId, 100D);
+        return addColumn(i18n, grid, E::getDescription, "header.description", columnId, DEFAULT_MIN_WIDTH);
     }
 
     /**
@@ -169,10 +171,10 @@ public final class GridComponentBuilder {
     public static <E extends ProxyNamedEntity> List<Column<E, String>> addCreatedAndModifiedColumns(final Grid<E> grid,
             final VaadinMessageSource i18n) {
         final List<Column<E, String>> columns = new ArrayList<>();
-        columns.add(addColumn(i18n, grid, E::getCreatedBy, "header.createdBy", CREATED_BY_ID, 100D));
-        columns.add(addColumn(i18n, grid, E::getCreatedDate, "header.createdDate", CREATED_DATE_ID, 100D));
-        columns.add(addColumn(i18n, grid, E::getLastModifiedBy, "header.modifiedBy", MODIFIED_BY_ID, 100D));
-        columns.add(addColumn(i18n, grid, E::getModifiedDate, "header.modifiedDate", MODIFIED_DATE_ID, 100D));
+        columns.add(addColumn(i18n, grid, E::getCreatedBy, "header.createdBy", CREATED_BY_ID, DEFAULT_MIN_WIDTH));
+        columns.add(addColumn(i18n, grid, E::getCreatedDate, "header.createdDate", CREATED_DATE_ID, DEFAULT_MIN_WIDTH));
+        columns.add(addColumn(i18n, grid, E::getLastModifiedBy, "header.modifiedBy", MODIFIED_BY_ID, DEFAULT_MIN_WIDTH));
+        columns.add(addColumn(i18n, grid, E::getModifiedDate, "header.modifiedDate", MODIFIED_DATE_ID, DEFAULT_MIN_WIDTH));
         return columns;
     }
 
@@ -193,7 +195,7 @@ public final class GridComponentBuilder {
      */
     public static <E> Column<E, String> addVersionColumn(final Grid<E> grid, final VaadinMessageSource i18n,
             final ValueProvider<E, String> valueProvider, final String columnId) {
-        return addColumn(i18n, grid, valueProvider, "header.version", columnId, 100D);
+        return addColumn(i18n, grid, valueProvider, "header.version", columnId, DEFAULT_MIN_WIDTH);
     }
 
     private static <E, T> Column<E, T> addColumn(final VaadinMessageSource i18n, final Grid<E> grid,

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterTargetGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterTargetGrid.java
@@ -27,6 +27,7 @@ import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 public class TargetFilterTargetGrid extends AbstractGrid<ProxyTarget, String> {
     private static final long serialVersionUID = 1L;
 
+    private static final String TARGET_CONTROLLER_ID = "controllerId";
     private static final String TARGET_NAME_ID = "targetName";
     private static final String TARGET_DESCRIPTION_ID = "targetDescription";
     private static final String TARGET_STATUS_ID = "targetStatus";
@@ -72,6 +73,8 @@ public class TargetFilterTargetGrid extends AbstractGrid<ProxyTarget, String> {
 
     @Override
     public void addColumns() {
+        addControllerIdColumn();
+
         GridComponentBuilder.addNameColumn(this, i18n, TARGET_NAME_ID);
 
         GridComponentBuilder.addDescriptionColumn(this, i18n, TARGET_DESCRIPTION_ID);
@@ -82,5 +85,10 @@ public class TargetFilterTargetGrid extends AbstractGrid<ProxyTarget, String> {
         GridComponentBuilder.addCreatedAndModifiedColumns(this, i18n);
 
         getColumns().forEach(column -> column.setHidable(true));
+    }
+
+    private Column<ProxyTarget, String> addControllerIdColumn() {
+        return GridComponentBuilder.addColumn(this, ProxyTarget::getControllerId).setId(TARGET_CONTROLLER_ID)
+                .setCaption(i18n.getMessage("header.controllerId"));
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterTargetGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/TargetFilterTargetGrid.java
@@ -27,7 +27,7 @@ import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 public class TargetFilterTargetGrid extends AbstractGrid<ProxyTarget, String> {
     private static final long serialVersionUID = 1L;
 
-    private static final String TARGET_CONTROLLER_ID = "controllerId";
+    private static final String TARGET_CONTROLLER_ID = "targetControllerId";
     private static final String TARGET_NAME_ID = "targetName";
     private static final String TARGET_DESCRIPTION_ID = "targetDescription";
     private static final String TARGET_STATUS_ID = "targetStatus";
@@ -73,7 +73,7 @@ public class TargetFilterTargetGrid extends AbstractGrid<ProxyTarget, String> {
 
     @Override
     public void addColumns() {
-        addControllerIdColumn();
+        GridComponentBuilder.addControllerIdColumn(this, i18n, TARGET_CONTROLLER_ID);
 
         GridComponentBuilder.addNameColumn(this, i18n, TARGET_NAME_ID);
 
@@ -87,8 +87,4 @@ public class TargetFilterTargetGrid extends AbstractGrid<ProxyTarget, String> {
         getColumns().forEach(column -> column.setHidable(true));
     }
 
-    private Column<ProxyTarget, String> addControllerIdColumn() {
-        return GridComponentBuilder.addColumn(this, ProxyTarget::getControllerId).setId(TARGET_CONTROLLER_ID)
-                .setCaption(i18n.getMessage("header.controllerId"));
-    }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetGrid.java
@@ -73,7 +73,7 @@ public class TargetGrid extends AbstractGrid<ProxyTarget, TargetManagementFilter
     private static final long serialVersionUID = 1L;
 
     private static final String TARGET_STATUS_ID = "targetStatus";
-    private static final String TARGET_CONTROLLER_ID = "controllerId";
+    private static final String TARGET_CONTROLLER_ID = "targetControllerId";
     private static final String TARGET_NAME_ID = "targetName";
     private static final String TARGET_POLLING_STATUS_ID = "targetPolling";
     private static final String TARGET_DESC_ID = "targetDescription";
@@ -312,8 +312,7 @@ public class TargetGrid extends AbstractGrid<ProxyTarget, TargetManagementFilter
     }
 
     private Column<ProxyTarget, String> addControllerIdColumn() {
-        return GridComponentBuilder.addColumn(this, ProxyTarget::getControllerId).setId(TARGET_CONTROLLER_ID)
-                .setCaption(i18n.getMessage("header.controllerId"));
+        return GridComponentBuilder.addControllerIdColumn(this, i18n, TARGET_CONTROLLER_ID);
     }
 
     private Column<ProxyTarget, String> addNameColumn() {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/management/targettable/TargetGrid.java
@@ -73,6 +73,7 @@ public class TargetGrid extends AbstractGrid<ProxyTarget, TargetManagementFilter
     private static final long serialVersionUID = 1L;
 
     private static final String TARGET_STATUS_ID = "targetStatus";
+    private static final String TARGET_CONTROLLER_ID = "controllerId";
     private static final String TARGET_NAME_ID = "targetName";
     private static final String TARGET_POLLING_STATUS_ID = "targetPolling";
     private static final String TARGET_DESC_ID = "targetDescription";
@@ -310,6 +311,11 @@ public class TargetGrid extends AbstractGrid<ProxyTarget, TargetManagementFilter
                 Arrays.asList(addPinColumn(), addDeleteColumn()));
     }
 
+    private Column<ProxyTarget, String> addControllerIdColumn() {
+        return GridComponentBuilder.addColumn(this, ProxyTarget::getControllerId).setId(TARGET_CONTROLLER_ID)
+                .setCaption(i18n.getMessage("header.controllerId"));
+    }
+
     private Column<ProxyTarget, String> addNameColumn() {
         return GridComponentBuilder.addNameColumn(this, i18n, TARGET_NAME_ID);
     }
@@ -340,6 +346,7 @@ public class TargetGrid extends AbstractGrid<ProxyTarget, TargetManagementFilter
     @Override
     protected void addMaxColumns() {
         addNameColumn().setExpandRatio(2);
+        addControllerIdColumn().setExpandRatio(2);
 
         GridComponentBuilder.addDescriptionColumn(this, i18n, TARGET_DESC_ID).setExpandRatio(2);
         GridComponentBuilder.addCreatedAndModifiedColumns(this, i18n);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetGrid.java
@@ -30,7 +30,7 @@ import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 public class RolloutGroupTargetGrid extends AbstractGrid<ProxyTarget, Long> {
     private static final long serialVersionUID = 1L;
 
-    private static final String TARGET_CONTROLLER_ID = "controllerId";
+    private static final String TARGET_CONTROLLER_ID = "targetControllerId";
 
     private final RolloutManagementUIState rolloutManagementUIState;
 
@@ -67,7 +67,7 @@ public class RolloutGroupTargetGrid extends AbstractGrid<ProxyTarget, Long> {
 
     @Override
     public void addColumns() {
-        addControllerIdColumn().setExpandRatio(2);
+        GridComponentBuilder.addControllerIdColumn(this, i18n, TARGET_CONTROLLER_ID).setExpandRatio(2);
 
         GridComponentBuilder.addNameColumn(this, i18n, SPUILabelDefinitions.VAR_NAME).setExpandRatio(2);
 
@@ -96,8 +96,4 @@ public class RolloutGroupTargetGrid extends AbstractGrid<ProxyTarget, Long> {
         return masterEntitySupport;
     }
 
-    private Column<ProxyTarget, String> addControllerIdColumn() {
-        return GridComponentBuilder.addColumn(this, ProxyTarget::getControllerId).setId(TARGET_CONTROLLER_ID)
-                .setCaption(i18n.getMessage("header.controllerId"));
-    }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetGrid.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/rolloutgrouptargets/RolloutGroupTargetGrid.java
@@ -30,6 +30,8 @@ import org.eclipse.hawkbit.ui.utils.UIComponentIdProvider;
 public class RolloutGroupTargetGrid extends AbstractGrid<ProxyTarget, Long> {
     private static final long serialVersionUID = 1L;
 
+    private static final String TARGET_CONTROLLER_ID = "controllerId";
+
     private final RolloutManagementUIState rolloutManagementUIState;
 
     private final RolloutActionStatusIconSupplier<ProxyTarget> actionStatusIconSupplier;
@@ -65,9 +67,11 @@ public class RolloutGroupTargetGrid extends AbstractGrid<ProxyTarget, Long> {
 
     @Override
     public void addColumns() {
-        GridComponentBuilder.addNameColumn(this, i18n, SPUILabelDefinitions.VAR_NAME).setExpandRatio(3);
+        addControllerIdColumn().setExpandRatio(2);
 
-        GridComponentBuilder.addDescriptionColumn(this, i18n, SPUILabelDefinitions.VAR_DESC).setExpandRatio(3);
+        GridComponentBuilder.addNameColumn(this, i18n, SPUILabelDefinitions.VAR_NAME).setExpandRatio(2);
+
+        GridComponentBuilder.addDescriptionColumn(this, i18n, SPUILabelDefinitions.VAR_DESC).setExpandRatio(2);
 
         GridComponentBuilder.addIconColumn(this, actionStatusIconSupplier::getLabel, SPUILabelDefinitions.VAR_STATUS,
                 i18n.getMessage("header.status"));
@@ -90,5 +94,10 @@ public class RolloutGroupTargetGrid extends AbstractGrid<ProxyTarget, Long> {
      */
     public MasterEntitySupport<ProxyRolloutGroup> getMasterEntitySupport() {
         return masterEntitySupport;
+    }
+
+    private Column<ProxyTarget, String> addControllerIdColumn() {
+        return GridComponentBuilder.addColumn(this, ProxyTarget::getControllerId).setId(TARGET_CONTROLLER_ID)
+                .setCaption(i18n.getMessage("header.controllerId"));
     }
 }

--- a/hawkbit-ui/src/main/resources/messages.properties
+++ b/hawkbit-ui/src/main/resources/messages.properties
@@ -642,6 +642,7 @@ calendar.second=second
 calendar.seconds=seconds
 
 header.name = Name
+header.controllerId = Controller ID
 header.vendor = Vendor
 header.version = Version
 header.description = Description


### PR DESCRIPTION
Add the controllerId column to the targetGrid of the deployment, rollout target and filter search result view.

Signed-off-by: Michael Herdt <Michael.Herdt@bosch.io>