### PR TITLE
Abort input stream if needed

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/model/AbstractDbArtifact.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/model/AbstractDbArtifact.java
@@ -64,8 +64,16 @@ public abstract class AbstractDbArtifact {
     /**
      * Creates an {@link InputStream} on this artifact. Caller has to take care
      * of closing the stream. Repeatable calls open a new {@link InputStream}.
-     * 
+     *
      * @return {@link InputStream} to read from artifact.
      */
     public abstract InputStream getFileInputStream();
+
+    /**
+     * Used to abort the stream before it is finally closed. This is needed when the
+     * download is aborted, for example.
+     */
+    public void abortIfNeeded() {
+        // do abort input stream if needed
+    }
 }

--- a/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/FileStreamingUtil.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/FileStreamingUtil.java
@@ -215,6 +215,7 @@ public final class FileStreamingUtil {
             copyStreams(from, to, progressListener, r.getStart(), r.getLength(), filename);
         } catch (final IOException e) {
             artifact.abortIfNeeded();
+            throw e;
         } finally {
             from.close();
         }


### PR DESCRIPTION
Add a method to cancel an Artifact Input Stream before it is closed.

Signed-off-by: Michael Herdt <Michael.Herdt@bosch.io>