### PR TITLE
Remove mysql_user and update documentation

### DIFF
--- a/docs/content/gettingstarted.md
+++ b/docs/content/gettingstarted.md
@@ -31,6 +31,13 @@ In addition, the following vendors offer free trial accounts for their Eclipse h
 | MySQL |  | &#10003; | &#10003; | 
 | RabbitMQ |  | &#10003; | &#10003; | 
 
+HawkBit Update Server docker container login credentials:
+
+| Username | Password |
+|---|---|
+| admin | admin |
+| hawkBit Update Server
+
 ### A: Run hawkBit Update Server as Docker Container
 
 Start the hawkBit Update Server as a single container

--- a/hawkbit-runtime/docker/docker-compose-stack.yml
+++ b/hawkbit-runtime/docker/docker-compose-stack.yml
@@ -31,6 +31,8 @@ services:
 
   # ---------------------
   # hawkBit simulator
+  # username: admin
+  # password: admin
   # ---------------------
   simulator:
     image: "hawkbit/hawkbit-device-simulator:latest"
@@ -79,7 +81,7 @@ services:
         condition: on-failure
     environment:
       MYSQL_DATABASE: "hawkbit"
-      MYSQL_USER: "root"
+      # MYSQL_USER: "root" is created by default in the container for mysql 5.7+
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
 
 

--- a/hawkbit-runtime/docker/docker-compose.yml
+++ b/hawkbit-runtime/docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     image: "mysql:5.7"
     environment:
       MYSQL_DATABASE: "hawkbit"
-      MYSQL_USER: "root"
+      # MYSQL_USER: "root" is created by default in the container for mysql 5.7+
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
     restart: always
     ports:
@@ -41,6 +41,8 @@ services:
 
   # ---------------------
   # HawkBit service
+  # username: admin
+  # password: admin
   # ---------------------
   hawkbit:
     image: "hawkbit/hawkbit-update-server:latest-mysql"


### PR DESCRIPTION
Should resolve issue #1138.

Removed the MYSQL_USER value from docker and replaced with a comment. Added a comment in the docker-compose.yml and docker-compose-stack.yml to include the default login details, also added the login details as a table to the getting started guide.