### PR TITLE
Fix test name in order to get executed by surefire

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLParserValidationOracleTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLParserValidationOracleTest.java
@@ -27,7 +27,7 @@ import io.qameta.allure.Story;
 
 @Feature("Component Tests - Repository")
 @Story("RSQL filter suggestion")
-public class RsqlParserValidationOracleTest extends AbstractJpaIntegrationTest {
+public class RSQLParserValidationOracleTest extends AbstractJpaIntegrationTest {
 
     @Autowired
     private RsqlValidationOracle rsqlValidationOracle;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLRolloutGroupFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLRolloutGroupFieldTest.java
@@ -29,7 +29,7 @@ import io.qameta.allure.Story;
 
 @Feature("Component Tests - Repository")
 @Story("RSQL filter rollout group")
-public class RSQLRolloutGroupFields extends AbstractJpaIntegrationTest {
+public class RSQLRolloutGroupFieldTest extends AbstractJpaIntegrationTest {
 
     private Long rolloutGroupId;
     private Rollout rollout;
@@ -48,7 +48,6 @@ public class RSQLRolloutGroupFields extends AbstractJpaIntegrationTest {
     @Test
     @Description("Test filter rollout group by  id")
     public void testFilterByParameterId() {
-        assertRSQLQuery(RolloutGroupFields.ID.name() + "==*", 3);
         assertRSQLQuery(RolloutGroupFields.ID.name() + "==" + rolloutGroupId, 1);
         assertRSQLQuery(RolloutGroupFields.ID.name() + "!=" + rolloutGroupId, 3);
         assertRSQLQuery(RolloutGroupFields.ID.name() + "==" + -1, 0);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLRolloutGroupFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLRolloutGroupFieldTest.java
@@ -61,7 +61,7 @@ public class RSQLRolloutGroupFieldTest extends AbstractJpaIntegrationTest {
         assertRSQLQuery(RolloutGroupFields.ID.name() + "==*", 4);
         assertRSQLQuery(RolloutGroupFields.ID.name() + "==noexist*", 0);
         assertRSQLQuery(RolloutGroupFields.ID.name() + "=in=(" + rolloutGroupId + ",10000000)", 1);
-        assertRSQLQuery(RolloutGroupFields.ID.name() + "=out=(" + rolloutGroupId + ",10000000)", 2);
+        assertRSQLQuery(RolloutGroupFields.ID.name() + "=out=(" + rolloutGroupId + ",10000000)", 3);
     }
 
     @Test
@@ -86,12 +86,12 @@ public class RSQLRolloutGroupFieldTest extends AbstractJpaIntegrationTest {
         assertRSQLQuery(RolloutGroupFields.DESCRIPTION.name() + "=out=(group-1,notexist)", 3);
     }
 
-    private void assertRSQLQuery(final String rsqlParam, final long expcetedTargets) {
+    private void assertRSQLQuery(final String rsqlParam, final long expectedTargets) {
         final Page<RolloutGroup> findTargetPage = rolloutGroupManagement.findByRolloutAndRsql(PageRequest.of(0, 100),
                 rollout.getId(), rsqlParam);
         final long countTargetsAll = findTargetPage.getTotalElements();
         assertThat(findTargetPage).isNotNull();
-        assertThat(countTargetsAll).isEqualTo(expcetedTargets);
+        assertThat(countTargetsAll).isEqualTo(expectedTargets);
     }
 
     private Rollout createRollout(final String name, final int amountGroups, final long distributionSetId,


### PR DESCRIPTION
This PR will fix that `RSQLRolloutGroupFields` was never part of the any build test execution since the class was not picked up by hawkbit's `maven-surefire-plugin` configuration (the Java class name should contain `Test`, `Tests` or `IT`). In addition one of the tests of `RSQLRolloutGroupFields` contained an assertion that was never true, which is also removed.

Signed-off-by: Florian Ruschbaschan <Florian.Ruschbaschan@bosch.io>