### PR TITLE
Set DdiActionFeedback ID deprecated

### DIFF
--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedback.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedback.java
@@ -37,6 +37,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiActionFeedback {
+    /**
+     * @deprecated
+     * This ID is always given by the actionId path variable.
+     * Will be removed in future versions.
+     */
+    @Deprecated
     private final Long id;
     private final String time;
 

--- a/hawkbit-rest/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -351,13 +351,6 @@ public class DdiRootController implements DdiRootControllerRestApi {
         final Target target = controllerManagement.getByControllerId(controllerId)
                 .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
 
-        if (!actionId.equals(feedback.getId())) {
-            LOG.warn(
-                    "provideBasedeploymentActionFeedback: action in payload ({}) was not identical to action in path ({}).",
-                    feedback.getId(), actionId);
-            return ResponseEntity.notFound().build();
-        }
-
         final Action action = findActionWithExceptionIfNotFound(actionId);
         if (!action.getTarget().getId().equals(target.getId())) {
             LOG.warn(GIVEN_ACTION_IS_NOT_ASSIGNED_TO_GIVEN_TARGET, action.getId(), target.getId());
@@ -370,7 +363,7 @@ public class DdiRootController implements DdiRootControllerRestApi {
             return new ResponseEntity<>(HttpStatus.GONE);
         }
 
-        controllerManagement.addUpdateActionStatus(generateUpdateStatus(feedback, controllerId, feedback.getId()));
+        controllerManagement.addUpdateActionStatus(generateUpdateStatus(feedback, controllerId, actionId));
 
         return ResponseEntity.ok().build();
 
@@ -501,13 +494,6 @@ public class DdiRootController implements DdiRootControllerRestApi {
         final Target target = controllerManagement.getByControllerId(controllerId)
                 .orElseThrow(() -> new EntityNotFoundException(Target.class, controllerId));
 
-        if (!actionId.equals(feedback.getId())) {
-            LOG.warn(
-                    "provideBasedeploymentActionFeedback: action in payload ({}) was not identical to action in path ({}).",
-                    feedback.getId(), actionId);
-            return ResponseEntity.notFound().build();
-        }
-
         final Action action = findActionWithExceptionIfNotFound(actionId);
         if (!action.getTarget().getId().equals(target.getId())) {
             LOG.warn(GIVEN_ACTION_IS_NOT_ASSIGNED_TO_GIVEN_TARGET, action.getId(), target.getId());
@@ -515,7 +501,7 @@ public class DdiRootController implements DdiRootControllerRestApi {
         }
 
         controllerManagement
-                .addCancelActionStatus(generateActionCancelStatus(feedback, target, feedback.getId(), entityFactory));
+                .addCancelActionStatus(generateActionCancelStatus(feedback, target, actionId, entityFactory));
         return ResponseEntity.ok().build();
     }
 

--- a/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiCancelActionTest.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiCancelActionTest.java
@@ -523,18 +523,6 @@ public class DdiCancelActionTest extends AbstractDDiApiIntegrationTest {
                         .content(JsonBuilder.cancelActionFeedback("sdfsdfsdfs", "closed"))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isBadRequest());
-        mvc.perform(post("/{tenant}/controller/v1/" + TestdataFactory.DEFAULT_CONTROLLER_ID + "/cancelAction/"
-                + cancelAction.getId() + "/feedback", tenantAware.getCurrentTenant())
-                        .content(JsonBuilder.cancelActionFeedback("1234", "closed"))
-                        .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
-                .andDo(MockMvcResultPrinter.print()).andExpect(status().isNotFound());
-
-        // right action but for wrong target
-        mvc.perform(post("/{tenant}/controller/v1/" + TestdataFactory.DEFAULT_CONTROLLER_ID + "/cancelAction/"
-                + cancelAction.getId() + "/feedback", tenantAware.getCurrentTenant())
-                        .content(JsonBuilder.cancelActionFeedback(cancelAction2.getId().toString(), "closed"))
-                        .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
-                .andDo(MockMvcResultPrinter.print()).andExpect(status().isNotFound());
 
         // finally get it right :)
         mvc.perform(post("/{tenant}/controller/v1/" + TestdataFactory.DEFAULT_CONTROLLER_ID + "/cancelAction/"

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/ddi/documentation/DdiApiModelProperties.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/ddi/documentation/DdiApiModelProperties.java
@@ -26,13 +26,15 @@ final class DdiApiModelProperties {
 
     static final String TARGET_RESULT_FINISHED = "defined status of the result";
 
-    static final String TARGET_RESULT_PROGRESS = "progress assumption of the device";
+    static final String TARGET_RESULT_PROGRESS = "progress assumption of the device (currently not supported).";
 
     static final String TARGET_PROGRESS_CNT = "current progress level";
 
     static final String TARGET_PROGRESS_OF = "assumption concerning max progress level";
 
     static final String ACTION_ID = "id of the action";
+
+    static final String FEEDBACK_ACTION_ID = "(@deprecated) id of the action";
 
     static final String CANCEL_ACTION = "action that needs to be canceled";
 

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/ddi/documentation/RootControllerDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/ddi/documentation/RootControllerDocumentationTest.java
@@ -181,7 +181,7 @@ public class RootControllerDocumentationTest extends AbstractApiRestDocumentatio
                         pathParameters(parameterWithName("tenant").description(ApiModelPropertiesGeneric.TENANT),
                                 parameterWithName("controllerId").description(DdiApiModelProperties.CONTROLLER_ID),
                                 parameterWithName("actionId").description(DdiApiModelProperties.ACTION_ID_CANCELED)),
-                        requestFields(optionalRequestFieldWithPath("id").description(DdiApiModelProperties.ACTION_ID),
+                        requestFields(optionalRequestFieldWithPath("id").description(DdiApiModelProperties.FEEDBACK_ACTION_ID),
                                 requestFieldWithPath("status").description(DdiApiModelProperties.TARGET_STATUS),
                                 requestFieldWithPath("status.execution")
                                         .description(DdiApiModelProperties.TARGET_EXEC_STATUS).type("enum")
@@ -384,7 +384,7 @@ public class RootControllerDocumentationTest extends AbstractApiRestDocumentatio
                                 parameterWithName("controllerId").description(DdiApiModelProperties.CONTROLLER_ID),
                                 parameterWithName("actionId").description(DdiApiModelProperties.ACTION_ID)),
 
-                        requestFields(optionalRequestFieldWithPath("id").description(DdiApiModelProperties.ACTION_ID),
+                        requestFields(optionalRequestFieldWithPath("id").description(DdiApiModelProperties.FEEDBACK_ACTION_ID),
                                 requestFieldWithPath("status").description(DdiApiModelProperties.TARGET_STATUS),
                                 requestFieldWithPath("status.execution")
                                         .description(DdiApiModelProperties.TARGET_EXEC_STATUS).type("enum")


### PR DESCRIPTION
According to the [official DDI API hawkbit documentation](https://www.eclipse.org/hawkbit/apis/ddi_api/), the `feedbackID` was never mandatory as a part of the request body because it was already given by the `actionID` path variable. But the current implementation was not working without it and resulted in a HTTP 404 error code. 
This PR will improve the code and replace the internal usage of the `feedbackID` by the already given `actionID` for both DDI feedback endpoints. Furthermore a `@deprecated` notice is added to the `feedbackID` that it could be removed later on.

Signed-off-by: Florian Ruschbaschan <Florian.Ruschbaschan@bosch.io>