### PR TITLE
Publish target assign event

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
@@ -147,6 +147,9 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
                 if (!hasPendingCancellations(target.getControllerId())) {
                     sendUpdateMessageToTarget(assignedEvent.getActions().get(target.getControllerId()), target,
                             softwareModules);
+                } else {
+                    LOG.debug("Target {} has pending cancellations. Will not send update message to it.",
+                            target.getControllerId());
                 }
             });
         });

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
@@ -144,8 +144,10 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
         final List<Target> filteredTargetList = getTargetsWithoutPendingCancellations(
                 assignedEvent.getActions().keySet());
 
-        LOG.debug("targetAssignDistributionSet retrieved. I will forward it to DMF broker.");
-        sendUpdateMessageToTarget(assignedEvent, filteredTargetList);
+        if (!filteredTargetList.isEmpty()) {
+            LOG.debug("targetAssignDistributionSet retrieved. I will forward it to DMF broker.");
+            sendUpdateMessageToTarget(assignedEvent, filteredTargetList);
+        }
     }
 
     /**
@@ -176,9 +178,6 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
 
     private void sendUpdateMessageToTarget(final TargetAssignDistributionSetEvent assignedEvent,
             final List<Target> targets) {
-        if (targets.isEmpty()) {
-            return;
-        }
         distributionSetManagement.get(assignedEvent.getDistributionSetId()).ifPresent(ds -> {
             final Map<SoftwareModule, List<SoftwareModuleMetadata>> softwareModules = getSoftwareModulesWithMetadata(
                     ds);

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
@@ -216,7 +216,7 @@ public abstract class AbstractAmqpServiceIntegrationTest extends AbstractAmqpInt
         return message;
     }
 
-    protected void sendActionUpdateStatus(final DmfActionUpdateStatus actionStatus) {
+    protected void createAndSendActionStatusUpdateMessage(final DmfActionUpdateStatus actionStatus) {
         final Message eventMessage = createEventMessage(TENANT_EXIST, EventTopic.UPDATE_ACTION_STATUS, actionStatus);
         getDmfClient().send(eventMessage);
     }

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
@@ -199,7 +199,6 @@ public abstract class AbstractAmqpServiceIntegrationTest extends AbstractAmqpInt
     protected void assertDownloadAndInstallMessage(final Set<SoftwareModule> softwareModules,
             final String controllerId) {
         assertAssignmentMessage(softwareModules, controllerId, EventTopic.DOWNLOAD_AND_INSTALL);
-
     }
 
     protected void assertDownloadMessage(final Set<SoftwareModule> dsModules, final String controllerId) {

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
@@ -70,6 +70,7 @@ public abstract class AbstractAmqpServiceIntegrationTest extends AbstractAmqpInt
 
     protected static final String TENANT_EXIST = "DEFAULT";
     protected static final String CREATED_BY = "CONTROLLER_PLUG_AND_PLAY";
+    protected static final String CORRELATION_ID = UUID.randomUUID().toString();
 
     protected ReplyToListener replyToListener;
     private DeadletterListener deadletterListener;
@@ -214,6 +215,20 @@ public abstract class AbstractAmqpServiceIntegrationTest extends AbstractAmqpInt
         final Message message = createPingMessage(correlationId, tenant);
         getDmfClient().send(message);
         return message;
+    }
+
+    protected void sendActionUpdateStatus(final DmfActionUpdateStatus actionStatus) {
+        final Message eventMessage = createEventMessage(TENANT_EXIST, EventTopic.UPDATE_ACTION_STATUS, actionStatus);
+        getDmfClient().send(eventMessage);
+    }
+
+    protected Message createEventMessage(final String tenant, final EventTopic eventTopic, final Object payload) {
+        final MessageProperties messageProperties = createMessagePropertiesWithTenant(tenant);
+        messageProperties.getHeaders().put(MessageHeaderKey.TYPE, MessageType.EVENT.toString());
+        messageProperties.getHeaders().put(MessageHeaderKey.TOPIC, eventTopic.toString());
+        messageProperties.setCorrelationId(CORRELATION_ID);
+
+        return createMessage(payload, messageProperties);
     }
 
     protected void verifyReplyToListener() {

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
@@ -50,7 +50,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
-import org.springframework.amqp.rabbit.junit.BrokerRunningSupport;
 import org.springframework.amqp.rabbit.test.RabbitListenerTestHarness;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.test.binder.TestSupportBinderAutoConfiguration;

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageDispatcherServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageDispatcherServiceIntegrationTest.java
@@ -170,7 +170,7 @@ public class AmqpMessageDispatcherServiceIntegrationTest extends AbstractAmqpSer
         assertCancelActionMessage(getFirstAssignedActionId(assignmentResult), controllerId);
 
         // confirm the cancel of the first action should lead to expose the latest action
-        sendActionUpdateStatus(
+        createAndSendActionStatusUpdateMessage(
                 new DmfActionUpdateStatus(getFirstAssignedActionId(assignmentResult), DmfActionStatus.CANCELED));
         // verify latest action is exposed
         assertDownloadAndInstallMessage(distributionSet2.getModules(), controllerId);

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageDispatcherServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageDispatcherServiceIntegrationTest.java
@@ -153,9 +153,15 @@ public class AmqpMessageDispatcherServiceIntegrationTest extends AbstractAmqpSer
 
         final DistributionSetAssignmentResult assignmentResult = registerTargetAndAssignDistributionSet(controllerId);
         final DistributionSet distributionSet2 = testdataFactory.createDistributionSet();
+
         testdataFactory.addSoftwareModuleMetadata(distributionSet2);
+
+        // first assignment will be canceled -> Open cancellations -> No message through the DMF
         assignDistributionSet(distributionSet2.getId(), controllerId);
-        assertDownloadAndInstallMessage(distributionSet2.getModules(), controllerId);
+
+        // should not get the message of the second assignment
+        assertDownloadAndInstallMessage(assignmentResult.getDistributionSet().getModules(), controllerId);
+
         assertCancelActionMessage(getFirstAssignedActionId(assignmentResult), controllerId);
 
         createAndSendThingCreated(controllerId, TENANT_EXIST);

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageDispatcherServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageDispatcherServiceIntegrationTest.java
@@ -15,7 +15,6 @@ import org.eclipse.hawkbit.dmf.amqp.api.EventTopic;
 import org.eclipse.hawkbit.dmf.amqp.api.MessageHeaderKey;
 import org.eclipse.hawkbit.dmf.json.model.DmfActionRequest;
 import org.eclipse.hawkbit.dmf.json.model.DmfActionStatus;
-import org.eclipse.hawkbit.dmf.json.model.DmfActionUpdateStatus;
 import org.eclipse.hawkbit.dmf.json.model.DmfDownloadAndUpdateRequest;
 import org.eclipse.hawkbit.dmf.json.model.DmfMultiActionRequest;
 import org.eclipse.hawkbit.dmf.json.model.DmfMultiActionRequest.DmfMultiActionElement;
@@ -170,11 +169,11 @@ public class AmqpMessageDispatcherServiceIntegrationTest extends AbstractAmqpSer
         assertCancelActionMessage(getFirstAssignedActionId(assignmentResult), controllerId);
 
         // confirm the cancel of the first action should lead to expose the latest action
-        createAndSendActionStatusUpdateMessage(
-                new DmfActionUpdateStatus(getFirstAssignedActionId(assignmentResult), DmfActionStatus.CANCELED));
+        createAndSendActionStatusUpdateMessage(controllerId, getFirstAssignedActionId(assignmentResult),
+                DmfActionStatus.CANCELED);
+
         // verify latest action is exposed
         assertDownloadAndInstallMessage(distributionSet2.getModules(), controllerId);
-
     }
 
     @Test
@@ -351,7 +350,7 @@ public class AmqpMessageDispatcherServiceIntegrationTest extends AbstractAmqpSer
 
     private void updateActionViaDmfClient(final String controllerId, final long actionId,
             final DmfActionStatus status) {
-        createAndSendActionStatusUpdateMessage(controllerId, TENANT_EXIST, actionId, status);
+        createAndSendActionStatusUpdateMessage(controllerId, actionId, status);
     }
 
     private Long assignNewDsToTarget(final String controllerId) {

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageHandlerServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageHandlerServiceIntegrationTest.java
@@ -78,7 +78,6 @@ import io.qameta.allure.Story;
 @Feature("Component Tests - Device Management Federation API")
 @Story("Amqp Message Handler Service")
 public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServiceIntegrationTest {
-    private static final String CORRELATION_ID = UUID.randomUUID().toString();
     private static final String TARGET_PREFIX = "Dmf_hand_";
 
     @Autowired
@@ -953,11 +952,6 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
         return actionId;
     }
 
-    private void sendActionUpdateStatus(final DmfActionUpdateStatus actionStatus) {
-        final Message eventMessage = createEventMessage(TENANT_EXIST, EventTopic.UPDATE_ACTION_STATUS, actionStatus);
-        getDmfClient().send(eventMessage);
-    }
-
     private void registerTargetAndSendAndAssertUpdateActionStatus(final DmfActionStatus sendActionStatus,
             final Status expectedActionStatus, final String controllerId) {
         final Long actionId = registerTargetAndSendActionStatus(sendActionStatus, controllerId);
@@ -993,15 +987,6 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
                 throw new RuntimeException(e);
             }
         });
-    }
-
-    private Message createEventMessage(final String tenant, final EventTopic eventTopic, final Object payload) {
-        final MessageProperties messageProperties = createMessagePropertiesWithTenant(tenant);
-        messageProperties.getHeaders().put(MessageHeaderKey.TYPE, MessageType.EVENT.toString());
-        messageProperties.getHeaders().put(MessageHeaderKey.TOPIC, eventTopic.toString());
-        messageProperties.setCorrelationId(CORRELATION_ID);
-
-        return createMessage(payload, messageProperties);
     }
 
     private void sendUpdateAttributeMessage(final String target, final String tenant,

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageHandlerServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageHandlerServiceIntegrationTest.java
@@ -296,7 +296,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
     @Description("Tests null topic message header. This message should forwarded to the deadletter queue")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void nullTopicHeader() {
-        final Message eventMessage = createEventMessage(TENANT_EXIST, EventTopic.UPDATE_ACTION_STATUS, "");
+        final Message eventMessage = createUpdateActionEventMessage(TENANT_EXIST, "");
         eventMessage.getMessageProperties().getHeaders().put(MessageHeaderKey.TOPIC, null);
         getDmfClient().send(eventMessage);
 
@@ -307,7 +307,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
     @Description("Tests null topic message header. This message should forwarded to the deadletter queue")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void emptyTopicHeader() {
-        final Message eventMessage = createEventMessage(TENANT_EXIST, EventTopic.UPDATE_ACTION_STATUS, "");
+        final Message eventMessage = createUpdateActionEventMessage(TENANT_EXIST, "");
         eventMessage.getMessageProperties().getHeaders().put(MessageHeaderKey.TOPIC, "");
         getDmfClient().send(eventMessage);
 
@@ -318,7 +318,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
     @Description("Tests null topic message header. This message should forwarded to the deadletter queue")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void invalidTopicHeader() {
-        final Message eventMessage = createEventMessage(TENANT_EXIST, EventTopic.UPDATE_ACTION_STATUS, "");
+        final Message eventMessage = createUpdateActionEventMessage(TENANT_EXIST, "");
         eventMessage.getMessageProperties().getHeaders().put(MessageHeaderKey.TOPIC, "NotExist");
         getDmfClient().send(eventMessage);
 
@@ -329,7 +329,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
     @Description("Tests missing topic message header. This message should forwarded to the deadletter queue")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void missingTopicHeader() {
-        final Message eventMessage = createEventMessage(TENANT_EXIST, EventTopic.UPDATE_ACTION_STATUS, "");
+        final Message eventMessage = createUpdateActionEventMessage(TENANT_EXIST, "");
         eventMessage.getMessageProperties().getHeaders().remove(MessageHeaderKey.TOPIC);
         getDmfClient().send(eventMessage);
 
@@ -340,7 +340,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
     @Description("Tests invalid null message content. This message should forwarded to the deadletter queue")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void updateActionStatusWithNullContent() {
-        final Message eventMessage = createEventMessage(TENANT_EXIST, EventTopic.UPDATE_ACTION_STATUS, null);
+        final Message eventMessage = createUpdateActionEventMessage(TENANT_EXIST, null);
         getDmfClient().send(eventMessage);
         verifyOneDeadLetterMessage();
     }
@@ -349,7 +349,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
     @Description("Tests invalid empty message content. This message should forwarded to the deadletter queue")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void updateActionStatusWithEmptyContent() {
-        final Message eventMessage = createEventMessage(TENANT_EXIST, EventTopic.UPDATE_ACTION_STATUS, "");
+        final Message eventMessage = createUpdateActionEventMessage(TENANT_EXIST, "");
         getDmfClient().send(eventMessage);
         verifyOneDeadLetterMessage();
     }
@@ -358,8 +358,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
     @Description("Tests invalid json message content. This message should forwarded to the deadletter queue")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void updateActionStatusWithInvalidJsonContent() {
-        final Message eventMessage = createEventMessage(TENANT_EXIST, EventTopic.UPDATE_ACTION_STATUS,
-                "Invalid Content");
+        final Message eventMessage = createUpdateActionEventMessage(TENANT_EXIST, "Invalid Content");
         getDmfClient().send(eventMessage);
         verifyOneDeadLetterMessage();
     }
@@ -369,8 +368,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
     public void updateActionStatusWithInvalidActionId() {
         final DmfActionUpdateStatus actionUpdateStatus = new DmfActionUpdateStatus(1L, DmfActionStatus.RUNNING);
-        final Message eventMessage = createEventMessage(TENANT_EXIST, EventTopic.UPDATE_ACTION_STATUS,
-                actionUpdateStatus);
+        final Message eventMessage = createUpdateActionEventMessage(TENANT_EXIST, actionUpdateStatus);
         getDmfClient().send(eventMessage);
         verifyOneDeadLetterMessage();
     }
@@ -420,7 +418,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
 
     @Test
     @Description("Register a target and send a update action status (download). Verify if the updated action status is correct.")
-    @ExpectEvents({@Expect(type = TargetCreatedEvent.class, count = 1),
+    @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 1),
             @Expect(type = ActionCreatedEvent.class, count = 1),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
@@ -434,7 +432,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
 
     @Test
     @Description("Register a target and send a update action status (error). Verify if the updated action status is correct.")
-    @ExpectEvents({@Expect(type = TargetCreatedEvent.class, count = 1),
+    @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 1),
             @Expect(type = ActionUpdatedEvent.class, count = 1), @Expect(type = ActionCreatedEvent.class, count = 1),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
@@ -517,7 +515,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
 
     @Test
     @Description("Verify receiving a download message if a deployment is done with window configured but before maintenance window start time.")
-    @ExpectEvents({@Expect(type = TargetCreatedEvent.class, count = 1),
+    @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 1),
             @Expect(type = ActionCreatedEvent.class, count = 1),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
@@ -613,7 +611,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
         final Long actionId = registerTargetAndCancelActionId(controllerId);
         final Long actionNotExist = actionId + 1;
 
-        createAndSendActionStatusUpdateMessage(new DmfActionUpdateStatus(actionNotExist, DmfActionStatus.CANCELED));
+        createAndSendActionStatusUpdateMessage(controllerId, actionNotExist, DmfActionStatus.CANCELED);
         verifyOneDeadLetterMessage();
     }
 
@@ -647,7 +645,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
 
         final Long actionId = registerTargetAndCancelActionId(controllerId);
 
-        createAndSendActionStatusUpdateMessage(new DmfActionUpdateStatus(actionId, DmfActionStatus.CANCEL_REJECTED));
+        createAndSendActionStatusUpdateMessage(controllerId, actionId, DmfActionStatus.CANCEL_REJECTED);
         assertAction(actionId, 1, Status.RUNNING, Status.CANCELING, Status.CANCEL_REJECTED);
     }
 
@@ -844,7 +842,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
         Long actionId = Long.parseLong(getJsonFieldFromBody(message.getBody(), "actionId"));
 
         // Send DOWNLOADED message
-        createAndSendActionStatusUpdateMessage(new DmfActionUpdateStatus(actionId, DmfActionStatus.DOWNLOADED));
+        createAndSendActionStatusUpdateMessage(controllerId, actionId, DmfActionStatus.DOWNLOADED);
         assertAction(actionId, 1, Status.RUNNING, Status.DOWNLOADED);
         Mockito.verifyZeroInteractions(getDeadletterListener());
 
@@ -876,14 +874,14 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
         Long actionId = Long.parseLong(getJsonFieldFromBody(message.getBody(), "actionId"));
 
         // Send DOWNLOADED message, should result in the action being closed
-        createAndSendActionStatusUpdateMessage(new DmfActionUpdateStatus(actionId, DmfActionStatus.DOWNLOADED));
+        createAndSendActionStatusUpdateMessage(controllerId, actionId, DmfActionStatus.DOWNLOADED);
         assertAction(actionId, 1, Status.RUNNING, Status.DOWNLOADED);
         Mockito.verifyZeroInteractions(getDeadletterListener());
 
         verifyAssignedDsAndInstalledDs(controllerId, distributionSet.getId(), null);
 
         // Send FINISHED message
-        createAndSendActionStatusUpdateMessage(new DmfActionUpdateStatus(actionId, DmfActionStatus.FINISHED));
+        createAndSendActionStatusUpdateMessage(controllerId, actionId, DmfActionStatus.FINISHED);
         assertAction(actionId, 2, Status.RUNNING, Status.DOWNLOADED, Status.FINISHED);
         Mockito.verifyZeroInteractions(getDeadletterListener());
 
@@ -946,7 +944,7 @@ public class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServic
     private Long registerTargetAndSendActionStatus(final DmfActionStatus sendActionStatus, final String controllerId) {
         final DistributionSetAssignmentResult assignmentResult = registerTargetAndAssignDistributionSet(controllerId);
         final Long actionId = getFirstAssignedActionId(assignmentResult);
-        createAndSendActionStatusUpdateMessage(new DmfActionUpdateStatus(actionId, sendActionStatus));
+        createAndSendActionStatusUpdateMessage(controllerId, actionId, sendActionStatus);
         return actionId;
     }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
@@ -505,4 +505,15 @@ public interface DeploymentManagement {
     @PreAuthorize(SpringEvalExpressions.IS_SYSTEM_CODE)
     int deleteActionsByStatusAndLastModifiedBefore(@NotNull Set<Action.Status> status, long lastModified);
 
+    /**
+     * Checks if there is an action for the device with the given controller ID that
+     * is in the {@link Action.Status#CANCELING} state.
+     *
+     * @param controllerId
+     *            of target
+     * @return if actions in CANCELING state are present
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    boolean hasPendingCancellations(@NotEmpty String controllerId);
+
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -830,6 +830,12 @@ public class JpaDeploymentManagement extends JpaActionManagement implements Depl
         return deleteQuery.executeUpdate();
     }
 
+    @Override
+    public boolean hasPendingCancellations(String controllerId) {
+        return actionRepository.existsByTargetControllerIdAndStatusAndActiveIsTrue(controllerId,
+                Action.Status.CANCELING);
+    }
+
     private static String getQueryForDeleteActionsByStatusAndLastModifiedBeforeString(final Database database) {
         return QUERY_DELETE_ACTIONS_BY_STATE_AND_LAST_MODIFIED.getOrDefault(database,
                 QUERY_DELETE_ACTIONS_BY_STATE_AND_LAST_MODIFIED_DEFAULT);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/OnlineDsAssignmentStrategy.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/OnlineDsAssignmentStrategy.java
@@ -167,7 +167,7 @@ public class OnlineDsAssignmentStrategy extends AbstractDsAssignmentStrategy {
     private DistributionSetAssignmentResult sendDistributionSetAssignedEvent(
             final DistributionSetAssignmentResult assignmentResult) {
         final List<Action> filteredActions = filterCancellations(assignmentResult.getAssignedEntity())
-                .filter(action -> !hasPendingCancellations(action.getTarget())).collect(Collectors.toList());
+                .collect(Collectors.toList());
         final DistributionSet set = assignmentResult.getDistributionSet();
         sendTargetAssignDistributionSetEvent(set.getTenant(), set.getId(), filteredActions);
         return assignmentResult;
@@ -182,11 +182,6 @@ public class OnlineDsAssignmentStrategy extends AbstractDsAssignmentStrategy {
         afterCommit.afterCommit(() -> eventPublisherHolder.getEventPublisher()
                 .publishEvent(new TargetAssignDistributionSetEvent(tenant, distributionSetId, actions,
                         eventPublisherHolder.getApplicationId(), actions.get(0).isMaintenanceWindowAvailable())));
-    }
-
-    private boolean hasPendingCancellations(final Target target) {
-        return actionRepository.existsByTargetControllerIdAndStatusAndActiveIsTrue(target.getControllerId(),
-                Status.CANCELING);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
@@ -945,8 +945,8 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = CancelTargetAssignmentEvent.class, count = 4 * 2),
             @Expect(type = DistributionSetCreatedEvent.class, count = 3),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 9),
-            @Expect(type = TargetAssignDistributionSetEvent.class, count = 2) })
-    public void mutipleDeployments() throws InterruptedException {
+            @Expect(type = TargetAssignDistributionSetEvent.class, count = 3) })
+    public void multipleDeployments() throws InterruptedException {
         final String undeployedTargetPrefix = "undep-T";
         final int noOfUndeployedTargets = 5;
 


### PR DESCRIPTION
Throw the TargetAssignDistributionSetEvent even if there are actions in CANCELING state present. Filter the actions on the receiver side. In this case at the DMF.
