### PR TITLE
Fix output folder for REST docu tests

### DIFF
--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/ddi/documentation/RootControllerDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/ddi/documentation/RootControllerDocumentationTest.java
@@ -55,10 +55,14 @@ import io.qameta.allure.Story;
 public class RootControllerDocumentationTest extends AbstractApiRestDocumentation {
     private static final String CONTROLLER_ID = "CONTROLLER_ID";
 
+    @Override
+    public String getResourceName() {
+        return "rootcontroller";
+    }
+
     @BeforeEach
     public void setUp() {
         host = "ddi-api.host";
-        resourceName = "rootcontroller";
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/AbstractApiRestDocumentation.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/AbstractApiRestDocumentation.java
@@ -65,7 +65,7 @@ import io.qameta.allure.Feature;
  * Parent class for all Management API rest documentation classes.
  *
  */
-@Feature("Documentation Verfication - API")
+@Feature("Documentation Verification - API")
 @ExtendWith(RestDocumentationExtension.class)
 @ContextConfiguration(classes = { DdiApiConfiguration.class, MgmtApiConfiguration.class, RestConfiguration.class,
         RepositoryApplicationConfiguration.class, TestConfiguration.class, TestSupportBinderAutoConfiguration.class })
@@ -80,17 +80,17 @@ public abstract class AbstractApiRestDocumentation extends AbstractRestIntegrati
 
     protected MockMvc mockMvc;
 
-    protected String resourceName = "output";
-
     protected RestDocumentationResultHandler document;
 
     protected String arrayPrefix;
 
     protected String host = "management-api.host";
 
+    public abstract String getResourceName();
+
     @BeforeEach
-    protected void setupMvc(RestDocumentationContextProvider restDocContext) {
-        this.document = document(resourceName + "/{method-name}", preprocessRequest(prettyPrint()),
+    protected void setupMvc(final RestDocumentationContextProvider restDocContext) {
+        this.document = document(getResourceName() + "/{method-name}", preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()));
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
                 .apply(MockMvcRestDocumentation.documentationConfiguration(restDocContext).uris()

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/AbstractApiRestDocumentation.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/AbstractApiRestDocumentation.java
@@ -86,6 +86,12 @@ public abstract class AbstractApiRestDocumentation extends AbstractRestIntegrati
 
     protected String host = "management-api.host";
 
+    /**
+     * The generated REST docs snippets will be outputted to an own resource folder.
+     * The child class has to specify the name of that output folder where to put its corresponding snippets.
+     *
+     * @return the name of the resource folder
+     */
     public abstract String getResourceName();
 
     @BeforeEach

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/DistributionSetTagResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/DistributionSetTagResourceDocumentationTest.java
@@ -56,9 +56,13 @@ public class DistributionSetTagResourceDocumentationTest extends AbstractApiRest
 
     private DistributionSet distributionSet;
 
+    @Override
+    public String getResourceName() {
+        return "distributionsettag";
+    }
+
     @BeforeEach
     public void setUp() {
-        resourceName = "distributionsettag";
         distributionSet = createDistributionSet();
     }
 

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/DistributionSetTypesDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/DistributionSetTypesDocumentationTest.java
@@ -37,7 +37,6 @@ import org.eclipse.hawkbit.rest.documentation.MgmtApiModelProperties;
 import org.eclipse.hawkbit.rest.util.JsonBuilder;
 import org.eclipse.hawkbit.rest.util.MockMvcResultPrinter;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -54,9 +53,9 @@ import io.qameta.allure.Story;
 @Story("DistributionSetTypes Resource")
 public class DistributionSetTypesDocumentationTest extends AbstractApiRestDocumentation {
 
-    @BeforeEach
-    public void setUp() {
-        this.resourceName = "distributionsettypes";
+    @Override
+    public String getResourceName() {
+        return "distributionsettypes";
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/DistributionSetsDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/DistributionSetsDocumentationTest.java
@@ -39,7 +39,6 @@ import org.eclipse.hawkbit.rest.util.JsonBuilder;
 import org.eclipse.hawkbit.rest.util.MockMvcResultPrinter;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
@@ -58,9 +57,9 @@ import io.qameta.allure.Story;
 @Story("DistributionSet Resource")
 public class DistributionSetsDocumentationTest extends AbstractApiRestDocumentation {
 
-    @BeforeEach
-    public void setUp() {
-        resourceName = "distributionsets";
+    @Override
+    public String getResourceName() {
+        return "distributionsets";
     }
 
     @Test
@@ -452,7 +451,6 @@ public class DistributionSetsDocumentationTest extends AbstractApiRestDocumentat
                 .andDo(this.document.document(pathParameters(
                         parameterWithName("distributionSetId").description(ApiModelPropertiesGeneric.ITEM_ID),
                         parameterWithName("softwareModuleId").description(ApiModelPropertiesGeneric.ITEM_ID))));
-        ;
     }
 
     @Test
@@ -591,7 +589,7 @@ public class DistributionSetsDocumentationTest extends AbstractApiRestDocumentat
     }
 
     @Test
-    @Description("Update a single meta data value for speficic key." + " Required Permission: "
+    @Description("Update a single meta data value for specific key." + " Required Permission: "
             + SpPermission.UPDATE_REPOSITORY)
     public void updateMetadata() throws Exception {
         // prepare and create metadata for update

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/RolloutResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/RolloutResourceDocumentationTest.java
@@ -68,9 +68,13 @@ public class RolloutResourceDocumentationTest extends AbstractApiRestDocumentati
     @Autowired
     private RolloutTestApprovalStrategy approvalStrategy;
 
+    @Override
+    public String getResourceName() {
+        return "rollouts";
+    }
+
     @BeforeEach
     public void setUp() {
-        this.resourceName = "rollouts";
         arrayPrefix = "content[].";
         approvalStrategy.setApprovalNeeded(false);
     }

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/SoftwaremoduleTypesDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/SoftwaremoduleTypesDocumentationTest.java
@@ -31,7 +31,6 @@ import org.eclipse.hawkbit.rest.documentation.MgmtApiModelProperties;
 import org.eclipse.hawkbit.rest.util.JsonBuilder;
 import org.eclipse.hawkbit.rest.util.MockMvcResultPrinter;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -47,9 +46,9 @@ import io.qameta.allure.Story;
 @Story("Softwaremoduletypes Resource")
 public class SoftwaremoduleTypesDocumentationTest extends AbstractApiRestDocumentation {
 
-    @BeforeEach
-    public void setUp() {
-        this.resourceName = "softwaremoduletypes";
+    @Override
+    public String getResourceName() {
+        return "softwaremoduletypes";
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/SoftwaremodulesDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/SoftwaremodulesDocumentationTest.java
@@ -40,7 +40,6 @@ import org.eclipse.hawkbit.rest.util.JsonBuilder;
 import org.eclipse.hawkbit.rest.util.MockMvcResultPrinter;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
@@ -58,9 +57,9 @@ import io.qameta.allure.Story;
 @Story("Softwaremodule Resource")
 public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentation {
 
-    @BeforeEach
-    public void setUp() {
-        resourceName = "softwaremodules";
+    @Override
+    public String getResourceName() {
+        return "softwaremodules";
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetFilterQueriesResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetFilterQueriesResourceDocumentationTest.java
@@ -32,7 +32,6 @@ import org.eclipse.hawkbit.rest.documentation.ApiModelPropertiesGeneric;
 import org.eclipse.hawkbit.rest.documentation.MgmtApiModelProperties;
 import org.eclipse.hawkbit.rest.util.MockMvcResultPrinter;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -54,9 +53,9 @@ public class TargetFilterQueriesResourceDocumentationTest extends AbstractApiRes
     private static final String EXAMPLE_TFQ_NAME = "filter1";
     private static final String EXAMPLE_TFQ_QUERY = "name==*";
 
-    @BeforeEach
-    public void setUp() {
-        resourceName = "targetfilters";
+    @Override
+    public String getResourceName() {
+        return "targetfilters";
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
@@ -42,7 +42,6 @@ import org.eclipse.hawkbit.rest.documentation.MgmtApiModelProperties;
 import org.eclipse.hawkbit.rest.util.MockMvcResultPrinter;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort.Direction;
@@ -68,9 +67,9 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
 
     private final String targetId = "137";
 
-    @BeforeEach
-    public void setUp() {
-        resourceName = "targets";
+    @Override
+    public String getResourceName() {
+        return "targets";
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetTagResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetTagResourceDocumentationTest.java
@@ -57,9 +57,13 @@ public class TargetTagResourceDocumentationTest extends AbstractApiRestDocumenta
 
     private DistributionSet distributionSet;
 
+    @Override
+    public String getResourceName() {
+        return "targettag";
+    }
+
     @BeforeEach
     public void setUp() {
-        resourceName = "targettag";
         distributionSet = createDistributionSet();
     }
 

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TenantResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TenantResourceDocumentationTest.java
@@ -32,7 +32,6 @@ import org.eclipse.hawkbit.rest.documentation.MgmtApiModelProperties;
 import org.eclipse.hawkbit.rest.util.MockMvcResultPrinter;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -95,9 +94,9 @@ public class TenantResourceDocumentationTest extends AbstractApiRestDocumentatio
     @Autowired
     protected TenantConfigurationProperties tenantConfigurationProperties;
 
-    @BeforeEach
-    public void setUp() {
-        resourceName = "tenant";
+    @Override
+    public String getResourceName() {
+        return "tenant";
     }
 
     @Test


### PR DESCRIPTION
The output folder for the REST documentation snippets was not set properly by the child classes anymore. All snippets were put in the same default folder "output" that was set as the resource name in the abstract class. 
Now every child class has to implement the abstract method `getResourceName()` to define an own output folder for the corresponding resource again. 

Signed-off-by: Natalia Kislicyn <natalia.kislicyn@bosch.io>