### PR TITLE
Refactoring TargetFilterQueryManagement

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetFilterQueryManagement.java
@@ -18,6 +18,7 @@ import org.eclipse.hawkbit.repository.QuotaManagement;
 import org.eclipse.hawkbit.repository.TargetFields;
 import org.eclipse.hawkbit.repository.TargetFilterQueryFields;
 import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
+import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.repository.builder.AutoAssignDistributionSetUpdate;
 import org.eclipse.hawkbit.repository.builder.GenericTargetFilterQueryUpdate;
@@ -66,7 +67,7 @@ import com.google.common.collect.Lists;
 public class JpaTargetFilterQueryManagement implements TargetFilterQueryManagement {
 
     private final TargetFilterQueryRepository targetFilterQueryRepository;
-    private final TargetRepository targetRepository;
+    private final TargetManagement targetManagement;
 
     private final VirtualPropertyReplacer virtualPropertyReplacer;
 
@@ -79,12 +80,12 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     private final Database database;
 
     JpaTargetFilterQueryManagement(final TargetFilterQueryRepository targetFilterQueryRepository,
-            final TargetRepository targetRepository, final VirtualPropertyReplacer virtualPropertyReplacer,
+            final TargetManagement targetManagement, final VirtualPropertyReplacer virtualPropertyReplacer,
             final DistributionSetManagement distributionSetManagement, final QuotaManagement quotaManagement,
             final Database database, final TenantConfigurationManagement tenantConfigurationManagement,
             final SystemSecurityContext systemSecurityContext, final TenantAware tenantAware) {
         this.targetFilterQueryRepository = targetFilterQueryRepository;
-        this.targetRepository = targetRepository;
+        this.targetManagement = targetManagement;
         this.virtualPropertyReplacer = virtualPropertyReplacer;
         this.distributionSetManagement = distributionSetManagement;
         this.quotaManagement = quotaManagement;
@@ -295,8 +296,7 @@ public class JpaTargetFilterQueryManagement implements TargetFilterQueryManageme
     }
 
     private void assertMaxTargetsQuota(final String query) {
-        QuotaHelper.assertAssignmentQuota(
-                targetRepository.count(RSQLUtility.parse(query, TargetFields.class, virtualPropertyReplacer, database)),
+        QuotaHelper.assertAssignmentQuota(targetManagement.countByRsql(query),
                 quotaManagement.getMaxTargetsPerAutoAssignment(), Target.class, TargetFilterQuery.class);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -522,8 +522,8 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
      *
      * @param targetFilterQueryRepository
      *            holding {@link TargetFilterQuery} entities
-     * @param targetRepository
-     *            holding {@link Target} entities
+     * @param targetManagement
+     *            managing {@link Target} entities
      * @param virtualPropertyReplacer
      *            for RSQL handling
      * @param distributionSetManagement
@@ -540,12 +540,12 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
     @Bean
     @ConditionalOnMissingBean
     TargetFilterQueryManagement targetFilterQueryManagement(
-            final TargetFilterQueryRepository targetFilterQueryRepository, final TargetRepository targetRepository,
+            final TargetFilterQueryRepository targetFilterQueryRepository, final TargetManagement targetManagement,
             final VirtualPropertyReplacer virtualPropertyReplacer,
             final DistributionSetManagement distributionSetManagement, final QuotaManagement quotaManagement,
             final JpaProperties properties, final TenantConfigurationManagement tenantConfigurationManagement,
             final SystemSecurityContext systemSecurityContext, final TenantAware tenantAware) {
-        return new JpaTargetFilterQueryManagement(targetFilterQueryRepository, targetRepository,
+        return new JpaTargetFilterQueryManagement(targetFilterQueryRepository, targetManagement,
                 virtualPropertyReplacer, distributionSetManagement, quotaManagement, properties.getDatabase(),
                 tenantConfigurationManagement, systemSecurityContext, tenantAware);
     }


### PR DESCRIPTION
Use TargetManagement for the quota related count operation when activating auto assignment instead of performing this operation directly on the repository.

Signed-off-by: Michael Herdt <Michael.Herdt@bosch.io>