### PR TITLE
README.md: Add rauc-hawkbit-updater to the list of clients supporting hawkBit

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Additionally, the hawkBit project has the long term goal to provide [Eclipse Hon
 There are clients outside of the Eclipse IoT eco system as well, e.g.:
 
 - [SWupdate](https://github.com/sbabic/swupdate) which is a Linux Update agent with focus on a efficient and safe way to update embedded systems.
-- [rauc-hawkbit](https://github.com/rauc/rauc-hawkbit) which is a python-based hawkBit client application and library for the [RAUC](https://github.com/rauc/rauc) update framework.
+- [rauc-hawkbit-updater](https://github.com/rauc/rauc-hawkbit-updater) which is a hawkBit client for the [RAUC](https://github.com/rauc/rauc) update framework written in C/glib.
+- [rauc-hawkbit](https://github.com/rauc/rauc-hawkbit) which is a python-based hawkBit client demo application and library for the [RAUC](https://github.com/rauc/rauc) update framework.
 - [hawkbit-rs](https://github.com/collabora/hawkbit-rs) provides a couple of [Rust](https://www.rust-lang.org) crates to help [implement](https://crates.io/crates/hawkbit) and [test](https://crates.io/crates/hawkbit_mock) hawkBit clients.
 
 # Runtime dependencies and support


### PR DESCRIPTION
We've just released version 1.0 of the rauc-hawkbit-updater client that we consider to be halfway stable and usable in real-world applications, thus I would say this is a good point in time to add it to the list of clients outside the Eclipse ecosystem so that both projects can continue to benefit from each other.

Link to SW: https://github.com/rauc/rauc-hawkbit-updater
Documentation: https://rauc-hawkbit-updater.readthedocs.io/en/latest/ (still deserves some more content)

The python variant (https://github.com/rauc/rauc-hawkbit) that was primarily written for demo purposes did not receive major updates within the last time, thus adding the word 'demo' here should be appropriate to indicate that the C variant is probably the better choice when not doing prototyping.