### PR TITLE
Support case-insensitive RSQL expressions /target filters

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtility.java
@@ -136,7 +136,7 @@ public final class RSQLUtility {
     public static <A extends Enum<A> & FieldNameProvider, T> Specification<T> parse(final String rsql,
             final Class<A> fieldNameProvider, final VirtualPropertyReplacer virtualPropertyReplacer,
             final Database database) {
-        return new RSQLSpecification<>(rsql.toLowerCase(), fieldNameProvider, virtualPropertyReplacer, database);
+        return new RSQLSpecification<>(rsql, fieldNameProvider, virtualPropertyReplacer, database);
     }
 
     /**
@@ -162,7 +162,7 @@ public final class RSQLUtility {
         try {
             LOGGER.debug("Parsing rsql string {}", rsql);
             final Set<ComparisonOperator> operators = RSQLOperators.defaultOperators();
-            return new RSQLParser(operators).parse(rsql);
+            return new RSQLParser(operators).parse(rsql.toLowerCase());
         } catch (final IllegalArgumentException e) {
             throw new RSQLParameterSyntaxException("rsql filter must not be null", e);
         } catch (final RSQLParserException e) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtilityTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtilityTest.java
@@ -142,6 +142,13 @@ public class RSQLUtilityTest {
         RSQLUtility.validateRsqlFor(rsql2, TestFieldEnum.class);
         RSQLUtility.validateRsqlFor(rsql3, TestFieldEnum.class);
     }
+    
+    @Test
+    @Description("Verify that RSQL expressions are validated case insensitive")
+    public void mixedCaseRsqlFieldValidation() {
+        final String rsqlWithMixedCase = "name==b And name==c aND Name==d OR NAME=iN=y oR nAme=IN=z";
+        RSQLUtility.validateRsqlFor(rsqlWithMixedCase, TargetFields.class);
+    }
 
     @Test
     public void wrongRsqlSyntaxThrowSyntaxException() {


### PR DESCRIPTION
Pull request [1121](https://github.com/eclipse/hawkbit/pull/1121) mistakenly introduced strict validation of case sensitivity for RSQL expressions. To not break existing filters, this aspect of the RSQL validation and parsing logic needs to be reverted.

Signed-off-by: Stefan Behl <stefan.behl@bosch.io>