### PR TITLE
Fix the creation of the Usage Report

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaSystemManagement.java
@@ -183,12 +183,7 @@ public class JpaSystemManagement implements CurrentTenantCacheKeyGenerator, Syst
     }
 
     private void usageStatsPerTenant(final SystemUsageReportWithTenants report) {
-        final List<String> tenants = findTenants(PageRequest.of(0, MAX_TENANTS_QUERY)).getContent();
-
-        tenants.forEach(tenant -> tenantAware.runAsTenant(tenant, () -> {
-            report.addTenantData(systemStatsManagement.getStatsOfTenant());
-            return null;
-        }));
+        forEachTenant(tenant -> report.addTenantData(systemStatsManagement.getStatsOfTenant()));
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SystemManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/SystemManagementTest.java
@@ -42,6 +42,16 @@ public class SystemManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
+    @Description("Ensures that getSystemUsageStatisticsWithTenants returns the usage of all tenants and not only the first 1000 (max page size).")
+    public void systemUsageReportCollectsStatisticsOfManyTenants() throws Exception {
+        // Prepare tenants
+        createTestTenantsForSystemStatistics(1050, 0, 0, 0);
+
+        final List<TenantUsage> tenants = systemManagement.getSystemUsageStatisticsWithTenants().getTenants();
+        assertThat(tenants).hasSize(1051); // +1 from the setup
+    }
+
+    @Test
     @Description("Checks that the system report calculates correctly the artifact size of all tenants in the system. It ignores deleted software modules with their artifacts.")
     public void systemUsageReportCollectsArtifactsOfAllTenants() throws Exception {
         // Prepare tenants


### PR DESCRIPTION
Currently, a page request is created for a maximum 1000 tenants to generate the usage report. The existing forEachTenant method is now used to create the report for all existing tenants.

Signed-off-by: Michael Herdt <Michael.Herdt@bosch.io>