### PR TITLE
Use an empty AMQP Message body instead of a null value

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
@@ -367,7 +367,7 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
             return;
         }
 
-        final Message message = new Message(null, createConnectorMessagePropertiesDeleteThing(tenant, controllerId));
+        final Message message = new Message("".getBytes(), createConnectorMessagePropertiesDeleteThing(tenant, controllerId));
         amqpSenderService.sendMessage(message, URI.create(targetAddress));
     }
 
@@ -409,7 +409,7 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
             return;
         }
 
-        final Message message = new Message(null,
+        final Message message = new Message("".getBytes(),
                 createConnectorMessagePropertiesEvent(tenant, controllerId, EventTopic.REQUEST_ATTRIBUTES_UPDATE));
 
         amqpSenderService.sendMessage(message, URI.create(targetAddress));

--- a/hawkbit-dmf/hawkbit-dmf-rabbitmq-test/src/main/java/org/eclipse/hawkbit/rabbitmq/test/AbstractAmqpIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-rabbitmq-test/src/main/java/org/eclipse/hawkbit/rabbitmq/test/AbstractAmqpIntegrationTest.java
@@ -66,7 +66,7 @@ public abstract class AbstractAmqpIntegrationTest extends AbstractIntegrationTes
     protected Message createMessage(final Object payload, final MessageProperties messageProperties) {
         if (payload == null) {
             messageProperties.setContentType(MessageProperties.CONTENT_TYPE_JSON);
-            return new Message(null, messageProperties);
+            return new Message("".getBytes(), messageProperties);
         }
         return getDmfClient().getMessageConverter().toMessage(payload, messageProperties);
     }


### PR DESCRIPTION
With [spring-amqp#1313](https://github.com/spring-projects/spring-amqp/issues/1313) introduced in [v2.2.17.RELEASE](https://github.com/spring-projects/spring-amqp/releases/tag/v2.2.17.RELEASE) null is no longer allowed as [Message](https://github.com/spring-projects/spring-amqp/blob/main/spring-amqp/src/main/java/org/springframework/amqp/core/Message.java) body value. This PR already solves the problem for future springboot upgrades.