### PR TITLE
docker-compose.yml: remove MYSQL_USER

### DIFF
--- a/hawkbit-runtime/docker/docker-compose.yml
+++ b/hawkbit-runtime/docker/docker-compose.yml
@@ -31,7 +31,6 @@ services:
     image: "mysql:5.7"
     environment:
       MYSQL_DATABASE: "hawkbit"
-      MYSQL_USER: "root"
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
     restart: always
     ports:


### PR DESCRIPTION
Recent docker images for mysql fail to start with the message:
[ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD
are for configuring a regular user and cannot be used for the root user

Remove the MYSQL_USER env var as it is no longer needed:
https://stackoverflow.com/a/66910240/813810

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>