### PR TITLE
Permission matrix updated

### DIFF
--- a/docs/content/concepts/authorization.md
+++ b/docs/content/concepts/authorization.md
@@ -12,7 +12,9 @@ However, keep in mind that hawkBit does not offer an off the shelf authenticatio
 The default implementation is single user/tenant with basic auth and the logged in user is provided with all permissions. Additionally, the application properties may be configured for multiple static users; see [Multiple Users](#multiple-users) for details.
 
 ## DDI API
+
 An authenticated target is permitted to:
+
 - retrieve commands from the server
 - provide feedback to the the server
 - download artifacts that are assigned to it
@@ -22,6 +24,7 @@ A target might be permitted to download artifacts without authentication (if ena
 ## Management API and UI
 
 ### Multiple Users
+
 hawkBit optionally supports configuring multiple static users through the application properties. In this case, the user and password Spring security properties are ignored.
 An example configuration is given below.
 
@@ -42,6 +45,7 @@ An example configuration is given below.
 A permissions value of `ALL` will provide that user with all possible permissions. Passwords need to be specified with the used password encoder in brackets. In this example, `noop` is used as the plaintext encoder. For production use, it is recommended to use a hash function designed for passwords such as *bcrypt*. See this [blog post](https://spring.io/blog/2017/11/01/spring-security-5-0-0-rc1-released#password-storage-format) for more information on password encoders in Spring Security.
 
 ### OpenID Connect
+
 hawkbit supports authentication providers which use the OpenID Connect standard, an authentication layer built on top of the OAuth 2.0 protocol.
 An example configuration is given below.
 
@@ -54,6 +58,7 @@ An example configuration is given below.
     spring.security.oauth2.client.provider.oidc.jwk-set-uri=https://oidc-provider/jwk-set-uri
 
 ### Delivered Permissions
+
 - READ_/UPDATE_/CREATE_/DELETE_TARGETS for:
   - Target entities including metadata (that includes also the installed and assigned distribution sets)
   - Target tags
@@ -77,18 +82,19 @@ An example configuration is given below.
 - TENANT_CONFIGURATION
   - Permission to administrate the tenant settings.
 
-- ROLLOUT_MANAGEMENT
-  - Permission to provision targets through rollouts.
+- READ_/UPDATE_/CREATE_/DELETE_/HANDLE_/APPROVE_ROLLOUT for:
+  - Managing rollouts and provision targets through a rollout.
 
 ### Permission Matrix for example uses cases that need more than one permission
 
 Use Case                                                                   | Needed permissions
--------------------------------------------------------------------------- | --------------------------------------------------
-Search _targets_ by installed or assigned _distribution set_               | READ_TARGET, READ_REPOSITORY
+-------------------------------------------------------------------------- | ---------------------------------------------------------------------------
+Search _targets_ by installed or assigned _distribution set_               | READ_REPOSITORY, READ_TARGET
 Assign _DS_ to a _target_                                                  | READ_REPOSITORY, UPDATE_TARGET
-Assign DS to target through a _Rollout_, i.e. _Rollout_ creation and start | READ_REPOSITORY, UPDATE_TARGET, ROLLOUT_MANAGEMENT
-Read _Rollout_ status including its _deployment groups_                    | ROLLOUT_MANAGEMENT
-Checks _targets_ inside _Rollout deployment group_                         | READ_TARGET, ROLLOUT_MANAGEMENT
+Assign DS to target through a _Rollout_, i.e. _Rollout_ creation and start | READ_REPOSITORY, READ_TARGET, READ_ROLLOUT, CREATE_ROLLOUT, HANDLE_ROLLOUT
+Read _Rollout_ status including its _deployment groups_                    | READ_REPOSITORY, READ_ROLLOUT
+Checks _targets_ inside _Rollout deployment group_                         | READ_REPOSITORY, READ_TARGET, READ_ROLLOUT
 
 ## Device Management Federation API
+
 The provided _RabbitMQ_ [vhost and user](https://www.rabbitmq.com/access-control.html) should be provided with the necessary permissions to send messages to hawkBit through the exchange and receive messages from it through the specified queue.


### PR DESCRIPTION
Fixed non-existing `ROLLOUT_MANAGEMENT` permission and updated use case table accordingly 

Fixes https://github.com/eclipse/hawkbit/issues/966