### PR TITLE
Set key of DistributionSetType and SoftwareModuleType required

### DIFF
--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionsettype/MgmtDistributionSetType.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionsettype/MgmtDistributionSetType.java
@@ -30,7 +30,7 @@ public class MgmtDistributionSetType extends MgmtNamedEntity {
     @JsonProperty(value = "id", required = true)
     private Long moduleId;
 
-    @JsonProperty
+    @JsonProperty(required = true)
     private String key;
 
     @JsonProperty

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionsettype/MgmtDistributionSetTypeRequestBodyPost.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionsettype/MgmtDistributionSetTypeRequestBodyPost.java
@@ -23,7 +23,7 @@ public class MgmtDistributionSetTypeRequestBodyPost extends MgmtDistributionSetT
     @JsonProperty(required = true)
     private String name;
 
-    @JsonProperty
+    @JsonProperty(required = true)
     private String key;
 
     @JsonProperty

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleType.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleType.java
@@ -27,7 +27,7 @@ public class MgmtSoftwareModuleType extends MgmtNamedEntity {
     @JsonProperty(value = "id", required = true)
     private Long moduleId;
 
-    @JsonProperty
+    @JsonProperty(required = true)
     private String key;
 
     @JsonProperty

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleTypeRequestBodyPost.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleTypeRequestBodyPost.java
@@ -19,7 +19,7 @@ public class MgmtSoftwareModuleTypeRequestBodyPost extends MgmtSoftwareModuleTyp
     @JsonProperty(required = true)
     private String name;
 
-    @JsonProperty
+    @JsonProperty(required = true)
     private String key;
 
     @JsonProperty


### PR DESCRIPTION
According to [distributionsettypes-api-guide](https://www.eclipse.org/hawkbit/rest-api/distributionsettypes-api-guide/#_request_fields) the name as well as the key are marked as required. This PR will enforce it also for `key` within the REST model classes.

Signed-off-by: Florian Ruschbaschan <Florian.Ruschbaschan@bosch.io>