### PR TITLE
Feature/enforce hash validation for uploads

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/AbstractArtifactRepository.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/AbstractArtifactRepository.java
@@ -66,9 +66,8 @@ public abstract class AbstractArtifactRepository implements ArtifactRepository {
             checkHashes(sha1Hash16, md5Hash16, sha256Hash16, providedHashes);
 
             // Check if file with same sha1 hash exists and if so return it
-            final AbstractDbArtifact existing = getArtifactBySha1(tenant, sha1Hash16);
-            if (existing != null) {
-                return addMissingHashes(existing, sha1Hash16, md5Hash16, sha256Hash16);
+            if (existsByTenantAndSha1(tenant, sha1Hash16)) {
+                return addMissingHashes(getArtifactBySha1(tenant, sha1Hash16), sha1Hash16, md5Hash16, sha256Hash16);
             }
 
             return store(sanitizeTenant(tenant), new DbArtifactHash(sha1Hash16, md5Hash16, sha256Hash16), contentType,

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/model/AbstractDbArtifact.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/model/AbstractDbArtifact.java
@@ -19,9 +19,10 @@ import org.springframework.util.Assert;
 public abstract class AbstractDbArtifact {
 
     private final String artifactId;
-    private final DbArtifactHash hashes;
     private final long size;
     private final String contentType;
+
+    private DbArtifactHash hashes;
 
     protected AbstractDbArtifact(final String artifactId, final DbArtifactHash hashes, final long size,
             final String contentType) {
@@ -48,6 +49,13 @@ public abstract class AbstractDbArtifact {
     }
 
     /**
+     * Set hashes of the artifact
+     */
+    public void setHashes(final DbArtifactHash hashes) {
+        this.hashes = hashes;
+    }
+
+    /**
      * @return site of the artifact in bytes
      */
     public long getSize() {
@@ -62,8 +70,8 @@ public abstract class AbstractDbArtifact {
     }
 
     /**
-     * Creates an {@link InputStream} on this artifact. Caller has to take care
-     * of closing the stream. Repeatable calls open a new {@link InputStream}.
+     * Creates an {@link InputStream} on this artifact. Caller has to take care of
+     * closing the stream. Repeatable calls open a new {@link InputStream}.
      * 
      * @return {@link InputStream} to read from artifact.
      */

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaArtifactManagement.java
@@ -43,7 +43,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 
 /**
@@ -105,20 +104,8 @@ public class JpaArtifactManagement implements ArtifactManagement {
 
         assertArtifactQuota(moduleId, 1);
 
-        return getOrCreateArtifact(artifactUpload)
-                .map(artifact -> storeArtifactMetadata(softwareModule, filename, artifact, existing)).orElse(null);
-    }
-
-    private Optional<AbstractDbArtifact> getOrCreateArtifact(final ArtifactUpload artifactUpload) {
-        final String providedSha1Sum = artifactUpload.getProvidedSha1Sum();
-
-        if (!StringUtils.isEmpty(providedSha1Sum)
-                && artifactRepository.existsByTenantAndSha1(tenantAware.getCurrentTenant(), providedSha1Sum)) {
-            return Optional
-                    .ofNullable(artifactRepository.getArtifactBySha1(tenantAware.getCurrentTenant(), providedSha1Sum));
-        }
-
-        return Optional.of(storeArtifact(artifactUpload));
+        final AbstractDbArtifact artifact = storeArtifact(artifactUpload);
+        return storeArtifactMetadata(softwareModule, filename, artifact, existing);
     }
 
     private AbstractDbArtifact storeArtifact(final ArtifactUpload artifactUpload) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ArtifactManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ArtifactManagementTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
- * <p>
+ * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
This PR is fixing two bugs in the artifact upload REST API. 
1. When uploading an already existing artifact only the sha1 hash is returned in the response body.
2. The user provided hashes in an upload request are never validated for an upload of an already existing artifact (or at least an artifact matching the user provided hash, since the real hash values for the uploaded artifact never got calculated)