### PR TITLE
Remove default vhost environment variable for RabbitMQ in Docker setup

### DIFF
--- a/hawkbit-runtime/docker/docker-compose-stack.yml
+++ b/hawkbit-runtime/docker/docker-compose-stack.yml
@@ -41,8 +41,6 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    environment:
-      RABBITMQ_DEFAULT_VHOST: "/"
 
   # ---------------------
   # hawkBit service

--- a/hawkbit-runtime/docker/docker-compose.yml
+++ b/hawkbit-runtime/docker/docker-compose.yml
@@ -16,8 +16,6 @@ services:
   # ---------------------
   rabbitmq:
     image: "rabbitmq:3-management"
-    environment:
-      RABBITMQ_DEFAULT_VHOST: "/"
     restart: always
     ports:
       - "15672:15672"


### PR DESCRIPTION
RABBITMQ_DEFAULT_VHOST is deprecated. As the default vhost setting
defaults to "/" anyway, it can be safely removed.

Fixes #1157.

See: https://www.rabbitmq.com/configure.html (search for `default_vhost`, there's no anchor to link it directly).