### PR TITLE
Feature/speedup quota tests

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutEventTest.java
@@ -39,7 +39,7 @@ public class RolloutEventTest extends AbstractRemoteEntityEventTest<Rollout> {
 
         return rolloutManagement.create(
                 entityFactory.rollout().create().name("exampleRollout").targetFilterQuery("controllerId==*").set(ds),
-                10, new RolloutGroupConditionBuilder().withDefaults()
+                5, new RolloutGroupConditionBuilder().withDefaults()
                         .successCondition(RolloutGroupSuccessCondition.THRESHOLD, "10").build());
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutGroupEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutGroupEventTest.java
@@ -81,7 +81,7 @@ public class RolloutGroupEventTest extends AbstractRemoteEntityEventTest<Rollout
 
         final Rollout entity = rolloutManagement.create(
                 entityFactory.rollout().create().name("exampleRollout").targetFilterQuery("controllerId==*").set(ds),
-                10, new RolloutGroupConditionBuilder().withDefaults()
+                5, new RolloutGroupConditionBuilder().withDefaults()
                         .successCondition(RolloutGroupSuccessCondition.THRESHOLD, "10").build());
 
         return rolloutGroupManagement.findByRollout(PAGE, entity.getId()).getContent().get(0);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
@@ -255,12 +255,12 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Test verifies that an assignment with automatic cancelation works correctly even if the update is split into multiple partitions on the database.")
-    @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = Constants.MAX_ENTRIES_IN_STATEMENT + 10),
-            @Expect(type = TargetUpdatedEvent.class, count = 2 * (Constants.MAX_ENTRIES_IN_STATEMENT + 10)),
+    @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 20),
+            @Expect(type = TargetUpdatedEvent.class, count = 40),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 2),
-            @Expect(type = ActionCreatedEvent.class, count = 2 * (Constants.MAX_ENTRIES_IN_STATEMENT + 10)),
-            @Expect(type = CancelTargetAssignmentEvent.class, count = Constants.MAX_ENTRIES_IN_STATEMENT + 10),
-            @Expect(type = ActionUpdatedEvent.class, count = Constants.MAX_ENTRIES_IN_STATEMENT + 10),
+            @Expect(type = ActionCreatedEvent.class, count = 40),
+            @Expect(type = CancelTargetAssignmentEvent.class, count = 20),
+            @Expect(type = ActionUpdatedEvent.class, count = 20),
             @Expect(type = DistributionSetCreatedEvent.class, count = 2),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 6) })
     public void multiAssigmentHistoryOverMultiplePagesResultsInTwoActiveAction() {
@@ -271,14 +271,14 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         final DistributionSet cancelDs2 = testdataFactory.createDistributionSet("Canceled DS", "1.2",
                 Collections.emptyList());
 
-        final List<Target> targets = testdataFactory.createTargets(Constants.MAX_ENTRIES_IN_STATEMENT + 10);
+        final List<Target> targets = testdataFactory.createTargets(quotaManagement.getMaxTargetsPerAutoAssignment());
 
         assertThat(deploymentManagement.countActionsAll()).isEqualTo(0);
 
         assignDistributionSet(cancelDs, targets).getAssignedEntity();
-        assertThat(deploymentManagement.countActionsAll()).isEqualTo(Constants.MAX_ENTRIES_IN_STATEMENT + 10);
+        assertThat(deploymentManagement.countActionsAll()).isEqualTo(quotaManagement.getMaxTargetsPerAutoAssignment());
         assignDistributionSet(cancelDs2, targets).getAssignedEntity();
-        assertThat(deploymentManagement.countActionsAll()).isEqualTo(2 * (Constants.MAX_ENTRIES_IN_STATEMENT + 10));
+        assertThat(deploymentManagement.countActionsAll()).isEqualTo(2 * quotaManagement.getMaxTargetsPerAutoAssignment());
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetManagementTest.java
@@ -944,12 +944,12 @@ public class DistributionSetManagementTest extends AbstractJpaIntegrationTest {
         final DistributionSet ds1 = testdataFactory.createDistributionSet("testDs1");
         final DistributionSet ds2 = testdataFactory.createDistributionSet("testDs2");
 
-        for (int index = 0; index < 10; index++) {
+        for (int index = 0; index < quotaManagement.getMaxMetaDataEntriesPerDistributionSet(); index++) {
             createDistributionSetMetadata(ds1.getId(),
                     new JpaDistributionSetMetadata("key" + index, ds1, "value" + index));
         }
 
-        for (int index = 0; index < 8; index++) {
+        for (int index = 0; index <= quotaManagement.getMaxMetaDataEntriesPerDistributionSet() - 2; index++) {
             createDistributionSetMetadata(ds2.getId(),
                     new JpaDistributionSetMetadata("key" + index, ds2, "value" + index));
         }
@@ -960,11 +960,11 @@ public class DistributionSetManagementTest extends AbstractJpaIntegrationTest {
         final Page<DistributionSetMetadata> metadataOfDs2 = distributionSetManagement
                 .findMetaDataByDistributionSetId(PageRequest.of(0, 100), ds2.getId());
 
-        assertThat(metadataOfDs1.getNumberOfElements()).isEqualTo(10);
-        assertThat(metadataOfDs1.getTotalElements()).isEqualTo(10);
+        assertThat(metadataOfDs1.getNumberOfElements()).isEqualTo(quotaManagement.getMaxMetaDataEntriesPerDistributionSet());
+        assertThat(metadataOfDs1.getTotalElements()).isEqualTo(quotaManagement.getMaxMetaDataEntriesPerDistributionSet());
 
-        assertThat(metadataOfDs2.getNumberOfElements()).isEqualTo(8);
-        assertThat(metadataOfDs2.getTotalElements()).isEqualTo(8);
+        assertThat(metadataOfDs2.getNumberOfElements()).isEqualTo(quotaManagement.getMaxMetaDataEntriesPerDistributionSet() - 1);
+        assertThat(metadataOfDs2.getTotalElements()).isEqualTo(quotaManagement.getMaxMetaDataEntriesPerDistributionSet() - 1);
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutGroupManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutGroupManagementTest.java
@@ -44,11 +44,11 @@ public class RolloutGroupManagementTest extends AbstractJpaIntegrationTest {
     @Description("Verifies that management queries react as specfied on calls for non existing entities "
             + " by means of throwing EntityNotFoundException.")
     @ExpectEvents({ @Expect(type = RolloutDeletedEvent.class, count = 0),
-            @Expect(type = RolloutGroupCreatedEvent.class, count = 10),
-            @Expect(type = RolloutGroupUpdatedEvent.class, count = 10),
+            @Expect(type = RolloutGroupCreatedEvent.class, count = 5),
+            @Expect(type = RolloutGroupUpdatedEvent.class, count = 5),
             @Expect(type = DistributionSetCreatedEvent.class, count = 1),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
-            @Expect(type = RolloutUpdatedEvent.class, count = 1), @Expect(type = TargetCreatedEvent.class, count = 10),
+            @Expect(type = RolloutUpdatedEvent.class, count = 1), @Expect(type = TargetCreatedEvent.class, count = 5),
             @Expect(type = RolloutCreatedEvent.class, count = 1) })
     public void entityQueriesReferringToNotExistingEntitiesThrowsException() {
         testdataFactory.createRollout("xxx");

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -189,12 +189,12 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     @Description("Verifies that management queries react as specfied on calls for non existing entities "
             + " by means of throwing EntityNotFoundException.")
     @ExpectEvents({ @Expect(type = RolloutDeletedEvent.class, count = 0),
-            @Expect(type = RolloutGroupCreatedEvent.class, count = 10),
-            @Expect(type = RolloutGroupUpdatedEvent.class, count = 10),
+            @Expect(type = RolloutGroupCreatedEvent.class, count = 5),
+            @Expect(type = RolloutGroupUpdatedEvent.class, count = 5),
             @Expect(type = DistributionSetCreatedEvent.class, count = 1),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
             @Expect(type = RolloutUpdatedEvent.class, count = 1), @Expect(type = RolloutCreatedEvent.class, count = 1),
-            @Expect(type = TargetCreatedEvent.class, count = 10) })
+            @Expect(type = TargetCreatedEvent.class, count = 5) })
     public void entityQueriesReferringToNotExistingEntitiesThrowsException() {
         testdataFactory.createRollout("xxx");
 
@@ -1473,10 +1473,10 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     public void createRolloutWithGroupDefinition() throws Exception {
         final String rolloutName = "rolloutTest3";
 
-        final int amountTargetsInGroup1 = 100;
+        final int amountTargetsInGroup1 = 10;
         final int percentTargetsInGroup1 = 100;
 
-        final int amountTargetsInGroup1and2 = 500;
+        final int amountTargetsInGroup1and2 = 20;
         final int percentTargetsInGroup2 = 20;
         final int percentTargetsInGroup3 = 100;
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SystemManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SystemManagementTest.java
@@ -81,17 +81,17 @@ public class SystemManagementTest extends AbstractJpaIntegrationTest {
     @Description("Checks that the system report calculates correctly the actions size of all tenants in the system")
     public void systemUsageReportCollectsActionsOfAllTenants() throws Exception {
         // Prepare tenants
-        createTestTenantsForSystemStatistics(2, 0, 100, 2);
+        createTestTenantsForSystemStatistics(2, 0, 20, 2);
 
         // 2 tenants, 100 targets each, 2 deployments per target => 400
-        assertThat(systemManagement.getSystemUsageStatistics().getOverallActions()).isEqualTo(400);
+        assertThat(systemManagement.getSystemUsageStatistics().getOverallActions()).isEqualTo(80);
 
         // per tenant data
         final List<TenantUsage> tenants = systemManagement.getSystemUsageStatisticsWithTenants().getTenants();
         assertThat(tenants).hasSize(3);
         assertThat(tenants).containsOnly(new TenantUsage("default"),
-                new TenantUsage("tenant0").setTargets(100).setActions(200),
-                new TenantUsage("tenant1").setTargets(100).setActions(200));
+                new TenantUsage("tenant0").setTargets(20).setActions(40),
+                new TenantUsage("tenant1").setTargets(20).setActions(40));
     }
 
     private byte[] createTestTenantsForSystemStatistics(final int tenants, final int artifactSize, final int targets,

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignCheckerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignCheckerTest.java
@@ -112,7 +112,7 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
                         .ds(setA.getId()));
 
         final String targetDsAIdPref = "targ";
-        final List<Target> targets = testdataFactory.createTargets(100, targetDsAIdPref,
+        final List<Target> targets = testdataFactory.createTargets(25, targetDsAIdPref,
                 targetDsAIdPref.concat(" description"));
         final int targetsCount = targets.size();
 
@@ -131,12 +131,12 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
         verifyThatTargetsHaveDistributionSetAssignment(setB, targets.subList(10, 20), targetsCount);
 
         // Count the number of targets that will be assigned with setA
-        assertThat(targetManagement.countByRsqlAndNonDS(setA.getId(), targetFilterQuery.getQuery())).isEqualTo(90);
+        assertThat(targetManagement.countByRsqlAndNonDS(setA.getId(), targetFilterQuery.getQuery())).isEqualTo(15);
 
         // Run the check
         autoAssignChecker.check();
 
-        verifyThatTargetsHaveDistributionSetAssignment(setA, targets.subList(5, 100), targetsCount);
+        verifyThatTargetsHaveDistributionSetAssignment(setA, targets.subList(5, 25), targetsCount);
 
         // first 5 should keep their dsB, because they already had the dsA once
         verifyThatTargetsHaveDistributionSetAssignment(setB, targets.subList(0, 5), targetsCount);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/event/RepositoryEntityEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/event/RepositoryEntityEventTest.java
@@ -91,7 +91,7 @@ public class RepositoryEntityEventTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Verifies that the rollout deleted event is published when a rollout has been deleted")
     public void rolloutDeletedEventIsPublished() throws InterruptedException {
-        final int amountTargetsForRollout = 500;
+        final int amountTargetsForRollout = 50;
         final int amountGroups = 5;
         final String successCondition = "50";
         final String errorCondition = "80";

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/TestdataFactory.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/TestdataFactory.java
@@ -1138,8 +1138,8 @@ public class TestdataFactory {
      * @return created {@link Rollout}
      */
     public Rollout createRollout(final String prefix) {
-        createTargets(10, prefix);
-        return createRolloutByVariables(prefix, prefix + " description", 10, "controllerId==" + prefix + "*",
+        createTargets(5, prefix);
+        return createRolloutByVariables(prefix, prefix + " description", 5, "controllerId==" + prefix + "*",
                 createDistributionSet(prefix), "50", "5");
     }
 

--- a/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactDownloadTest.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactDownloadTest.java
@@ -170,7 +170,7 @@ public class DdiArtifactDownloadTest extends AbstractDDiApiIntegrationTest {
         final DistributionSet ds = testdataFactory.createDistributionSet("");
 
         // create artifact
-        final int artifactSize = 5 * 1024 * 1024;
+        final int artifactSize = (int) quotaManagement.getMaxArtifactSize();
         final byte random[] = RandomUtils.nextBytes(artifactSize);
         final Artifact artifact = artifactManagement.create(new ArtifactUpload(new ByteArrayInputStream(random),
                 ds.findFirstModuleByType(osType).get().getId(), "file1", false, artifactSize));
@@ -238,7 +238,7 @@ public class DdiArtifactDownloadTest extends AbstractDDiApiIntegrationTest {
         // create ds
         final DistributionSet ds = testdataFactory.createDistributionSet("");
 
-        final int resultLength = 5 * 1000 * 1024;
+        final int resultLength = (int) quotaManagement.getMaxArtifactSize();
 
         // create artifact
         final byte random[] = RandomUtils.nextBytes(resultLength);
@@ -250,7 +250,7 @@ public class DdiArtifactDownloadTest extends AbstractDDiApiIntegrationTest {
         // now assign and download successful
         assignDistributionSet(ds, targets);
 
-        final int range = 100 * 1024;
+        final int range = resultLength / 50;
 
         // full file download with standard range request
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResourceTest.java
@@ -103,7 +103,7 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
     public void createRolloutWithNotWellFormedFilterReturnsBadRequest() throws Exception {
         final DistributionSet dsA = testdataFactory.createDistributionSet("");
         mvc.perform(post("/rest/v1/rollouts")
-                .content(JsonBuilder.rollout("name", "desc", 10, dsA.getId(), "name=test", null))
+                .content(JsonBuilder.rollout("name", "desc", 5, dsA.getId(), "name=test", null))
                 .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isBadRequest())
                 .andExpect(jsonPath("errorCode", equalTo("hawkbit.server.error.rest.param.rsqlParamSyntax")))
@@ -131,7 +131,7 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
         testdataFactory.createTargets(20, "target", "rollout");
 
         final DistributionSet dsA = testdataFactory.createDistributionSet("");
-        postRollout("rollout1", 10, dsA.getId(), "id==target*", 20, Action.ActionType.FORCED);
+        postRollout("rollout1", 5, dsA.getId(), "id==target*", 20, Action.ActionType.FORCED);
     }
 
     @Test
@@ -368,7 +368,7 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
         testdataFactory.createTargets(20, "target", "rollout");
 
         // setup - create 2 rollouts
-        postRollout("rollout1", 10, dsA.getId(), "id==target*", 20, Action.ActionType.FORCED);
+        postRollout("rollout1", 5, dsA.getId(), "id==target*", 20, Action.ActionType.FORCED);
         postRollout("rollout2", 5, dsA.getId(), "id==target-0001*", 10, Action.ActionType.FORCED);
 
         // Run here, because Scheduler is disabled during tests
@@ -409,7 +409,7 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
         testdataFactory.createTargets(20, "target", "rollout");
 
         // setup - create 2 rollouts
-        postRollout("rollout1", 10, dsA.getId(), "id==target*", 20, Action.ActionType.FORCED);
+        postRollout("rollout1", 5, dsA.getId(), "id==target*", 20, Action.ActionType.FORCED);
         postRollout("rollout2", 5, dsA.getId(), "id==target*", 20, Action.ActionType.FORCED);
 
         // Run here, because Scheduler is disabled during tests
@@ -790,7 +790,7 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
     @Description("Start the rollout in async mode")
     public void startingRolloutSwitchesIntoRunningStateAsync() throws Exception {
 
-        final int amountTargets = 1000;
+        final int amountTargets = 50;
         testdataFactory.createTargets(amountTargets, "rollout", "rollout");
         final DistributionSet dsA = testdataFactory.createDistributionSet("");
 
@@ -913,7 +913,7 @@ public class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTes
         testdataFactory.createTargets(20, "target", "rollout");
 
         final DistributionSet dsA = testdataFactory.createDistributionSet("");
-        postRollout("rollout1", 10, dsA.getId(), "id==target*", 20, Action.ActionType.DOWNLOAD_ONLY);
+        postRollout("rollout1", 5, dsA.getId(), "id==target*", 20, Action.ActionType.DOWNLOAD_ONLY);
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/AbstractRestIntegrationTest.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/AbstractRestIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.cloud.stream.test.binder.TestSupportBinderAutoConfiguration;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder;
@@ -31,6 +32,7 @@ import org.springframework.web.context.WebApplicationContext;
 @ContextConfiguration(classes = { RestConfiguration.class, RepositoryApplicationConfiguration.class,
         TestConfiguration.class, TestSupportBinderAutoConfiguration.class })
 @AutoConfigureMockMvc
+@TestPropertySource(locations = { "classpath:/rest-test.properties" })
 public abstract class AbstractRestIntegrationTest extends AbstractIntegrationTest {
 
     protected MockMvc mvc;

--- a/hawkbit-rest/hawkbit-rest-core/src/test/resources/rest-test.properties
+++ b/hawkbit-rest/hawkbit-rest-core/src/test/resources/rest-test.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+# Copyright (c) 2021 Bosch.IO GmbH and others.
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -24,10 +24,3 @@ hawkbit.server.security.dos.maxTargetDistributionSetAssignmentsPerManualAssignme
 hawkbit.server.security.dos.maxTargetsPerAutoAssignment=20
 hawkbit.server.security.dos.maxActionsPerTarget=20
 # Quota - END
-
-# Debug utility functions - START
-logging.level.org.eclipse.persistence=ERROR
-spring.jpa.properties.eclipselink.logging.level=FINE
-spring.jpa.properties.eclipselink.logging.level.sql=FINE
-spring.jpa.properties.eclipselink.logging.parameters=true
-# Debug utility functions - END

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/RolloutResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/RolloutResourceDocumentationTest.java
@@ -181,7 +181,7 @@ public class RolloutResourceDocumentationTest extends AbstractApiRestDocumentati
         final String name = "exampleRollout";
         final String type = "forced";
         final String description = "Rollout for all named targets";
-        final int groupSize = 10;
+        final int groupSize = 5;
         final Long dsId = testdataFactory.createDistributionSet().getId();
         final String targetFilter = "id==targets-*";
 
@@ -640,7 +640,7 @@ public class RolloutResourceDocumentationTest extends AbstractApiRestDocumentati
         if (isMultiAssignmentsEnabled()) {
             rolloutCreate.weight(400);
         }
-        final Rollout rollout = rolloutManagement.create(rolloutCreate, 10, new RolloutGroupConditionBuilder()
+        final Rollout rollout = rolloutManagement.create(rolloutCreate, 5, new RolloutGroupConditionBuilder()
                 .withDefaults().successCondition(RolloutGroupSuccessCondition.THRESHOLD, "10").build());
 
         // Run here, because Scheduler is disabled during tests


### PR DESCRIPTION
Reduced the number of created entities in tests in order to speed up the builds

- Reduced the quota limits in order to hit those limits faster in tests