### PR TITLE
Do not accept valid token headers by default

### DIFF
--- a/hawkbit-runtime/hawkbit-update-server/src/main/resources/application.properties
+++ b/hawkbit-runtime/hawkbit-update-server/src/main/resources/application.properties
@@ -14,8 +14,8 @@ spring.main.allow-bean-definition-overriding=true
 
 # DDI authentication configuration
 hawkbit.server.ddi.security.authentication.anonymous.enabled=false
-hawkbit.server.ddi.security.authentication.targettoken.enabled=true
-hawkbit.server.ddi.security.authentication.gatewaytoken.enabled=true
+hawkbit.server.ddi.security.authentication.targettoken.enabled=false
+hawkbit.server.ddi.security.authentication.gatewaytoken.enabled=false
 
 # Optional events
 hawkbit.server.repository.publish-target-poll-event=false


### PR DESCRIPTION
The default DDI configuration excepted valid target and gateway token headers even the option to allow them was not set explicitly within settings menu of the management UI. Documentation clearly state that both need to be enabled first  

Fixes #1066