### PR TITLE
ManagementApi: Action does not have property containing rollout name

### DIFF
--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtAction.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtAction.java
@@ -65,6 +65,12 @@ public class MgmtAction extends MgmtBaseEntity {
 
     @JsonProperty
     private MgmtMaintenanceWindow maintenanceWindow;
+    
+    @JsonProperty
+    private Long rollout;
+
+    @JsonProperty
+    private String rolloutName;
 
     public MgmtMaintenanceWindow getMaintenanceWindow() {
         return maintenanceWindow;
@@ -121,4 +127,21 @@ public class MgmtAction extends MgmtBaseEntity {
     public void setType(final String type) {
         this.type = type;
     }
+
+    public Long getRollout() {
+        return rollout;
+    }
+
+    public void setRollout(Long rollout) {
+        this.rollout = rollout;
+    }
+
+    public String getRolloutName() {
+        return rolloutName;
+    }
+
+    public void setRolloutName(String rolloutName) {
+        this.rolloutName = rolloutName;
+    }
+
 }

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
@@ -84,6 +84,10 @@ public final class MgmtRestConstants {
      * The target URL mapping, href link for canceled actions.
      */
     public static final String TARGET_V1_ACTION_STATUS = "status";
+    /**
+     * The target URL mapping, href link for a rollout.
+     */
+    public static final String TARGET_V1_ROLLOUT = "rollout";
 
     /**
      * The target URL mapping rest resource.

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
@@ -28,6 +28,7 @@ import org.eclipse.hawkbit.mgmt.json.model.target.MgmtTarget;
 import org.eclipse.hawkbit.mgmt.json.model.target.MgmtTargetRequestBody;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtDistributionSetRestApi;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtRolloutRestApi;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtTargetRestApi;
 import org.eclipse.hawkbit.repository.ActionFields;
 import org.eclipse.hawkbit.repository.ActionStatusFields;
@@ -39,6 +40,7 @@ import org.eclipse.hawkbit.repository.model.Action.ActionType;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.repository.model.MetaData;
 import org.eclipse.hawkbit.repository.model.PollStatus;
+import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetMetadata;
 import org.eclipse.hawkbit.rest.data.ResponseList;
@@ -215,6 +217,12 @@ public final class MgmtTargetMapper {
             result.setStatus(MgmtAction.ACTION_FINISHED);
         }
 
+        Rollout rollout = action.getRollout();
+        if (rollout != null) {
+            result.setRollout(rollout.getId());
+            result.setRolloutName(rollout.getName());
+        }
+        
         if (action.hasMaintenanceSchedule()) {
             final MgmtMaintenanceWindow maintenanceWindow = new MgmtMaintenanceWindow();
             maintenanceWindow.setSchedule(action.getMaintenanceWindowSchedule());
@@ -248,6 +256,12 @@ public final class MgmtTargetMapper {
                 ActionStatusFields.ID.getFieldName() + ":" + SortDirection.DESC))
                         .withRel(MgmtRestConstants.TARGET_V1_ACTION_STATUS));
 
+        Rollout rollout = action.getRollout();
+        if (rollout != null) {
+            result.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRollout(rollout.getId()))
+                    .withRel(MgmtRestConstants.TARGET_V1_ROLLOUT));
+        }
+        
         return result;
     }
 

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
@@ -256,7 +256,7 @@ public final class MgmtTargetMapper {
                 ActionStatusFields.ID.getFieldName() + ":" + SortDirection.DESC))
                         .withRel(MgmtRestConstants.TARGET_V1_ACTION_STATUS));
 
-        Rollout rollout = action.getRollout();
+        final Rollout rollout = action.getRollout();
         if (rollout != null) {
             result.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRollout(rollout.getId()))
                     .withRel(MgmtRestConstants.TARGET_V1_ROLLOUT));

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.mgmt.rest.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
@@ -51,6 +52,7 @@ import org.eclipse.hawkbit.repository.model.ActionStatus;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.MetaData;
 import org.eclipse.hawkbit.repository.model.NamedEntity;
+import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetMetadata;
@@ -2038,6 +2040,39 @@ public class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest
                     .andExpect(jsonPath("content.[2].weight", equalTo(customWeightHigh)));
         }
 
+    }
+    
+    @Test
+    @Description("An action provides information of the rollout it was created for (if any).")
+    public void getActionWithRolloutInfo() throws Exception {
+
+        // setup
+        final int amountTargets = 10;
+        final List<Target> targets = testdataFactory.createTargets(amountTargets, "trg", "trg");
+        final DistributionSet ds = testdataFactory.createDistributionSet("");
+
+        final Rollout rollout = testdataFactory.createRolloutByVariables("My Rollout", "My Rollout Description", 1,
+                "name==trg*", ds, "50", "5");
+        rolloutManagement.start(rollout.getId());
+        rolloutManagement.handleRollouts();
+
+        // get all actions for the first target
+        final Target target = targets.get(0);
+        mvc.perform(get("/rest/v1/targets/{targetId}/actions", target.getControllerId())).andExpect(status().isOk())
+                .andDo(MockMvcResultPrinter.print())
+                .andExpect(jsonPath("content.[0].rollout", equalTo(rollout.getId().intValue())))
+                .andExpect(jsonPath("content.[0].rolloutName", equalTo(rollout.getName())));
+
+        // get the first action for the first target;
+        // verify that also the rollout link is present
+        final Slice<Action> action = deploymentManagement.findActionsByTarget(target.getControllerId(),
+                PageRequest.of(0, 100));
+        assertThat(action.getContent()).hasSize(1);
+        mvc.perform(get("/rest/v1/targets/{targetId}/actions/{actionId}", target.getControllerId(),
+                action.getContent().get(0).getId())).andExpect(status().isOk()).andDo(MockMvcResultPrinter.print())
+                .andExpect(jsonPath("$.rollout", equalTo(rollout.getId().intValue())))
+                .andExpect(jsonPath("$.rolloutName", equalTo(rollout.getName()))).andExpect(jsonPath(
+                        "$._links.rollout.href", containsString("/rest/v1/rollouts/" + rollout.getId().intValue())));
     }
 
 }

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
@@ -31,6 +31,7 @@ public final class MgmtApiModelProperties {
     public static final String LINK_TO_METADATA = "The link to the metadata.";
     public static final String LINK_TO_MANDATORY_SMT = "Link to mandatory software modules types in this distribution set type.";
     public static final String LINK_TO_OPTIONAL_SMT = "Link to optional software modules types in this distribution set type.";
+    public static final String LINK_TO_ROLLOUT = "The link to the rollout.";
 
     // software module types
     public static final String SMT_TYPE = "The type of the software module identified by its key.";
@@ -142,6 +143,10 @@ public final class MgmtApiModelProperties {
     public static final String ACTION_LIST = "List of actions.";
 
     public static final String ACTION_WEIGHT = "Weight of the action showing the importance of the update.";
+
+    public static final String ACTION_ROLLOUT = "The ID of the rollout this action was created for.";
+
+    public static final String ACTION_ROLLOUT_NAME = "The name of the rollout this action was created for.";
 
     public static final String IP_ADDRESS = "Last known IP address of the target. Only presented if IP address of the target itself is known (connected directly through DDI API).";
 


### PR DESCRIPTION
This pull request delivers an enhancement of the following two REST entry points in the Management REST API:
* HTTP GET /rest/v1/targets/{targetId}/actions
* HTTP GET /rest/v1/targets/{targetId}/actions/{actionId}

If an action is created in the scope of a rollout, the JSON payload representing the action now contains the following two additional (optional) properties "rollout" (holding the rollout ID) and "rolloutName" (holding the name of the rollout). If a specific action is requested (via HTTP GET /rest/v1/targets/{targetId}/actions/{actionId}), the payload will also provide a link to the rollout (link relation "rollout"). Example:
```
{
  "id" : 17,
  "forceType" : "timeforced",
  "type" : "update",
  "status" : "finished",
  [...]
  "rollout": 123,
  "rolloutName": "My rollout",
  "_links" : {
    "self" : {
      "href" : "https://management-api.host.com/rest/v1/targets/137/actions/17"
    },
    [...]
    "rollout": {
      "href": "https://management-api.host.com/rest/v1/rollouts/123"
    }
  }
}
```

In the Management UI, this information is already exposed.