### PR TITLE
Test: max DS Types per TargetType

### DIFF
--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTypeResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTypeResourceTest.java
@@ -539,16 +539,15 @@ class MgmtTargetTypeResourceTest extends AbstractManagementApiIntegrationTest {
     @WithUser(principal = TEST_USER, allSpPermissions = true)
     @Description("Verifies quota enforcement for /rest/v1/targettypes/{ID}/compatibledistributionsettypes POST requests.")
     void assignDistributionSetTypeToTargetTypeUntilQuotaExceeded() throws Exception {
-        String typeName = "TestTypeQuota";
-        final TargetType testType = createTestTargetTypeInDB(typeName);
+        final TargetType testType = createTestTargetTypeInDB("TestTypeQuota");
 
         // create distribution set types
         final int maxDistributionSetTypes = quotaManagement.getMaxDistributionSetTypesPerTargetType();
         final List<Long> dsTypeIds = Lists.newArrayList();
         for (int i = 0; i < maxDistributionSetTypes + 1; ++i) {
-            final DistributionSetTypeCreate dsCreate = entityFactory.distributionSetType().create().name("dsType_" + i)
-                    .description("dsType_" + i).colour("#000000").key("dsType_" + i);
-            dsTypeIds.add(distributionSetTypeManagement.create(dsCreate).getId());
+            final DistributionSetType ds = testdataFactory.findOrCreateDistributionSetType("dsType_" + i,
+                    "dsType_" + i);
+            dsTypeIds.add(ds.getId());
         }
 
         // verify quota enforcement for distribution set types

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTypeResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTypeResourceTest.java
@@ -19,9 +19,13 @@ import io.qameta.allure.Feature;
 import io.qameta.allure.Step;
 import io.qameta.allure.Story;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.util.Lists;
+import org.eclipse.hawkbit.exception.SpServerError;
 import org.eclipse.hawkbit.im.authentication.SpPermission;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
+import org.eclipse.hawkbit.repository.builder.DistributionSetTypeCreate;
 import org.eclipse.hawkbit.repository.builder.TargetTypeCreate;
+import org.eclipse.hawkbit.repository.exception.AssignmentQuotaExceededException;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.NamedEntity;
 import org.eclipse.hawkbit.repository.model.TargetType;
@@ -529,6 +533,36 @@ class MgmtTargetTypeResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(status().isOk()).andExpect(jsonPath("size", equalTo(2)))
                 .andExpect(jsonPath("total", equalTo(2))).andExpect(jsonPath("content[0].name", equalTo("TestName123")))
                 .andExpect(jsonPath("content[1].name", equalTo("TestName1234")));
+    }
+
+    @Test
+    @WithUser(principal = TEST_USER, allSpPermissions = true)
+    @Description("Verifies quota enforcement for /rest/v1/targettypes/{ID}/compatibledistributionsettypes POST requests.")
+    void assignDistributionSetTypeToTargetTypeUntilQuotaExceeded() throws Exception {
+        String typeName = "TestTypeQuota";
+        final TargetType testType = createTestTargetTypeInDB(typeName);
+
+        // create distribution set types
+        final int maxDistributionSetTypes = quotaManagement.getMaxDistributionSetTypesPerTargetType();
+        final List<Long> dsTypeIds = Lists.newArrayList();
+        for (int i = 0; i < maxDistributionSetTypes + 1; ++i) {
+            final DistributionSetTypeCreate dsCreate = entityFactory.distributionSetType().create().name("dsType_" + i)
+                    .description("dsType_" + i).colour("#000000").key("dsType_" + i);
+            dsTypeIds.add(distributionSetTypeManagement.create(dsCreate).getId());
+        }
+
+        // verify quota enforcement for distribution set types
+        mvc.perform(post(TARGETTYPE_DSTYPES_ENDPOINT, testType.getId())
+                .content(JsonBuilder.ids(dsTypeIds.subList(0, dsTypeIds.size() - 1)))
+                .contentType(MediaType.APPLICATION_JSON)).andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk());
+
+        mvc.perform(post(TARGETTYPE_DSTYPES_ENDPOINT, testType.getId())
+                .content("[{\"id\":" + dsTypeIds.get(dsTypeIds.size() - 1) + "}]")
+                .contentType(MediaType.APPLICATION_JSON)).andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.exceptionClass", equalTo(AssignmentQuotaExceededException.class.getName())))
+                .andExpect(jsonPath("$.errorCode", equalTo(SpServerError.SP_QUOTA_EXCEEDED.getKey())));
     }
 
     @Step


### PR DESCRIPTION
With the introduction of Target Types it is also possible to define a maximum number of distribution set types that can be assigned to a target type. 
This PR adds a test to this functionality.

Signed-off-by: Natalia Kislicyn <natalia.kislicyn@bosch.io>