### PR TITLE
Fix CANCEL_REJECTED action status icon

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/builder/StatusIconBuilder.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/builder/StatusIconBuilder.java
@@ -83,6 +83,7 @@ public final class StatusIconBuilder {
             addMapping(Status.DOWNLOAD, VaadinIcons.CLOUD_DOWNLOAD, SPUIStyleDefinitions.STATUS_ICON_PENDING);
             addMapping(Status.DOWNLOADED, VaadinIcons.CLOUD_DOWNLOAD, SPUIStyleDefinitions.STATUS_ICON_GREEN);
             addMapping(Status.CANCELING, VaadinIcons.CLOSE_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_PENDING);
+            addMapping(Status.CANCEL_REJECTED, VaadinIcons.EXCLAMATION_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_ORANGE);
             addMapping(Status.CANCELED, VaadinIcons.CLOSE_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_GREEN);
             addMapping(Status.ERROR, VaadinIcons.EXCLAMATION_CIRCLE, SPUIStyleDefinitions.STATUS_ICON_RED);
         }

--- a/hawkbit-ui/src/main/resources/messages.properties
+++ b/hawkbit-ui/src/main/resources/messages.properties
@@ -295,6 +295,7 @@ tooltip.action.status.warning=Warning
 tooltip.action.status.running=Running
 tooltip.action.status.canceled=Cancelled
 tooltip.action.status.canceling=Canceling
+tooltip.action.status.cancel_rejected=Cancel Rejected
 tooltip.action.status.retrieved=Retrieved
 tooltip.action.status.download=Downloading
 tooltip.action.status.downloaded=Downloaded


### PR DESCRIPTION
Fix the action status icon "CANCEL_REJECTED" because it was displayed as unknown

Signed-off-by: Michael Herdt <Michael.Herdt@bosch.io>