### PR TITLE
bugfix missing OidcUser principal class

### DIFF
--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SecurityContextTenantAware.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SecurityContextTenantAware.java
@@ -24,6 +24,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 /**
  * A {@link TenantAware} implementation which retrieves the ID of the tenant
@@ -74,6 +75,9 @@ public class SecurityContextTenantAware implements TenantAware {
             if (principal instanceof UserPrincipal) {
                 return ((UserPrincipal) principal).getUsername();
             }
+            if (principal instanceof OidcUser) {
+                return ((OidcUser) principal).getPreferredUsername();
+            }            
         }
         return null;
     }


### PR DESCRIPTION
This PR will fix an issue I encountered using hawkBit with OIDC authentication schema (SpringSecurity oauth2). 
If SecurityContextTenantAware.getCurrentUsername return a null value, multiple error come up across the application:
-  e.g. if you are assigning a deployment which causes a sp_action
Some issues I encountered end up in the DB layer for the latest (e.g. Caused by: java.sql.SQLException: Column 'initiated_by' cannot be null) 
This fix at least ensures that there is a Username in case of OIDC usage. 
/Martin