### PR TITLE
Feature/remove junit5 leftovers

### DIFF
--- a/hawkbit-artifact-repository-filesystem/src/test/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemTest.java
+++ b/hawkbit-artifact-repository-filesystem/src/test/java/org/eclipse/hawkbit/artifact/repository/ArtifactFilesystemTest.java
@@ -17,12 +17,11 @@ import java.io.IOException;
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
 import org.eclipse.hawkbit.artifact.repository.model.DbArtifactHash;
-
+import org.junit.jupiter.api.Test;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
-import org.junit.jupiter.api.Test;
 
 @Feature("Unit Tests - Artifact File System Repository")
 @Story("Test storing artifact binaries in the file-system")
@@ -34,6 +33,7 @@ public class ArtifactFilesystemTest {
         final File file = new File("fileWhichTotalDoesNotExists");
         final ArtifactFilesystem underTest = new ArtifactFilesystem(file, "fileWhichTotalDoesNotExists",
                 new DbArtifactHash("1", "2", "3"), 0L, null);
+
         try {
             underTest.getFileInputStream();
             Assertions.fail("Expected a FileNotFoundException because file does not exists");

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpControllerAuthenticationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpControllerAuthenticationTest.java
@@ -75,7 +75,6 @@ public class AmqpControllerAuthenticationTest {
 
     private static final String SHA1 = "12345";
     private static final Long ARTIFACT_ID = 1123L;
-    private static final Long ARTIFACT_SIZE = 6666L;
     private static final String TENANT = "DEFAULT";
     private static final Long TENANT_ID = 123L;
     private static final String CONTROLLER_ID = "123";
@@ -175,7 +174,7 @@ public class AmqpControllerAuthenticationTest {
 
     @Test
     @Description("Tests authentication manager without principal")
-    public void testAuthenticationBadCredentialsWithoutPricipal() {
+    public void testAuthenticationBadCredentialsWithoutPrincipal() {
         final DmfTenantSecurityToken securityToken = new DmfTenantSecurityToken(TENANT, TENANT_ID, CONTROLLER_ID,
                 TARGET_ID, FileResource.createFileResourceBySha1(SHA1));
         Assertions.assertThrows(BadCredentialsException.class,
@@ -200,7 +199,7 @@ public class AmqpControllerAuthenticationTest {
 
     @Test
     @Description("Tests authentication successful")
-    public void testsuccessfulAuthentication() {
+    public void testSuccessfulAuthentication() {
         final DmfTenantSecurityToken securityToken = new DmfTenantSecurityToken(TENANT, TENANT_ID, CONTROLLER_ID,
                 TARGET_ID, FileResource.createFileResourceBySha1(SHA1));
         when(tenantConfigurationManagementMock.getConfigurationValue(
@@ -213,7 +212,7 @@ public class AmqpControllerAuthenticationTest {
 
     @Test
     @Description("Tests authentication message without principal")
-    public void testAuthenticationMessageBadCredentialsWithoutPricipal() {
+    public void testAuthenticationMessageBadCredentialsWithoutPrincipal() {
         final MessageProperties messageProperties = createMessageProperties(null);
 
         final DmfTenantSecurityToken securityToken = new DmfTenantSecurityToken(TENANT, TENANT_ID, CONTROLLER_ID,

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpControllerAuthenticationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpControllerAuthenticationTest.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.amqp;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -43,7 +44,6 @@ import org.eclipse.hawkbit.security.DmfTenantSecurityToken.FileResource;
 import org.eclipse.hawkbit.security.SecurityContextTenantAware;
 import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -185,9 +185,9 @@ public class AmqpControllerAuthenticationTest {
 
         mockAuthenticationWithoutPrincipal();
 
-        Assertions.assertThrows(BadCredentialsException.class,
-                () -> authenticationManager.doAuthenticate(securityToken),
-                "BadCredentialsException was expected since principal was missing");
+        assertThatExceptionOfType(BadCredentialsException.class)
+                .as("BadCredentialsException was expected since principal was missing")
+                .isThrownBy(() -> authenticationManager.doAuthenticate(securityToken));
     }
 
     @Test
@@ -202,9 +202,9 @@ public class AmqpControllerAuthenticationTest {
 
         securityToken.putHeader(DmfTenantSecurityToken.AUTHORIZATION_HEADER, "TargetToken 12" + CONTROLLER_ID);
 
-        Assertions.assertThrows(BadCredentialsException.class,
-                () -> authenticationManager.doAuthenticate(securityToken),
-                "BadCredentialsException was expected due to wrong credential");
+        assertThatExceptionOfType(BadCredentialsException.class)
+                .as("BadCredentialsException was expected due to wrong credential")
+                .isThrownBy(() -> authenticationManager.doAuthenticate(securityToken));
     }
 
     @Test

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpControllerAuthenticationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpControllerAuthenticationTest.java
@@ -9,10 +9,10 @@
 package org.eclipse.hawkbit.amqp;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,11 +43,12 @@ import org.eclipse.hawkbit.security.DmfTenantSecurityToken.FileResource;
 import org.eclipse.hawkbit.security.SecurityContextTenantAware;
 import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -69,7 +70,7 @@ import io.qameta.allure.Story;
  */
 @Feature("Component Tests - Device Management Federation API")
 @Story("AmqpController Authentication Test")
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AmqpControllerAuthenticationTest {
 
     private static final String SHA1 = "12345";
@@ -113,41 +114,41 @@ public class AmqpControllerAuthenticationTest {
     private static final TenantConfigurationValue<Boolean> CONFIG_VALUE_TRUE = TenantConfigurationValue
             .<Boolean> builder().value(Boolean.TRUE).build();
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         messageConverter = new Jackson2JsonMessageConverter();
         final RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
-        when(rabbitTemplate.getMessageConverter()).thenReturn(messageConverter);
+        lenient().when(rabbitTemplate.getMessageConverter()).thenReturn(messageConverter);
 
-        final DdiSecurityProperties secruityProperties = mock(DdiSecurityProperties.class);
+        final DdiSecurityProperties securityProperties = mock(DdiSecurityProperties.class);
         final Rp rp = mock(Rp.class);
         final DdiSecurityProperties.Authentication ddiAuthentication = mock(DdiSecurityProperties.Authentication.class);
         final Anonymous anonymous = mock(Anonymous.class);
-        when(secruityProperties.getRp()).thenReturn(rp);
+        when(securityProperties.getRp()).thenReturn(rp);
         when(rp.getSslIssuerHashHeader()).thenReturn("X-Ssl-Issuer-Hash-%d");
-        when(secruityProperties.getAuthentication()).thenReturn(ddiAuthentication);
-        when(ddiAuthentication.getAnonymous()).thenReturn(anonymous);
-        when(anonymous.isEnabled()).thenReturn(false);
+        lenient().when(securityProperties.getAuthentication()).thenReturn(ddiAuthentication);
+        lenient().when(ddiAuthentication.getAnonymous()).thenReturn(anonymous);
+        lenient().when(anonymous.isEnabled()).thenReturn(false);
 
         when(tenantConfigurationManagementMock.getConfigurationValue(any(), eq(Boolean.class)))
                 .thenReturn(CONFIG_VALUE_FALSE);
 
         final ControllerManagement controllerManagement = mock(ControllerManagement.class);
-        when(controllerManagement.getByControllerId(anyString())).thenReturn(Optional.of(targetMock));
-        when(controllerManagement.get(any(Long.class))).thenReturn(Optional.of(targetMock));
+        lenient().when(controllerManagement.getByControllerId(anyString())).thenReturn(Optional.of(targetMock));
+        lenient().when(controllerManagement.get(any(Long.class))).thenReturn(Optional.of(targetMock));
 
-        when(targetMock.getSecurityToken()).thenReturn(CONTROLLER_ID);
-        when(targetMock.getControllerId()).thenReturn(CONTROLLER_ID);
+        lenient().when(targetMock.getSecurityToken()).thenReturn(CONTROLLER_ID);
+        lenient().when(targetMock.getControllerId()).thenReturn(CONTROLLER_ID);
 
         final SecurityContextTenantAware tenantAware = new SecurityContextTenantAware();
         final SystemSecurityContext systemSecurityContext = new SystemSecurityContext(tenantAware);
 
         final TenantMetaData tenantMetaData = mock(TenantMetaData.class);
-        when(tenantMetaData.getTenant()).thenReturn(TENANT);
-        when(systemManagement.getTenantMetadata(TENANT_ID)).thenReturn(tenantMetaData);
+        lenient().when(tenantMetaData.getTenant()).thenReturn(TENANT);
+        lenient().when(systemManagement.getTenantMetadata(TENANT_ID)).thenReturn(tenantMetaData);
 
         authenticationManager = new AmqpControllerAuthentication(systemManagement, controllerManagement,
-                tenantConfigurationManagementMock, tenantAware, secruityProperties, systemSecurityContext);
+                tenantConfigurationManagementMock, tenantAware, securityProperties, systemSecurityContext);
 
         authenticationManager.postConstruct();
 
@@ -155,8 +156,8 @@ public class AmqpControllerAuthenticationTest {
                 new JpaSoftwareModuleType("a key", "a name", null, 1), "a name", null, null, null));
         testArtifact.setId(1L);
 
-        when(artifactManagementMock.get(ARTIFACT_ID)).thenReturn(Optional.of(testArtifact));
-        when(artifactManagementMock.findFirstBySHA1(SHA1)).thenReturn(Optional.of(testArtifact));
+        lenient().when(artifactManagementMock.get(ARTIFACT_ID)).thenReturn(Optional.of(testArtifact));
+        lenient().when(artifactManagementMock.findFirstBySHA1(SHA1)).thenReturn(Optional.of(testArtifact));
 
         amqpMessageHandlerService = new AmqpMessageHandlerService(rabbitTemplate,
                 mock(AmqpMessageDispatcherService.class), controllerManagementMock, new JpaEntityFactory(),
@@ -166,47 +167,40 @@ public class AmqpControllerAuthenticationTest {
                 authenticationManager, artifactManagementMock, cacheMock, hostnameResolverMock,
                 controllerManagementMock, tenantAware);
 
-        when(hostnameResolverMock.resolveHostname()).thenReturn(new URL("http://localhost"));
+        lenient().when(hostnameResolverMock.resolveHostname()).thenReturn(new URL("http://localhost"));
 
-        when(controllerManagementMock.hasTargetArtifactAssigned(TARGET_ID, SHA1)).thenReturn(true);
-        when(controllerManagementMock.hasTargetArtifactAssigned(CONTROLLER_ID, SHA1)).thenReturn(true);
+        lenient().when(controllerManagementMock.hasTargetArtifactAssigned(TARGET_ID, SHA1)).thenReturn(true);
+        lenient().when(controllerManagementMock.hasTargetArtifactAssigned(CONTROLLER_ID, SHA1)).thenReturn(true);
     }
 
     @Test
     @Description("Tests authentication manager without principal")
-    public void testAuthenticationeBadCredantialsWithoutPricipal() {
+    public void testAuthenticationBadCredentialsWithoutPricipal() {
         final DmfTenantSecurityToken securityToken = new DmfTenantSecurityToken(TENANT, TENANT_ID, CONTROLLER_ID,
                 TARGET_ID, FileResource.createFileResourceBySha1(SHA1));
-        try {
-            authenticationManager.doAuthenticate(securityToken);
-            fail("BadCredentialsException was excepeted since principal was missing");
-        } catch (final BadCredentialsException exception) {
-            // test ok - exception was excepted
-        }
-
+        Assertions.assertThrows(BadCredentialsException.class,
+                () -> authenticationManager.doAuthenticate(securityToken),
+                "BadCredentialsException was expected since principal was missing");
     }
 
     @Test
     @Description("Tests authentication manager without wrong credential")
-    public void testAuthenticationBadCredantialsWithWrongCredential() {
+    public void testAuthenticationBadCredentialsWithWrongCredential() {
         final DmfTenantSecurityToken securityToken = new DmfTenantSecurityToken(TENANT, TENANT_ID, CONTROLLER_ID,
                 TARGET_ID, FileResource.createFileResourceBySha1(SHA1));
         when(tenantConfigurationManagementMock.getConfigurationValue(
                 eq(TenantConfigurationKey.AUTHENTICATION_MODE_TARGET_SECURITY_TOKEN_ENABLED), eq(Boolean.class)))
                         .thenReturn(CONFIG_VALUE_TRUE);
         securityToken.putHeader(DmfTenantSecurityToken.AUTHORIZATION_HEADER, "TargetToken 12" + CONTROLLER_ID);
-        try {
-            authenticationManager.doAuthenticate(securityToken);
-            fail("BadCredentialsException was excepeted due to wrong credential");
-        } catch (final BadCredentialsException exception) {
-            // test ok - exception was excepted
-        }
 
+        Assertions.assertThrows(BadCredentialsException.class,
+                () -> authenticationManager.doAuthenticate(securityToken),
+                "BadCredentialsException was expected due to wrong credential");
     }
 
     @Test
-    @Description("Tests authentication successfull")
-    public void testSuccessfullAuthentication() {
+    @Description("Tests authentication successful")
+    public void testsuccessfulAuthentication() {
         final DmfTenantSecurityToken securityToken = new DmfTenantSecurityToken(TENANT, TENANT_ID, CONTROLLER_ID,
                 TARGET_ID, FileResource.createFileResourceBySha1(SHA1));
         when(tenantConfigurationManagementMock.getConfigurationValue(
@@ -219,7 +213,7 @@ public class AmqpControllerAuthenticationTest {
 
     @Test
     @Description("Tests authentication message without principal")
-    public void testAuthenticationMessageBadCredantialsWithoutPricipal() {
+    public void testAuthenticationMessageBadCredentialsWithoutPricipal() {
         final MessageProperties messageProperties = createMessageProperties(null);
 
         final DmfTenantSecurityToken securityToken = new DmfTenantSecurityToken(TENANT, TENANT_ID, CONTROLLER_ID,
@@ -238,7 +232,7 @@ public class AmqpControllerAuthenticationTest {
 
     @Test
     @Description("Tests authentication message without wrong credential")
-    public void testAuthenticationMessageBadCredantialsWithWrongCredential() {
+    public void testAuthenticationMessageBadCredentialsWithWrongCredential() {
         final MessageProperties messageProperties = createMessageProperties(null);
         final DmfTenantSecurityToken securityToken = new DmfTenantSecurityToken(TENANT, TENANT_ID, CONTROLLER_ID,
                 TARGET_ID, FileResource.createFileResourceBySha1(SHA1));
@@ -259,8 +253,8 @@ public class AmqpControllerAuthenticationTest {
     }
 
     @Test
-    @Description("Tests authentication message successfull")
-    public void successfullMessageAuthentication() {
+    @Description("Tests authentication message successful")
+    public void successfulMessageAuthentication() {
         final MessageProperties messageProperties = createMessageProperties(null);
         final DmfTenantSecurityToken securityToken = new DmfTenantSecurityToken(TENANT, null, CONTROLLER_ID, null,
                 FileResource.createFileResourceBySha1(SHA1));
@@ -287,8 +281,8 @@ public class AmqpControllerAuthenticationTest {
     }
 
     @Test
-    @Description("Tests authentication message successfull with targetId intead of controllerId provided and artifactId instead of SHA1.")
-    public void successfullMessageAuthenticationWithTargetIdAndArtifactId() {
+    @Description("Tests authentication message successful with targetId intead of controllerId provided and artifactId instead of SHA1.")
+    public void successfulMessageAuthenticationWithTargetIdAndArtifactId() {
         final MessageProperties messageProperties = createMessageProperties(null);
         final DmfTenantSecurityToken securityToken = new DmfTenantSecurityToken(TENANT, null, null, TARGET_ID,
                 FileResource.createFileResourceByArtifactId(ARTIFACT_ID));
@@ -315,8 +309,8 @@ public class AmqpControllerAuthenticationTest {
     }
 
     @Test
-    @Description("Tests authentication message successfull")
-    public void successfullMessageAuthenticationWithTenantid() {
+    @Description("Tests authentication message successful")
+    public void successfulMessageAuthenticationWithTenantid() {
         final MessageProperties messageProperties = createMessageProperties(null);
         final DmfTenantSecurityToken securityToken = new DmfTenantSecurityToken(null, TENANT_ID, CONTROLLER_ID,
                 TARGET_ID, FileResource.createFileResourceBySha1(SHA1));

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/BaseAmqpServiceTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/BaseAmqpServiceTest.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.amqp;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.hawkbit.dmf.json.model.DmfActionStatus;
@@ -16,7 +17,6 @@ import org.eclipse.hawkbit.dmf.json.model.DmfActionUpdateStatus;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,9 +66,9 @@ public class BaseAmqpServiceTest {
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void convertMessageWithNullContent() {
         final Message message = createMessage(null);
-        Assertions.assertThrows(MessageConversionException.class,
-                () -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class),
-                "Expected MessageConversionException for invalid JSON");
+        assertThatExceptionOfType(MessageConversionException.class)
+                .as("Expected MessageConversionException for invalid JSON")
+                .isThrownBy(() -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class));
     }
 
     @Test
@@ -76,9 +76,9 @@ public class BaseAmqpServiceTest {
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void updateActionStatusWithEmptyContent() {
         final Message message = createMessage("".getBytes());
-        Assertions.assertThrows(MessageConversionException.class,
-                () -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class),
-                "Expected MessageConversionException for invalid JSON");
+        assertThatExceptionOfType(MessageConversionException.class)
+                .as("Expected MessageConversionException for invalid JSON")
+                .isThrownBy(() -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class));
     }
 
     @Test
@@ -88,9 +88,9 @@ public class BaseAmqpServiceTest {
         final Message message = createMessage("Invalid Json".getBytes());
         when(rabbitTemplate.getMessageConverter()).thenReturn(new Jackson2JsonMessageConverter());
 
-        Assertions.assertThrows(MessageConversionException.class,
-                () -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class),
-                "Expected MessageConversionException for invalid JSON");
+        assertThatExceptionOfType(MessageConversionException.class)
+                .as("Expected MessageConversionException for invalid JSON")
+                .isThrownBy(() -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class));
     }
 
     private Message createMessage(final byte[] body) {

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/BaseAmqpServiceTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/BaseAmqpServiceTest.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.amqp;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
 import org.eclipse.hawkbit.dmf.json.model.DmfActionStatus;
 import org.eclipse.hawkbit.dmf.json.model.DmfActionUpdateStatus;
@@ -44,7 +44,6 @@ public class BaseAmqpServiceTest {
 
     @BeforeEach
     public void setup() {
-        lenient().when(rabbitTemplate.getMessageConverter()).thenReturn(new Jackson2JsonMessageConverter());
         baseAmqpService = new BaseAmqpService(rabbitTemplate);
     }
 
@@ -52,6 +51,7 @@ public class BaseAmqpServiceTest {
     @Description("Verify that the message conversion works")
     public void convertMessageTest() {
         final DmfActionUpdateStatus actionUpdateStatus = createActionStatus();
+        when(rabbitTemplate.getMessageConverter()).thenReturn(new Jackson2JsonMessageConverter());
 
         final Message message = rabbitTemplate.getMessageConverter().toMessage(actionUpdateStatus,
                 createJsonProperties());
@@ -65,7 +65,7 @@ public class BaseAmqpServiceTest {
     @Description("Tests invalid null message content")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void convertMessageWithNullContent() {
-        Message message = createMessage(null);
+        final Message message = createMessage(null);
         Assertions.assertThrows(MessageConversionException.class,
                 () -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class),
                 "Expected MessageConversionException for invalid JSON");
@@ -75,7 +75,7 @@ public class BaseAmqpServiceTest {
     @Description("Tests invalid empty message content")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void updateActionStatusWithEmptyContent() {
-        Message message = createMessage("".getBytes());
+        final Message message = createMessage("".getBytes());
         Assertions.assertThrows(MessageConversionException.class,
                 () -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class),
                 "Expected MessageConversionException for invalid JSON");
@@ -85,13 +85,15 @@ public class BaseAmqpServiceTest {
     @Description("Tests invalid json message content")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void updateActionStatusWithInvalidJsonContent() {
-        Message message = createMessage("Invalid Json".getBytes());
+        final Message message = createMessage("Invalid Json".getBytes());
+        when(rabbitTemplate.getMessageConverter()).thenReturn(new Jackson2JsonMessageConverter());
+
         Assertions.assertThrows(MessageConversionException.class,
                 () -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class),
                 "Expected MessageConversionException for invalid JSON");
     }
 
-    private Message createMessage(byte[] body) {
+    private Message createMessage(final byte[] body) {
         return new Message(body, createJsonProperties());
     }
 

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/BaseAmqpServiceTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/BaseAmqpServiceTest.java
@@ -9,20 +9,18 @@
 package org.eclipse.hawkbit.amqp;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
 
 import org.eclipse.hawkbit.dmf.json.model.DmfActionStatus;
 import org.eclipse.hawkbit.dmf.json.model.DmfActionUpdateStatus;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
@@ -61,52 +59,46 @@ public class BaseAmqpServiceTest {
                 DmfActionUpdateStatus.class);
 
         assertThat(convertedActionUpdateStatus).isEqualToComparingFieldByField(actionUpdateStatus);
-
     }
 
     @Test
     @Description("Tests invalid null message content")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void convertMessageWithNullContent() {
-        try {
-            baseAmqpService.convertMessage(new Message(null, createJsonProperties()), DmfActionUpdateStatus.class);
-            fail("Expected MessageConversionException for inavlid JSON");
-        } catch (final MessageConversionException e) {
-            // expected
-        }
-
+        Message message = createMessage(null);
+        Assertions.assertThrows(MessageConversionException.class,
+                () -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class),
+                "Expected MessageConversionException for invalid JSON");
     }
 
     @Test
     @Description("Tests invalid empty message content")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void updateActionStatusWithEmptyContent() {
-        try {
-            baseAmqpService.convertMessage(new Message("".getBytes(), createJsonProperties()),
-                    DmfActionUpdateStatus.class);
-            fail("Expected MessageConversionException for inavlid JSON");
-        } catch (final MessageConversionException e) {
-            // expected
-        }
-    }
-
-    private MessageProperties createJsonProperties() {
-        final MessageProperties messageProperties = new MessageProperties();
-        messageProperties.setContentType(MessageProperties.CONTENT_TYPE_JSON);
-        return messageProperties;
+        Message message = createMessage("".getBytes());
+        Assertions.assertThrows(MessageConversionException.class,
+                () -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class),
+                "Expected MessageConversionException for invalid JSON");
     }
 
     @Test
     @Description("Tests invalid json message content")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void updateActionStatusWithInvalidJsonContent() {
-        try {
-            baseAmqpService.convertMessage(new Message("Invalid Json".getBytes(), createJsonProperties()),
-                    DmfActionUpdateStatus.class);
-            fail("Expected MessageConversionException for inavlid JSON");
-        } catch (final MessageConversionException e) {
-            // expected
-        }
+        Message message = createMessage("Invalid Json".getBytes());
+        Assertions.assertThrows(MessageConversionException.class,
+                () -> baseAmqpService.convertMessage(message, DmfActionUpdateStatus.class),
+                "Expected MessageConversionException for invalid JSON");
+    }
+
+    private Message createMessage(byte[] body) {
+        return new Message(body, createJsonProperties());
+    }
+
+    private MessageProperties createJsonProperties() {
+        final MessageProperties messageProperties = new MessageProperties();
+        messageProperties.setContentType(MessageProperties.CONTENT_TYPE_JSON);
+        return messageProperties;
     }
 
     private DmfActionUpdateStatus createActionStatus() {

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/listener/ReplyToListener.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/listener/ReplyToListener.java
@@ -8,7 +8,7 @@
  */
 package org.eclipse.hawkbit.integration.listener;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/hawkbit-http-security/src/test/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProviderTest.java
+++ b/hawkbit-http-security/src/test/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProviderTest.java
@@ -12,9 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
+import java.util.Collections;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -31,7 +30,6 @@ import io.qameta.allure.Story;
 @Feature("Unit Tests - Security")
 @Story("PreAuthToken Source TrustAuthentication Provider Test")
 @ExtendWith(MockitoExtension.class)
-// TODO: create description annotations
 public class PreAuthTokenSourceTrustAuthenticationProviderTest {
 
     private static final String REQUEST_SOURCE_IP = "127.0.0.1";
@@ -49,11 +47,11 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
         final String principal = "controllerIdURL";
         final String credentials = "controllerIdHeader";
         final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                Arrays.asList(credentials));
+                Collections.singletonList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
-        Assertions.assertThrows(BadCredentialsException.class, () -> underTestWithoutSourceIpCheck.authenticate(token),
-                "Should not work with wrong credentials");
+        assertThatExceptionOfType(BadCredentialsException.class).as("Should not work with wrong credentials")
+                .isThrownBy(() -> underTestWithoutSourceIpCheck.authenticate(token));
     }
 
     @Test
@@ -62,7 +60,7 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
         final String principal = "controllerId";
         final String credentials = "controllerId";
         final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                Arrays.asList(credentials));
+                Collections.singletonList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
         final Authentication authenticate = underTestWithoutSourceIpCheck.authenticate(token);
@@ -71,28 +69,27 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
 
     @Test
     @Description("Testing that the controllerId in the URI request match with the controllerId in the request header but the request are not coming from a trustful source.")
-    public void priniciapAndCredentialsAreTheSameButSourceIpRequestNotMatching2() {
+    public void principalAndCredentialsAreTheSameButSourceIpRequestNotMatching2() {
         final String remoteAddress = "192.168.1.1";
         final String principal = "controllerId";
         final String credentials = "controllerId";
         final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                Arrays.asList(credentials));
+                Collections.singletonList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
         when(webAuthenticationDetailsMock.getRemoteAddress()).thenReturn(remoteAddress);
 
-        Assertions.assertThrows(InsufficientAuthenticationException.class, () -> {
-            underTestWithSourceIpCheck.authenticate(token);
-        }, "as source is not trusted.");
+        assertThatExceptionOfType(InsufficientAuthenticationException.class).as("as source is not trusted.")
+                .isThrownBy(() -> underTestWithSourceIpCheck.authenticate(token));
     }
 
     @Test
-    @Description("Testing that the controllerId in the URI request match with the controllerId in the request header and the source Ip is matching the allowed remote IP address.")
-    public void priniciapAndCredentialsAreTheSameAndSourceIpIsTrusted() {
+    @Description("Testing that the controllerId in the URI request match with the controllerId in the request header and the source IP is matching the allowed remote IP address.")
+    public void principalAndCredentialsAreTheSameAndSourceIpIsTrusted() {
         final String principal = "controllerId";
         final String credentials = "controllerId";
         final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                Arrays.asList(credentials));
+                Collections.singletonList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
         when(webAuthenticationDetailsMock.getRemoteAddress()).thenReturn(REQUEST_SOURCE_IP);
@@ -103,13 +100,14 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
     }
 
     @Test
-    public void priniciapAndCredentialsAreTheSameAndSourceIpIsWithinList() {
+    @Description("Testing that the controllerId in the URI request match with the controllerId in the request header and the source IP matches one of the allowed remote IP addresses.")
+    public void principalAndCredentialsAreTheSameAndSourceIpIsWithinList() {
         final String[] trustedIPAddresses = new String[] { "192.168.1.1", "192.168.1.2", REQUEST_SOURCE_IP,
                 "192.168.1.3" };
         final String principal = "controllerId";
         final String credentials = "controllerId";
         final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                Arrays.asList(credentials));
+                Collections.singletonList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
         when(webAuthenticationDetailsMock.getRemoteAddress()).thenReturn(REQUEST_SOURCE_IP);
@@ -123,12 +121,13 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
     }
 
     @Test
+    @Description("Testing that the controllerId in the URI request match with the controllerId in the request header and the source IP does not match any of the allowed remote IP addresses.")
     public void principalAndCredentialsAreTheSameSourceIpListNotMatches() {
         final String[] trustedIPAddresses = new String[] { "192.168.1.1", "192.168.1.2", "192.168.1.3" };
         final String principal = "controllerId";
         final String credentials = "controllerId";
         final PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(principal,
-                Arrays.asList(credentials));
+                Collections.singletonList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
         when(webAuthenticationDetailsMock.getRemoteAddress()).thenReturn(REQUEST_SOURCE_IP);

--- a/hawkbit-http-security/src/test/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProviderTest.java
+++ b/hawkbit-http-security/src/test/java/org/eclipse/hawkbit/security/PreAuthTokenSourceTrustAuthenticationProviderTest.java
@@ -52,14 +52,8 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
                 Arrays.asList(credentials));
         token.setDetails(webAuthenticationDetailsMock);
 
-        // test, should throw authentication exception
-        try {
-            underTestWithoutSourceIpCheck.authenticate(token);
-            Assertions.fail("Should not work with wrong credentials");
-        } catch (final BadCredentialsException e) {
-
-        }
-
+        Assertions.assertThrows(BadCredentialsException.class, () -> underTestWithoutSourceIpCheck.authenticate(token),
+                "Should not work with wrong credentials");
     }
 
     @Test
@@ -77,7 +71,7 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
 
     @Test
     @Description("Testing that the controllerId in the URI request match with the controllerId in the request header but the request are not coming from a trustful source.")
-    public void priniciapAndCredentialsAreTheSameButSourceIpRequestNotMatching() {
+    public void priniciapAndCredentialsAreTheSameButSourceIpRequestNotMatching2() {
         final String remoteAddress = "192.168.1.1";
         final String principal = "controllerId";
         final String credentials = "controllerId";
@@ -87,14 +81,9 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
 
         when(webAuthenticationDetailsMock.getRemoteAddress()).thenReturn(remoteAddress);
 
-        // test, should throw authentication exception
-
-        try {
+        Assertions.assertThrows(InsufficientAuthenticationException.class, () -> {
             underTestWithSourceIpCheck.authenticate(token);
-            Assertions.fail("as source is not trusted.");
-        } catch (final InsufficientAuthenticationException e) {
-
-        }
+        }, "as source is not trusted.");
     }
 
     @Test
@@ -147,6 +136,7 @@ public class PreAuthTokenSourceTrustAuthenticationProviderTest {
         final PreAuthTokenSourceTrustAuthenticationProvider underTestWithList = new PreAuthTokenSourceTrustAuthenticationProvider(
                 trustedIPAddresses);
 
-        assertThatExceptionOfType(InsufficientAuthenticationException.class).isThrownBy(()-> underTestWithList.authenticate(token));
+        assertThatExceptionOfType(InsufficientAuthenticationException.class)
+                .isThrownBy(() -> underTestWithList.authenticate(token));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-core/src/test/java/org/eclipse/hawkbit/event/BusProtoStuffMessageConverterTest.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/test/java/org/eclipse/hawkbit/event/BusProtoStuffMessageConverterTest.java
@@ -65,12 +65,11 @@ public class BusProtoStuffMessageConverterTest {
     @Description("Verifies that a MessageConversationException is thrown on missing event-type information encoding")
     public void missingEventTypeMappingThrowsMessageConversationException() {
         final DummyRemoteEntityEvent dummyEvent = new DummyRemoteEntityEvent(targetMock, "applicationId");
-        try {
-            underTest.convertToInternal(dummyEvent, new MessageHeaders(new HashMap<>()), null);
-            Assertions.fail("Missing MessageConversationException for un-defined event-type");
-        } catch (final MessageConversionException e) {
-            // expected exception
-        }
+        final MessageHeaders messageHeaders = new MessageHeaders(new HashMap<>());
+
+        org.junit.jupiter.api.Assertions.assertThrows(MessageConversionException.class,
+                () -> underTest.convertToInternal(dummyEvent, messageHeaders, null),
+                "Missing MessageConversationException for un-defined event-type");
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-core/src/test/java/org/eclipse/hawkbit/event/BusProtoStuffMessageConverterTest.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/test/java/org/eclipse/hawkbit/event/BusProtoStuffMessageConverterTest.java
@@ -9,11 +9,11 @@
 package org.eclipse.hawkbit.event;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.hawkbit.repository.event.remote.entity.RemoteEntityEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
 import org.eclipse.hawkbit.repository.model.Target;
@@ -67,9 +67,9 @@ public class BusProtoStuffMessageConverterTest {
         final DummyRemoteEntityEvent dummyEvent = new DummyRemoteEntityEvent(targetMock, "applicationId");
         final MessageHeaders messageHeaders = new MessageHeaders(new HashMap<>());
 
-        org.junit.jupiter.api.Assertions.assertThrows(MessageConversionException.class,
-                () -> underTest.convertToInternal(dummyEvent, messageHeaders, null),
-                "Missing MessageConversationException for un-defined event-type");
+        assertThatExceptionOfType(MessageConversionException.class)
+                .as("Missing MessageConversationException for un-defined event-type")
+                .isThrownBy(() -> underTest.convertToInternal(dummyEvent, messageHeaders, null));
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/AbstractRemoteEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/AbstractRemoteEventTest.java
@@ -8,7 +8,7 @@
  */
 package org.eclipse.hawkbit.repository.event.remote;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Map;
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/RemoteIdEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/RemoteIdEventTest.java
@@ -17,6 +17,8 @@ import java.util.Arrays;
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/AbstractRemoteEntityEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/AbstractRemoteEntityEventTest.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ArtifactManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ArtifactManagementTest.java
@@ -10,8 +10,7 @@ package org.eclipse.hawkbit.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -44,6 +43,7 @@ import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
 import org.eclipse.hawkbit.repository.test.util.HashGeneratorUtils;
 import org.eclipse.hawkbit.repository.test.util.WithSpringAuthorityRule;
 import org.eclipse.hawkbit.repository.test.util.WithUser;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Lists;
@@ -259,8 +259,7 @@ public class ArtifactManagementTest extends AbstractJpaIntegrationTest {
 
     /**
      * Test method for
-     * {@link org.eclipse.hawkbit.repository.ArtifactManagement#delete(long)}
-     * .
+     * {@link org.eclipse.hawkbit.repository.ArtifactManagement#delete(long)} .
      * 
      * @throws IOException
      */
@@ -452,12 +451,8 @@ public class ArtifactManagementTest extends AbstractJpaIntegrationTest {
     @WithUser(allSpPermissions = true, removeFromAllPermission = { SpPermission.DOWNLOAD_REPOSITORY_ARTIFACT })
     @Description("Trys and fails to load an artifact without required permission. Checks if expected InsufficientPermissionException is thrown.")
     public void loadArtifactBinaryWithoutDownloadArtifactThrowsPermissionDenied() {
-        try {
-            artifactManagement.loadArtifactBinary("123");
-            fail("Should not have worked with missing permission.");
-        } catch (final InsufficientPermissionException e) {
-
-        }
+        Assertions.assertThrows(InsufficientPermissionException.class,
+                () -> artifactManagement.loadArtifactBinary("123"), "Should not have worked with missing permission.");
     }
 
     @Test
@@ -527,8 +522,8 @@ public class ArtifactManagementTest extends AbstractJpaIntegrationTest {
             throws IOException {
         try (final InputStream inputStream = artifactManagement.loadArtifactBinary(artifact.get().getHashes().getSha1())
                 .get().getFileInputStream()) {
-            assertTrue("The stored binary matches the given binary",
-                    IOUtils.contentEquals(new ByteArrayInputStream(randomBytes), inputStream));
+            assertTrue(IOUtils.contentEquals(new ByteArrayInputStream(randomBytes), inputStream),
+                    "The stored binary matches the given binary");
         }
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ArtifactManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ArtifactManagementTest.java
@@ -43,7 +43,6 @@ import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
 import org.eclipse.hawkbit.repository.test.util.HashGeneratorUtils;
 import org.eclipse.hawkbit.repository.test.util.WithSpringAuthorityRule;
 import org.eclipse.hawkbit.repository.test.util.WithUser;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Lists;
@@ -451,8 +450,9 @@ public class ArtifactManagementTest extends AbstractJpaIntegrationTest {
     @WithUser(allSpPermissions = true, removeFromAllPermission = { SpPermission.DOWNLOAD_REPOSITORY_ARTIFACT })
     @Description("Trys and fails to load an artifact without required permission. Checks if expected InsufficientPermissionException is thrown.")
     public void loadArtifactBinaryWithoutDownloadArtifactThrowsPermissionDenied() {
-        Assertions.assertThrows(InsufficientPermissionException.class,
-                () -> artifactManagement.loadArtifactBinary("123"), "Should not have worked with missing permission.");
+        assertThatExceptionOfType(InsufficientPermissionException.class)
+                .as("Should not have worked with missing permission.")
+                .isThrownBy(() -> artifactManagement.loadArtifactBinary("123"));
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
@@ -11,7 +11,6 @@ package org.eclipse.hawkbit.repository.jpa;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -431,9 +430,9 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         assertThat(actionStatusRepository.findAll()).as("wrong size of action status").hasSize(4);
 
         // force quit assignment
-        org.junit.jupiter.api.Assertions.assertThrows(ForceQuitActionNotAllowedException.class,
-                () -> deploymentManagement.forceQuitAction(assigningAction.getId()),
-                "expected ForceQuitActionNotAllowedException");
+        assertThatExceptionOfType(ForceQuitActionNotAllowedException.class)
+                .as("expected ForceQuitActionNotAllowedException")
+                .isThrownBy(() -> deploymentManagement.forceQuitAction(assigningAction.getId()));
     }
 
     private JpaAction assignSet(final Target target, final DistributionSet ds) {
@@ -478,8 +477,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
         assertThat(actionRepository.count()).isEqualTo(20);
         assertThat(actionRepository.findByDistributionSetId(PAGE, ds.getId())).as("Offline actions are not active")
-                .allMatch(action -> !action.isActive())
-                .as("Actions should be initiated by current user")
+                .allMatch(action -> !action.isActive()).as("Actions should be initiated by current user")
                 .allMatch(a -> a.getInitiatedBy().equals(tenantAware.getCurrentUsername()));
 
         assertThat(targetManagement.findByInstalledDistributionSet(PAGE, ds.getId()).getContent())
@@ -915,9 +913,9 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         final DistributionSet incomplete = distributionSetManagement.create(entityFactory.distributionSet().create()
                 .name("incomplete").version("v1").type(standardDsType).modules(Collections.singletonList(ah.getId())));
 
-        org.junit.jupiter.api.Assertions.assertThrows(IncompleteDistributionSetException.class,
-                () -> assignDistributionSet(incomplete, targets),
-                "expected IncompleteDistributionSetException");
+        assertThatExceptionOfType(IncompleteDistributionSetException.class)
+                .as("expected IncompleteDistributionSetException")
+                .isThrownBy(() -> assignDistributionSet(incomplete, targets));
 
         final DistributionSet nowComplete = distributionSetManagement.assignSoftwareModules(incomplete.getId(),
                 Sets.newHashSet(os.getId()));
@@ -1209,32 +1207,35 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
         targ = targetManagement.getByControllerID(targ.getControllerId()).get();
 
-        assertEquals(0,
-                deploymentManagement.findActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements(), "active target actions are wrong");
+        assertEquals(0, deploymentManagement.findActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements(),
+                "active target actions are wrong");
         assertEquals(1,
-                deploymentManagement.findInActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements(), "active actions are wrong");
+                deploymentManagement.findInActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements(),
+                "active actions are wrong");
 
         assertEquals(TargetUpdateStatus.IN_SYNC, targ.getUpdateStatus(), "tagret update status is not correct");
-        assertEquals(dsA,
-                deploymentManagement.getAssignedDistributionSet(targ.getControllerId()).get(), "wrong assigned ds");
-        assertEquals(dsA,
-                deploymentManagement.getInstalledDistributionSet(targ.getControllerId()).get(), "wrong installed ds");
+        assertEquals(dsA, deploymentManagement.getAssignedDistributionSet(targ.getControllerId()).get(),
+                "wrong assigned ds");
+        assertEquals(dsA, deploymentManagement.getInstalledDistributionSet(targ.getControllerId()).get(),
+                "wrong installed ds");
 
         targs = assignDistributionSet(dsB.getId(), "target-id-A").getAssignedEntity().stream().map(Action::getTarget)
                 .collect(Collectors.toList());
 
         targ = targs.iterator().next();
 
-        assertEquals(1,
-                deploymentManagement.findActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements(), "active actions are wrong");
+        assertEquals(1, deploymentManagement.findActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements(),
+                "active actions are wrong");
         assertEquals(TargetUpdateStatus.PENDING,
-                targetManagement.getByControllerID(targ.getControllerId()).get().getUpdateStatus(), "target status is wrong");
-        assertEquals(dsB,
-                deploymentManagement.getAssignedDistributionSet(targ.getControllerId()).get(), "wrong assigned ds");
+                targetManagement.getByControllerID(targ.getControllerId()).get().getUpdateStatus(),
+                "target status is wrong");
+        assertEquals(dsB, deploymentManagement.getAssignedDistributionSet(targ.getControllerId()).get(),
+                "wrong assigned ds");
         assertEquals(dsA.getId(),
-                deploymentManagement.getInstalledDistributionSet(targ.getControllerId()).get().getId(), "Installed ds is wrong");
-        assertEquals(dsB, deploymentManagement
-                .findActiveActionsByTarget(PAGE, targ.getControllerId()).getContent().get(0).getDistributionSet(), "Active ds is wrong");
+                deploymentManagement.getInstalledDistributionSet(targ.getControllerId()).get().getId(),
+                "Installed ds is wrong");
+        assertEquals(dsB, deploymentManagement.findActiveActionsByTarget(PAGE, targ.getControllerId()).getContent()
+                .get(0).getDistributionSet(), "Active ds is wrong");
 
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
@@ -10,8 +10,8 @@ package org.eclipse.hawkbit.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -431,11 +431,9 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         assertThat(actionStatusRepository.findAll()).as("wrong size of action status").hasSize(4);
 
         // force quit assignment
-        try {
-            deploymentManagement.forceQuitAction(assigningAction.getId());
-            fail("expected ForceQuitActionNotAllowedException");
-        } catch (final ForceQuitActionNotAllowedException ex) {
-        }
+        org.junit.jupiter.api.Assertions.assertThrows(ForceQuitActionNotAllowedException.class,
+                () -> deploymentManagement.forceQuitAction(assigningAction.getId()),
+                "expected ForceQuitActionNotAllowedException");
     }
 
     private JpaAction assignSet(final Target target, final DistributionSet ds) {
@@ -917,11 +915,9 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         final DistributionSet incomplete = distributionSetManagement.create(entityFactory.distributionSet().create()
                 .name("incomplete").version("v1").type(standardDsType).modules(Collections.singletonList(ah.getId())));
 
-        try {
-            assignDistributionSet(incomplete, targets);
-            fail("expected IncompleteDistributionSetException");
-        } catch (final IncompleteDistributionSetException ex) {
-        }
+        org.junit.jupiter.api.Assertions.assertThrows(IncompleteDistributionSetException.class,
+                () -> assignDistributionSet(incomplete, targets),
+                "expected IncompleteDistributionSetException");
 
         final DistributionSet nowComplete = distributionSetManagement.assignSoftwareModules(incomplete.getId(),
                 Sets.newHashSet(os.getId()));
@@ -1213,32 +1209,32 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
         targ = targetManagement.getByControllerID(targ.getControllerId()).get();
 
-        assertEquals("active target actions are wrong", 0,
-                deploymentManagement.findActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements());
-        assertEquals("active actions are wrong", 1,
-                deploymentManagement.findInActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements());
+        assertEquals(0,
+                deploymentManagement.findActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements(), "active target actions are wrong");
+        assertEquals(1,
+                deploymentManagement.findInActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements(), "active actions are wrong");
 
-        assertEquals("tagret update status is not correct", TargetUpdateStatus.IN_SYNC, targ.getUpdateStatus());
-        assertEquals("wrong assigned ds", dsA,
-                deploymentManagement.getAssignedDistributionSet(targ.getControllerId()).get());
-        assertEquals("wrong installed ds", dsA,
-                deploymentManagement.getInstalledDistributionSet(targ.getControllerId()).get());
+        assertEquals(TargetUpdateStatus.IN_SYNC, targ.getUpdateStatus(), "tagret update status is not correct");
+        assertEquals(dsA,
+                deploymentManagement.getAssignedDistributionSet(targ.getControllerId()).get(), "wrong assigned ds");
+        assertEquals(dsA,
+                deploymentManagement.getInstalledDistributionSet(targ.getControllerId()).get(), "wrong installed ds");
 
         targs = assignDistributionSet(dsB.getId(), "target-id-A").getAssignedEntity().stream().map(Action::getTarget)
                 .collect(Collectors.toList());
 
         targ = targs.iterator().next();
 
-        assertEquals("active actions are wrong", 1,
-                deploymentManagement.findActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements());
-        assertEquals("target status is wrong", TargetUpdateStatus.PENDING,
-                targetManagement.getByControllerID(targ.getControllerId()).get().getUpdateStatus());
-        assertEquals("wrong assigned ds", dsB,
-                deploymentManagement.getAssignedDistributionSet(targ.getControllerId()).get());
-        assertEquals("Installed ds is wrong", dsA.getId(),
-                deploymentManagement.getInstalledDistributionSet(targ.getControllerId()).get().getId());
-        assertEquals("Active ds is wrong", dsB, deploymentManagement
-                .findActiveActionsByTarget(PAGE, targ.getControllerId()).getContent().get(0).getDistributionSet());
+        assertEquals(1,
+                deploymentManagement.findActiveActionsByTarget(PAGE, targ.getControllerId()).getTotalElements(), "active actions are wrong");
+        assertEquals(TargetUpdateStatus.PENDING,
+                targetManagement.getByControllerID(targ.getControllerId()).get().getUpdateStatus(), "target status is wrong");
+        assertEquals(dsB,
+                deploymentManagement.getAssignedDistributionSet(targ.getControllerId()).get(), "wrong assigned ds");
+        assertEquals(dsA.getId(),
+                deploymentManagement.getInstalledDistributionSet(targ.getControllerId()).get().getId(), "Installed ds is wrong");
+        assertEquals(dsB, deploymentManagement
+                .findActiveActionsByTarget(PAGE, targ.getControllerId()).getContent().get(0).getDistributionSet(), "Active ds is wrong");
 
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTagManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTagManagementTest.java
@@ -9,8 +9,8 @@
 package org.eclipse.hawkbit.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.repository.DistributionSetTagManagement;
+import org.eclipse.hawkbit.repository.builder.TagCreate;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetTagUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetTagUpdatedEvent;
@@ -30,6 +31,7 @@ import org.eclipse.hawkbit.repository.model.DistributionSetTagAssignmentResult;
 import org.eclipse.hawkbit.repository.model.Tag;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.qameta.allure.Description;
@@ -107,63 +109,59 @@ public class DistributionSetTagManagementTest extends AbstractJpaIntegrationTest
         // search for not deleted
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(true)
                 .setTagNames(Arrays.asList(tagA.getName()));
-        assertEquals("filter works not correct",
-                dsAs.spliterator().getExactSizeIfKnown() + dsABs.spliterator().getExactSizeIfKnown()
+        assertEquals(dsAs.spliterator().getExactSizeIfKnown() + dsABs.spliterator().getExactSizeIfKnown()
                         + dsACs.spliterator().getExactSizeIfKnown() + dsABCs.spliterator().getExactSizeIfKnown(),
                 distributionSetManagement.findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build())
-                        .getTotalElements());
+                        .getTotalElements(), "filter works not correct");
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(true)
                 .setTagNames(Arrays.asList(tagB.getName()));
-        assertEquals("filter works not correct",
+        assertEquals(
                 dsBs.spliterator().getExactSizeIfKnown() + dsABs.spliterator().getExactSizeIfKnown()
                         + dsBCs.spliterator().getExactSizeIfKnown() + dsABCs.spliterator().getExactSizeIfKnown(),
                 distributionSetManagement.findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build())
-                        .getTotalElements());
+                        .getTotalElements(), "filter works not correct");
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(true)
                 .setTagNames(Arrays.asList(tagC.getName()));
-        assertEquals("filter works not correct",
-                dsCs.spliterator().getExactSizeIfKnown() + dsACs.spliterator().getExactSizeIfKnown()
+        assertEquals(                dsCs.spliterator().getExactSizeIfKnown() + dsACs.spliterator().getExactSizeIfKnown()
                         + dsBCs.spliterator().getExactSizeIfKnown() + dsABCs.spliterator().getExactSizeIfKnown(),
                 distributionSetManagement.findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build())
-                        .getTotalElements());
+                        .getTotalElements(), "filter works not correct");
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(true)
                 .setTagNames(Arrays.asList(tagX.getName()));
-        assertEquals("filter works not correct", 0, distributionSetManagement
-                .findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build()).getTotalElements());
+        assertEquals(0, distributionSetManagement
+                .findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build()).getTotalElements(), "filter works not correct");
 
-        assertEquals("wrong tag size", 5, distributionSetTagRepository.findAll().spliterator().getExactSizeIfKnown());
+        assertEquals(5, distributionSetTagRepository.findAll().spliterator().getExactSizeIfKnown(), "wrong tag size");
 
         distributionSetTagManagement.delete(tagY.getName());
-        assertEquals("wrong tag size", 4, distributionSetTagRepository.findAll().spliterator().getExactSizeIfKnown());
+        assertEquals(4, distributionSetTagRepository.findAll().spliterator().getExactSizeIfKnown(), "wrong tag size");
         distributionSetTagManagement.delete(tagX.getName());
-        assertEquals("wrong tag size", 3, distributionSetTagRepository.findAll().spliterator().getExactSizeIfKnown());
+        assertEquals(3, distributionSetTagRepository.findAll().spliterator().getExactSizeIfKnown(), "wrong tag size");
 
         distributionSetTagManagement.delete(tagB.getName());
-        assertEquals("wrong tag size", 2, distributionSetTagRepository.findAll().spliterator().getExactSizeIfKnown());
+        assertEquals(2, distributionSetTagRepository.findAll().spliterator().getExactSizeIfKnown(), "wrong tag size");
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(Boolean.TRUE)
                 .setTagNames(Arrays.asList(tagA.getName()));
-        assertEquals("filter works not correct",
-                dsAs.spliterator().getExactSizeIfKnown() + dsABs.spliterator().getExactSizeIfKnown()
+        assertEquals(                dsAs.spliterator().getExactSizeIfKnown() + dsABs.spliterator().getExactSizeIfKnown()
                         + dsACs.spliterator().getExactSizeIfKnown() + dsABCs.spliterator().getExactSizeIfKnown(),
                 distributionSetManagement.findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build())
-                        .getTotalElements());
+                        .getTotalElements(), "filter works not correct");
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(Boolean.TRUE)
                 .setTagNames(Arrays.asList(tagB.getName()));
-        assertEquals("filter works not correct", 0, distributionSetManagement
-                .findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build()).getTotalElements());
+        assertEquals(0, distributionSetManagement
+                .findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build()).getTotalElements(), "filter works not correct");
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(Boolean.TRUE)
                 .setTagNames(Arrays.asList(tagC.getName()));
-        assertEquals("filter works not correct",
-                dsCs.spliterator().getExactSizeIfKnown() + dsACs.spliterator().getExactSizeIfKnown()
+        assertEquals(                dsCs.spliterator().getExactSizeIfKnown() + dsACs.spliterator().getExactSizeIfKnown()
                         + dsBCs.spliterator().getExactSizeIfKnown() + dsABCs.spliterator().getExactSizeIfKnown(),
                 distributionSetManagement.findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build())
-                        .getTotalElements());
+                        .getTotalElements(), "filter works not correct");
     }
 
     @Test
@@ -252,13 +250,12 @@ public class DistributionSetTagManagementTest extends AbstractJpaIntegrationTest
     @Test
     @Description("Ensures that a tag cannot be created if one exists already with that name (ecpects EntityAlreadyExistsException).")
     public void failedDuplicateDsTagNameException() {
-        distributionSetTagManagement.create(entityFactory.tag().create().name("A"));
-        try {
-            distributionSetTagManagement.create(entityFactory.tag().create().name("A"));
-            fail("should not have worked as tag already exists");
-        } catch (final EntityAlreadyExistsException e) {
+        final TagCreate tag = entityFactory.tag().create().name("A");
+        distributionSetTagManagement.create(tag);
 
-        }
+        Assertions.assertThrows(EntityAlreadyExistsException.class,
+                () -> distributionSetTagManagement.create(tag),
+                "should not have worked as tag already exists");
     }
 
     @Test
@@ -267,12 +264,9 @@ public class DistributionSetTagManagementTest extends AbstractJpaIntegrationTest
         distributionSetTagManagement.create(entityFactory.tag().create().name("A"));
         final DistributionSetTag tag = distributionSetTagManagement.create(entityFactory.tag().create().name("B"));
 
-        try {
-            distributionSetTagManagement.update(entityFactory.tag().update(tag.getId()).name("A"));
-            fail("should not have worked as tag already exists");
-        } catch (final EntityAlreadyExistsException e) {
-
-        }
+        Assertions.assertThrows(EntityAlreadyExistsException.class,
+                () -> distributionSetTagManagement.update(entityFactory.tag().update(tag.getId()).name("A")),
+                "should not have worked as tag already exists");
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTagManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DistributionSetTagManagementTest.java
@@ -9,8 +9,8 @@
 package org.eclipse.hawkbit.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +31,6 @@ import org.eclipse.hawkbit.repository.model.DistributionSetTagAssignmentResult;
 import org.eclipse.hawkbit.repository.model.Tag;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.qameta.allure.Description;
@@ -112,7 +111,8 @@ public class DistributionSetTagManagementTest extends AbstractJpaIntegrationTest
         assertEquals(dsAs.spliterator().getExactSizeIfKnown() + dsABs.spliterator().getExactSizeIfKnown()
                         + dsACs.spliterator().getExactSizeIfKnown() + dsABCs.spliterator().getExactSizeIfKnown(),
                 distributionSetManagement.findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build())
-                        .getTotalElements(), "filter works not correct");
+                        .getTotalElements(),
+                "filter works not correct");
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(true)
                 .setTagNames(Arrays.asList(tagB.getName()));
@@ -120,19 +120,22 @@ public class DistributionSetTagManagementTest extends AbstractJpaIntegrationTest
                 dsBs.spliterator().getExactSizeIfKnown() + dsABs.spliterator().getExactSizeIfKnown()
                         + dsBCs.spliterator().getExactSizeIfKnown() + dsABCs.spliterator().getExactSizeIfKnown(),
                 distributionSetManagement.findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build())
-                        .getTotalElements(), "filter works not correct");
+                        .getTotalElements(),
+                "filter works not correct");
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(true)
                 .setTagNames(Arrays.asList(tagC.getName()));
-        assertEquals(                dsCs.spliterator().getExactSizeIfKnown() + dsACs.spliterator().getExactSizeIfKnown()
+        assertEquals(dsCs.spliterator().getExactSizeIfKnown() + dsACs.spliterator().getExactSizeIfKnown()
                         + dsBCs.spliterator().getExactSizeIfKnown() + dsABCs.spliterator().getExactSizeIfKnown(),
                 distributionSetManagement.findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build())
-                        .getTotalElements(), "filter works not correct");
+                        .getTotalElements(),
+                "filter works not correct");
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(true)
                 .setTagNames(Arrays.asList(tagX.getName()));
         assertEquals(0, distributionSetManagement
-                .findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build()).getTotalElements(), "filter works not correct");
+                .findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build()).getTotalElements(),
+                "filter works not correct");
 
         assertEquals(5, distributionSetTagRepository.findAll().spliterator().getExactSizeIfKnown(), "wrong tag size");
 
@@ -146,22 +149,25 @@ public class DistributionSetTagManagementTest extends AbstractJpaIntegrationTest
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(Boolean.TRUE)
                 .setTagNames(Arrays.asList(tagA.getName()));
-        assertEquals(                dsAs.spliterator().getExactSizeIfKnown() + dsABs.spliterator().getExactSizeIfKnown()
+        assertEquals(dsAs.spliterator().getExactSizeIfKnown() + dsABs.spliterator().getExactSizeIfKnown()
                         + dsACs.spliterator().getExactSizeIfKnown() + dsABCs.spliterator().getExactSizeIfKnown(),
                 distributionSetManagement.findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build())
-                        .getTotalElements(), "filter works not correct");
+                        .getTotalElements(),
+                "filter works not correct");
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(Boolean.TRUE)
                 .setTagNames(Arrays.asList(tagB.getName()));
         assertEquals(0, distributionSetManagement
-                .findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build()).getTotalElements(), "filter works not correct");
+                .findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build()).getTotalElements(),
+                "filter works not correct");
 
         distributionSetFilterBuilder = getDistributionSetFilterBuilder().setIsComplete(Boolean.TRUE)
                 .setTagNames(Arrays.asList(tagC.getName()));
-        assertEquals(                dsCs.spliterator().getExactSizeIfKnown() + dsACs.spliterator().getExactSizeIfKnown()
+        assertEquals(dsCs.spliterator().getExactSizeIfKnown() + dsACs.spliterator().getExactSizeIfKnown()
                         + dsBCs.spliterator().getExactSizeIfKnown() + dsABCs.spliterator().getExactSizeIfKnown(),
                 distributionSetManagement.findByDistributionSetFilter(PAGE, distributionSetFilterBuilder.build())
-                        .getTotalElements(), "filter works not correct");
+                        .getTotalElements(),
+                "filter works not correct");
     }
 
     @Test
@@ -253,9 +259,8 @@ public class DistributionSetTagManagementTest extends AbstractJpaIntegrationTest
         final TagCreate tag = entityFactory.tag().create().name("A");
         distributionSetTagManagement.create(tag);
 
-        Assertions.assertThrows(EntityAlreadyExistsException.class,
-                () -> distributionSetTagManagement.create(tag),
-                "should not have worked as tag already exists");
+        assertThatExceptionOfType(EntityAlreadyExistsException.class).as("should not have worked as tag already exists")
+                .isThrownBy(() -> distributionSetTagManagement.create(tag));
     }
 
     @Test
@@ -264,9 +269,9 @@ public class DistributionSetTagManagementTest extends AbstractJpaIntegrationTest
         distributionSetTagManagement.create(entityFactory.tag().create().name("A"));
         final DistributionSetTag tag = distributionSetTagManagement.create(entityFactory.tag().create().name("B"));
 
-        Assertions.assertThrows(EntityAlreadyExistsException.class,
-                () -> distributionSetTagManagement.update(entityFactory.tag().update(tag.getId()).name("A")),
-                "should not have worked as tag already exists");
+        assertThatExceptionOfType(EntityAlreadyExistsException.class).as("should not have worked as tag already exists")
+                .isThrownBy(
+                        () -> distributionSetTagManagement.update(entityFactory.tag().update(tag.getId()).name("A")));
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleManagementTest.java
@@ -10,8 +10,8 @@ package org.eclipse.hawkbit.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -42,6 +42,7 @@ import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
 import org.eclipse.hawkbit.repository.test.util.WithUser;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -164,12 +165,9 @@ public class SoftwareModuleManagementTest extends AbstractJpaIntegrationTest {
     @Description("Create Software Module call fails when called for existing entity.")
     public void createModuleCallFailsForExistingModule() {
         testdataFactory.createSoftwareModuleOs();
-        try {
-            testdataFactory.createSoftwareModuleOs();
-            fail("Should not have worked as module already exists.");
-        } catch (final EntityAlreadyExistsException e) {
-
-        }
+        Assertions.assertThrows(EntityAlreadyExistsException.class,
+                () -> testdataFactory.createSoftwareModuleOs(),
+                "Should not have worked as module already exists.");
     }
 
     @Test
@@ -304,7 +302,7 @@ public class SoftwareModuleManagementTest extends AbstractJpaIntegrationTest {
         // [VERIFY EXPECTED RESULT]:
         // verify: assignedModule is marked as deleted
         assignedModule = softwareModuleManagement.get(assignedModule.getId()).get();
-        assertTrue("The module should be flagged as deleted", assignedModule.isDeleted());
+        assertTrue(assignedModule.isDeleted(), "The module should be flagged as deleted");
         assertThat(softwareModuleManagement.findAll(PAGE)).hasSize(0);
         assertThat(softwareModuleRepository.findAll()).hasSize(1);
 
@@ -344,7 +342,7 @@ public class SoftwareModuleManagementTest extends AbstractJpaIntegrationTest {
         // [VERIFY EXPECTED RESULT]:
         // verify: assignedModule is marked as deleted
         assignedModule = softwareModuleManagement.get(assignedModule.getId()).get();
-        assertTrue("The found module should be flagged deleted", assignedModule.isDeleted());
+        assertTrue(assignedModule.isDeleted(), "The found module should be flagged deleted");
         assertThat(softwareModuleManagement.findAll(PAGE)).hasSize(0);
         assertThat(softwareModuleRepository.findAll()).hasSize(1);
 
@@ -451,8 +449,8 @@ public class SoftwareModuleManagementTest extends AbstractJpaIntegrationTest {
         // verify: SoftwareModuleX and SofwtareModule are marked as deleted
         assertThat(moduleX).isNotNull();
         assertThat(moduleY).isNotNull();
-        assertTrue("The module should be flagged deleted", moduleX.isDeleted());
-        assertTrue("The module should be flagged deleted", moduleY.isDeleted());
+        assertTrue(moduleX.isDeleted(), "The module should be flagged deleted");
+        assertTrue(moduleY.isDeleted(), "The module should be flagged deleted");
         assertThat(softwareModuleManagement.findAll(PAGE)).hasSize(0);
         assertThat(softwareModuleRepository.findAll()).hasSize(2);
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleManagementTest.java
@@ -11,7 +11,6 @@ package org.eclipse.hawkbit.repository.jpa;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -23,8 +22,8 @@ import java.util.List;
 import org.apache.commons.lang3.RandomUtils;
 import org.eclipse.hawkbit.repository.builder.SoftwareModuleMetadataCreate;
 import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleCreatedEvent;
-import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.AssignmentQuotaExceededException;
+import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet;
 import org.eclipse.hawkbit.repository.jpa.model.JpaSoftwareModuleMetadata;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTarget;
@@ -42,7 +41,6 @@ import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
 import org.eclipse.hawkbit.repository.test.util.WithUser;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -165,9 +163,9 @@ public class SoftwareModuleManagementTest extends AbstractJpaIntegrationTest {
     @Description("Create Software Module call fails when called for existing entity.")
     public void createModuleCallFailsForExistingModule() {
         testdataFactory.createSoftwareModuleOs();
-        Assertions.assertThrows(EntityAlreadyExistsException.class,
-                () -> testdataFactory.createSoftwareModuleOs(),
-                "Should not have worked as module already exists.");
+        assertThatExceptionOfType(EntityAlreadyExistsException.class)
+                .as("Should not have worked as module already exists.")
+                .isThrownBy(() -> testdataFactory.createSoftwareModuleOs());
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleTypeManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SoftwareModuleTypeManagementTest.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.List;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFilterQueryManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFilterQueryManagementTest.java
@@ -10,12 +10,12 @@ package org.eclipse.hawkbit.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.List;
@@ -108,8 +108,8 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
         final String filterName = "new target filter";
         final TargetFilterQuery targetFilterQuery = targetFilterQueryManagement
                 .create(entityFactory.targetFilterQuery().create().name(filterName).query("name==PendingTargets001"));
-        assertEquals("Retrieved newly created custom target filter", targetFilterQuery,
-                targetFilterQueryManagement.getByName(filterName).get());
+        assertEquals(targetFilterQuery,
+                targetFilterQueryManagement.getByName(filterName).get(), "Retrieved newly created custom target filter");
     }
 
     @Test
@@ -139,8 +139,8 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
 
         final List<TargetFilterQuery> results = targetFilterQueryManagement
                 .findByRsql(PageRequest.of(0, 10), "name==" + filterName).getContent();
-        assertEquals("Search result should have 1 result", 1, results.size());
-        assertEquals("Retrieved newly created custom target filter", targetFilterQuery, results.get(0));
+        assertEquals(1, results.size(), "Search result should have 1 result");
+        assertEquals(targetFilterQuery, results.get(0), "Retrieved newly created custom target filter");
     }
 
     @Test
@@ -157,13 +157,9 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
         targetFilterQueryManagement
                 .create(entityFactory.targetFilterQuery().create().name(filterName).query("name==PendingTargets001"));
 
-        try {
-            targetFilterQueryManagement.create(
-                    entityFactory.targetFilterQuery().create().name(filterName).query("name==PendingTargets001"));
-            fail("should not have worked as query already exists");
-        } catch (final EntityAlreadyExistsException e) {
-
-        }
+        org.junit.jupiter.api.Assertions.assertThrows(EntityAlreadyExistsException.class,
+                () -> targetFilterQueryManagement.create(entityFactory.targetFilterQuery().create().name(filterName).query("name==PendingTargets001")),
+                "should not have worked as query already exists");
     }
 
     @Test
@@ -173,9 +169,8 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
         final TargetFilterQuery targetFilterQuery = targetFilterQueryManagement
                 .create(entityFactory.targetFilterQuery().create().name(filterName).query("name==PendingTargets001"));
         targetFilterQueryManagement.delete(targetFilterQuery.getId());
-        assertFalse("Returns null as the target filter is deleted",
-                targetFilterQueryManagement.get(targetFilterQuery.getId()).isPresent());
-
+        assertFalse(
+                targetFilterQueryManagement.get(targetFilterQuery.getId()).isPresent(), "Returns null as the target filter is deleted");
     }
 
     @Test
@@ -188,9 +183,8 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
         final String newQuery = "status==UNKNOWN";
         targetFilterQueryManagement
                 .update(entityFactory.targetFilterQuery().update(targetFilterQuery.getId()).query(newQuery));
-        assertEquals("Returns updated target filter query", newQuery,
-                targetFilterQueryManagement.getByName(filterName).get().getQuery());
-
+        assertEquals(newQuery,
+                targetFilterQueryManagement.getByName(filterName).get().getQuery(), "Returns updated target filter query");
     }
 
     @Test
@@ -245,7 +239,6 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
             final DistributionSet distributionSet) {
         // assigning a distribution set with TIMEFORCED action is supposed to
         // fail as only FORCED and SOFT action types are allowed
-
         assertThatExceptionOfType(InvalidAutoAssignActionTypeException.class)
                 .isThrownBy(() -> targetFilterQueryManagement.updateAutoAssignDS(
                         entityFactory.targetFilterQuery().updateAutoAssign(targetFilterQuery.getId())
@@ -278,8 +271,8 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
             final ActionType actionType) {
         final TargetFilterQuery tfq = targetFilterQueryManagement.getByName(filterName).get();
 
-        assertEquals("Returns correct distribution set", distributionSet, tfq.getAutoAssignDistributionSet());
-        assertEquals("Return correct action type", actionType, tfq.getAutoAssignActionType());
+        assertEquals(distributionSet, tfq.getAutoAssignDistributionSet(), "Returns correct distribution set");
+        assertEquals(actionType, tfq.getAutoAssignActionType(), "Return correct action type");
     }
 
     @Test
@@ -335,16 +328,16 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
 
         // Check if target filter query is there
         TargetFilterQuery tfq = targetFilterQueryManagement.getByName(filterName).get();
-        assertEquals("Returns correct distribution set", distributionSet, tfq.getAutoAssignDistributionSet());
-        assertEquals("Return correct action type", ActionType.FORCED, tfq.getAutoAssignActionType());
+        assertEquals(distributionSet, tfq.getAutoAssignDistributionSet(), "Returns correct distribution set");
+        assertEquals(ActionType.FORCED, tfq.getAutoAssignActionType(), "Return correct action type");
 
         distributionSetManagement.delete(distributionSet.getId());
 
         // Check if auto assign distribution set is null
         tfq = targetFilterQueryManagement.getByName(filterName).get();
-        assertNotNull("Returns target filter query", tfq);
-        assertNull("Returns distribution set as null", tfq.getAutoAssignDistributionSet());
-        assertNull("Returns action type as null", tfq.getAutoAssignActionType());
+        assertNotNull(tfq, "Returns target filter query");
+        assertNull(tfq.getAutoAssignDistributionSet(), "Returns distribution set as null");
+        assertNull(tfq.getAutoAssignActionType(), "Returns action type as null");
     }
 
     @Test
@@ -366,20 +359,20 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
 
         // Check if target filter query is there with the distribution set
         TargetFilterQuery tfq = targetFilterQueryManagement.getByName(filterName).get();
-        assertEquals("Returns correct distribution set", distributionSet, tfq.getAutoAssignDistributionSet());
-        assertEquals("Return correct action type", ActionType.FORCED, tfq.getAutoAssignActionType());
+        assertEquals(distributionSet, tfq.getAutoAssignDistributionSet(), "Returns correct distribution set");
+        assertEquals(ActionType.FORCED, tfq.getAutoAssignActionType(), "Return correct action type");
 
         distributionSetManagement.delete(distributionSet.getId());
 
         // Check if distribution set is still in the database with deleted flag
-        assertTrue("Distribution set should be deleted",
-                distributionSetManagement.get(distributionSet.getId()).get().isDeleted());
+        assertTrue(
+                distributionSetManagement.get(distributionSet.getId()).get().isDeleted(), "Distribution set should be deleted");
 
         // Check if auto assign distribution set is null
         tfq = targetFilterQueryManagement.getByName(filterName).get();
-        assertNotNull("Returns target filter query", tfq);
-        assertNull("Returns distribution set as null", tfq.getAutoAssignDistributionSet());
-        assertNull("Returns action type as null", tfq.getAutoAssignActionType());
+        assertNotNull(tfq, "Returns target filter query");
+        assertNull(tfq.getAutoAssignDistributionSet(), "Returns distribution set as null");
+        assertNull(tfq.getAutoAssignActionType(), "Returns action type as null");
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFilterQueryManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFilterQueryManagementTest.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,11 +27,11 @@ import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetCreated
 import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetFilterQueryCreatedEvent;
+import org.eclipse.hawkbit.repository.exception.AssignmentQuotaExceededException;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.InvalidAutoAssignActionTypeException;
 import org.eclipse.hawkbit.repository.exception.InvalidAutoAssignDistributionSetException;
 import org.eclipse.hawkbit.repository.exception.MultiAssignmentIsNotEnabledException;
-import org.eclipse.hawkbit.repository.exception.AssignmentQuotaExceededException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterUnsupportedFieldException;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.ActionType;
@@ -108,8 +107,8 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
         final String filterName = "new target filter";
         final TargetFilterQuery targetFilterQuery = targetFilterQueryManagement
                 .create(entityFactory.targetFilterQuery().create().name(filterName).query("name==PendingTargets001"));
-        assertEquals(targetFilterQuery,
-                targetFilterQueryManagement.getByName(filterName).get(), "Retrieved newly created custom target filter");
+        assertEquals(targetFilterQuery, targetFilterQueryManagement.getByName(filterName).get(),
+                "Retrieved newly created custom target filter");
     }
 
     @Test
@@ -146,8 +145,9 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
     @Test
     @Description("Test searching a target filter query with an invalid filter.")
     public void searchTargetFilterQueryInvalidField() {
-        Assertions.assertThatExceptionOfType(RSQLParameterUnsupportedFieldException.class).isThrownBy(
-                () -> targetFilterQueryManagement.findByRsql(PageRequest.of(0, 10), "unknownField==testValue").getContent());
+        Assertions.assertThatExceptionOfType(RSQLParameterUnsupportedFieldException.class)
+                .isThrownBy(() -> targetFilterQueryManagement
+                        .findByRsql(PageRequest.of(0, 10), "unknownField==testValue").getContent());
     }
 
     @Test
@@ -157,9 +157,10 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
         targetFilterQueryManagement
                 .create(entityFactory.targetFilterQuery().create().name(filterName).query("name==PendingTargets001"));
 
-        org.junit.jupiter.api.Assertions.assertThrows(EntityAlreadyExistsException.class,
-                () -> targetFilterQueryManagement.create(entityFactory.targetFilterQuery().create().name(filterName).query("name==PendingTargets001")),
-                "should not have worked as query already exists");
+        assertThatExceptionOfType(EntityAlreadyExistsException.class)
+                .as("should not have worked as query already exists")
+                .isThrownBy(() -> targetFilterQueryManagement.create(
+                        entityFactory.targetFilterQuery().create().name(filterName).query("name==PendingTargets001")));
     }
 
     @Test
@@ -169,8 +170,8 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
         final TargetFilterQuery targetFilterQuery = targetFilterQueryManagement
                 .create(entityFactory.targetFilterQuery().create().name(filterName).query("name==PendingTargets001"));
         targetFilterQueryManagement.delete(targetFilterQuery.getId());
-        assertFalse(
-                targetFilterQueryManagement.get(targetFilterQuery.getId()).isPresent(), "Returns null as the target filter is deleted");
+        assertFalse(targetFilterQueryManagement.get(targetFilterQuery.getId()).isPresent(),
+                "Returns null as the target filter is deleted");
     }
 
     @Test
@@ -183,8 +184,8 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
         final String newQuery = "status==UNKNOWN";
         targetFilterQueryManagement
                 .update(entityFactory.targetFilterQuery().update(targetFilterQuery.getId()).query(newQuery));
-        assertEquals(newQuery,
-                targetFilterQueryManagement.getByName(filterName).get().getQuery(), "Returns updated target filter query");
+        assertEquals(newQuery, targetFilterQueryManagement.getByName(filterName).get().getQuery(),
+                "Returns updated target filter query");
     }
 
     @Test
@@ -365,8 +366,8 @@ public class TargetFilterQueryManagementTest extends AbstractJpaIntegrationTest 
         distributionSetManagement.delete(distributionSet.getId());
 
         // Check if distribution set is still in the database with deleted flag
-        assertTrue(
-                distributionSetManagement.get(distributionSet.getId()).get().isDeleted(), "Distribution set should be deleted");
+        assertTrue(distributionSetManagement.get(distributionSet.getId()).get().isDeleted(),
+                "Distribution set should be deleted");
 
         // Check if auto assign distribution set is null
         tfq = targetFilterQueryManagement.getByName(filterName).get();

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetTagManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetTagManagementTest.java
@@ -10,7 +10,7 @@ package org.eclipse.hawkbit.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLActionFieldsTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLActionFieldsTest.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.repository.jpa.rsql;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.hawkbit.repository.ActionFields;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterUnsupportedFieldException;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLDistributionSetFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLDistributionSetFieldTest.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.repository.jpa.rsql;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFieldTest.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.repository.jpa.rsql;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFilterQueryFieldsTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLTargetFilterQueryFieldsTest.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.repository.jpa.rsql;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.hawkbit.repository.TargetFilterQueryFields;
 import org.eclipse.hawkbit.repository.jpa.AbstractJpaIntegrationTest;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtilityTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtilityTest.java
@@ -8,7 +8,7 @@
  */
 package org.eclipse.hawkbit.repository.jpa.rsql;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/VirtualPropertyResolverTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/VirtualPropertyResolverTest.java
@@ -8,9 +8,10 @@
  */
 package org.eclipse.hawkbit.repository.jpa.rsql;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+
 import static org.mockito.Mockito.when;
 
 import org.apache.commons.lang3.text.StrSubstitutor;

--- a/hawkbit-repository/hawkbit-repository-test/pom.xml
+++ b/hawkbit-repository/hawkbit-repository-test/pom.xml
@@ -9,7 +9,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <parent>
       <groupId>org.eclipse.hawkbit</groupId>
@@ -48,19 +48,19 @@
          <artifactId>mariadb-java-client</artifactId>
       </dependency>
       <dependency>
-      	<groupId>com.microsoft.sqlserver</groupId>
-       	<artifactId>mssql-jdbc</artifactId>
+         <groupId>com.microsoft.sqlserver</groupId>
+         <artifactId>mssql-jdbc</artifactId>
       </dependency>
       <dependency>
-		<groupId>org.postgresql</groupId>
-    	<artifactId>postgresql</artifactId>
-	  </dependency>
+         <groupId>org.postgresql</groupId>
+         <artifactId>postgresql</artifactId>
+      </dependency>
       <!-- Add a JDBC DB2 compatabile driver if you want to run tests against DB2, e.g. -->
-<!--       <dependency> -->
-<!--          <groupId>com.ibm.db2.jcc</groupId> -->
-<!--          <artifactId>db2jcc4</artifactId> -->
-<!--          <version>11.1.2.2</version> -->
-<!--       </dependency> -->
+      <!--       <dependency> -->
+      <!--          <groupId>com.ibm.db2.jcc</groupId> -->
+      <!--          <artifactId>db2jcc4</artifactId> -->
+      <!--          <version>11.1.2.2</version> -->
+      <!--       </dependency> -->
       <dependency>
          <groupId>org.springframework.boot</groupId>
          <artifactId>spring-boot-starter-logging</artifactId>
@@ -76,7 +76,7 @@
       <dependency>
          <groupId>org.springframework</groupId>
          <artifactId>spring-context-support</artifactId>
-      </dependency>      
+      </dependency>
       <dependency>
          <groupId>com.google.guava</groupId>
          <artifactId>guava</artifactId>
@@ -88,7 +88,7 @@
       <dependency>
          <groupId>net._01001111</groupId>
          <artifactId>jlorem</artifactId>
-      </dependency>      
+      </dependency>
       <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-lang3</artifactId>
@@ -116,6 +116,12 @@
       <dependency>
          <groupId>org.springframework.cloud</groupId>
          <artifactId>spring-cloud-stream-binder-test</artifactId>
+         <exclusions>
+            <exclusion>
+               <groupId>junit</groupId>
+               <artifactId>junit</artifactId>
+            </exclusion>
+         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.springframework.cloud</groupId>

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/matcher/EventVerifier.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.repository.test.matcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Method;
 import java.util.Iterator;
@@ -20,10 +21,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.eclipse.hawkbit.repository.event.remote.RemoteIdEvent;
 import org.eclipse.hawkbit.repository.event.remote.RemoteTenantAwareEvent;
 import org.eclipse.hawkbit.repository.event.remote.TargetAssignDistributionSetEvent;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.bus.event.RemoteApplicationEvent;
@@ -37,8 +39,6 @@ import org.springframework.test.context.support.AbstractTestExecutionListener;
 import com.google.common.collect.ConcurrentHashMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
-import org.awaitility.Awaitility;
-import org.awaitility.core.ConditionTimeoutException;
 
 /**
  * Test rule to setup and verify the event count for a method.
@@ -107,7 +107,7 @@ public class EventVerifier extends AbstractTestExecutionListener {
                         .until(() -> eventCaptor.getCountFor(expectedEvent.type()), equalTo(expectedEvent.count()));
 
             } catch (final ConditionTimeoutException ex) {
-                Assert.fail("Did not receive the expected amount of events form " + expectedEvent.type() + " Expected: "
+                fail("Did not receive the expected amount of events form " + expectedEvent.type() + " Expected: "
                         + expectedEvent.count() + " but was: " + eventCaptor.getCountFor(expectedEvent.type()));
             }
         }
@@ -124,7 +124,7 @@ public class EventVerifier extends AbstractTestExecutionListener {
                 final int count = eventCaptor.getCountFor(element);
                 failMessage.append(element + " with count: " + count + " ");
             }
-            Assert.fail(failMessage.toString());
+            fail(failMessage.toString());
         }
 
     }

--- a/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactDownloadTest.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiArtifactDownloadTest.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.ddi.rest.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -190,8 +190,8 @@ public class DdiArtifactDownloadTest extends AbstractDDiApiIntegrationTest {
                 .andExpect(header().string("Content-Disposition", "attachment;filename=" + artifact.getFilename()))
                 .andReturn();
 
-        assertTrue("The same file that was uploaded is expected when downloaded",
-                Arrays.equals(result.getResponse().getContentAsByteArray(), random));
+        assertTrue(
+                Arrays.equals(result.getResponse().getContentAsByteArray(), random), "The same file that was uploaded is expected when downloaded");
 
         // download complete
         assertThat(downLoadProgress).isEqualTo(10);

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtContentTypeTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtContentTypeTest.java
@@ -28,7 +28,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -238,8 +238,8 @@ public class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegra
         try (InputStream fileInputStream = artifactManagement
                 .loadArtifactBinary(softwareModuleManagement.get(sm.getId()).get().getArtifacts().get(0).getSha1Hash())
                 .get().getFileInputStream()) {
-            assertTrue("Wrong artifact content",
-                    IOUtils.contentEquals(new ByteArrayInputStream(random), fileInputStream));
+            assertTrue(
+                    IOUtils.contentEquals(new ByteArrayInputStream(random), fileInputStream), "Wrong artifact content");
         }
 
         // hashes
@@ -486,7 +486,7 @@ public class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegra
                 .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM))
                 .andExpect(header().string("ETag", artifact.getSha1Hash())).andReturn();
 
-        assertTrue("Wrong response content", Arrays.equals(result.getResponse().getContentAsByteArray(), random));
+        assertTrue(Arrays.equals(result.getResponse().getContentAsByteArray(), random), "Wrong response content");
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/filter/ExcludePathAwareShallowETagFilterTest.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/filter/ExcludePathAwareShallowETagFilterTest.java
@@ -21,19 +21,19 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
 @Feature("Unit Tests - Security")
 @Story("Exclude path aware shallow ETag filter")
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ExcludePathAwareShallowETagFilterTest {
 
     @Mock

--- a/hawkbit-rest/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/json/model/ExceptionInfoTest.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/json/model/ExceptionInfoTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;

--- a/hawkbit-rest/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/util/SortUtilityTest.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/util/SortUtilityTest.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.rest.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
@@ -17,7 +17,7 @@ import org.eclipse.hawkbit.repository.TargetFields;
 import org.eclipse.hawkbit.rest.exception.SortParameterSyntaxErrorException;
 import org.eclipse.hawkbit.rest.exception.SortParameterUnsupportedDirectionException;
 import org.eclipse.hawkbit.rest.exception.SortParameterUnsupportedFieldException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Sort.Order;
 
 import io.qameta.allure.Description;


### PR DESCRIPTION
`spring-cloud-stream-binder-test` has added the JUnit4 dependency to `hawkbit-repository-test`. Therefore modules that include this dependency can still make use of JUnit4. This PR will replace all JUnit4 leftovers with JUnit5.