### PR TITLE
Isolation level datasource configuration

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -95,6 +95,7 @@ import org.eclipse.hawkbit.tenancy.TenantAware;
 import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -155,7 +156,17 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
         super(dataSource, properties, jtaTransactionManagerProvider, transactionManagerCustomizers);
     }
 
+    /**
+     * Datasource configuration that adapts the connection properties based on
+     * the configured Spring transaction's isolation level and readOnly flag.
+     * Used to fix read-only database connections by EclipseLink for read
+     * replication (see
+     * https://github.com/spring-projects/spring-framework/issues/12547).
+     *
+     */
     @Configuration
+    @ConditionalOnClass(HikariDataSource.class)
+    @ConditionalOnProperty(prefix = "hawkbit.datasource.isolation.level", name = "enabled", matchIfMissing = false)
     static class IsolationLevelDataSourceConfig {
 
         @Bean

--- a/hawkbit-runtime/hawkbit-update-server/pom.xml
+++ b/hawkbit-runtime/hawkbit-update-server/pom.xml
@@ -83,6 +83,7 @@
       <dependency>
          <groupId>org.mariadb.jdbc</groupId>
          <artifactId>mariadb-java-client</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.eclipse.hawkbit</groupId>

--- a/hawkbit-runtime/hawkbit-update-server/pom.xml
+++ b/hawkbit-runtime/hawkbit-update-server/pom.xml
@@ -83,7 +83,6 @@
       <dependency>
          <groupId>org.mariadb.jdbc</groupId>
          <artifactId>mariadb-java-client</artifactId>
-         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.eclipse.hawkbit</groupId>


### PR DESCRIPTION
Due to a shared cache concept implementation of EclipseLink read only database connections are not being established correctly for replicated MySQL systems: https://github.com/spring-projects/spring-framework/issues/12547. This PR introduces optional configuration override to wrap the HikariDatasource into IsolationLevelDataSourceAdapter that sets Spring transaction's isolation level as well as readOnly flag directly on underlying connection for each DB request.