### PR TITLE
Fix database migration scripts

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_16__add_action_initiated_by___DB2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_16__add_action_initiated_by___DB2.sql
@@ -1,2 +1,3 @@
-ALTER TABLE sp_action ADD COLUMN initiated_by VARCHAR(64) NOT NULL;
+ALTER TABLE sp_action ADD COLUMN initiated_by VARCHAR(64) NOT NULL DEFAULT '';
+ALTER TABLE sp_action ALTER COLUMN initiated_by DROP DEFAULT;
 ALTER TABLE sp_target_filter_query ADD COLUMN auto_assign_initiated_by VARCHAR(64);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_16__add_action_initiated_by___POSTGRESQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_16__add_action_initiated_by___POSTGRESQL.sql
@@ -1,5 +1,7 @@
 ALTER TABLE sp_action
-ADD COLUMN initiated_by VARCHAR (64) NOT NULL;
+ADD COLUMN initiated_by VARCHAR (64) NOT NULL DEFAULT '';
+ALTER TABLE sp_action
+ALTER COLUMN initiated_by DROP DEFAULT;
 
 ALTER TABLE sp_target_filter_query
 ADD COLUMN auto_assign_initiated_by VARCHAR (64);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_16__add_action_initiated_by___SQL_SERVER.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_16__add_action_initiated_by___SQL_SERVER.sql
@@ -1,2 +1,3 @@
-ALTER TABLE sp_action ADD initiated_by VARCHAR(64) NOT NULL;
+ALTER TABLE sp_action ADD initiated_by VARCHAR(64) NOT NULL CONSTRAINT DF_SpAction_InitiatedBy DEFAULT '';
+ALTER TABLE sp_action DROP CONSTRAINT DF_SpAction_InitiatedBy;
 ALTER TABLE sp_target_filter_query ADD auto_assign_initiated_by VARCHAR(64);


### PR DESCRIPTION
There is a bug in the database migration scripts version 1_12_16 for PostgreSQL, Microsoft SQL Server and DB2.
The script for DB2 does not work, the scripts for PostgreSQL and Microsoft SQL Server only work if the sp_action table is empty. The reason is that a column was added that does not allow a null value, which results in an error.
To fix that a default value was added to the column. The default value is an empty string and the default is removed from the column after is is created. That way we get the same behaviour that we have when using MySQL.