### PR TITLE
Feature - TargetType compatibility check

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
@@ -21,9 +21,9 @@ import javax.validation.constraints.NotNull;
 import org.eclipse.hawkbit.im.authentication.SpPermission.SpringEvalExpressions;
 import org.eclipse.hawkbit.repository.builder.TargetCreate;
 import org.eclipse.hawkbit.repository.builder.TargetUpdate;
+import org.eclipse.hawkbit.repository.exception.AssignmentQuotaExceededException;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
-import org.eclipse.hawkbit.repository.exception.AssignmentQuotaExceededException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterSyntaxException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterUnsupportedFieldException;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
@@ -34,8 +34,8 @@ import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.eclipse.hawkbit.repository.model.TargetMetadata;
 import org.eclipse.hawkbit.repository.model.TargetTag;
-import org.eclipse.hawkbit.repository.model.TargetType;
 import org.eclipse.hawkbit.repository.model.TargetTagAssignmentResult;
+import org.eclipse.hawkbit.repository.model.TargetType;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -83,23 +83,21 @@ public interface TargetManagement {
      * Count {@link Target}s for all the given filter parameters.
      *
      * @param status
-     *            find targets having one of these {@link TargetUpdateStatus}s.
-     *            Set to <code>null</code> in case this is not required.
+     *            find targets having one of these {@link TargetUpdateStatus}s. Set
+     *            to <code>null</code> in case this is not required.
      * @param overdueState
-     *            find targets that are overdue (targets that did not respond
-     *            during the configured intervals: poll_itvl + overdue_itvl).
-     *            Set to <code>null</code> in case this is not required.
+     *            find targets that are overdue (targets that did not respond during
+     *            the configured intervals: poll_itvl + overdue_itvl). Set to
+     *            <code>null</code> in case this is not required.
      * @param searchText
-     *            to find targets having the text anywhere in name or
-     *            description. Set <code>null</code> in case this is not
-     *            required.
-     * @param installedOrAssignedDistributionSetId
-     *            to find targets having the {@link DistributionSet} as
-     *            installed or assigned. Set to <code>null</code> in case this
-     *            is not required.
-     * @param tagNames
-     *            to find targets which are having any one in this tag names.
+     *            to find targets having the text anywhere in name or description.
      *            Set <code>null</code> in case this is not required.
+     * @param installedOrAssignedDistributionSetId
+     *            to find targets having the {@link DistributionSet} as installed or
+     *            assigned. Set to <code>null</code> in case this is not required.
+     * @param tagNames
+     *            to find targets which are having any one in this tag names. Set
+     *            <code>null</code> in case this is not required.
      * @param selectTargetWithNoTag
      *            flag to select targets with no tag assigned
      *
@@ -127,7 +125,8 @@ public interface TargetManagement {
     long countByInstalledDistributionSet(long distId);
 
     /**
-     * Checks if there is already a {@link Target} that has the given distribution set Id assigned or installed.
+     * Checks if there is already a {@link Target} that has the given distribution
+     * set Id assigned or installed.
      *
      * @param distId
      *            to search for
@@ -137,7 +136,7 @@ public interface TargetManagement {
      *             if distribution set with given ID does not exist
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET + SpringEvalExpressions.HAS_AUTH_OR
-                          + SpringEvalExpressions.HAS_AUTH_READ_REPOSITORY)
+            + SpringEvalExpressions.HAS_AUTH_READ_REPOSITORY)
     boolean existsByInstalledOrAssignedDistributionSet(long distId);
 
     /**
@@ -181,8 +180,8 @@ public interface TargetManagement {
      * @throws EntityAlreadyExistsException
      *             given target already exists.
      * @throws ConstraintViolationException
-     *             if fields are not filled as specified. Check
-     *             {@link TargetCreate} for field constraints.
+     *             if fields are not filled as specified. Check {@link TargetCreate}
+     *             for field constraints.
      *
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_CREATE_TARGET)
@@ -190,9 +189,9 @@ public interface TargetManagement {
 
     /**
      * creates multiple {@link Target}s. If some of the given {@link Target}s
-     * already exists in the DB a {@link EntityAlreadyExistsException} is
-     * thrown. {@link Target}s contain all objects of the parameter targets,
-     * including duplicates.
+     * already exists in the DB a {@link EntityAlreadyExistsException} is thrown.
+     * {@link Target}s contain all objects of the parameter targets, including
+     * duplicates.
      *
      * @param creates
      *            to be created.
@@ -201,8 +200,8 @@ public interface TargetManagement {
      * @throws EntityAlreadyExistsException
      *             of one of the given targets already exist.
      * @throws ConstraintViolationException
-     *             if fields are not filled as specified. Check
-     *             {@link TargetCreate} for field constraints.
+     *             if fields are not filled as specified. Check {@link TargetCreate}
+     *             for field constraints.
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_CREATE_TARGET)
     List<Target> create(@NotNull @Valid Collection<TargetCreate> creates);
@@ -232,9 +231,8 @@ public interface TargetManagement {
     void deleteByControllerID(@NotEmpty String controllerID);
 
     /**
-     * Finds all targets for all the given parameter {@link TargetFilterQuery}
-     * and that don't have the specified distribution set in their action
-     * history.
+     * Finds all targets for all the given parameter {@link TargetFilterQuery} and
+     * that don't have the specified distribution set in their action history.
      *
      * @param pageRequest
      *            the pageRequest to enhance the query for paging and sorting
@@ -248,13 +246,12 @@ public interface TargetManagement {
      *             if distribution set with given ID does not exist
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
-    Page<Target> findByTargetFilterQueryAndNonDS(@NotNull Pageable pageRequest, long distributionSetId,
+    Page<Target> findByTargetFilterQueryAndNonDSAndCompatible(@NotNull Pageable pageRequest, long distributionSetId,
             @NotNull String rsqlParam);
 
     /**
-     * Counts all targets for all the given parameter {@link TargetFilterQuery}
-     * and that don't have the specified distribution set in their action
-     * history.
+     * Counts all targets for all the given parameter {@link TargetFilterQuery} and
+     * that don't have the specified distribution set in their action history.
      *
      * @param distributionSetId
      *            id of the {@link DistributionSet}
@@ -266,11 +263,11 @@ public interface TargetManagement {
      *             if distribution set with given ID does not exist
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
-    long countByRsqlAndNonDS(long distributionSetId, @NotNull String rsqlParam);
+    long countByRsqlAndNonDSAndCompatible(long distributionSetId, @NotNull String rsqlParam);
 
     /**
-     * Finds all targets for all the given parameter {@link TargetFilterQuery}
-     * and that are not assigned to one of the {@link RolloutGroup}s
+     * Finds all targets for all the given parameter {@link TargetFilterQuery} and
+     * that are not assigned to one of the {@link RolloutGroup}s
      *
      * @param pageRequest
      *            the pageRequest to enhance the query for paging and sorting
@@ -285,8 +282,8 @@ public interface TargetManagement {
             @NotEmpty Collection<Long> groups, @NotNull String rsqlParam);
 
     /**
-     * Counts all targets for all the given parameter {@link TargetFilterQuery}
-     * and that are not assigned to one of the {@link RolloutGroup}s
+     * Counts all targets for all the given parameter {@link TargetFilterQuery} and
+     * that are not assigned to one of the {@link RolloutGroup}s
      *
      * @param groups
      *            the list of {@link RolloutGroup}s
@@ -298,8 +295,8 @@ public interface TargetManagement {
     long countByRsqlAndNotInRolloutGroups(@NotEmpty Collection<Long> groups, @NotNull String rsqlParam);
 
     /**
-     * Finds all targets of the provided {@link RolloutGroup} that have no
-     * Action for the RolloutGroup.
+     * Finds all targets of the provided {@link RolloutGroup} that have no Action
+     * for the RolloutGroup.
      *
      * @param pageRequest
      *            the pageRequest to enhance the query for paging and sorting
@@ -331,8 +328,8 @@ public interface TargetManagement {
     Page<Target> findByAssignedDistributionSet(@NotNull Pageable pageReq, long distributionSetID);
 
     /**
-     * Retrieves {@link Target}s by the assigned {@link DistributionSet}
-     * possible including additional filtering based on the given {@code spec}.
+     * Retrieves {@link Target}s by the assigned {@link DistributionSet} possible
+     * including additional filtering based on the given {@code spec}.
      * 
      * @param pageReq
      *            page parameter
@@ -375,14 +372,14 @@ public interface TargetManagement {
     Optional<Target> getByControllerID(@NotEmpty String controllerId);
 
     /**
-     * Filter {@link Target}s for all the given parameters. If all parameters
-     * except pageable are null, all available {@link Target}s are returned.
+     * Filter {@link Target}s for all the given parameters. If all parameters except
+     * pageable are null, all available {@link Target}s are returned.
      *
      * @param pageable
      *            page parameters
      * @param filterParams
-     *            the filters to apply; only filters are enabled that have
-     *            non-null value; filters are AND-gated
+     *            the filters to apply; only filters are enabled that have non-null
+     *            value; filters are AND-gated
      *
      * @return the found {@link Target}s
      * 
@@ -409,8 +406,8 @@ public interface TargetManagement {
     Page<Target> findByInstalledDistributionSet(@NotNull Pageable pageReq, long distributionSetID);
 
     /**
-     * retrieves {@link Target}s by the installed {@link DistributionSet}
-     * including additional filtering based on the given {@code spec}.
+     * retrieves {@link Target}s by the installed {@link DistributionSet} including
+     * additional filtering based on the given {@code spec}.
      * 
      * @param pageReq
      *            page parameter
@@ -435,8 +432,7 @@ public interface TargetManagement {
             @NotNull String rsqlParam);
 
     /**
-     * Retrieves the {@link Target} which have a certain
-     * {@link TargetUpdateStatus}.
+     * Retrieves the {@link Target} which have a certain {@link TargetUpdateStatus}.
      *
      * @param pageable
      *            page parameter
@@ -499,8 +495,7 @@ public interface TargetManagement {
     Slice<Target> findByTargetFilterQuery(@NotNull Pageable pageable, long targetFilterQueryId);
 
     /**
-     * method retrieves all {@link Target}s from the repo in the following
-     * order:
+     * method retrieves all {@link Target}s from the repo in the following order:
      * <p>
      * 1) {@link Target}s which have the given {@link DistributionSet} as
      * {@link Target#getTarget()} {@link Target#getInstalledDistributionSet()}
@@ -516,8 +511,8 @@ public interface TargetManagement {
      * @param orderByDistributionId
      *            {@link DistributionSet#getId()} to be ordered by
      * @param filterParams
-     *            the filters to apply; only filters are enabled that have
-     *            non-null value; filters are AND-gated
+     *            the filters to apply; only filters are enabled that have non-null
+     *            value; filters are AND-gated
      * @return a paged result {@link Page} of the {@link Target}s in a defined
      *         order.
      * 
@@ -567,9 +562,9 @@ public interface TargetManagement {
     Page<Target> findByRsqlAndTag(@NotNull Pageable pageable, @NotNull String rsqlParam, long tagId);
 
     /**
-     * Toggles {@link TargetTag} assignment to given {@link Target}s by means
-     * that if some (or all) of the targets in the list have the {@link Tag} not
-     * yet assigned, they will be. Only if all of theme have the tag already assigned
+     * Toggles {@link TargetTag} assignment to given {@link Target}s by means that
+     * if some (or all) of the targets in the list have the {@link Tag} not yet
+     * assigned, they will be. Only if all of theme have the tag already assigned
      * they will be removed instead.
      *
      * @param controllerIds
@@ -634,8 +629,8 @@ public interface TargetManagement {
      * @throws EntityNotFoundException
      *             if given target does not exist
      * @throws ConstraintViolationException
-     *             if fields are not filled as specified. Check
-     *             {@link TargetUpdate} for field constraints.
+     *             if fields are not filled as specified. Check {@link TargetUpdate}
+     *             for field constraints.
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_TARGET)
     Target update(@NotNull @Valid TargetUpdate update);
@@ -724,8 +719,7 @@ public interface TargetManagement {
      * Creates a list of target meta data entries.
      *
      * @param controllerId
-     *            {@link Target} controller id the metadata has to be created
-     *            for
+     *            {@link Target} controller id the metadata has to be created for
      * @param metadata
      *            the meta data entries to create or update
      * @return the updated or created target meta data entries
@@ -738,8 +732,8 @@ public interface TargetManagement {
      *             specific key
      * 
      * @throws AssignmentQuotaExceededException
-     *             if the maximum number of {@link MetaData} entries is exceeded
-     *             for the addressed {@link Target}
+     *             if the maximum number of {@link MetaData} entries is exceeded for
+     *             the addressed {@link Target}
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_REPOSITORY)
     List<TargetMetadata> createMetaData(@NotEmpty String controllerId, @NotEmpty Collection<MetaData> metadata);
@@ -819,15 +813,13 @@ public interface TargetManagement {
      * Updates a target meta data value if corresponding entry exists.
      *
      * @param controllerId
-     *            {@link Target} controller id of the meta data entry to be
-     *            updated
+     *            {@link Target} controller id of the meta data entry to be updated
      * @param metadata
      *            meta data entry to be updated
      * @return the updated meta data entry
      * 
      * @throws EntityNotFoundException
-     *             in case the meta data entry does not exists and cannot be
-     *             updated
+     *             in case the meta data entry does not exists and cannot be updated
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_REPOSITORY)
     TargetMetadata updateMetadata(@NotEmpty String controllerId, @NotNull MetaData metadata);

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
@@ -27,6 +27,7 @@ import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterSyntaxException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterUnsupportedFieldException;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.MetaData;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.repository.model.Tag;
@@ -275,11 +276,15 @@ public interface TargetManagement {
      *            the list of {@link RolloutGroup}s
      * @param rsqlParam
      *            filter definition in RSQL syntax
+     * @param distributionSetType
+     *            type of the {@link DistributionSet} the targets must be compatible
+     *            with
      * @return a page of the found {@link Target}s
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
-    Page<Target> findByTargetFilterQueryAndNotInRolloutGroups(@NotNull Pageable pageRequest,
-            @NotEmpty Collection<Long> groups, @NotNull String rsqlParam);
+    Page<Target> findByTargetFilterQueryAndNotInRolloutGroupsAndCompatible(@NotNull Pageable pageRequest,
+            @NotEmpty Collection<Long> groups, @NotNull String rsqlParam,
+            @NotNull DistributionSetType distributionSetType);
 
     /**
      * Counts all targets for all the given parameter {@link TargetFilterQuery} and
@@ -289,10 +294,14 @@ public interface TargetManagement {
      *            the list of {@link RolloutGroup}s
      * @param rsqlParam
      *            filter definition in RSQL syntax
+     * @param distributionSetType
+     *            type of the {@link DistributionSet} the targets must be compatible
+     *            with
      * @return count of the found {@link Target}s
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
-    long countByRsqlAndNotInRolloutGroups(@NotEmpty Collection<Long> groups, @NotNull String rsqlParam);
+    long countByRsqlAndNotInRolloutGroupsAndCompatible(@NotEmpty Collection<Long> groups, @NotNull String rsqlParam,
+            @NotNull DistributionSetType distributionSetType);
 
     /**
      * Finds all targets of the provided {@link RolloutGroup} that have no Action

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -58,6 +58,7 @@ import org.eclipse.hawkbit.repository.jpa.specifications.SpecificationsBuilder;
 import org.eclipse.hawkbit.repository.jpa.specifications.TargetSpecifications;
 import org.eclipse.hawkbit.repository.jpa.utils.QuotaHelper;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.MetaData;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.repository.model.Target;
@@ -84,8 +85,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
-
-import com.google.common.collect.Lists;
 
 /**
  * JPA implementation of {@link TargetManagement}.
@@ -707,23 +706,23 @@ public class JpaTargetManagement implements TargetManagement {
                 virtualPropertyReplacer, database);
         final Specification<JpaTarget> dsNotInActions = TargetSpecifications
                 .hasNotDistributionSetInActions(distributionSetId);
-        final Specification<JpaTarget> isCompatible = TargetSpecifications
+        final Specification<JpaTarget> isCompatibleWithDsType = TargetSpecifications
                 .isCompatibleWithDistributionSetType(distSetTypeId);
 
-        return findTargetsBySpec(spec.and(dsNotInActions).and(isCompatible), pageRequest);
-
+        return findTargetsBySpec(spec.and(dsNotInActions).and(isCompatibleWithDsType), pageRequest);
     }
 
     @Override
-    public Page<Target> findByTargetFilterQueryAndNotInRolloutGroups(final Pageable pageRequest,
-            final Collection<Long> groups, final String targetFilterQuery) {
+    public Page<Target> findByTargetFilterQueryAndNotInRolloutGroupsAndCompatible(final Pageable pageRequest,
+            final Collection<Long> groups, final String targetFilterQuery, final DistributionSetType dsType) {
 
         final Specification<JpaTarget> spec = RSQLUtility.buildRsqlSpecification(targetFilterQuery, TargetFields.class,
                 virtualPropertyReplacer, database);
+        final Specification<JpaTarget> notInRolloutGroups = TargetSpecifications.isNotInRolloutGroups(groups);
+        final Specification<JpaTarget> isCompatibleWithDsType = TargetSpecifications
+                .isCompatibleWithDistributionSetType(dsType.getId());
 
-        return findTargetsBySpec((root, cq, cb) -> cb.and(spec.toPredicate(root, cq, cb),
-                TargetSpecifications.isNotInRolloutGroups(groups).toPredicate(root, cq, cb)), pageRequest);
-
+        return findTargetsBySpec((spec.and(notInRolloutGroups).and(isCompatibleWithDsType)), pageRequest);
     }
 
     @Override
@@ -738,11 +737,13 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
-    public long countByRsqlAndNotInRolloutGroups(final Collection<Long> groups, final String targetFilterQuery) {
+    public long countByRsqlAndNotInRolloutGroupsAndCompatible(final Collection<Long> groups,
+            final String targetFilterQuery, final DistributionSetType dsType) {
         final Specification<JpaTarget> spec = RSQLUtility.buildRsqlSpecification(targetFilterQuery, TargetFields.class,
                 virtualPropertyReplacer, database);
         final List<Specification<JpaTarget>> specList = Arrays.asList(spec,
-                TargetSpecifications.isNotInRolloutGroups(groups));
+                TargetSpecifications.isNotInRolloutGroups(groups),
+                TargetSpecifications.isCompatibleWithDistributionSetType(dsType.getId()));
 
         return countByCriteriaAPI(specList);
     }
@@ -754,10 +755,9 @@ public class JpaTargetManagement implements TargetManagement {
 
         final Specification<JpaTarget> spec = RSQLUtility.buildRsqlSpecification(targetFilterQuery, TargetFields.class,
                 virtualPropertyReplacer, database);
-        final List<Specification<JpaTarget>> specList = Lists.newArrayListWithExpectedSize(2);
-        specList.add(spec);
-        specList.add(TargetSpecifications.hasNotDistributionSetInActions(distributionSetId));
-        specList.add(TargetSpecifications.isCompatibleWithDistributionSetType(distSetTypeId));
+        final List<Specification<JpaTarget>> specList = Arrays.asList(spec,
+                TargetSpecifications.hasNotDistributionSetInActions(distributionSetId),
+                TargetSpecifications.isCompatibleWithDistributionSetType(distSetTypeId));
 
         return countByCriteriaAPI(specList);
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignChecker.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignChecker.java
@@ -84,14 +84,15 @@ public class AutoAssignChecker extends AbstractAutoAssignExecutor {
             do {
 
                 final List<String> controllerIds = targetManagement
-                        .findByTargetFilterQueryAndNonDS(PageRequest.of(0, Constants.MAX_ENTRIES_IN_STATEMENT),
+                        .findByTargetFilterQueryAndNonDSAndCompatible(
+                                PageRequest.of(0, Constants.MAX_ENTRIES_IN_STATEMENT),
                                 targetFilterQuery.getAutoAssignDistributionSet().getId(), targetFilterQuery.getQuery())
                         .getContent().stream().map(Target::getControllerId).collect(Collectors.toList());
                 count = runTransactionalAssignment(targetFilterQuery, controllerIds);
 
             } while (count == Constants.MAX_ENTRIES_IN_STATEMENT);
 
-        } catch (PersistenceException | AbstractServerRtException e) {
+        } catch (final PersistenceException | AbstractServerRtException e) {
             LOGGER.error("Error during auto assign check of target filter query " + targetFilterQuery.getId(), e);
         }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.List;
 
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.ListJoin;
 import javax.persistence.criteria.MapJoin;
@@ -25,11 +26,15 @@ import javax.validation.constraints.NotNull;
 import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
 import org.eclipse.hawkbit.repository.jpa.model.JpaAction_;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet;
+import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSetType;
+import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSetType_;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet_;
 import org.eclipse.hawkbit.repository.jpa.model.JpaRolloutGroup_;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTarget;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTargetTag;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTargetTag_;
+import org.eclipse.hawkbit.repository.jpa.model.JpaTargetType;
+import org.eclipse.hawkbit.repository.jpa.model.JpaTargetType_;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTarget_;
 import org.eclipse.hawkbit.repository.jpa.model.RolloutTargetGroup;
 import org.eclipse.hawkbit.repository.jpa.model.RolloutTargetGroup_;
@@ -185,15 +190,14 @@ public final class TargetSpecifications {
 
     /**
      * {@link Specification} for retrieving {@link Target}s that are overdue. A
-     * target is overdue if it did not respond during the configured
-     * intervals:<br>
+     * target is overdue if it did not respond during the configured intervals:<br>
      * <em>poll_itvl + overdue_itvl</em>
      *
      * @param overdueTimestamp
      *            the calculated timestamp to compare with the last respond of a
      *            target (lastTargetQuery).<br>
-     *            The <code>overdueTimestamp</code> has to be calculated with
-     *            the following expression:<br>
+     *            The <code>overdueTimestamp</code> has to be calculated with the
+     *            following expression:<br>
      *            <em>overdueTimestamp = nowTimestamp - poll_itvl -
      *            overdue_itvl</em>
      *
@@ -205,8 +209,8 @@ public final class TargetSpecifications {
     }
 
     /**
-     * {@link Specification} for retrieving {@link Target}s by "like
-     * controllerId or like name or like description".
+     * {@link Specification} for retrieving {@link Target}s by "like controllerId or
+     * like name or like description".
      *
      * @param searchText
      *            to be filtered on
@@ -240,8 +244,8 @@ public final class TargetSpecifications {
     }
 
     /**
-     * {@link Specification} for retrieving {@link Target}s by "like
-     * controllerId or like name or like description or like attribute value".
+     * {@link Specification} for retrieving {@link Target}s by "like controllerId or
+     * like name or like description or like attribute value".
      *
      * @param searchText
      *            to be filtered on
@@ -252,8 +256,7 @@ public final class TargetSpecifications {
     }
 
     /**
-     * {@link Specification} for retrieving {@link Target}s by "like
-     * controllerId".
+     * {@link Specification} for retrieving {@link Target}s by "like controllerId".
      *
      * @param distributionId
      *            to be filtered on
@@ -264,8 +267,8 @@ public final class TargetSpecifications {
     }
 
     /**
-     * Finds all targets by given {@link Target#getControllerId()}s and which
-     * are not yet assigned to given {@link DistributionSet}.
+     * Finds all targets by given {@link Target#getControllerId()}s and which are
+     * not yet assigned to given {@link DistributionSet}.
      *
      * @param tIDs
      *            to search for.
@@ -298,8 +301,8 @@ public final class TargetSpecifications {
     }
 
     /**
-     * {@link Specification} for retrieving {@link Target}s by "has no tag
-     * names"or "has at least on of the given tag names".
+     * {@link Specification} for retrieving {@link Target}s by "has no tag names"or
+     * "has at least on of the given tag names".
      *
      * @param tagNames
      *            to be filtered on
@@ -341,8 +344,8 @@ public final class TargetSpecifications {
     }
 
     /**
-     * {@link Specification} for retrieving {@link Target}s by assigned
-     * distribution set.
+     * {@link Specification} for retrieving {@link Target}s by assigned distribution
+     * set.
      *
      * @param distributionSetId
      *            the ID of the distribution set which must be assigned
@@ -369,6 +372,24 @@ public final class TargetSpecifications {
                     distributionSetId));
 
             return cb.isNull(actionsJoin.get(JpaAction_.id));
+        };
+    }
+
+    /**
+     * {@link Specification} for retrieving {@link Target}s that are compatible with
+     * given DistributionSetType
+     *
+     * @param distributionSetTypeId
+     *            the ID of the distribution set type which must compatible
+     * @return the {@link Target} {@link Specification}
+     */
+    public static Specification<JpaTarget> isCompatibleWithDistributionSetType(final Long distributionSetTypeId) {
+        return (targetRoot, query, cb) -> {
+            final Join<JpaTarget, JpaTargetType> targetTypeJoin = targetRoot.join(JpaTarget_.targetType);
+            final SetJoin<JpaTargetType, JpaDistributionSetType> distSetTypeJoin = targetTypeJoin
+                    .join(JpaTargetType_.distributionSetTypes);
+            return cb.or(cb.isNull(targetRoot.get(JpaTarget_.targetType)),
+                    cb.equal(distSetTypeJoin.get(JpaDistributionSetType_.id), distributionSetTypeId));
         };
     }
 
@@ -423,8 +444,8 @@ public final class TargetSpecifications {
     }
 
     /**
-     * {@link Specification} for retrieving {@link Target}s that have no Action
-     * of the {@link RolloutGroup}.
+     * {@link Specification} for retrieving {@link Target}s that have no Action of
+     * the {@link RolloutGroup}.
      *
      * @param group
      *            the {@link RolloutGroup}
@@ -445,8 +466,8 @@ public final class TargetSpecifications {
     }
 
     /**
-     * {@link Specification} for retrieving {@link Target}s by assigned
-     * distribution set.
+     * {@link Specification} for retrieving {@link Target}s by assigned distribution
+     * set.
      *
      * @param distributionSetId
      *            the ID of the distribution set which must be assigned
@@ -470,5 +491,15 @@ public final class TargetSpecifications {
             final SetJoin<JpaTarget, JpaTargetTag> tags = targetRoot.join(JpaTarget_.tags, JoinType.LEFT);
             return cb.equal(tags.get(JpaTargetTag_.id), tagId);
         };
+    }
+
+    /**
+     * {@link Specification} for retrieving {@link Target}s that have a
+     * {@link org.eclipse.hawkbit.repository.model.TargetType} assigned
+     * 
+     * @return the {@link Target} {@link Specification}
+     */
+    public static Specification<JpaTarget> hasTargetType() {
+        return (targetRoot, query, cb) -> cb.isNotNull(targetRoot.get(JpaTarget_.targetType));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.validation.ConstraintViolationException;
@@ -40,6 +41,7 @@ import org.eclipse.hawkbit.repository.event.remote.entity.TargetUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TenantConfigurationCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TenantConfigurationUpdatedEvent;
 import org.eclipse.hawkbit.repository.exception.AssignmentQuotaExceededException;
+import org.eclipse.hawkbit.repository.exception.DistributionSetTypeNotInTargetTypeException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.exception.ForceQuitActionNotAllowedException;
 import org.eclipse.hawkbit.repository.exception.IncompleteDistributionSetException;
@@ -61,6 +63,7 @@ import org.eclipse.hawkbit.repository.model.DistributionSetAssignmentResult;
 import org.eclipse.hawkbit.repository.model.DistributionSetTag;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.model.TargetType;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
@@ -68,6 +71,7 @@ import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.T
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort.Direction;
 
@@ -86,25 +90,25 @@ import io.qameta.allure.Story;
  */
 @Feature("Component Tests - Repository")
 @Story("Deployment Management")
-public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
+class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     private static final boolean STATE_ACTIVE = true;
     private static final boolean STATE_INACTIVE = false;
 
     @Test
-    @Description("Verifies that management get access react as specfied on calls for non existing entities by means "
+    @Description("Verifies that management get access react as specified on calls for non existing entities by means "
             + "of Optional not present.")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
-    public void nonExistingEntityAccessReturnsNotPresent() {
+    void nonExistingEntityAccessReturnsNotPresent() {
         assertThat(deploymentManagement.findAction(1234L)).isNotPresent();
         assertThat(deploymentManagement.findActionWithDetails(NOT_EXIST_IDL)).isNotPresent();
     }
 
     @Test
-    @Description("Verifies that management queries react as specfied on calls for non existing entities "
+    @Description("Verifies that management queries react as specified on calls for non existing entities "
             + " by means of throwing EntityNotFoundException.")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1) })
-    public void entityQueriesReferringToNotExistingEntitiesThrowsException() {
+    void entityQueriesReferringToNotExistingEntitiesThrowsException() {
         final Target target = testdataFactory.createTarget();
         final String dsName = "DistributionSet";
 
@@ -127,7 +131,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Test verifies that the repistory retrieves the action including all defined (lazy) details.")
-    public void findActionWithLazyDetails() {
+    void findActionWithLazyDetails() {
         final DistributionSet testDs = testdataFactory.createDistributionSet("TestDs", "1.0",
                 new ArrayList<DistributionSetTag>());
         final List<Target> testTarget = testdataFactory.createTargets(1);
@@ -144,7 +148,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Test verifies that actions of a target are found by using id-based search.")
-    public void findActionByTargetId() {
+    void findActionByTargetId() {
         final DistributionSet testDs = testdataFactory.createDistributionSet("TestDs", "1.0",
                 new ArrayList<DistributionSetTag>());
         final List<Target> testTarget = testdataFactory.createTargets(1);
@@ -162,7 +166,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Test verifies that the 'max actions per target' quota is enforced.")
-    public void assertMaxActionsPerTargetQuotaIsEnforced() {
+    void assertMaxActionsPerTargetQuotaIsEnforced() {
 
         final int maxActions = quotaManagement.getMaxActionsPerTarget();
         final Target testTarget = testdataFactory.createTarget();
@@ -180,7 +184,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("An assignment request with more assignments than allowed by 'maxTargetDistributionSetAssignmentsPerManualAssignment' quota throws an exception.")
-    public void assignmentRequestThatIsTooLarge() {
+    void assignmentRequestThatIsTooLarge() {
         final int maxActions = quotaManagement.getMaxTargetDistributionSetAssignmentsPerManualAssignment();
         final DistributionSet ds1 = testdataFactory.createDistributionSet("1");
         final DistributionSet ds2 = testdataFactory.createDistributionSet("2");
@@ -195,7 +199,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Test verifies that action-states of an action are found by using id-based search.")
-    public void findActionStatusByActionId() {
+    void findActionStatusByActionId() {
         final DistributionSet testDs = testdataFactory.createDistributionSet("TestDs", "1.0", Collections.emptyList());
         final List<Target> testTarget = testdataFactory.createTargets(1);
         // one action with one action status is generated
@@ -213,7 +217,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Test verifies that messages of an action-status are found by using id-based search.")
-    public void findMessagesByActionStatusId() {
+    void findMessagesByActionStatusId() {
         final DistributionSet testDs = testdataFactory.createDistributionSet("TestDs", "1.0",
                 new ArrayList<DistributionSetTag>());
         final List<Target> testTarget = testdataFactory.createTargets(1);
@@ -239,7 +243,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Ensures that tag to distribution set assignment that does not exist will cause EntityNotFoundException.")
-    public void assignDistributionSetToTagThatDoesNotExistThrowsException() {
+    void assignDistributionSetToTagThatDoesNotExistThrowsException() {
         final List<Long> assignDS = Lists.newArrayListWithExpectedSize(5);
         for (int i = 0; i < 4; i++) {
             assignDS.add(testdataFactory.createDistributionSet("DS" + i, "1.0", Collections.emptyList()).getId());
@@ -264,7 +268,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = ActionUpdatedEvent.class, count = Constants.MAX_ENTRIES_IN_STATEMENT + 10),
             @Expect(type = DistributionSetCreatedEvent.class, count = 2),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 6) })
-    public void multiAssigmentHistoryOverMultiplePagesResultsInTwoActiveAction() {
+    void multiAssigmentHistoryOverMultiplePagesResultsInTwoActiveAction() {
 
         final DistributionSet cancelDs = testdataFactory.createDistributionSet("Canceled DS", "1.0",
                 Collections.emptyList());
@@ -274,7 +278,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
         final List<Target> targets = testdataFactory.createTargets(Constants.MAX_ENTRIES_IN_STATEMENT + 10);
 
-        assertThat(deploymentManagement.countActionsAll()).isEqualTo(0);
+        assertThat(deploymentManagement.countActionsAll()).isZero();
 
         assignDistributionSet(cancelDs, targets).getAssignedEntity();
         assertThat(deploymentManagement.countActionsAll()).isEqualTo(Constants.MAX_ENTRIES_IN_STATEMENT + 10);
@@ -286,7 +290,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
     @Description("Cancels multiple active actions on a target. Expected behaviour is that with two active "
             + "actions after canceling the second active action the first one is still running as it is not touched by the cancelation. After canceling the first one "
             + "also the target goes back to IN_SYNC as no open action is left.")
-    public void manualCancelWithMultipleAssignmentsCancelLastOneFirst() {
+    void manualCancelWithMultipleAssignmentsCancelLastOneFirst() {
         final Action action = prepareFinishedUpdate("4712", "installed", true);
         final Target target = action.getTarget();
         final DistributionSet dsFirst = testdataFactory.createDistributionSet("", true);
@@ -311,7 +315,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         controllerManagement.addCancelActionStatus(
                 entityFactory.actionStatus().create(secondAction.getId()).status(Status.CANCELED));
         assertThat(actionStatusRepository.findAll()).as("wrong size of actions status").hasSize(7);
-        assertThat(deploymentManagement.getAssignedDistributionSet("4712").get()).as("wrong ds").isEqualTo(dsFirst);
+        assertThat(deploymentManagement.getAssignedDistributionSet("4712")).as("wrong ds").contains(dsFirst);
         assertThat(targetManagement.getByControllerID("4712").get().getUpdateStatus()).as("wrong update status")
                 .isEqualTo(TargetUpdateStatus.PENDING);
 
@@ -322,8 +326,8 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         controllerManagement.addCancelActionStatus(
                 entityFactory.actionStatus().create(firstAction.getId()).status(Status.CANCELED));
         assertThat(actionStatusRepository.findAll()).as("wrong size of action status").hasSize(9);
-        assertThat(deploymentManagement.getAssignedDistributionSet("4712").get()).as("wrong assigned ds")
-                .isEqualTo(dsInstalled);
+        assertThat(deploymentManagement.getAssignedDistributionSet("4712")).as("wrong assigned ds")
+                .contains(dsInstalled);
         assertThat(targetManagement.getByControllerID("4712").get().getUpdateStatus()).as("wrong update status")
                 .isEqualTo(TargetUpdateStatus.IN_SYNC);
     }
@@ -332,7 +336,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
     @Description("Cancels multiple active actions on a target. Expected behaviour is that with two active "
             + "actions after canceling the first active action the system switched to second one. After canceling this one "
             + "also the target goes back to IN_SYNC as no open action is left.")
-    public void manualCancelWithMultipleAssignmentsCancelMiddleOneFirst() {
+    void manualCancelWithMultipleAssignmentsCancelMiddleOneFirst() {
         final Action action = prepareFinishedUpdate("4712", "installed", true);
         final Target target = action.getTarget();
         final DistributionSet dsFirst = testdataFactory.createDistributionSet("", true);
@@ -357,8 +361,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         controllerManagement.addCancelActionStatus(
                 entityFactory.actionStatus().create(firstAction.getId()).status(Status.CANCELED));
         assertThat(actionStatusRepository.findAll()).as("wrong size of action status").hasSize(7);
-        assertThat(deploymentManagement.getAssignedDistributionSet("4712").get()).as("wrong assigned ds")
-                .isEqualTo(dsSecond);
+        assertThat(deploymentManagement.getAssignedDistributionSet("4712")).as("wrong assigned ds").contains(dsSecond);
         assertThat(targetManagement.getByControllerID("4712").get().getUpdateStatus()).as("wrong target update status")
                 .isEqualTo(TargetUpdateStatus.PENDING);
 
@@ -366,21 +369,20 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         deploymentManagement.cancelAction(secondAction.getId());
         secondAction = (JpaAction) deploymentManagement.findActionWithDetails(secondAction.getId()).get();
         assertThat(actionStatusRepository.findAll()).as("wrong size of action status").hasSize(8);
-        assertThat(deploymentManagement.getAssignedDistributionSet("4712").get()).as("wrong assigned ds")
-                .isEqualTo(dsSecond);
+        assertThat(deploymentManagement.getAssignedDistributionSet("4712")).as("wrong assigned ds").contains(dsSecond);
         // confirm cancellation
         controllerManagement.addCancelActionStatus(
                 entityFactory.actionStatus().create(secondAction.getId()).status(Status.CANCELED));
         // cancelled success -> back to dsInstalled
-        assertThat(deploymentManagement.getAssignedDistributionSet("4712").get()).as("wrong installed ds")
-                .isEqualTo(dsInstalled);
+        assertThat(deploymentManagement.getAssignedDistributionSet("4712")).as("wrong installed ds")
+                .contains(dsInstalled);
         assertThat(targetManagement.getByControllerID("4712").get().getUpdateStatus())
                 .as("wrong target info update status").isEqualTo(TargetUpdateStatus.IN_SYNC);
     }
 
     @Test
     @Description("Force Quit an Assignment. Expected behaviour is that the action is canceled and is marked as deleted. The assigned Software module")
-    public void forceQuitSetActionToInactive() throws InterruptedException {
+    void forceQuitSetActionToInactive() throws InterruptedException {
         final Action action = prepareFinishedUpdate("4712", "installed", true);
         final Target target = action.getTarget();
         final DistributionSet dsInstalled = action.getDistributionSet();
@@ -407,15 +409,15 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
         // verify
         assertThat(assigningAction.getStatus()).as("wrong size of status").isEqualTo(Status.CANCELED);
-        assertThat(deploymentManagement.getAssignedDistributionSet("4712").get()).as("wrong assigned ds")
-                .isEqualTo(dsInstalled);
+        assertThat(deploymentManagement.getAssignedDistributionSet("4712")).as("wrong assigned ds")
+                .contains(dsInstalled);
         assertThat(targetManagement.getByControllerID("4712").get().getUpdateStatus()).as("wrong target update status")
                 .isEqualTo(TargetUpdateStatus.IN_SYNC);
     }
 
     @Test
     @Description("Force Quit an not canceled Assignment. Expected behaviour is that the action can not be force quit and there is thrown an exception.")
-    public void forceQuitNotAllowedThrowsException() {
+    void forceQuitNotAllowedThrowsException() {
         final Action action = prepareFinishedUpdate("4712", "installed", true);
         final Target target = action.getTarget();
 
@@ -441,8 +443,8 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         assignDistributionSet(ds.getId(), target.getControllerId());
         assertThat(targetManagement.getByControllerID(target.getControllerId()).get().getUpdateStatus())
                 .as("wrong update status").isEqualTo(TargetUpdateStatus.PENDING);
-        assertThat(deploymentManagement.getAssignedDistributionSet(target.getControllerId()).get())
-                .as("wrong assigned ds").isEqualTo(ds);
+        assertThat(deploymentManagement.getAssignedDistributionSet(target.getControllerId())).as("wrong assigned ds")
+                .contains(ds);
         final JpaAction action = actionRepository
                 .findByTargetAndDistributionSet(PAGE, (JpaTarget) target, (JpaDistributionSet) ds).getContent().get(0);
         assertThat(action).as("action should not be null").isNotNull();
@@ -457,7 +459,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = DistributionSetCreatedEvent.class, count = 2),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 6),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 1) })
-    public void assignedDistributionSet() {
+    void assignedDistributionSet() {
 
         final List<String> controllerIds = testdataFactory.createTargets(10).stream().map(Target::getControllerId)
                 .collect(Collectors.toList());
@@ -499,7 +501,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = DistributionSetCreatedEvent.class, count = 2),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 6),
             @Expect(type = TenantConfigurationCreatedEvent.class, count = 1) })
-    public void multiOfflineAssignment() {
+    void multiOfflineAssignment() {
         final List<String> targetIds = testdataFactory.createTargets(2).stream().map(Target::getControllerId)
                 .collect(Collectors.toList());
         final List<Long> dsIds = testdataFactory.createDistributionSets(2).stream().map(DistributionSet::getId)
@@ -532,7 +534,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 2),
             @Expect(type = TenantConfigurationCreatedEvent.class, count = 1),
             @Expect(type = TenantConfigurationUpdatedEvent.class, count = 1) })
-    public void assignDistributionSetAndAutoCloseActiveActions() {
+    void assignDistributionSetAndAutoCloseActiveActions() {
         tenantConfigurationManagement
                 .addOrUpdateConfiguration(TenantConfigurationKey.REPOSITORY_ACTIONS_AUTOCLOSE_ENABLED, true);
 
@@ -571,7 +573,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = MultiActionCancelEvent.class, count = 0),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 0),
             @Expect(type = TenantConfigurationCreatedEvent.class, count = 1) })
-    public void previousAssignmentsAreNotCanceledInMultiAssignMode() {
+    void previousAssignmentsAreNotCanceledInMultiAssignMode() {
         enableMultiAssignments();
         final List<Target> targets = testdataFactory.createTargets(10);
         final List<String> targetIds = targets.stream().map(Target::getControllerId).collect(Collectors.toList());
@@ -613,7 +615,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = MultiActionAssignEvent.class, count = 1),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 0),
             @Expect(type = TenantConfigurationCreatedEvent.class, count = 1) })
-    public void multiAssignmentInOneRequest() {
+    void multiAssignmentInOneRequest() {
         final List<Target> targets = testdataFactory.createTargets(2);
         final List<DistributionSet> distributionSets = testdataFactory.createDistributionSets(2);
         final List<DeploymentRequest> deploymentRequests = createAssignmentRequests(distributionSets, targets, 34);
@@ -645,7 +647,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = ActionUpdatedEvent.class, count = 4),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 0),
             @Expect(type = TenantConfigurationCreatedEvent.class, count = 1) })
-    public void cancelMultiAssignmentActions() {
+    void cancelMultiAssignmentActions() {
         final List<Target> targets = testdataFactory.createTargets(2);
         final List<DistributionSet> distributionSets = testdataFactory.createDistributionSets(2);
         final List<DeploymentRequest> deploymentRequests = createAssignmentRequests(distributionSets, targets, 34);
@@ -677,7 +679,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("A Request resulting in multiple assignments to a single target is only allowed when multiassignment is enabled.")
-    public void multipleAssignmentsToTargetOnlyAllowedInMultiAssignMode() {
+    void multipleAssignmentsToTargetOnlyAllowedInMultiAssignMode() {
         final Target target = testdataFactory.createTarget();
         final List<DistributionSet> distributionSets = testdataFactory.createDistributionSets(2);
 
@@ -697,7 +699,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Assigning distribution set to the list of targets with a non-existing one leads to successful assignment of valid targets, while not found targets are silently ignored.")
-    public void assignDistributionSetToNotExistingTarget() {
+    void assignDistributionSetToNotExistingTarget() {
         final String notExistingId = "notExistingTarget";
 
         final DistributionSet createdDs = testdataFactory.createDistributionSet();
@@ -713,7 +715,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
                 createdDs, knownTargetIds);
 
         for (final DistributionSetAssignmentResult assignDistributionSetsResult : assignDistributionSetsResults) {
-            assertThat(assignDistributionSetsResult.getAlreadyAssigned()).isEqualTo(0);
+            assertThat(assignDistributionSetsResult.getAlreadyAssigned()).isZero();
             assertThat(assignDistributionSetsResult.getAssigned()).isEqualTo(2);
             assertThat(assignDistributionSetsResult.getTotal()).isEqualTo(2);
         }
@@ -738,7 +740,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = ActionCreatedEvent.class, count = 3), @Expect(type = TargetUpdatedEvent.class, count = 2),
             @Expect(type = MultiActionAssignEvent.class, count = 1),
             @Expect(type = TenantConfigurationCreatedEvent.class, count = 1) })
-    public void duplicateAssignmentsInRequestAreOnlyRemovedIfMultiassignmentDisabled() {
+    void duplicateAssignmentsInRequestAreOnlyRemovedIfMultiassignmentDisabled() {
         final String targetId = testdataFactory.createTarget().getControllerId();
         final Long dsId = testdataFactory.createDistributionSet().getId();
         final List<DeploymentRequest> twoEqualAssignments = Collections.nCopies(2,
@@ -766,7 +768,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 0),
             @Expect(type = TenantConfigurationCreatedEvent.class, count = 1) })
-    public void maxActionsPerTargetIsCheckedBeforeAssignmentExecution() {
+    void maxActionsPerTargetIsCheckedBeforeAssignmentExecution() {
         final int maxActions = quotaManagement.getMaxActionsPerTarget();
         final String controllerId = testdataFactory.createTarget().getControllerId();
         final Long dsId = testdataFactory.createDistributionSet().getId();
@@ -777,12 +779,12 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         enableMultiAssignments();
         Assertions.assertThatExceptionOfType(AssignmentQuotaExceededException.class)
                 .isThrownBy(() -> deploymentManagement.assignDistributionSets(deploymentRequests));
-        assertThat(actionRepository.countByTargetControllerId(controllerId)).isEqualTo(0);
+        assertThat(actionRepository.countByTargetControllerId(controllerId)).isZero();
     }
 
     @Test
     @Description("An assignment request without a weight is ok when multi assignment in enabled.")
-    public void weightNotRequiredInMultiAssignmentMode() {
+    void weightNotRequiredInMultiAssignmentMode() {
         final String targetId = testdataFactory.createTarget().getControllerId();
         final Long dsId = testdataFactory.createDistributionSet().getId();
 
@@ -799,7 +801,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 1),
             @Expect(type = DistributionSetCreatedEvent.class, count = 1),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3) })
-    public void weightNotAllowedWhenMultiAssignmentModeNotEnabled() {
+    void weightNotAllowedWhenMultiAssignmentModeNotEnabled() {
         final String targetId = testdataFactory.createTarget().getControllerId();
         final Long dsId = testdataFactory.createDistributionSet().getId();
 
@@ -818,7 +820,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = ActionCreatedEvent.class, count = 2), @Expect(type = TargetUpdatedEvent.class, count = 2),
             @Expect(type = MultiActionAssignEvent.class, count = 2),
             @Expect(type = TenantConfigurationCreatedEvent.class, count = 1) })
-    public void weightValidatedAndSaved() {
+    void weightValidatedAndSaved() {
         final String targetId = testdataFactory.createTarget().getControllerId();
         final Long dsId = testdataFactory.createDistributionSet().getId();
         final DeploymentRequest valideRequest1 = DeploymentManagement.deploymentRequest(targetId, dsId)
@@ -855,7 +857,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = TargetCreatedEvent.class, count = 30), @Expect(type = ActionCreatedEvent.class, count = 20),
             @Expect(type = TargetUpdatedEvent.class, count = 20),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3) })
-    public void assignDistributionSet2Targets() {
+    void assignDistributionSet2Targets() {
 
         final String myCtrlIDPref = "myCtrlID";
         final Iterable<Target> savedNakedTargets = testdataFactory.createTargets(10, myCtrlIDPref, "first description");
@@ -890,7 +892,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         for (final Target myt : savedNakedTargets) {
             final Target t = targetManagement.getByControllerID(myt.getControllerId()).get();
             assertThat(deploymentManagement.countActionsByTarget(t.getControllerId())).as("action should be empty")
-                    .isEqualTo(0L);
+                    .isZero();
         }
 
         for (final Target myt : savedDeployedTargets) {
@@ -915,7 +917,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = DistributionSetUpdatedEvent.class, count = 1)
 
     })
-    public void failDistributionSetAssigmentThatIsNotComplete() throws InterruptedException {
+    void failDistributionSetAssigmentThatIsNotComplete() throws InterruptedException {
         final List<Target> targets = testdataFactory.createTargets(10);
 
         final SoftwareModule ah = testdataFactory.createSoftwareModuleApp();
@@ -946,7 +948,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = DistributionSetCreatedEvent.class, count = 3),
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 9),
             @Expect(type = TargetAssignDistributionSetEvent.class, count = 3) })
-    public void multipleDeployments() throws InterruptedException {
+    void multipleDeployments() throws InterruptedException {
         final String undeployedTargetPrefix = "undep-T";
         final int noOfUndeployedTargets = 5;
 
@@ -1002,7 +1004,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
     @Description("Multiple deployments or distribution set to target assignment test including finished response "
             + "from target/controller. Expected behaviour is that in case of OK finished update the target will go to "
             + "IN_SYNC status and installed DS is set to the assigned DS entry.")
-    public void assignDistributionSetAndAddFinishedActionStatus() {
+    void assignDistributionSetAndAddFinishedActionStatus() {
         final PageRequest pageRequest = PageRequest.of(0, 100, Direction.ASC, ActionStatusFields.ID.getFieldName());
 
         final DeploymentResult deployResWithDsA = prepareComplexRepo("undep-A-T", 2, "dep-A-T", 4, 1, "dsA");
@@ -1049,14 +1051,14 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         // verify, that dsA is deployed correctly
         for (final Target t_ : updatedTsDsA) {
             final Target t = targetManagement.getByControllerID(t_.getControllerId()).get();
-            assertThat(deploymentManagement.getAssignedDistributionSet(t.getControllerId()).get())
-                    .as("assigned ds is wrong").isEqualTo(dsA);
-            assertThat(deploymentManagement.getInstalledDistributionSet(t.getControllerId()).get())
-                    .as("installed ds is wrong").isEqualTo(dsA);
+            assertThat(deploymentManagement.getAssignedDistributionSet(t.getControllerId())).as("assigned ds is wrong")
+                    .contains(dsA);
+            assertThat(deploymentManagement.getInstalledDistributionSet(t.getControllerId()))
+                    .as("installed ds is wrong").contains(dsA);
             assertThat(targetManagement.getByControllerID(t.getControllerId()).get().getUpdateStatus())
                     .as("wrong target info update status").isEqualTo(TargetUpdateStatus.IN_SYNC);
             assertThat(deploymentManagement.findActiveActionsByTarget(PAGE, t.getControllerId()))
-                    .as("no actions should be active").hasSize(0);
+                    .as("no actions should be active").isEmpty();
         }
 
         // deploy dsA to the target which already have dsB deployed -> must
@@ -1077,8 +1079,8 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
         for (final Target t_ : deployed2DS) {
             final Target t = targetManagement.getByControllerID(t_.getControllerId()).get();
-            assertThat(deploymentManagement.getAssignedDistributionSet(t.getControllerId()).get())
-                    .as("assigned ds is wrong").isEqualTo(dsA);
+            assertThat(deploymentManagement.getAssignedDistributionSet(t.getControllerId())).as("assigned ds is wrong")
+                    .contains(dsA);
             assertThat(deploymentManagement.getInstalledDistributionSet(t.getControllerId()))
                     .as("installed ds should be null").isNotPresent();
             assertThat(targetManagement.getByControllerID(t.getControllerId()).get().getUpdateStatus())
@@ -1095,7 +1097,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Deletes distribution set. Expected behaviour is that a soft delete is performed "
             + "if the DS is assigned to a target and a hard delete if the DS is not in use at all.")
-    public void deleteDistributionSet() {
+    void deleteDistributionSet() {
 
         final PageRequest pageRequest = PageRequest.of(0, 100, Direction.ASC, "id");
 
@@ -1126,7 +1128,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
         // verify that deleted attribute is used correctly
         List<DistributionSet> allFoundDS = distributionSetManagement.findByCompleted(PAGE, true).getContent();
-        assertThat(allFoundDS.size()).as("no ds should be founded").isEqualTo(0);
+        assertThat(allFoundDS.size()).as("no ds should be founded").isZero();
 
         assertThat(distributionSetRepository.findAll(SpecificationsBuilder.combineWithAnd(Arrays
                 .asList(DistributionSetSpecification.isDeleted(true), DistributionSetSpecification.isCompleted(true))),
@@ -1143,7 +1145,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         // successfully and no activeAction is referring to created distribution
         // sets
         allFoundDS = distributionSetManagement.findByCompleted(pageRequest, true).getContent();
-        assertThat(allFoundDS.size()).as("no ds should be founded").isEqualTo(0);
+        assertThat(allFoundDS.size()).as("no ds should be founded").isZero();
         assertThat(distributionSetRepository.findAll(SpecificationsBuilder.combineWithAnd(Arrays
                 .asList(DistributionSetSpecification.isDeleted(true), DistributionSetSpecification.isCompleted(true))),
                 PAGE).getContent()).as("wrong size of founded ds").hasSize(noOfDistributionSets);
@@ -1151,8 +1153,8 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description("Deletes multiple targets and verfies that all related metadata is also deleted.")
-    public void deletesTargetsAndVerifyCascadeDeletes() {
+    @Description("Deletes multiple targets and verifies that all related metadata is also deleted.")
+    void deletesTargetsAndVerifyCascadeDeletes() {
 
         final String undeployedTargetPrefix = "undep-T";
         final int noOfUndeployedTargets = 2;
@@ -1182,7 +1184,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Testing if changing target and the status without refreshing the entities from the DB (e.g. concurrent changes from UI and from controller) works")
-    public void alternatingAssignmentAndAddUpdateActionStatus() {
+    void alternatingAssignmentAndAddUpdateActionStatus() {
 
         final DistributionSet dsA = testdataFactory.createDistributionSet("a");
         final DistributionSet dsB = testdataFactory.createDistributionSet("b");
@@ -1205,8 +1207,8 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         assertThat(deploymentManagement.countActionsByTarget(targ.getControllerId())).as("Target actions are wrong")
                 .isEqualTo(1);
         assertThat(targ.getUpdateStatus()).as("UpdateStatus of target is wrong").isEqualTo(TargetUpdateStatus.PENDING);
-        assertThat(deploymentManagement.getAssignedDistributionSet(targ.getControllerId()).get())
-                .as("Assigned distribution set of target is wrong").isEqualTo(dsA);
+        assertThat(deploymentManagement.getAssignedDistributionSet(targ.getControllerId()))
+                .as("Assigned distribution set of target is wrong").contains(dsA);
         assertThat(deploymentManagement.findActiveActionsByTarget(PAGE, targ.getControllerId()).getContent().get(0)
                 .getDistributionSet()).as("Distribution set of actionn is wrong").isEqualTo(dsA);
         assertThat(deploymentManagement.findActiveActionsByTarget(PAGE, targ.getControllerId()).getContent().get(0)
@@ -1251,9 +1253,9 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description("The test verfies that the DS itself is not changed because of an target assignment"
+    @Description("The test verifies that the DS itself is not changed because of an target assignment"
             + " which is a relationship but not a changed on the entity itself..")
-    public void checkThatDsRevisionsIsNotChangedWithTargetAssignment() {
+    void checkThatDsRevisionsIsNotChangedWithTargetAssignment() {
         final DistributionSet dsA = testdataFactory.createDistributionSet("a");
         testdataFactory.createDistributionSet("b");
         final Target targ = testdataFactory.createTarget("target-id-A");
@@ -1269,7 +1271,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Tests the switch from a soft to hard update by API")
-    public void forceSoftAction() {
+    void forceSoftAction() {
         // prepare
         final Target target = testdataFactory.createTarget("knownControllerId");
         final DistributionSet ds = testdataFactory.createDistributionSet("a");
@@ -1291,7 +1293,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Tests the switch from a hard to hard update by API, e.g. which in fact should not change anything.")
-    public void forceAlreadyForcedActionNothingChanges() {
+    void forceAlreadyForcedActionNothingChanges() {
         // prepare
         final Target target = testdataFactory.createTarget("knownControllerId");
         final DistributionSet ds = testdataFactory.createDistributionSet("a");
@@ -1299,7 +1301,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         final DistributionSetAssignmentResult assignDistributionSet = assignDistributionSet(ds.getId(),
                 target.getControllerId(), ActionType.FORCED);
         final Long actionId = getFirstAssignedActionId(assignDistributionSet);
-        // verify perparation
+        // verify preparation
         Action findAction = deploymentManagement.findAction(actionId).get();
         assertThat(findAction.getActionType()).as("action type is wrong").isEqualTo(ActionType.FORCED);
 
@@ -1314,7 +1316,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Tests the computation of already assigned entities returned as a result of an assignment")
-    public void testAlreadyAssignedAndAssignedActionsInAssignmentResult() {
+    void testAlreadyAssignedAndAssignedActionsInAssignmentResult() {
         // create target1, distributionSet, assign ds to target1 and finish
         // update (close all actions)
         final Action action = prepareFinishedUpdate("target1", "ds", false);
@@ -1342,7 +1344,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that the DistributionSetAssignmentResult not contains already assigned targets.")
-    public void verifyDistributionSetAssignmentResultNotContainsAlreadyAssignedTargets() {
+    void verifyDistributionSetAssignmentResultNotContainsAlreadyAssignedTargets() {
         final DistributionSet dsToTargetAssigned = testdataFactory.createDistributionSet("ds-3");
 
         // create assigned DS
@@ -1352,9 +1354,77 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         assertThat(assignmentResult.getAssignedEntity()).hasSize(1);
 
         assignmentResult = assignDistributionSet(dsToTargetAssigned.getId(), savedTarget.getControllerId());
-        assertThat(assignmentResult.getAssignedEntity()).hasSize(0);
+        assertThat(assignmentResult.getAssignedEntity()).isEmpty();
 
         assertThat(distributionSetRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    @Description("Verify that the DistributionSet assignments work for multiple targets of the same target type within the same request.")
+    void verifyDSAssignmentForMultipleTargetsWithSameTargetType() {
+        final DistributionSet ds = testdataFactory.createDistributionSet("test-ds");
+        final TargetType targetType = testdataFactory.createTargetType("test-type",
+                Collections.singletonList(ds.getType()));
+
+        final List<DeploymentRequest> deploymentRequests = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            final Target target1 = testdataFactory.createTarget("test-target-" + i, "test-target-" + i,
+                    targetType.getId());
+            final DeploymentRequest deployment = DeploymentManagement
+                    .deploymentRequest(target1.getControllerId(), ds.getId()).build();
+            deploymentRequests.add(deployment);
+        }
+
+        deploymentManagement.assignDistributionSets(deploymentRequests);
+
+        final List<Target> content = targetManagement.findAll(Pageable.unpaged()).getContent();
+
+        content.stream().map(JpaTarget.class::cast)
+                .forEach(jpaTarget -> assertThat(jpaTarget.getAssignedDistributionSet()).isEqualTo(ds));
+    }
+
+    @Test
+    @Description("Verify that the DistributionSet assignments work for multiple targets of different target types within the same request.")
+    void verifyDSAssignmentForMultipleTargetsWithDifferentTargetTypes() {
+        final DistributionSet ds1 = testdataFactory.createDistributionSet("test-ds1");
+        final DistributionSet ds2 = testdataFactory.createDistributionSet("test-ds2");
+        final TargetType targetType1 = testdataFactory.createTargetType("test-type1",
+                Collections.singletonList(ds1.getType()));
+        final TargetType targetType2 = testdataFactory.createTargetType("test-type2",
+                Collections.singletonList(ds2.getType()));
+        final Target target1 = testdataFactory.createTarget("test-target1", "test-target1", targetType1.getId());
+        final Target target2 = testdataFactory.createTarget("test-target2", "test-target2", targetType2.getId());
+
+        final DeploymentRequest deployment1 = DeploymentManagement
+                .deploymentRequest(target1.getControllerId(), ds1.getId()).build();
+        final DeploymentRequest deployment2 = DeploymentManagement
+                .deploymentRequest(target2.getControllerId(), ds2.getId()).build();
+        final List<DeploymentRequest> deploymentRequests = Arrays.asList(deployment1, deployment2);
+
+        deploymentManagement.assignDistributionSets(deploymentRequests);
+
+        final Optional<DistributionSet> assignedDs1 = targetManagement.getByControllerID(target1.getControllerId())
+                .map(JpaTarget.class::cast).map(JpaTarget::getAssignedDistributionSet);
+        final Optional<DistributionSet> assignedDs2 = targetManagement.getByControllerID(target2.getControllerId())
+                .map(JpaTarget.class::cast).map(JpaTarget::getAssignedDistributionSet);
+
+        assertThat(assignedDs1).contains(ds1);
+        assertThat(assignedDs2).contains(ds2);
+    }
+
+    @Test
+    @Description("Verify that the DistributionSet assignment fails for target with incompatible target type.")
+    void verifyDSAssignmentFailsForTargetsWithIncompatibleTargetTypes() {
+        final DistributionSet ds = testdataFactory.createDistributionSet("test-ds");
+        final TargetType targetType = testdataFactory.createTargetType("test-type", Collections.emptyList());
+        final Target target = testdataFactory.createTarget("test-target", "test-target", targetType.getId());
+
+        final DeploymentRequest deploymentRequest = DeploymentManagement
+                .deploymentRequest(target.getControllerId(), ds.getId()).build();
+        final List<DeploymentRequest> deploymentRequests = Collections.singletonList(deploymentRequest);
+
+        assertThatExceptionOfType(DistributionSetTypeNotInTargetTypeException.class)
+                .isThrownBy(() -> deploymentManagement.assignDistributionSets(deploymentRequests));
     }
 
     /**
@@ -1407,7 +1477,7 @@ public class DeploymentManagementTest extends AbstractJpaIntegrationTest {
 
     }
 
-    private class DeploymentResult {
+    private static class DeploymentResult {
         final List<Long> deployedTargetIDs = new ArrayList<>();
         final List<Long> undeployedTargetIDs = new ArrayList<>();
         final List<Long> distributionSetIDs = new ArrayList<>();

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/RolloutManagementTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import org.assertj.core.api.Condition;
 import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.builder.RolloutCreate;
 import org.eclipse.hawkbit.repository.builder.RolloutGroupCreate;
+import org.eclipse.hawkbit.repository.builder.RolloutUpdate;
 import org.eclipse.hawkbit.repository.event.remote.RolloutDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.RolloutGroupDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.TargetAssignDistributionSetEvent;
@@ -67,15 +69,16 @@ import org.eclipse.hawkbit.repository.model.RolloutGroup.RolloutGroupSuccessCond
 import org.eclipse.hawkbit.repository.model.RolloutGroupConditionBuilder;
 import org.eclipse.hawkbit.repository.model.RolloutGroupConditions;
 import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.model.TargetType;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -86,20 +89,20 @@ import io.qameta.allure.Step;
 import io.qameta.allure.Story;
 
 /**
- * Junit tests for RolloutManagment.
+ * Junit tests for RolloutManagement.
  */
 @Feature("Component Tests - Repository")
 @Story("Rollout Management")
-public class RolloutManagementTest extends AbstractJpaIntegrationTest {
+class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @BeforeEach
-    public void reset() {
+    void reset() {
         this.approvalStrategy.setApprovalNeeded(false);
     }
 
     @Test
     @Description("Verifies that a running action with distribution-set (A) is not canceled by a rollout which tries to also assign a distribution-set (A)")
-    public void rolloutShouldNotCancelRunningActionWithTheSameDistributionSet() {
+    void rolloutShouldNotCancelRunningActionWithTheSameDistributionSet() {
         // manually assign distribution set to target
         final String knownControllerId = "controller12345";
         final DistributionSet knownDistributionSet = testdataFactory.createDistributionSet();
@@ -133,7 +136,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verifies that a running action is auto canceled by a rollout which assigns another distribution-set.")
-    public void rolloutAssignesNewDistributionSetAndAutoCloseActiveActions() {
+    void rolloutAssignesNewDistributionSetAndAutoCloseActiveActions() {
         tenantConfigurationManagement
                 .addOrUpdateConfiguration(TenantConfigurationKey.REPOSITORY_ACTIONS_AUTOCLOSE_ENABLED, true);
 
@@ -175,17 +178,17 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description("Verifies that management get access reacts as specfied on calls for non existing entities by means "
+    @Description("Verifies that management get access reacts as specified on calls for non existing entities by means "
             + "of Optional not present.")
     @ExpectEvents({ @Expect(type = TargetCreatedEvent.class, count = 0) })
-    public void nonExistingEntityAccessReturnsNotPresent() {
+    void nonExistingEntityAccessReturnsNotPresent() {
         assertThat(rolloutManagement.get(NOT_EXIST_IDL)).isNotPresent();
         assertThat(rolloutManagement.getByName(NOT_EXIST_ID)).isNotPresent();
         assertThat(rolloutManagement.getWithDetailedStatus(NOT_EXIST_IDL)).isNotPresent();
     }
 
     @Test
-    @Description("Verifies that management queries react as specfied on calls for non existing entities "
+    @Description("Verifies that management queries react as specified on calls for non existing entities "
             + " by means of throwing EntityNotFoundException.")
     @ExpectEvents({ @Expect(type = RolloutDeletedEvent.class, count = 0),
             @Expect(type = RolloutGroupCreatedEvent.class, count = 10),
@@ -194,7 +197,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
             @Expect(type = RolloutUpdatedEvent.class, count = 1), @Expect(type = RolloutCreatedEvent.class, count = 1),
             @Expect(type = TargetCreatedEvent.class, count = 10) })
-    public void entityQueriesReferringToNotExistingEntitiesThrowsException() {
+    void entityQueriesReferringToNotExistingEntitiesThrowsException() {
         testdataFactory.createRollout("xxx");
 
         verifyThrownExceptionBy(() -> rolloutManagement.delete(NOT_EXIST_IDL), "Rollout");
@@ -209,7 +212,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verifying that the rollout is created correctly, executing the filter and split up the targets in the correct group size.")
-    public void creatingRolloutIsCorrectPersisted() {
+    void creatingRolloutIsCorrectPersisted() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
         final int amountGroups = 5;
@@ -227,7 +230,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verifying that when the rollout is started the actions for all targets in the rollout is created and the state of the first group is running as well as the corresponding actions")
-    public void startRolloutSetFirstGroupAndActionsInRunningStateAndOthersInScheduleState() {
+    void startRolloutSetFirstGroupAndActionsInRunningStateAndOthersInScheduleState() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
         final int amountGroups = 5;
@@ -243,10 +246,12 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         assertThat(firstGroup.getStatus()).isEqualTo(RolloutGroupStatus.RUNNING);
 
         // verify other groups are scheduled
-        final List<RolloutGroup> scheduledGroups = rolloutGroupManagement.findByRollout(
-                new OffsetBasedPageRequest(1, 100, Sort.by(Direction.ASC, "id")), createdRollout.getId()).getContent();
-        scheduledGroups.forEach(group -> assertThat(group.getStatus()).isEqualTo(RolloutGroupStatus.SCHEDULED)
-                .as("group which should be in scheduled state is in " + group.getStatus() + " state"));
+        final List<RolloutGroup> scheduledGroups = rolloutGroupManagement
+                .findByRollout(new OffsetBasedPageRequest(1, 100, Sort.by(Direction.ASC, "id")), createdRollout.getId())
+                .getContent();
+        scheduledGroups.forEach(group -> assertThat(group.getStatus())
+                .as("group which should be in scheduled state is in " + group.getStatus() + " state")
+                .isEqualTo(RolloutGroupStatus.SCHEDULED));
         // verify that the first group actions has been started and are in state
         // running
         final List<Action> runningActions = findActionsByRolloutAndStatus(createdRollout, Status.RUNNING);
@@ -260,7 +265,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verifying that a finish condition of a group is hit the next group of the rollout is also started")
-    public void checkRunningRolloutsDoesNotStartNextGroupIfFinishConditionIsNotHit() {
+    void checkRunningRolloutsDoesNotStartNextGroupIfFinishConditionIsNotHit() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
         final int amountGroups = 5;
@@ -284,23 +289,25 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final List<RolloutGroup> runningRolloutGroups = rolloutGroupManagement
                 .findByRollout(new OffsetBasedPageRequest(0, 2, Sort.by(Direction.ASC, "id")), createdRollout.getId())
                 .getContent();
-        runningRolloutGroups.forEach(group -> assertThat(group.getStatus()).isEqualTo(RolloutGroupStatus.RUNNING)
+        runningRolloutGroups.forEach(group -> assertThat(group.getStatus())
                 .as("group should be in running state because it should be started but it is in " + group.getStatus()
-                        + " state"));
+                        + " state")
+                .isEqualTo(RolloutGroupStatus.RUNNING));
 
         // verify that the other groups are still in schedule state
         final List<RolloutGroup> scheduledRolloutGroups = rolloutGroupManagement
                 .findByRollout(new OffsetBasedPageRequest(2, 10, Sort.by(Direction.ASC, "id")), createdRollout.getId())
                 .getContent();
-        scheduledRolloutGroups.forEach(group -> assertThat(group.getStatus()).isEqualTo(RolloutGroupStatus.SCHEDULED)
+        scheduledRolloutGroups.forEach(group -> assertThat(group.getStatus())
                 .as("group should be in scheduled state because it should not be started but it is in "
-                        + group.getStatus() + " state"));
+                        + group.getStatus() + " state")
+                .isEqualTo(RolloutGroupStatus.SCHEDULED));
     }
 
     @Test
     // @Title("Deleting targets of a rollout")
     @Description("Verfiying that next group is started when targets of the group have been deleted.")
-    public void checkRunningRolloutsStartsNextGroupIfTargetsDeleted() {
+    void checkRunningRolloutsStartsNextGroupIfTargetsDeleted() {
 
         final int amountTargetsForRollout = 15;
         final int amountOtherTargets = 0;
@@ -401,7 +408,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verfiying that the error handling action of a group is executed to pause the current rollout")
-    public void checkErrorHitOfGroupCallsErrorActionToPauseTheRollout() {
+    void checkErrorHitOfGroupCallsErrorActionToPauseTheRollout() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
         final int amountGroups = 5;
@@ -436,14 +443,15 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         assertThat(errorGroup.get(0).getStatus()).isEqualTo(RolloutGroupStatus.ERROR);
 
         // all other groups should still be in scheduled state
-        final List<RolloutGroup> scheduleGroups = rolloutGroupManagement.findByRollout(
-                new OffsetBasedPageRequest(1, 100, Sort.by(Direction.ASC, "id")), createdRollout.getId()).getContent();
+        final List<RolloutGroup> scheduleGroups = rolloutGroupManagement
+                .findByRollout(new OffsetBasedPageRequest(1, 100, Sort.by(Direction.ASC, "id")), createdRollout.getId())
+                .getContent();
         scheduleGroups.forEach(group -> assertThat(group.getStatus()).isEqualTo(RolloutGroupStatus.SCHEDULED));
     }
 
     @Test
     @Description("Verfiying a paused rollout in case of error action hit can be resumed again")
-    public void errorActionPausesRolloutAndRolloutGetsResumedStartsNextScheduledGroup() {
+    void errorActionPausesRolloutAndRolloutGetsResumedStartsNextScheduledGroup() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
         final int amountGroups = 5;
@@ -470,8 +478,9 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         assertThat(rollout.getStatus()).isEqualTo(RolloutStatus.PAUSED);
 
         // all other groups should still be in scheduled state
-        final List<RolloutGroup> scheduleGroups = rolloutGroupManagement.findByRollout(
-                new OffsetBasedPageRequest(1, 100, Sort.by(Direction.ASC, "id")), createdRollout.getId()).getContent();
+        final List<RolloutGroup> scheduleGroups = rolloutGroupManagement
+                .findByRollout(new OffsetBasedPageRequest(1, 100, Sort.by(Direction.ASC, "id")), createdRollout.getId())
+                .getContent();
         scheduleGroups.forEach(group -> assertThat(group.getStatus()).isEqualTo(RolloutGroupStatus.SCHEDULED));
 
         // resume the rollout again after it gets paused by error action
@@ -493,7 +502,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verfiying that the rollout is starting group after group and gets finished at the end")
-    public void rolloutStartsGroupAfterGroupAndGetsFinished() {
+    void rolloutStartsGroupAfterGroupAndGetsFinished() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
         final int amountGroups = 5;
@@ -521,8 +530,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
         // verify all groups are in finished state
         rolloutGroupManagement
-                .findByRollout(new OffsetBasedPageRequest(0, 100, Sort.by(Direction.ASC, "id")),
-                        createdRollout.getId())
+                .findByRollout(new OffsetBasedPageRequest(0, 100, Sort.by(Direction.ASC, "id")), createdRollout.getId())
                 .forEach(group -> assertThat(group.getStatus()).isEqualTo(RolloutGroupStatus.FINISHED));
 
         // verify that rollout itself is in finished state
@@ -532,7 +540,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that the targets have the right status during the rollout.")
-    public void countCorrectStatusForEachTargetDuringRollout() {
+    void countCorrectStatusForEachTargetDuringRollout() {
 
         final int amountTargetsForRollout = 8;
         final int amountOtherTargets = 15;
@@ -595,7 +603,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that the targets have the right status during a download_only rollout.")
-    public void countCorrectStatusForEachTargetDuringDownloadOnlyRollout() {
+    void countCorrectStatusForEachTargetDuringDownloadOnlyRollout() {
 
         final int amountTargetsForRollout = 8;
         final int amountOtherTargets = 15;
@@ -662,7 +670,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that the targets have the right status during the rollout when an error emerges.")
-    public void countCorrectStatusForEachTargetDuringRolloutWithError() {
+    void countCorrectStatusForEachTargetDuringRolloutWithError() {
 
         final int amountTargetsForRollout = 8;
         final int amountOtherTargets = 15;
@@ -699,7 +707,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that the targets have the right status during the rollout when receiving the status of rollout groups.")
-    public void countCorrectStatusForEachTargetGroupDuringRollout() {
+    void countCorrectStatusForEachTargetGroupDuringRollout() {
 
         final int amountTargetsForRollout = 9;
         final int amountOtherTargets = 15;
@@ -740,7 +748,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that target actions of rollout get canceled when a manuel distribution sets assignment is done.")
-    public void targetsOfRolloutGetsManuelDsAssignment() {
+    void targetsOfRolloutGetsManuelDsAssignment() {
 
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 0;
@@ -783,7 +791,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that target actions of a rollout get cancelled when another rollout with same targets gets started.")
-    public void targetsOfRolloutGetDistributionSetAssignmentByOtherRollout() {
+    void targetsOfRolloutGetDistributionSetAssignmentByOtherRollout() {
 
         final int amountTargetsForRollout = 15;
         final int amountOtherTargets = 5;
@@ -824,7 +832,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that error status of DistributionSet installation during rollout can get rerun with second rollout so that all targets have some DistributionSet installed at the end.")
-    public void startSecondRolloutAfterFristRolloutEndenWithErrors() {
+    void startSecondRolloutAfterFristRolloutEndenWithErrors() {
 
         final int amountTargetsForRollout = 15;
         final int amountOtherTargets = 0;
@@ -877,12 +885,12 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         // 15 targets in finished/IN_SYNC status and same DS assigned
         assertThat(targetList.size()).isEqualTo(amountTargetsForRollout);
         targetList.stream().map(Target::getControllerId).map(deploymentManagement::getAssignedDistributionSet)
-                .forEach(d -> assertThat(d.get()).isEqualTo(distributionSet));
+                .forEach(d -> assertThat(d).contains(distributionSet));
     }
 
     @Test
     @Description("Verify that the rollout moves to the next group when the success condition was achieved and the error condition was not exceeded.")
-    public void successConditionAchievedAndErrorConditionNotExceeded() {
+    void successConditionAchievedAndErrorConditionNotExceeded() {
 
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 0;
@@ -907,7 +915,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that the rollout does not move to the next group when the sucess condition was not achieved.")
-    public void successConditionNotAchieved() {
+    void successConditionNotAchieved() {
 
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 0;
@@ -932,7 +940,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that the rollout pauses when the error condition was exceeded.")
-    public void errorConditionExceeded() {
+    void errorConditionExceeded() {
 
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 0;
@@ -948,12 +956,12 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         rolloutManagement.handleRollouts();
         // verify: 40% error -> should pause because errorCondition is 20%
         rolloutOne = rolloutManagement.get(rolloutOne.getId()).get();
-        assertThat(RolloutStatus.PAUSED).isEqualTo(rolloutOne.getStatus());
+        assertThat(rolloutOne.getStatus()).isEqualTo(RolloutStatus.PAUSED);
     }
 
     @Test
     @Description("Verify that all rollouts are return with expected target statuses.")
-    public void findAllRolloutsWithDetailedStatus() {
+    void findAllRolloutsWithDetailedStatus() {
 
         final int amountTargetsForRollout = 12;
         final int amountGroups = 2;
@@ -1029,7 +1037,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify the count of existing rollouts.")
-    public void rightCountForAllRollouts() {
+    void rightCountForAllRollouts() {
 
         final int amountTargetsForRollout = 6;
         final int amountGroups = 2;
@@ -1045,7 +1053,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify the count of filtered existing rollouts.")
-    public void countRolloutsAllByFilters() {
+    void countRolloutsAllByFilters() {
 
         final int amountTargetsForRollout = 6;
         final int amountGroups = 2;
@@ -1067,7 +1075,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that the filtering and sorting ascending for rollout is working correctly.")
-    public void findRolloutByFilters() {
+    void findRolloutByFilters() {
 
         final int amountTargetsForRollout = 6;
         final int amountGroups = 2;
@@ -1095,7 +1103,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that the expected rollout is found by name.")
-    public void findRolloutByName() {
+    void findRolloutByName() {
 
         final int amountTargetsForRollout = 12;
         final int amountGroups = 2;
@@ -1112,7 +1120,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that the percent count is acting like aspected when targets move to the status finished or error.")
-    public void getFinishedPercentForRunningGroup() {
+    void getFinishedPercentForRunningGroup() {
 
         final int amountTargetsForRollout = 10;
         final int amountGroups = 2;
@@ -1158,7 +1166,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that the expected targets are returned for the rollout groups.")
-    public void findRolloutGroupTargetsWithRsqlParam() {
+    void findRolloutGroupTargetsWithRsqlParam() {
 
         final int amountTargetsForRollout = 15;
         final int amountGroups = 3;
@@ -1210,7 +1218,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify the creation of a Rollout without targets throws an Exception.")
-    public void createRolloutNotMatchingTargets() {
+    void createRolloutNotMatchingTargets() {
         final int amountGroups = 5;
         final String successCondition = "50";
         final String errorCondition = "80";
@@ -1227,7 +1235,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify the creation of a Rollout with the same name throws an Exception.")
-    public void createDuplicateRollout() {
+    void createDuplicateRollout() {
         final int amountGroups = 5;
         final int amountTargetsForRollout = 10;
         final String successCondition = "50";
@@ -1248,7 +1256,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify the creation and the start of a Rollout with more groups than targets.")
-    public void createAndStartRolloutWithEmptyGroups() throws Exception {
+    void createAndStartRolloutWithEmptyGroups() throws Exception {
         final int amountTargetsForRollout = 3;
         final int amountGroups = 5;
         final String successCondition = "50";
@@ -1270,11 +1278,11 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         assertThat(groups.get(1).getStatus()).isEqualTo(RolloutGroupStatus.READY);
         assertThat(groups.get(1).getTotalTargets()).isEqualTo(1);
         assertThat(groups.get(2).getStatus()).isEqualTo(RolloutGroupStatus.READY);
-        assertThat(groups.get(2).getTotalTargets()).isEqualTo(0);
+        assertThat(groups.get(2).getTotalTargets()).isZero();
         assertThat(groups.get(3).getStatus()).isEqualTo(RolloutGroupStatus.READY);
         assertThat(groups.get(3).getTotalTargets()).isEqualTo(1);
         assertThat(groups.get(4).getStatus()).isEqualTo(RolloutGroupStatus.READY);
-        assertThat(groups.get(4).getTotalTargets()).isEqualTo(0);
+        assertThat(groups.get(4).getTotalTargets()).isZero();
 
         rolloutManagement.start(myRollout.getId());
 
@@ -1297,7 +1305,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify the creation and the start of a rollout.")
-    public void createAndStartRollout() throws Exception {
+    void createAndStartRollout() throws Exception {
 
         final int amountTargetsForRollout = 50;
         final int amountGroups = 5;
@@ -1338,7 +1346,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify that a rollout cannot be created if the 'max targets per rollout group' quota is violated.")
-    public void createRolloutFailsIfQuotaGroupQuotaIsViolated() throws Exception {
+    void createRolloutFailsIfQuotaGroupQuotaIsViolated() throws Exception {
 
         final int maxTargets = quotaManagement.getMaxTargetsPerRolloutGroup();
 
@@ -1356,16 +1364,16 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
                 .errorCondition(RolloutGroupErrorCondition.THRESHOLD, errorCondition)
                 .errorAction(RolloutGroupErrorAction.PAUSE, null).build();
 
-        assertThatExceptionOfType(AssignmentQuotaExceededException.class).isThrownBy(() -> rolloutManagement.create(
-                entityFactory.rollout().create().name(rolloutName).description(rolloutName)
-                        .targetFilterQuery("controllerId==" + targetPrefixName + "-*").set(distributionSet),
-                amountGroups, conditions));
+        final RolloutCreate rollout = entityFactory.rollout().create().name(rolloutName).description(rolloutName)
+                .targetFilterQuery("controllerId==" + targetPrefixName + "-*").set(distributionSet);
 
+        assertThatExceptionOfType(AssignmentQuotaExceededException.class)
+                .isThrownBy(() -> rolloutManagement.create(rollout, amountGroups, conditions));
     }
 
     @Test
     @Description("Verify that a rollout cannot be created based on group definitions if the 'max targets per rollout group' quota is violated for one of the groups.")
-    public void createRolloutWithGroupDefinitionsFailsIfQuotaGroupQuotaIsViolated() throws Exception {
+    void createRolloutWithGroupDefinitionsFailsIfQuotaGroupQuotaIsViolated() throws Exception {
 
         final int maxTargets = quotaManagement.getMaxTargetsPerRolloutGroup();
 
@@ -1419,7 +1427,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify the creation and the automatic start of a rollout.")
-    public void createAndAutoStartRollout() throws Exception {
+    void createAndAutoStartRollout() throws Exception {
 
         final int amountTargetsForRollout = 50;
         final int amountGroups = 5;
@@ -1469,7 +1477,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify the creation of a rollout with a groups definition.")
-    public void createRolloutWithGroupDefinition() throws Exception {
+    void createRolloutWithGroupDefinition() throws Exception {
         final String rolloutName = "rolloutTest3";
 
         final int amountTargetsInGroup1 = 100;
@@ -1529,7 +1537,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify rollout creation fails if group definition does not address all targets")
-    public void createRolloutWithGroupsNotMatchingTargets() throws Exception {
+    void createRolloutWithGroupsNotMatchingTargets() throws Exception {
         final String rolloutName = "rolloutTest4";
         final int amountTargetsForRollout = 500;
         final int percentTargetsInGroup1 = 20;
@@ -1550,7 +1558,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify rollout creation fails if group definition specifies illegal target percentage")
-    public void createRolloutWithIllegalPercentage() throws Exception {
+    void createRolloutWithIllegalPercentage() throws Exception {
         final String rolloutName = "rolloutTest6";
         final int amountTargetsForRollout = 10;
         final int percentTargetsInGroup1 = 101;
@@ -1571,7 +1579,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify rollout creation fails if the 'max rollout groups per rollout' quota is violated.")
-    public void createRolloutWithIllegalAmountOfGroups() throws Exception {
+    void createRolloutWithIllegalAmountOfGroups() throws Exception {
         final String rolloutName = "rolloutTest5";
         final int targets = 10;
         final int maxGroups = quotaManagement.getMaxRolloutGroupsPerRollout();
@@ -1587,7 +1595,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verify the start of a Rollout does not work during creation phase.")
-    public void createAndStartRolloutDuringCreationFails() throws Exception {
+    void createAndStartRolloutDuringCreationFails() throws Exception {
         final int amountTargetsForRollout = 3;
         final int amountGroups = 5;
         final String successCondition = "50";
@@ -1620,7 +1628,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Creating a rollout with approval role or approval engine disabled results in the rollout being in "
             + "READY state.")
-    public void createdRolloutWithApprovalRoleOrApprovalDisabledTransitionsToReadyState() {
+    void createdRolloutWithApprovalRoleOrApprovalDisabledTransitionsToReadyState() {
         approvalStrategy.setApprovalNeeded(false);
         final String successCondition = "50";
         final String errorCondition = "80";
@@ -1632,7 +1640,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Creating a rollout without approver role and approval enabled leads to transition to "
             + "WAITING_FOR_APPROVAL state.")
-    public void createdRolloutWithoutApprovalRoleTransitionsToWaitingForApprovalState() {
+    void createdRolloutWithoutApprovalRoleTransitionsToWaitingForApprovalState() {
         approvalStrategy.setApprovalNeeded(true);
         final String successCondition = "50";
         final String errorCondition = "80";
@@ -1643,7 +1651,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Approving a rollout leads to transition to READY state.")
-    public void approvedRolloutTransitionsToReadyState() {
+    void approvedRolloutTransitionsToReadyState() {
         approvalStrategy.setApprovalNeeded(true);
         final String successCondition = "50";
         final String errorCondition = "80";
@@ -1657,7 +1665,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Denying approval for a rollout leads to transition to APPROVAL_DENIED state.")
-    public void deniedRolloutTransitionsToApprovalDeniedState() {
+    void deniedRolloutTransitionsToApprovalDeniedState() {
         approvalStrategy.setApprovalNeeded(true);
         final String successCondition = "50";
         final String errorCondition = "80";
@@ -1678,7 +1686,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = SoftwareModuleCreatedEvent.class, count = 3),
             @Expect(type = RolloutGroupUpdatedEvent.class, count = 5),
             @Expect(type = RolloutCreatedEvent.class, count = 1) })
-    public void deleteRolloutWhichHasNeverStartedIsHardDeleted() {
+    void deleteRolloutWhichHasNeverStartedIsHardDeleted() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
         final int amountGroups = 5;
@@ -1710,7 +1718,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
             @Expect(type = ActionCreatedEvent.class, count = 10), @Expect(type = ActionUpdatedEvent.class, count = 2),
             @Expect(type = RolloutDeletedEvent.class, count = 1),
             @Expect(type = RolloutCreatedEvent.class, count = 1) })
-    public void deleteRolloutWhichHasBeenStartedBeforeIsSoftDeleted() {
+    void deleteRolloutWhichHasBeenStartedBeforeIsSoftDeleted() {
         final int amountTargetsForRollout = 10;
         final int amountOtherTargets = 15;
         final int amountGroups = 5;
@@ -1737,19 +1745,20 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         assertThat(deletedRollout).isNotNull();
 
         assertThat(deletedRollout.getStatus()).isEqualTo(RolloutStatus.DELETED);
+
+        final RolloutUpdate rolloutUpdate = entityFactory.rollout().update(createdRollout.getId()).description("test");
         assertThatExceptionOfType(EntityReadOnlyException.class)
-                .isThrownBy(() -> rolloutManagement
-                        .update(entityFactory.rollout().update(createdRollout.getId()).description("test")))
+                .isThrownBy(() -> rolloutManagement.update(rolloutUpdate))
                 .withMessageContaining("" + createdRollout.getId());
 
         assertThat(rolloutManagement.findAll(PAGE, true).getContent()).hasSize(1);
-        assertThat(rolloutManagement.findAll(PAGE, false).getContent()).hasSize(0);
+        assertThat(rolloutManagement.findAll(PAGE, false).getContent()).isEmpty();
         assertThat(rolloutGroupManagement.findByRolloutWithDetailedStatus(PAGE, createdRollout.getId()).getContent())
                 .hasSize(amountGroups);
 
         // verify that all scheduled actions are deleted
         assertThat(actionRepository.findByRolloutIdAndStatus(PAGE, deletedRollout.getId(), Status.SCHEDULED)
-                .getNumberOfElements()).isEqualTo(0);
+                .getNumberOfElements()).isZero();
         // verify that all running actions keep running
         assertThat(actionRepository.findByRolloutIdAndStatus(PAGE, deletedRollout.getId(), Status.RUNNING)
                 .getNumberOfElements()).isEqualTo(2);
@@ -1757,14 +1766,14 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Creating a rollout without weight value when multi assignment in enabled.")
-    public void weightNotRequiredInMultiAssignmentMode() {
+    void weightNotRequiredInMultiAssignmentMode() {
         enableMultiAssignments();
         createSimpleTestRolloutWithTargetsAndDistributionSet(10, 10, 2, "50", "80", ActionType.FORCED, null);
     }
 
     @Test
     @Description("Creating a rollout with a weight causes an error when multi assignment in disabled.")
-    public void weightNotAllowedWhenMultiAssignmentModeNotEnabled() {
+    void weightNotAllowedWhenMultiAssignmentModeNotEnabled() {
         Assertions.assertThatExceptionOfType(MultiAssignmentIsNotEnabledException.class)
                 .isThrownBy(() -> createSimpleTestRolloutWithTargetsAndDistributionSet(10, 10, 2, "50", "80",
                         ActionType.FORCED, 66));
@@ -1772,7 +1781,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Weight is validated and saved to the Rollout.")
-    public void weightValidatedAndSaved() {
+    void weightValidatedAndSaved() {
         final String targetPrefix = UUID.randomUUID().toString();
         testdataFactory.createTargets(4, targetPrefix);
         enableMultiAssignments();
@@ -1795,7 +1804,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("A Rollout with weight creats actions with weights")
-    public void actionsWithWeightAreCreated() {
+    void actionsWithWeightAreCreated() {
         final int amountOfTargets = 5;
         final int weight = 99;
         enableMultiAssignments();
@@ -1810,7 +1819,7 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Rollout can be created without weight in single assignment and be started in multi assignment")
-    public void createInSingleStartInMultiassigMode() {
+    void createInSingleStartInMultiassigMode() {
         final int amountOfTargets = 5;
         final Long rolloutId = createSimpleTestRolloutWithTargetsAndDistributionSet(amountOfTargets, 2, amountOfTargets,
                 "80", "50", null, null).getId();
@@ -1821,6 +1830,45 @@ public class RolloutManagementTest extends AbstractJpaIntegrationTest {
         final List<Action> actions = deploymentManagement.findActionsAll(PAGE).getContent();
         assertThat(actions).hasSize(amountOfTargets);
         assertThat(actions).allMatch(action -> !action.getWeight().isPresent());
+    }
+
+    @Test
+    @Description("Verify the that only compatible targets are part of a Rollout.")
+    void createAndStartRolloutWithTargetTypes() {
+        final int amountTargetsForRollout = 10;
+        final int amountIncompatibleTargetsForRollout = 5;
+        final String rolloutName = "rolloutTestCompatibility";
+
+        final DistributionSet testDs = testdataFactory.createDistributionSet("test-ds");
+        final TargetType targetType = testdataFactory.createTargetType("test-type", Collections.emptyList());
+
+        final List<Target> targets = testdataFactory.createTargets(amountTargetsForRollout, "testTarget-");
+        final List<Target> incompatibleTargets = testdataFactory
+                .createTargetsWithType(amountIncompatibleTargetsForRollout, targetType);
+
+        final RolloutGroupConditions conditions = new RolloutGroupConditionBuilder().withDefaults().build();
+        final RolloutCreate rolloutToCreate = entityFactory.rollout().create().name(rolloutName)
+                .targetFilterQuery("name==*").set(testDs);
+
+        final Rollout createdRollout = rolloutManagement.create(rolloutToCreate, 1, conditions);
+
+        // Let the executor handle created Rollout
+        rolloutManagement.handleRollouts();
+
+        final Rollout testRollout = rolloutManagement.get(createdRollout.getId()).get();
+        final List<RolloutGroup> rolloutGroups = rolloutGroupManagement
+                .findByRollout(Pageable.unpaged(), testRollout.getId()).getContent();
+
+        assertThat(testRollout.getStatus()).isEqualTo(RolloutStatus.READY);
+        assertThat(testRollout.getTotalTargets()).isEqualTo(amountTargetsForRollout);
+        assertThat(rolloutGroups).hasSize(1);
+        assertThat(rolloutGroups.get(0).getTotalTargets()).isEqualTo(amountTargetsForRollout);
+
+        final List<Target> rolloutGroupTargets = rolloutGroupManagement
+                .findTargetsOfRolloutGroup(Pageable.unpaged(), rolloutGroups.get(0).getId()).getContent();
+
+        assertThat(rolloutGroupTargets).hasSize(amountTargetsForRollout).containsExactlyElementsOf(targets)
+                .doesNotContainAnyElementsOf(incompatibleTargets);
     }
 
     private RolloutGroupCreate generateRolloutGroup(final int index, final Integer percentage,

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementSearchTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementSearchTest.java
@@ -22,12 +22,15 @@ import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.repository.FilterParams;
 import org.eclipse.hawkbit.repository.UpdateMode;
+import org.eclipse.hawkbit.repository.builder.DistributionSetCreate;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.eclipse.hawkbit.repository.model.TargetTag;
+import org.eclipse.hawkbit.repository.model.TargetType;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
 import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 import org.junit.jupiter.api.Test;
@@ -43,13 +46,13 @@ import io.qameta.allure.Story;
 
 @Feature("Component Tests - Repository")
 @Story("Target Management Searches")
-public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
+class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Tests different parameter combinations for target search operations. "
             + "That includes both the test itself, as a count operation with the same filters "
             + "and query definitions by RSQL (named and un-named).")
-    public void targetSearchWithVariousFilterCombinations() {
+    void targetSearchWithVariousFilterCombinations() {
         final TargetTag targTagX = targetTagManagement.create(entityFactory.tag().create().name("TargTag-X"));
         final TargetTag targTagY = targetTagManagement.create(entityFactory.tag().create().name("TargTag-Y"));
         final TargetTag targTagZ = targetTagManagement.create(entityFactory.tag().create().name("TargTag-Z"));
@@ -181,12 +184,11 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
             final List<TargetUpdateStatus> pending, final Target expected) {
         final String query = "updatestatus==pending and installedds.name==" + installedSet.getName();
         assertThat(targetManagement
-                .findByFilters(PAGE,
-                        new FilterParams(pending, null, null, installedSet.getId(), Boolean.FALSE, new String[0]))
+                .findByFilters(PAGE, new FilterParams(pending, null, null, installedSet.getId(), Boolean.FALSE))
                 .getContent())
                         .as("has number of elements").hasSize(1).as("that number is also returned by count query")
                         .hasSize(Ints.saturatedCast(targetManagement.countByFilters(pending, null, null,
-                                installedSet.getId(), Boolean.FALSE, new String[0])))
+                                installedSet.getId(), Boolean.FALSE)))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -268,12 +270,11 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 + setA.getName() + ") and (name==*targ-A* or description==*targ-A*)";
 
         assertThat(targetManagement
-                .findByFilters(PAGE,
-                        new FilterParams(pending, null, "%targ-A%", setA.getId(), Boolean.FALSE, new String[0]))
+                .findByFilters(PAGE, new FilterParams(pending, null, "%targ-A%", setA.getId(), Boolean.FALSE))
                 .getContent())
                         .as("has number of elements").hasSize(1).as("that number is also returned by count query")
                         .hasSize(Ints.saturatedCast(targetManagement.countByFilters(pending, null, "%targ-A%",
-                                setA.getId(), Boolean.FALSE, new String[0])))
+                                setA.getId(), Boolean.FALSE)))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -286,11 +287,10 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 + setA.getName() + ")";
 
         assertThat(targetManagement
-                .findByFilters(PAGE, new FilterParams(pending, null, null, setA.getId(), Boolean.FALSE, new String[0]))
-                .getContent())
+                .findByFilters(PAGE, new FilterParams(pending, null, null, setA.getId(), Boolean.FALSE)).getContent())
                         .as("has number of elements").hasSize(3).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(pending, null, null, setA.getId(),
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(
+                                targetManagement.countByFilters(pending, null, null, setA.getId(), Boolean.FALSE)))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -301,8 +301,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
             final List<Target> expected) {
         final String query = "updatestatus==pending";
 
-        assertThat(targetManagement
-                .findByFilters(PAGE, new FilterParams(pending, null, null, null, Boolean.FALSE, new String[0]))
+        assertThat(targetManagement.findByFilters(PAGE, new FilterParams(pending, null, null, null, Boolean.FALSE))
                 .getContent())
                         .as("has number of elements").hasSize(3).as("that number is also returned by count query")
                         .hasSize(Ints.saturatedCast(targetManagement.countByFilters(pending, null, null, null,
@@ -339,8 +338,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .findByFilters(PAGE, new FilterParams(unknown, null, "%targ-A%", null, Boolean.FALSE, new String[0]))
                 .getContent()).as("has number of elements").hasSize(99)
                         .as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(unknown, null, "%targ-A%", null,
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(
+                                targetManagement.countByFilters(unknown, null, "%targ-A%", null, Boolean.FALSE)))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -354,11 +353,10 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 + setA.getName() + ")";
 
         assertThat(targetManagement
-                .findByFilters(PAGE, new FilterParams(unknown, null, null, setA.getId(), Boolean.FALSE, new String[0]))
-                .getContent())
+                .findByFilters(PAGE, new FilterParams(unknown, null, null, setA.getId(), Boolean.FALSE)).getContent())
                         .as("has number of elements").hasSize(0).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(unknown, null, null, setA.getId(),
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(
+                                targetManagement.countByFilters(unknown, null, null, setA.getId(), Boolean.FALSE)))
                         .as("and filter query returns the same result")
                         .hasSize(targetManagement.findByRsql(PAGE, query).getContent().size());
     }
@@ -385,12 +383,11 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
             final List<Target> expected) {
         final String query = "updatestatus==unknown";
 
-        assertThat(targetManagement
-                .findByFilters(PAGE, new FilterParams(unknown, null, null, null, Boolean.FALSE, new String[0]))
+        assertThat(targetManagement.findByFilters(PAGE, new FilterParams(unknown, null, null, null, Boolean.FALSE))
                 .getContent()).as("has number of elements").hasSize(397)
                         .as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(unknown, null, null, null,
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(
+                                targetManagement.countByFilters(unknown, null, null, null, Boolean.FALSE)))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -404,11 +401,10 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
         final String query = "lastcontrollerrequestat=le=${overdue_ts};updatestatus==UNKNOWN";
 
         assertThat(targetManagement
-                .findByFilters(PAGE, new FilterParams(unknown, Boolean.TRUE, null, null, Boolean.FALSE, new String[0]))
-                .getContent()).as("has number of elements").hasSize(198)
-                        .as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(unknown, Boolean.TRUE, null, null,
-                                Boolean.FALSE, new String[0])))
+                .findByFilters(PAGE, new FilterParams(unknown, Boolean.TRUE, null, null, Boolean.FALSE)).getContent())
+                        .as("has number of elements").hasSize(198).as("that number is also returned by count query")
+                        .hasSize(Ints.saturatedCast(
+                                targetManagement.countByFilters(unknown, Boolean.TRUE, null, null, Boolean.FALSE)))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -420,12 +416,11 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 + " or installedds.name==" + setA.getName() + ")";
 
         assertThat(targetManagement
-                .findByFilters(PAGE,
-                        new FilterParams(null, null, "%targ-A%", setA.getId(), Boolean.FALSE, new String[0]))
+                .findByFilters(PAGE, new FilterParams(null, null, "%targ-A%", setA.getId(), Boolean.FALSE))
                 .getContent())
                         .as("has number of elements").hasSize(1).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(null, null, "%targ-A%",
-                                setA.getId(), Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(
+                                targetManagement.countByFilters(null, null, "%targ-A%", setA.getId(), Boolean.FALSE)))
                         .as("and contains the following elements").containsExactly(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -436,12 +431,11 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
     private void verifyThat3TargetsHaveDSAssigned(final DistributionSet setA, final List<Target> expected) {
         final String query = "assignedds.name==" + setA.getName() + " or installedds.name==" + setA.getName();
 
-        assertThat(targetManagement
-                .findByFilters(PAGE, new FilterParams(null, null, null, setA.getId(), Boolean.FALSE, new String[0]))
+        assertThat(targetManagement.findByFilters(PAGE, new FilterParams(null, null, null, setA.getId(), Boolean.FALSE))
                 .getContent())
                         .as("has number of elements").hasSize(3).as("that number is also returned by count query")
-                        .hasSize(Ints.saturatedCast(targetManagement.countByFilters(null, null, null, setA.getId(),
-                                Boolean.FALSE, new String[0])))
+                        .hasSize(Ints.saturatedCast(
+                                targetManagement.countByFilters(null, null, null, setA.getId(), Boolean.FALSE)))
                         .as("and contains the following elements").containsAll(expected)
                         .as("and filter query returns the same result")
                         .containsAll(targetManagement.findByRsql(PAGE, query).getContent());
@@ -560,18 +554,17 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
 
     @Step
     private void verifyThatRepositoryContains400Targets() {
-        assertThat(targetManagement.findByFilters(PAGE, new FilterParams(null, null, null, null, null, new String[0]))
-                .getContent()).as("Overall we expect that many targets in the repository").hasSize(400)
-                        .as("which is also reflected by repository count")
-                        .hasSize(Ints.saturatedCast(targetManagement.count()))
-                        .as("which is also reflected by call without specification")
-                        .containsAll(targetManagement.findAll(PAGE).getContent());
+        assertThat(targetManagement.findByFilters(PAGE, new FilterParams(null, null, null, null, null)).getContent())
+                .as("Overall we expect that many targets in the repository").hasSize(400)
+                .as("which is also reflected by repository count").hasSize(Ints.saturatedCast(targetManagement.count()))
+                .as("which is also reflected by call without specification")
+                .containsAll(targetManagement.findAll(PAGE).getContent());
 
     }
 
     @Test
     @Description("Tests the correct order of targets based on selected distribution set. The system expects to have an order based on installed, assigned DS.")
-    public void targetSearchWithVariousFilterCombinationsAndOrderByDistributionSet() {
+    void targetSearchWithVariousFilterCombinationsAndOrderByDistributionSet() {
 
         final List<Target> notAssigned = testdataFactory.createTargets(3, "not", "first description");
         List<Target> targAssigned = testdataFactory.createTargets(3, "assigned", "first description");
@@ -588,7 +581,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .stream().map(Action::getTarget).collect(Collectors.toList());
 
         final Slice<Target> result = targetManagement.findByFilterOrderByLinkedDistributionSet(PAGE, ds.getId(),
-                new FilterParams(null, null, null, null, Boolean.FALSE, new String[0]));
+                new FilterParams(null, null, null, null, Boolean.FALSE));
 
         final Comparator<TenantAwareBaseEntity> byId = (e1, e2) -> Long.compare(e2.getId(), e1.getId());
 
@@ -608,7 +601,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Tests the correct order of targets with applied overdue filter based on selected distribution set. The system expects to have an order based on installed, assigned DS.")
-    public void targetSearchWithOverdueFilterAndOrderByDistributionSet() {
+    void targetSearchWithOverdueFilterAndOrderByDistributionSet() {
 
         final Long lastTargetQueryAlwaysOverdue = 0L;
         final Long lastTargetQueryNotOverdue = Instant.now().toEpochMilli();
@@ -641,7 +634,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .stream().map(Action::getTarget).collect(Collectors.toList());
 
         final Slice<Target> result = targetManagement.findByFilterOrderByLinkedDistributionSet(PAGE, ds.getId(),
-                new FilterParams(null, Boolean.TRUE, null, null, Boolean.FALSE, new String[0]));
+                new FilterParams(null, Boolean.TRUE, null, null, Boolean.FALSE));
 
         final Comparator<TenantAwareBaseEntity> byId = (e1, e2) -> Long.compare(e2.getId(), e1.getId());
 
@@ -664,7 +657,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verfies that targets with given assigned DS are returned from repository.")
-    public void findTargetByAssignedDistributionSet() {
+    void findTargetByAssignedDistributionSet() {
         final DistributionSet assignedSet = testdataFactory.createDistributionSet("");
         testdataFactory.createTargets(10, "unassigned", "unassigned");
         List<Target> assignedtargets = testdataFactory.createTargets(10, "assigned", "assigned");
@@ -672,8 +665,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
         assignDistributionSet(assignedSet, assignedtargets);
 
         // get final updated version of targets
-        assignedtargets = targetManagement.getByControllerID(
-                assignedtargets.stream().map(target -> target.getControllerId()).collect(Collectors.toList()));
+        assignedtargets = targetManagement
+                .getByControllerID(assignedtargets.stream().map(Target::getControllerId).collect(Collectors.toList()));
 
         assertThat(targetManagement.findByAssignedDistributionSet(PAGE, assignedSet.getId()))
                 .as("Contains the assigned targets").containsAll(assignedtargets)
@@ -683,7 +676,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verifies that targets without given assigned DS are returned from repository.")
-    public void findTargetWithoutAssignedDistributionSet() {
+    void findTargetWithoutAssignedDistributionSet() {
         final DistributionSet assignedSet = testdataFactory.createDistributionSet("");
         final TargetFilterQuery tfq = targetFilterQueryManagement
                 .create(entityFactory.targetFilterQuery().create().name("tfq").query("name==*"));
@@ -700,8 +693,8 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description("Verfies that targets with given installed DS are returned from repository.")
-    public void findTargetByInstalledDistributionSet() {
+    @Description("Verifies that targets with given installed DS are returned from repository.")
+    void findTargetByInstalledDistributionSet() {
         final DistributionSet assignedSet = testdataFactory.createDistributionSet("");
         final DistributionSet installedSet = testdataFactory.createDistributionSet("another");
         testdataFactory.createTargets(10, "unassigned", "unassigned");
@@ -720,5 +713,52 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
                 .as("Contains the assigned targets").containsAll(installedtargets)
                 .as("and that means the following expected amount").hasSize(10);
 
+    }
+
+    @Test
+    @Description("Verifies that all compatible targets are returned from repository.")
+    void shouldFindAllTargetsCompatibleWithDS() {
+        final DistributionSet testDs = testdataFactory.createDistributionSet();
+        final TargetType targetType = testdataFactory.createTargetType("testType",
+                Collections.singletonList(testDs.getType()));
+        final TargetFilterQuery tfq = targetFilterQueryManagement
+                .create(entityFactory.targetFilterQuery().create().name("test-filter").query("name==*"));
+        final List<Target> targets = testdataFactory.createTargets(20, "withOutType");
+        final List<Target> targetWithCompatibleTypes = testdataFactory.createTargetsWithType(20, targetType);
+
+        final List<Target> result = targetManagement
+                .findByTargetFilterQueryAndNonDSAndCompatible(PAGE, testDs.getId(), tfq.getQuery()).getContent();
+
+        assertThat(result).as("count of targets").hasSize(targets.size() + targetWithCompatibleTypes.size())
+                .as("contains all targets").containsAll(targetWithCompatibleTypes).containsAll(targets);
+    }
+
+    @Test
+    @Description("Verifies that incompatible targets are not returned from repository.")
+    void shouldNotFindTargetsIncompatibleWithDS() {
+        final DistributionSetType dsType = testdataFactory.findOrCreateDistributionSetType("test-ds-type",
+                "test-ds-type");
+        final DistributionSet testDs = createDistSetWithType(dsType);
+        final TargetType incompatibleTargetType = testdataFactory.createTargetType("testType",
+                Collections.singletonList(testdataFactory.createDistributionSet().getType()));
+        final TargetFilterQuery tfq = targetFilterQueryManagement
+                .create(entityFactory.targetFilterQuery().create().name("test-filter").query("name==*"));
+
+        final List<Target> targetsWithOutType = testdataFactory.createTargets(20, "withOutType");
+        final List<Target> targetsWithIncompatibleType = testdataFactory.createTargetsWithType(20,
+                incompatibleTargetType);
+
+        final List<Target> result = targetManagement
+                .findByTargetFilterQueryAndNonDSAndCompatible(PAGE, testDs.getId(), tfq.getQuery()).getContent();
+
+        assertThat(result).as("count of targets").hasSize(targetsWithOutType.size())
+                .as("contains all compatible targets").containsAll(targetsWithOutType)
+                .as("does not contain incompatible targets").doesNotContainAnyElementsOf(targetsWithIncompatibleType);
+    }
+
+    private DistributionSet createDistSetWithType(final DistributionSetType type) {
+        final DistributionSetCreate dsCreate = entityFactory.distributionSet().create().name("test-ds").version("1.0")
+                .type(type);
+        return distributionSetManagement.create(dsCreate);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementSearchTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementSearchTest.java
@@ -693,7 +693,7 @@ public class TargetManagementSearchTest extends AbstractJpaIntegrationTest {
         assignDistributionSet(assignedSet, assignedTargets);
 
         final List<Target> result = targetManagement
-                .findByTargetFilterQueryAndNonDS(PAGE, assignedSet.getId(), tfq.getQuery()).getContent();
+                .findByTargetFilterQueryAndNonDSAndCompatible(PAGE, assignedSet.getId(), tfq.getQuery()).getContent();
         assertThat(result).as("count of targets").hasSize(unassignedTargets.size()).as("contains all targets")
                 .containsAll(unassignedTargets);
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetManagementTest.java
@@ -114,13 +114,14 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
                 "DistributionSet");
 
         verifyThrownExceptionBy(() -> targetManagement.countByTargetFilterQuery(NOT_EXIST_IDL), "TargetFilterQuery");
-        verifyThrownExceptionBy(() -> targetManagement.countByRsqlAndNonDS(NOT_EXIST_IDL, "name==*"),
+        verifyThrownExceptionBy(() -> targetManagement.countByRsqlAndNonDSAndCompatible(NOT_EXIST_IDL, "name==*"),
                 "DistributionSet");
 
         verifyThrownExceptionBy(() -> targetManagement.deleteByControllerID(NOT_EXIST_ID), "Target");
         verifyThrownExceptionBy(() -> targetManagement.delete(Collections.singletonList(NOT_EXIST_IDL)), "Target");
 
-        verifyThrownExceptionBy(() -> targetManagement.findByTargetFilterQueryAndNonDS(PAGE, NOT_EXIST_IDL, "name==*"),
+        verifyThrownExceptionBy(
+                () -> targetManagement.findByTargetFilterQueryAndNonDSAndCompatible(PAGE, NOT_EXIST_IDL, "name==*"),
                 "DistributionSet");
         verifyThrownExceptionBy(() -> targetManagement.findByInRolloutGroupWithoutAction(PAGE, NOT_EXIST_IDL),
                 "RolloutGroup");
@@ -475,8 +476,8 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
                 .isEqualTo(0);
         assertThat(targetManagement.countByInstalledDistributionSet(set2.getId())).as("Target count is wrong")
                 .isEqualTo(0);
-        assertThat(targetManagement.existsByInstalledOrAssignedDistributionSet(set2.getId())).as("Target count is wrong")
-                .isFalse();
+        assertThat(targetManagement.existsByInstalledOrAssignedDistributionSet(set2.getId()))
+                .as("Target count is wrong").isFalse();
 
         Target target = createTargetWithAttributes("4711");
 
@@ -502,8 +503,8 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
                 .isEqualTo(1);
         assertThat(targetManagement.countByInstalledDistributionSet(set2.getId())).as("Target count is wrong")
                 .isEqualTo(0);
-        assertThat(targetManagement.existsByInstalledOrAssignedDistributionSet(set2.getId())).as("Target count is wrong")
-                .isTrue();
+        assertThat(targetManagement.existsByInstalledOrAssignedDistributionSet(set2.getId()))
+                .as("Target count is wrong").isTrue();
         assertThat(target.getLastTargetQuery()).as("Target query is not work").isGreaterThanOrEqualTo(current);
         assertThat(deploymentManagement.getAssignedDistributionSet("4711").get()).as("Assigned ds size is wrong")
                 .isEqualTo(set2);
@@ -537,14 +538,14 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
     }
 
     /**
-     * verifies, that all {@link TargetTag} of parameter. NOTE: it's accepted
-     * that the target have additional tags assigned to them which are not
-     * contained within parameter tags.
+     * verifies, that all {@link TargetTag} of parameter. NOTE: it's accepted that
+     * the target have additional tags assigned to them which are not contained
+     * within parameter tags.
      *
      * @param strict
-     *            if true, the given targets MUST contain EXACTLY ALL given
-     *            tags, AND NO OTHERS. If false, the given targets MUST contain
-     *            ALL given tags, BUT MAY CONTAIN FURTHER ONE
+     *            if true, the given targets MUST contain EXACTLY ALL given tags,
+     *            AND NO OTHERS. If false, the given targets MUST contain ALL given
+     *            tags, BUT MAY CONTAIN FURTHER ONE
      * @param targets
      *            targets to be verified
      * @param tags
@@ -597,13 +598,16 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
         Long modifiedAt = savedTarget.getLastModifiedAt();
 
         assertThat(createdAt).as("CreatedAt compared with modifiedAt").isEqualTo(modifiedAt);
-        assertThat(savedTarget.getCreatedAt()).isNotNull().as("The createdAt attribute of the target should no be null");
-        assertThat(savedTarget.getLastModifiedAt()).isNotNull().as("The lastModifiedAt attribute of the target should no be null");
+        assertThat(savedTarget.getCreatedAt()).isNotNull()
+                .as("The createdAt attribute of the target should no be null");
+        assertThat(savedTarget.getLastModifiedAt()).isNotNull()
+                .as("The lastModifiedAt attribute of the target should no be null");
 
         Thread.sleep(1);
         savedTarget = targetManagement.update(
                 entityFactory.target().update(savedTarget.getControllerId()).description("changed description"));
-        assertThat(savedTarget.getLastModifiedAt()).isNotNull().as("The lastModifiedAt attribute of the target should not be null");
+        assertThat(savedTarget.getLastModifiedAt()).isNotNull()
+                .as("The lastModifiedAt attribute of the target should not be null");
         assertThat(createdAt).as("CreatedAt compared with saved modifiedAt")
                 .isNotEqualTo(savedTarget.getLastModifiedAt());
         assertThat(modifiedAt).as("ModifiedAt compared with saved modifiedAt")
@@ -1046,22 +1050,23 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
     @Description("Checks that target type for a target can be created, updated and unassigned.")
     public void createAndUpdateTargetTypeInTarget() {
         // create a target type
-        List<TargetType> targetTypes = testdataFactory.createTargetTypes("targettype", 2);
+        final List<TargetType> targetTypes = testdataFactory.createTargetTypes("targettype", 2);
         assertThat(targetTypes).hasSize(2);
         // create a target
         final Target target = testdataFactory.createTarget("target1", "testtarget", targetTypes.get(0).getId());
         // initial opt lock revision must be one
-        Optional<JpaTarget> targetFound = targetRepository.findById(target.getId());
+        final Optional<JpaTarget> targetFound = targetRepository.findById(target.getId());
         assertThat(targetFound).isPresent();
         assertThat(targetFound.get().getOptLockRevision()).isEqualTo(1);
         assertThat(targetFound.get().getTargetType().getId()).isEqualTo(targetTypes.get(0).getId());
 
         // update the target type
-        TargetUpdate targetUpdate = entityFactory.target().update(target.getControllerId()).targetType(targetTypes.get(1).getId());
+        final TargetUpdate targetUpdate = entityFactory.target().update(target.getControllerId())
+                .targetType(targetTypes.get(1).getId());
         targetManagement.update(targetUpdate);
 
         // opt lock revision must be changed
-        Optional<JpaTarget> targetFound1 = targetRepository.findById(target.getId());
+        final Optional<JpaTarget> targetFound1 = targetRepository.findById(target.getId());
         assertThat(targetFound1).isPresent();
         assertThat(targetFound1.get().getOptLockRevision()).isEqualTo(2);
         assertThat(targetFound1.get().getTargetType().getId()).isEqualTo(targetTypes.get(1).getId());
@@ -1070,7 +1075,7 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
         targetManagement.unAssignType(target.getControllerId());
 
         // opt lock revision must be changed
-        Optional<JpaTarget> targetFound2 = targetRepository.findById(target.getId());
+        final Optional<JpaTarget> targetFound2 = targetRepository.findById(target.getId());
         assertThat(targetFound2).isPresent();
         assertThat(targetFound2.get().getOptLockRevision()).isEqualTo(3);
         assertThat(targetFound2.get().getTargetType()).isNull();
@@ -1083,20 +1088,20 @@ public class TargetManagementTest extends AbstractJpaIntegrationTest {
         // create a target
         final Target target = testdataFactory.createTarget("target1", "testtarget");
         // initial opt lock revision must be one
-        Optional<JpaTarget> targetFound = targetRepository.findById(target.getId());
+        final Optional<JpaTarget> targetFound = targetRepository.findById(target.getId());
         assertThat(targetFound).isPresent();
         assertThat(targetFound.get().getOptLockRevision()).isEqualTo(1);
         assertThat(targetFound.get().getTargetType()).isNull();
 
         // create a target type
-        TargetType targetType = testdataFactory.findOrCreateTargetType("targettype");
+        final TargetType targetType = testdataFactory.findOrCreateTargetType("targettype");
         assertThat(targetType).isNotNull();
 
         // assign target type to target
         targetManagement.assignType(targetFound.get().getControllerId(), targetType.getId());
 
         // opt lock revision must be changed
-        Optional<JpaTarget> targetFound1 = targetRepository.findById(target.getId());
+        final Optional<JpaTarget> targetFound1 = targetRepository.findById(target.getId());
         assertThat(targetFound1).isPresent();
         assertThat(targetFound1.get().getOptLockRevision()).isEqualTo(2);
         assertThat(targetFound1.get().getTargetType().getId()).isEqualTo(targetType.getId());

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignCheckerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignCheckerTest.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.repository.jpa.autoassign;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,6 +26,7 @@ import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetAssignmentResult;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
+import org.eclipse.hawkbit.repository.model.TargetType;
 import org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +44,7 @@ import io.qameta.allure.Story;
  */
 @Feature("Component Tests - Repository")
 @Story("Auto assign checker")
-public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
+class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
 
     @Autowired
     private AutoAssignChecker autoAssignChecker;
@@ -52,7 +54,7 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Verifies that a running action is auto canceled by a AutoAssignment which assigns another distribution-set.")
-    public void autoAssignDistributionSetAndAutoCloseOldActions() {
+    void autoAssignDistributionSetAndAutoCloseOldActions() {
 
         tenantConfigurationManagement
                 .addOrUpdateConfiguration(TenantConfigurationKey.REPOSITORY_ACTIONS_AUTOCLOSE_ENABLED, true);
@@ -96,7 +98,7 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Test auto assignment of a DS to filtered targets")
-    public void checkAutoAssign() {
+    void checkAutoAssign() {
 
         final DistributionSet setA = testdataFactory.createDistributionSet("dsA"); // will
                                                                                    // be
@@ -147,7 +149,7 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Test auto assignment of an incomplete DS to filtered targets, that causes failures")
-    public void checkAutoAssignWithFailures() {
+    void checkAutoAssignWithFailures() {
 
         // incomplete distribution set that will be assigned
         final DistributionSet setF = distributionSetManagement.create(entityFactory.distributionSet().create()
@@ -231,7 +233,7 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("Test auto assignment of a distribution set with FORCED, SOFT and DOWNLOAD_ONLY action types")
-    public void checkAutoAssignWithDifferentActionTypes() {
+    void checkAutoAssignWithDifferentActionTypes() {
         final DistributionSet distributionSet = testdataFactory.createDistributionSet();
         final String targetDsAIdPref = "A";
         final String targetDsBIdPref = "B";
@@ -281,8 +283,8 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
     }
 
     @Test
-    @Description("An auto assignment target filter with weight creats actions with weights")
-    public void actionsWithWeightAreCreated() throws Exception {
+    @Description("An auto assignment target filter with weight creates actions with weights")
+    void actionsWithWeightAreCreated() throws Exception {
         final int amountOfTargets = 5;
         final DistributionSet ds = testdataFactory.createDistributionSet();
         final int weight = 32;
@@ -300,7 +302,7 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
 
     @Test
     @Description("An auto assignment target filter without weight still works after multi assignment is enabled")
-    public void filterWithoutWeightWorksInMultiAssignmentMode() throws Exception {
+    void filterWithoutWeightWorksInMultiAssignmentMode() throws Exception {
         final int amountOfTargets = 5;
         final DistributionSet ds = testdataFactory.createDistributionSet();
         targetFilterQueryManagement.create(
@@ -313,5 +315,27 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
         final List<Action> actions = deploymentManagement.findActionsAll(PAGE).getContent();
         assertThat(actions).hasSize(amountOfTargets);
         assertThat(actions).allMatch(action -> !action.getWeight().isPresent());
+    }
+
+    @Test
+    @Description("Verifies an auto assignment only creates actions for compatible targets")
+    void checkAutoAssignmentWithIncompatibleTargets() throws Exception {
+        final DistributionSet testDs = testdataFactory.createDistributionSet();
+        final TargetFilterQuery testFilter = targetFilterQueryManagement.create(entityFactory.targetFilterQuery()
+                .create().name("test-filter").query("name==*").autoAssignDistributionSet(testDs));
+
+        final TargetType incompatibleType = testdataFactory.createTargetType("incompatibleType",
+                Collections.emptyList());
+        testdataFactory.createTargetsWithType(10, incompatibleType);
+        final Target compatibleTarget = testdataFactory.createTarget();
+
+        final long compatibleCount = targetManagement.countByRsqlAndNonDSAndCompatible(testDs.getId(), testFilter.getQuery());
+        assertThat(compatibleCount).isEqualTo(1);
+
+        autoAssignChecker.check();
+
+        final List<Action> actions = deploymentManagement.findActionsAll(PAGE).getContent();
+        assertThat(actions).hasSize(1);
+        assertThat(actions.get(0).getTarget().getId()).isEqualTo(compatibleTarget.getId());
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignCheckerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoassign/AutoAssignCheckerTest.java
@@ -105,11 +105,11 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
         final DistributionSet setB = testdataFactory.createDistributionSet("dsB");
 
         // target filter query that matches all targets
-        final TargetFilterQuery targetFilterQuery = targetFilterQueryManagement.updateAutoAssignDS(
-                entityFactory.targetFilterQuery()
-                        .updateAutoAssign(targetFilterQueryManagement.create(
-                                entityFactory.targetFilterQuery().create().name("filterA").query("name==*")).getId())
-                        .ds(setA.getId()));
+        final TargetFilterQuery targetFilterQuery = targetFilterQueryManagement.updateAutoAssignDS(entityFactory
+                .targetFilterQuery()
+                .updateAutoAssign(targetFilterQueryManagement
+                        .create(entityFactory.targetFilterQuery().create().name("filterA").query("name==*")).getId())
+                .ds(setA.getId()));
 
         final String targetDsAIdPref = "targ";
         final List<Target> targets = testdataFactory.createTargets(100, targetDsAIdPref,
@@ -131,7 +131,8 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
         verifyThatTargetsHaveDistributionSetAssignment(setB, targets.subList(10, 20), targetsCount);
 
         // Count the number of targets that will be assigned with setA
-        assertThat(targetManagement.countByRsqlAndNonDS(setA.getId(), targetFilterQuery.getQuery())).isEqualTo(90);
+        assertThat(targetManagement.countByRsqlAndNonDSAndCompatible(setA.getId(), targetFilterQuery.getQuery()))
+                .isEqualTo(90);
 
         // Run the check
         autoAssignChecker.check();
@@ -221,10 +222,10 @@ public class AutoAssignCheckerTest extends AbstractJpaIntegrationTest {
             final DistributionSet distributionSet, final List<Target> targets) {
         final Set<String> targetIds = targets.stream().map(Target::getControllerId).collect(Collectors.toSet());
 
-        actionRepository.findByDistributionSetId(Pageable.unpaged(), distributionSet.getId())
-                .stream().filter(a -> targetIds.contains(a.getTarget().getControllerId()))
-                .forEach(a -> assertThat(a.getInitiatedBy()).as(
-                        "Action should be initiated by the user who initiated the auto assignment")
+        actionRepository.findByDistributionSetId(Pageable.unpaged(), distributionSet.getId()).stream()
+                .filter(a -> targetIds.contains(a.getTarget().getControllerId()))
+                .forEach(a -> assertThat(a.getInitiatedBy())
+                        .as("Action should be initiated by the user who initiated the auto assignment")
                         .isEqualTo(targetFilterQuery.getAutoAssignInitiatedBy()));
     }
 

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/TestdataFactory.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/TestdataFactory.java
@@ -121,8 +121,8 @@ public class TestdataFactory {
     public static final String SM_TYPE_RT = "runtime";
 
     /**
-     * Key of test "application" {@link SoftwareModuleType} : optional software
-     * in {@link #DS_TYPE_DEFAULT}.
+     * Key of test "application" {@link SoftwareModuleType} : optional software in
+     * {@link #DS_TYPE_DEFAULT}.
      */
     public static final String SM_TYPE_APP = "application";
 
@@ -169,8 +169,8 @@ public class TestdataFactory {
 
     /**
      * Creates {@link DistributionSet} in repository including three
-     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
-     * , {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} and
+     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT} ,
+     * {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} and
      * {@link DistributionSet#isRequiredMigrationStep()} <code>false</code>.
      * 
      * @param prefix
@@ -185,8 +185,8 @@ public class TestdataFactory {
 
     /**
      * Creates {@link DistributionSet} in repository including three
-     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
-     * , {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} and
+     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT} ,
+     * {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} and
      * {@link DistributionSet#isRequiredMigrationStep()} <code>false</code>.
      * 
      * @return {@link DistributionSet} entity.
@@ -197,8 +197,8 @@ public class TestdataFactory {
 
     /**
      * Creates {@link DistributionSet} in repository including three
-     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
-     * , {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} and
+     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT} ,
+     * {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} and
      * {@link DistributionSet#isRequiredMigrationStep()} <code>false</code>.
      * 
      * @param modules
@@ -212,8 +212,8 @@ public class TestdataFactory {
 
     /**
      * Creates {@link DistributionSet} in repository including three
-     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
-     * , {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} and
+     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT} ,
+     * {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} and
      * {@link DistributionSet#isRequiredMigrationStep()} <code>false</code>.
      * 
      * @param modules
@@ -230,8 +230,8 @@ public class TestdataFactory {
 
     /**
      * Creates {@link DistributionSet} in repository including three
-     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
-     * , {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION}.
+     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT} ,
+     * {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION}.
      * 
      * @param prefix
      *            for {@link SoftwareModule}s and {@link DistributionSet}s name,
@@ -247,8 +247,8 @@ public class TestdataFactory {
 
     /**
      * Creates {@link DistributionSet} in repository including three
-     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
-     * , {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} and
+     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT} ,
+     * {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} and
      * {@link DistributionSet#isRequiredMigrationStep()} <code>false</code>.
      * 
      * @param prefix
@@ -265,16 +265,15 @@ public class TestdataFactory {
 
     /**
      * Creates {@link DistributionSet} in repository including three
-     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
-     * , {@link #SM_TYPE_APP}.
+     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT} ,
+     * {@link #SM_TYPE_APP}.
      * 
      * @param prefix
      *            for {@link SoftwareModule}s and {@link DistributionSet}s name,
      *            vendor and description.
      * @param version
      *            {@link DistributionSet#getVersion()} and
-     *            {@link SoftwareModule#getVersion()} extended by a random
-     *            number.
+     *            {@link SoftwareModule#getVersion()} extended by a random number.
      * @param isRequiredMigrationStep
      *            for {@link DistributionSet#isRequiredMigrationStep()}
      * 
@@ -335,8 +334,7 @@ public class TestdataFactory {
      *            vendor and description.
      * @param version
      *            {@link DistributionSet#getVersion()} and
-     *            {@link SoftwareModule#getVersion()} extended by a random
-     *            number.
+     *            {@link SoftwareModule#getVersion()} extended by a random number.
      * @param isRequiredMigrationStep
      *            for {@link DistributionSet#isRequiredMigrationStep()}
      * @param modules
@@ -356,8 +354,8 @@ public class TestdataFactory {
 
     /**
      * Creates {@link DistributionSet} in repository including three
-     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
-     * , {@link #SM_TYPE_APP}.
+     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT} ,
+     * {@link #SM_TYPE_APP}.
      * 
      * @param prefix
      *            for {@link SoftwareModule}s and {@link DistributionSet}s name,
@@ -384,9 +382,9 @@ public class TestdataFactory {
 
     /**
      * Creates {@link DistributionSet}s in repository including three
-     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
-     * , {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} followed by an
-     * iterative number and {@link DistributionSet#isRequiredMigrationStep()}
+     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT} ,
+     * {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} followed by an iterative
+     * number and {@link DistributionSet#isRequiredMigrationStep()}
      * <code>false</code>.
      * 
      * @param number
@@ -400,8 +398,7 @@ public class TestdataFactory {
     }
 
     /**
-     * Create a list of {@link DistributionSet}s without modules, i.e.
-     * incomplete.
+     * Create a list of {@link DistributionSet}s without modules, i.e. incomplete.
      * 
      * @param number
      *            of {@link DistributionSet}s to create
@@ -421,9 +418,9 @@ public class TestdataFactory {
 
     /**
      * Creates {@link DistributionSet}s in repository including three
-     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
-     * , {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} followed by an
-     * iterative number and {@link DistributionSet#isRequiredMigrationStep()}
+     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT} ,
+     * {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} followed by an iterative
+     * number and {@link DistributionSet#isRequiredMigrationStep()}
      * <code>false</code>.
      * 
      * @param prefix
@@ -463,8 +460,8 @@ public class TestdataFactory {
     }
 
     /**
-     * Creates {@link Artifact}s for given {@link SoftwareModule} with a small
-     * text payload.
+     * Creates {@link Artifact}s for given {@link SoftwareModule} with a small text
+     * payload.
      * 
      * @param moduleId
      *            the {@link Artifact}s belong to.
@@ -482,8 +479,8 @@ public class TestdataFactory {
     }
 
     /**
-     * Create an {@link Artifact} for given {@link SoftwareModule} with a small
-     * text payload.
+     * Create an {@link Artifact} for given {@link SoftwareModule} with a small text
+     * payload.
      * 
      * @param artifactData
      *            the {@link Artifact} Inputstream
@@ -503,8 +500,8 @@ public class TestdataFactory {
     }
 
     /**
-     * Create an {@link Artifact} for given {@link SoftwareModule} with a small
-     * text payload.
+     * Create an {@link Artifact} for given {@link SoftwareModule} with a small text
+     * payload.
      *
      * @param artifactData
      *            the {@link Artifact} Inputstream
@@ -528,8 +525,8 @@ public class TestdataFactory {
 
     /**
      * Creates {@link SoftwareModule} with {@link #DEFAULT_VENDOR} and
-     * {@link #DEFAULT_VERSION} and random generated
-     * {@link Target#getDescription()} in the repository.
+     * {@link #DEFAULT_VERSION} and random generated {@link Target#getDescription()}
+     * in the repository.
      * 
      * @param typeKey
      *            of the {@link SoftwareModuleType}
@@ -541,10 +538,9 @@ public class TestdataFactory {
     }
 
     /**
-     * Creates {@link SoftwareModule} of type
-     * {@value Constants#SMT_DEFAULT_APP_KEY} with {@link #DEFAULT_VENDOR} and
-     * {@link #DEFAULT_VERSION} and random generated
-     * {@link Target#getDescription()} in the repository.
+     * Creates {@link SoftwareModule} of type {@value Constants#SMT_DEFAULT_APP_KEY}
+     * with {@link #DEFAULT_VENDOR} and {@link #DEFAULT_VERSION} and random
+     * generated {@link Target#getDescription()} in the repository.
      * 
      * 
      * @return persisted {@link SoftwareModule}.
@@ -554,10 +550,9 @@ public class TestdataFactory {
     }
 
     /**
-     * Creates {@link SoftwareModule} of type
-     * {@value Constants#SMT_DEFAULT_APP_KEY} with {@link #DEFAULT_VENDOR} and
-     * {@link #DEFAULT_VERSION} and random generated
-     * {@link Target#getDescription()} in the repository.
+     * Creates {@link SoftwareModule} of type {@value Constants#SMT_DEFAULT_APP_KEY}
+     * with {@link #DEFAULT_VENDOR} and {@link #DEFAULT_VERSION} and random
+     * generated {@link Target#getDescription()} in the repository.
      * 
      * @param prefix
      *            added to name and version
@@ -570,10 +565,9 @@ public class TestdataFactory {
     }
 
     /**
-     * Creates {@link SoftwareModule} of type
-     * {@value Constants#SMT_DEFAULT_OS_KEY} with {@link #DEFAULT_VENDOR} and
-     * {@link #DEFAULT_VERSION} and random generated
-     * {@link Target#getDescription()} in the repository.
+     * Creates {@link SoftwareModule} of type {@value Constants#SMT_DEFAULT_OS_KEY}
+     * with {@link #DEFAULT_VENDOR} and {@link #DEFAULT_VERSION} and random
+     * generated {@link Target#getDescription()} in the repository.
      * 
      * 
      * @return persisted {@link SoftwareModule}.
@@ -583,10 +577,9 @@ public class TestdataFactory {
     }
 
     /**
-     * Creates {@link SoftwareModule} of type
-     * {@value Constants#SMT_DEFAULT_OS_KEY} with {@link #DEFAULT_VENDOR} and
-     * {@link #DEFAULT_VERSION} and random generated
-     * {@link Target#getDescription()} in the repository.
+     * Creates {@link SoftwareModule} of type {@value Constants#SMT_DEFAULT_OS_KEY}
+     * with {@link #DEFAULT_VENDOR} and {@link #DEFAULT_VERSION} and random
+     * generated {@link Target#getDescription()} in the repository.
      * 
      * @param prefix
      *            added to name and version
@@ -600,8 +593,8 @@ public class TestdataFactory {
 
     /**
      * Creates {@link SoftwareModule} with {@link #DEFAULT_VENDOR} and
-     * {@link #DEFAULT_VERSION} and random generated
-     * {@link Target#getDescription()} in the repository.
+     * {@link #DEFAULT_VERSION} and random generated {@link Target#getDescription()}
+     * in the repository.
      * 
      * @param typeKey
      *            of the {@link SoftwareModuleType}
@@ -652,12 +645,12 @@ public class TestdataFactory {
      * @param targetName
      *            name of the target
      * @param targetTypeId
-     *          target type id
+     *            target type id
      * @return persisted {@link Target}
      */
     public Target createTarget(final String controllerId, final String targetName, final Long targetTypeId) {
-        final Target target = targetManagement
-                .create(entityFactory.target().create().controllerId(controllerId).name(targetName).targetType(targetTypeId));
+        final Target target = targetManagement.create(
+                entityFactory.target().create().controllerId(controllerId).name(targetName).targetType(targetTypeId));
         assertTargetProperlyCreated(target);
         return target;
     }
@@ -673,15 +666,14 @@ public class TestdataFactory {
 
     /**
      * Creates {@link DistributionSet}s in repository including three
-     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
-     * , {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} followed by an
-     * iterative number and {@link DistributionSet#isRequiredMigrationStep()}
+     * {@link SoftwareModule}s of types {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT} ,
+     * {@link #SM_TYPE_APP} with {@link #DEFAULT_VERSION} followed by an iterative
+     * number and {@link DistributionSet#isRequiredMigrationStep()}
      * <code>false</code>.
      * 
      * In addition it updates the created {@link DistributionSet}s and
-     * {@link SoftwareModule}s to ensure that
-     * {@link BaseEntity#getLastModifiedAt()} and
-     * {@link BaseEntity#getLastModifiedBy()} is filled.
+     * {@link SoftwareModule}s to ensure that {@link BaseEntity#getLastModifiedAt()}
+     * and {@link BaseEntity#getLastModifiedBy()} is filled.
      * 
      * @return persisted {@link DistributionSet}.
      */
@@ -699,8 +691,8 @@ public class TestdataFactory {
 
     /**
      * @return {@link DistributionSetType} with key {@link #DS_TYPE_DEFAULT} and
-     *         {@link SoftwareModuleType}s {@link #SM_TYPE_OS},
-     *         {@link #SM_TYPE_RT} , {@link #SM_TYPE_APP}.
+     *         {@link SoftwareModuleType}s {@link #SM_TYPE_OS}, {@link #SM_TYPE_RT}
+     *         , {@link #SM_TYPE_APP}.
      */
     public DistributionSetType findOrCreateDefaultTestDsType() {
         final List<SoftwareModuleType> mand = new ArrayList<>();
@@ -756,8 +748,8 @@ public class TestdataFactory {
 
     /**
      * Finds {@link SoftwareModuleType} in repository with given
-     * {@link SoftwareModuleType#getKey()} or creates if it does not exist yet
-     * with {@link SoftwareModuleType#getMaxAssignments()} = 1.
+     * {@link SoftwareModuleType#getKey()} or creates if it does not exist yet with
+     * {@link SoftwareModuleType#getMaxAssignments()} = 1.
      * 
      * @param key
      *            {@link SoftwareModuleType#getKey()}
@@ -780,9 +772,9 @@ public class TestdataFactory {
      * @return persisted {@link SoftwareModuleType}
      */
     public SoftwareModuleType findOrCreateSoftwareModuleType(final String key, final int maxAssignments) {
-        return softwareModuleTypeManagement.getByKey(key)
-                .orElseGet(() -> softwareModuleTypeManagement.create(entityFactory.softwareModuleType().create()
-                        .key(key).name(key).description(LOREM.words(10)).colour("#ffffff").maxAssignments(maxAssignments)));
+        return softwareModuleTypeManagement.getByKey(key).orElseGet(
+                () -> softwareModuleTypeManagement.create(entityFactory.softwareModuleType().create().key(key).name(key)
+                        .description(LOREM.words(10)).colour("#ffffff").maxAssignments(maxAssignments)));
     }
 
     /**
@@ -863,9 +855,8 @@ public class TestdataFactory {
     }
 
     /**
-     * Creates {@link Target}s in repository and with
-     * {@link #DEFAULT_CONTROLLER_ID} as prefix for
-     * {@link Target#getControllerId()}.
+     * Creates {@link Target}s in repository and with {@link #DEFAULT_CONTROLLER_ID}
+     * as prefix for {@link Target#getControllerId()}.
      * 
      * @param number
      *            of {@link Target}s to create
@@ -877,6 +868,27 @@ public class TestdataFactory {
         final List<TargetCreate> targets = Lists.newArrayListWithExpectedSize(number);
         for (int i = 0; i < number; i++) {
             targets.add(entityFactory.target().create().controllerId(DEFAULT_CONTROLLER_ID + i));
+        }
+
+        return targetManagement.create(targets);
+    }
+
+    /**
+     * Creates {@link Target}s in repository and with {@link TargetType}.
+     *
+     * @param number
+     *            of {@link Target}s to create
+     * @param targetType
+     *            targetType of targets to create
+     *
+     * @return {@link List} of {@link Target} entities
+     */
+    public List<Target> createTargetsWithType(final int number, final TargetType targetType) {
+
+        final List<TargetCreate> targets = Lists.newArrayListWithExpectedSize(number);
+        for (int i = 0; i < number; i++) {
+            targets.add(entityFactory.target().create().controllerId(DEFAULT_CONTROLLER_ID + i)
+                    .targetType(targetType.getId()));
         }
 
         return targetManagement.create(targets);
@@ -923,8 +935,7 @@ public class TestdataFactory {
 
     /**
      * Builds {@link Target} objects with given prefix for
-     * {@link Target#getControllerId()} followed by a number suffix starting
-     * with 0.
+     * {@link Target#getControllerId()} followed by a number suffix starting with 0.
      * 
      * @param numberOfTargets
      *            of {@link Target}s to generate
@@ -1040,8 +1051,7 @@ public class TestdataFactory {
     }
 
     /**
-     * Append {@link ActionStatus} to all {@link Action}s of given
-     * {@link Target}s.
+     * Append {@link ActionStatus} to all {@link Action}s of given {@link Target}s.
      * 
      * @param targets
      *            to add {@link ActionStatus}
@@ -1058,8 +1068,7 @@ public class TestdataFactory {
     }
 
     /**
-     * Append {@link ActionStatus} to all {@link Action}s of given
-     * {@link Target}s.
+     * Append {@link ActionStatus} to all {@link Action}s of given {@link Target}s.
      * 
      * @param targets
      *            to add {@link ActionStatus}
@@ -1157,8 +1166,8 @@ public class TestdataFactory {
      * {@link Target}s.
      * 
      * @param prefix
-     *            for rollouts name, description,
-     *            {@link Target#getControllerId()} filter
+     *            for rollouts name, description, {@link Target#getControllerId()}
+     *            filter
      * @return created {@link Rollout}
      */
     public Rollout createRollout(final String prefix) {
@@ -1168,12 +1177,12 @@ public class TestdataFactory {
     }
 
     /**
-     * Create the soft deleted {@link Rollout} with a new
-     * {@link DistributionSet} and {@link Target}s.
+     * Create the soft deleted {@link Rollout} with a new {@link DistributionSet}
+     * and {@link Target}s.
      * 
      * @param prefix
-     *            for rollouts name, description,
-     *            {@link Target#getControllerId()} filter
+     *            for rollouts name, description, {@link Target#getControllerId()}
+     *            filter
      * @return created {@link Rollout}
      */
     public Rollout createSoftDeletedRollout(final String prefix) {
@@ -1187,8 +1196,8 @@ public class TestdataFactory {
 
     /**
      * Finds {@link TargetType} in repository with given
-     * {@link TargetType#getName()} or creates if it does not exist yet.
-     * No ds types are assigned on creation.
+     * {@link TargetType#getName()} or creates if it does not exist yet. No ds types
+     * are assigned on creation.
      *
      * @param targetTypeName
      *            {@link TargetType#getName()}
@@ -1197,25 +1206,26 @@ public class TestdataFactory {
      */
     public TargetType findOrCreateTargetType(final String targetTypeName) {
         return targetTypeManagement.getByName(targetTypeName)
-                .orElseGet(() -> targetTypeManagement.create(entityFactory.targetType().create()
-                        .name(targetTypeName).description(targetTypeName + " description").colour(DEFAULT_COLOUR)));
+                .orElseGet(() -> targetTypeManagement.create(entityFactory.targetType().create().name(targetTypeName)
+                        .description(targetTypeName + " description").colour(DEFAULT_COLOUR)));
     }
-    
+
     /**
      * Creates {@link TargetType} in repository with given
-     * {@link TargetType#getName()}. Compatible distribution set types are assigned on creation 
+     * {@link TargetType#getName()}. Compatible distribution set types are assigned
+     * on creation
      *
      * @param targetTypeName
      *            {@link TargetType#getName()}
      *
      * @return persisted {@link TargetType}
      */
-    public TargetType createTargetType(final String targetTypeName, List<DistributionSetType> compatibleDsTypes) {
-        return targetTypeManagement.create(entityFactory.targetType().create()
-                        .name(targetTypeName).description(targetTypeName + " description").colour(DEFAULT_COLOUR)
-                        .compatible(compatibleDsTypes.stream().map(DistributionSetType::getId).collect(Collectors.toList())));
+    public TargetType createTargetType(final String targetTypeName, final List<DistributionSetType> compatibleDsTypes) {
+        return targetTypeManagement.create(entityFactory.targetType().create().name(targetTypeName)
+                .description(targetTypeName + " description").colour(DEFAULT_COLOUR)
+                .compatible(compatibleDsTypes.stream().map(DistributionSetType::getId).collect(Collectors.toList())));
     }
-        
+
     /**
      * Creates {@link TargetType} in repository with given
      * {@link TargetType#getName()}. No ds types are assigned on creation.
@@ -1225,11 +1235,11 @@ public class TestdataFactory {
      *
      * @return persisted {@link TargetType}
      */
-    public List<TargetType> createTargetTypes(final String targetTypePrefix, int count) {
+    public List<TargetType> createTargetTypes(final String targetTypePrefix, final int count) {
         final List<TargetTypeCreate> result = Lists.newArrayListWithExpectedSize(count);
         for (int i = 0; i < count; i++) {
-            result.add(entityFactory.targetType().create().name(targetTypePrefix + i).description(targetTypePrefix + " description")
-                    .colour(DEFAULT_COLOUR));
+            result.add(entityFactory.targetType().create().name(targetTypePrefix + i)
+                    .description(targetTypePrefix + " description").colour(DEFAULT_COLOUR));
         }
         return targetTypeManagement.create(result);
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/AutoAssignmentWindowController.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/filtermanagement/AutoAssignmentWindowController.java
@@ -92,7 +92,7 @@ public class AutoAssignmentWindowController extends
         // store/show dialog
         if (entity.isAutoAssignmentEnabled() && entity.getDistributionSetInfo() != null) {
             final Long autoAssignDsId = entity.getDistributionSetInfo().getId();
-            final Long targetsForAutoAssignmentCount = targetManagement.countByRsqlAndNonDS(autoAssignDsId,
+            final Long targetsForAutoAssignmentCount = targetManagement.countByRsqlAndNonDSAndCompatible(autoAssignDsId,
                     entity.getQuery());
 
             final String confirmationCaption = getI18n()

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
       <cron-utils.version>9.1.3</cron-utils.version>
       <jsoup.version>1.14.2</jsoup.version>
       <allure.version>2.13.6</allure.version>
-      <eclipselink.version>2.7.3</eclipselink.version>
+      <eclipselink.version>2.7.9</eclipselink.version>
       <gwtmockito.version>1.1.8</gwtmockito.version>
       <guava.version>30.1.1-jre</guava.version>
       <javax.el-api.version>2.2.4</javax.el-api.version>


### PR DESCRIPTION
This PR adds compatibility checks based on the lately introduced TargetTypes. #1160
If a device/target has an target type, only compatible distribution sets can be assigned.
Validation is added in deployment-managment for direct assignment, in auto-assignment and in rollout creation.