### PR TITLE
Make entity object of event optional

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -303,8 +304,9 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
             return;
         }
 
-        final Target target = cancelEvent.getEntity();
-        if (target != null) {
+        final Optional<Target> eventEntity = cancelEvent.getEntity();
+        if (eventEntity.isPresent()) {
+            final Target target = eventEntity.get();
             sendCancelMessageToTarget(cancelEvent.getTenant(), target.getControllerId(), cancelEvent.getActionId(),
                     target.getAddress());
         } else {
@@ -369,7 +371,8 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
             return;
         }
 
-        final Message message = new Message("".getBytes(), createConnectorMessagePropertiesDeleteThing(tenant, controllerId));
+        final Message message = new Message("".getBytes(),
+                createConnectorMessagePropertiesDeleteThing(tenant, controllerId));
         amqpSenderService.sendMessage(message, URI.create(targetAddress));
     }
 

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
@@ -144,7 +144,8 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTest {
         assertThat(downloadAndUpdateRequest.getTargetSecurityToken()).isEqualTo(TEST_TOKEN);
         for (final org.eclipse.hawkbit.dmf.json.model.DmfSoftwareModule softwareModule : downloadAndUpdateRequest
                 .getSoftwareModules()) {
-            assertThat(softwareModule.getArtifacts().isEmpty()).as("Artifact list for softwaremodule should be empty").isTrue();
+            assertThat(softwareModule.getArtifacts().isEmpty()).as("Artifact list for softwaremodule should be empty")
+                    .isTrue();
 
             assertThat(softwareModule.getMetadata()).containsExactly(
                     new DmfMetadata(TestdataFactory.VISIBLE_SM_MD_KEY, TestdataFactory.VISIBLE_SM_MD_VALUE));
@@ -185,7 +186,8 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTest {
         final DmfDownloadAndUpdateRequest downloadAndUpdateRequest = assertDownloadAndInstallMessage(sendMessage,
                 action.getId());
 
-        assertThat(downloadAndUpdateRequest.getSoftwareModules()).hasSize(3).as("DownloadAndUpdateRequest event should contains 3 software modules");
+        assertThat(downloadAndUpdateRequest.getSoftwareModules()).hasSize(3)
+                .as("DownloadAndUpdateRequest event should contains 3 software modules");
         assertThat(downloadAndUpdateRequest.getTargetSecurityToken()).isEqualTo(TEST_TOKEN);
 
         for (final DmfSoftwareModule softwareModule : downloadAndUpdateRequest.getSoftwareModules()) {
@@ -228,7 +230,7 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTest {
         amqpMessageDispatcherService
                 .targetCancelAssignmentToDistributionSet(cancelTargetAssignmentDistributionSetEvent);
         final Message sendMessage = createArgumentCapture(
-                cancelTargetAssignmentDistributionSetEvent.getEntity().getAddress());
+                cancelTargetAssignmentDistributionSetEvent.getEntity().get().getAddress());
         assertCancelMessage(sendMessage);
 
     }
@@ -285,9 +287,9 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTest {
     private void assertCancelMessage(final Message sendMessage) {
         assertEventMessage(sendMessage);
         final DmfActionRequest actionId = convertMessage(sendMessage, DmfActionRequest.class);
-        assertThat( actionId.getActionId()).isEqualTo(Long.valueOf(1)).as("Action ID should be 1");
-        assertThat(sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.TOPIC)).isEqualTo(EventTopic.CANCEL_DOWNLOAD)
-            .as("The topc in the message should be a CANCEL_DOWNLOAD value");
+        assertThat(actionId.getActionId()).isEqualTo(Long.valueOf(1)).as("Action ID should be 1");
+        assertThat(sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.TOPIC))
+                .isEqualTo(EventTopic.CANCEL_DOWNLOAD).as("The topc in the message should be a CANCEL_DOWNLOAD value");
     }
 
     private void assertDeleteMessage(final Message sendMessage) {
@@ -305,9 +307,11 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTest {
         final DmfDownloadAndUpdateRequest downloadAndUpdateRequest = convertMessage(sendMessage,
                 DmfDownloadAndUpdateRequest.class);
         assertThat(downloadAndUpdateRequest.getActionId()).isEqualTo(action);
-        assertThat(sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.TOPIC)).isEqualTo( EventTopic.DOWNLOAD_AND_INSTALL)
+        assertThat(sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.TOPIC))
+                .isEqualTo(EventTopic.DOWNLOAD_AND_INSTALL)
                 .as("The topic of the event should contain DOWNLOAD_AND_INSTALL");
-        assertThat(downloadAndUpdateRequest.getTargetSecurityToken()).isEqualTo(TEST_TOKEN).as("Security token of target");
+        assertThat(downloadAndUpdateRequest.getTargetSecurityToken()).isEqualTo(TEST_TOKEN)
+                .as("Security token of target");
 
         return downloadAndUpdateRequest;
     }
@@ -315,17 +319,18 @@ public class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTest {
     private void assertUpdateAttributesMessage(final Message sendMessage) {
         assertEventMessage(sendMessage);
 
-        assertThat(sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.TOPIC)).isEqualTo(EventTopic.REQUEST_ATTRIBUTES_UPDATE)
+        assertThat(sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.TOPIC))
+                .isEqualTo(EventTopic.REQUEST_ATTRIBUTES_UPDATE)
                 .as("The topic of the event should contain REQUEST_ATTRIBUTES_UPDATE");
     }
 
     private void assertEventMessage(final Message sendMessage) {
         assertThat(sendMessage).isNotNull().as("The message should not be null");
 
-        assertThat(sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.THING_ID)).isEqualTo(CONTROLLER_ID)
-            .as("The value of the message header THING_ID should be " + CONTROLLER_ID);
-        assertThat(sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.TYPE)).isEqualTo(MessageType.EVENT)
-                .as("The value of the message header TYPE should be EVENT");
+        assertThat(sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.THING_ID))
+                .isEqualTo(CONTROLLER_ID).as("The value of the message header THING_ID should be " + CONTROLLER_ID);
+        assertThat(sendMessage.getMessageProperties().getHeaders().get(MessageHeaderKey.TYPE))
+                .isEqualTo(MessageType.EVENT).as("The value of the message header TYPE should be EVENT");
         assertThat(sendMessage.getMessageProperties().getContentType()).isEqualTo(MessageProperties.CONTENT_TYPE_JSON)
                 .as("The content type message should be " + MessageProperties.CONTENT_TYPE_JSON);
     }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RemoteEntityEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RemoteEntityEvent.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.hawkbit.repository.event.remote.entity;
 
+import java.util.Optional;
+
 import org.eclipse.hawkbit.repository.event.remote.EventEntityManagerHolder;
 import org.eclipse.hawkbit.repository.event.remote.RemoteIdEvent;
 import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
@@ -52,11 +54,11 @@ public class RemoteEntityEvent<E extends TenantAwareBaseEntity> extends RemoteId
     }
 
     @JsonIgnore
-    public E getEntity() {
+    public Optional<E> getEntity() {
         if (entity == null) {
             entity = reloadEntityFromRepository();
         }
-        return entity;
+        return Optional.ofNullable(entity);
     }
 
     @SuppressWarnings("unchecked")

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/AbstractRemoteEntityEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/AbstractRemoteEntityEventTest.java
@@ -63,13 +63,13 @@ public abstract class AbstractRemoteEntityEventTest<E> extends AbstractRemoteEve
     }
 
     protected RemoteEntityEvent<?> assertEntity(final E baseEntity, final RemoteEntityEvent<?> event) {
-        assertThat(event.getEntity()).isSameAs(baseEntity);
+        assertThat(event.getEntity()).isPresent().get().isSameAs(baseEntity);
 
         RemoteEntityEvent<?> underTestCreatedEvent = createProtoStuffEvent(event);
-        assertThat(underTestCreatedEvent.getEntity()).isEqualTo(baseEntity);
+        assertThat(underTestCreatedEvent.getEntity()).isPresent().get().isEqualTo(baseEntity);
 
         underTestCreatedEvent = createJacksonEvent(event);
-        assertThat(underTestCreatedEvent.getEntity()).isEqualTo(baseEntity);
+        assertThat(underTestCreatedEvent.getEntity()).isPresent().get().isEqualTo(baseEntity);
         return underTestCreatedEvent;
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/ActionEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/ActionEventTest.java
@@ -16,11 +16,11 @@ import org.eclipse.hawkbit.repository.model.Action.ActionType;
 import org.eclipse.hawkbit.repository.model.Action.Status;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.Target;
+import org.junit.jupiter.api.Test;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
-import org.junit.jupiter.api.Test;
 
 /**
  * Test the remote entity events.
@@ -55,19 +55,19 @@ public class ActionEventTest extends AbstractRemoteEntityEventTest<Action> {
     protected RemoteEntityEvent<?> assertEntity(final Action baseEntity, final RemoteEntityEvent<?> e) {
         final AbstractActionEvent event = (AbstractActionEvent) e;
 
-        assertThat(event.getEntity()).isSameAs(baseEntity);
+        assertThat(event.getEntity()).hasValue(baseEntity);
         assertThat(event.getTargetId()).isEqualTo(1L);
         assertThat(event.getRolloutId()).isEqualTo(1L);
         assertThat(event.getRolloutGroupId()).isEqualTo(2L);
 
         AbstractActionEvent underTestCreatedEvent = createProtoStuffEvent(event);
-        assertThat(underTestCreatedEvent.getEntity()).isEqualTo(baseEntity);
+        assertThat(underTestCreatedEvent.getEntity()).hasValue(baseEntity);
         assertThat(underTestCreatedEvent.getTargetId()).isEqualTo(1L);
         assertThat(underTestCreatedEvent.getRolloutId()).isEqualTo(1L);
         assertThat(underTestCreatedEvent.getRolloutGroupId()).isEqualTo(2L);
 
         underTestCreatedEvent = createJacksonEvent(event);
-        assertThat(underTestCreatedEvent.getEntity()).isEqualTo(baseEntity);
+        assertThat(underTestCreatedEvent.getEntity()).hasValue(baseEntity);
         assertThat(underTestCreatedEvent.getTargetId()).isEqualTo(1L);
         assertThat(underTestCreatedEvent.getRolloutId()).isEqualTo(1L);
         assertThat(underTestCreatedEvent.getRolloutGroupId()).isEqualTo(2L);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutGroupEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/RolloutGroupEventTest.java
@@ -60,15 +60,15 @@ public class RolloutGroupEventTest extends AbstractRemoteEntityEventTest<Rollout
     protected RemoteEntityEvent<?> assertEntity(final RolloutGroup baseEntity, final RemoteEntityEvent<?> e) {
         final AbstractRolloutGroupEvent event = (AbstractRolloutGroupEvent) e;
 
-        assertThat(event.getEntity()).isSameAs(baseEntity);
+        assertThat(event.getEntity()).isPresent().get().isSameAs(baseEntity);
         assertThat(event.getRolloutId()).isEqualTo(1L);
 
         AbstractRolloutGroupEvent underTestCreatedEvent = createProtoStuffEvent(event);
-        assertThat(underTestCreatedEvent.getEntity()).isEqualTo(baseEntity);
+        assertThat(underTestCreatedEvent.getEntity()).isPresent().get().isEqualTo(baseEntity);
         assertThat(underTestCreatedEvent.getRolloutId()).isEqualTo(1L);
 
         underTestCreatedEvent = createJacksonEvent(event);
-        assertThat(underTestCreatedEvent.getEntity()).isEqualTo(baseEntity);
+        assertThat(underTestCreatedEvent.getEntity()).isPresent().get().isEqualTo(baseEntity);
         assertThat(underTestCreatedEvent.getRolloutId()).isEqualTo(1L);
 
         return underTestCreatedEvent;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/event/RepositoryEntityEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/event/RepositoryEntityEventTest.java
@@ -10,7 +10,6 @@ package org.eclipse.hawkbit.repository.jpa.event;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -23,6 +22,7 @@ import org.eclipse.hawkbit.repository.event.remote.SoftwareModuleDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.TargetDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.TargetTypeDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.DistributionSetCreatedEvent;
+import org.eclipse.hawkbit.repository.event.remote.entity.RemoteEntityEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.SoftwareModuleUpdatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetCreatedEvent;
@@ -67,7 +67,7 @@ public class RepositoryEntityEventTest extends AbstractJpaIntegrationTest {
 
         final TargetCreatedEvent targetCreatedEvent = eventListener.waitForEvent(TargetCreatedEvent.class);
         assertThat(targetCreatedEvent).isNotNull();
-        assertThat(targetCreatedEvent.getEntity().getId()).isEqualTo(createdTarget.getId());
+        assertThat(getIdOfEntity(targetCreatedEvent)).isEqualTo(createdTarget.getId());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class RepositoryEntityEventTest extends AbstractJpaIntegrationTest {
 
         final TargetUpdatedEvent targetUpdatedEvent = eventListener.waitForEvent(TargetUpdatedEvent.class);
         assertThat(targetUpdatedEvent).isNotNull();
-        assertThat(targetUpdatedEvent.getEntity().getId()).isEqualTo(createdTarget.getId());
+        assertThat(getIdOfEntity(targetUpdatedEvent)).isEqualTo(createdTarget.getId());
     }
 
     @Test
@@ -96,31 +96,32 @@ public class RepositoryEntityEventTest extends AbstractJpaIntegrationTest {
     @Test
     @Description("Verifies that the target type created event is published when a target type has been created")
     public void targetTypeCreatedEventIsPublished() throws InterruptedException {
-        TargetType createdTargetType = testdataFactory.findOrCreateTargetType("targettype");
+        final TargetType createdTargetType = testdataFactory.findOrCreateTargetType("targettype");
 
-        TargetTypeCreatedEvent targetTypeCreatedEvent = eventListener.waitForEvent(TargetTypeCreatedEvent.class);
+        final TargetTypeCreatedEvent targetTypeCreatedEvent = eventListener.waitForEvent(TargetTypeCreatedEvent.class);
         assertThat(targetTypeCreatedEvent).isNotNull();
-        assertThat(targetTypeCreatedEvent.getEntity().getId()).isEqualTo(createdTargetType.getId());
+        assertThat(getIdOfEntity(targetTypeCreatedEvent)).isEqualTo(createdTargetType.getId());
     }
 
     @Test
     @Description("Verifies that the target type updated event is published when a target type has been updated")
     public void targetTypeUpdatedEventIsPublished() throws InterruptedException {
-        TargetType createdTargetType = testdataFactory.findOrCreateTargetType("targettype");
-        targetTypeManagement.update(entityFactory.targetType().update(createdTargetType.getId()).name("updatedtargettype"));
+        final TargetType createdTargetType = testdataFactory.findOrCreateTargetType("targettype");
+        targetTypeManagement
+                .update(entityFactory.targetType().update(createdTargetType.getId()).name("updatedtargettype"));
 
-        TargetTypeUpdatedEvent targetTypeUpdatedEvent = eventListener.waitForEvent(TargetTypeUpdatedEvent.class);
+        final TargetTypeUpdatedEvent targetTypeUpdatedEvent = eventListener.waitForEvent(TargetTypeUpdatedEvent.class);
         assertThat(targetTypeUpdatedEvent).isNotNull();
-        assertThat(targetTypeUpdatedEvent.getEntity().getId()).isEqualTo(createdTargetType.getId());
+        assertThat(getIdOfEntity(targetTypeUpdatedEvent)).isEqualTo(createdTargetType.getId());
     }
 
     @Test
     @Description("Verifies that the target type deleted event is published when a target type has been deleted")
     public void targetTypeDeletedEventIsPublished() throws InterruptedException {
-        TargetType createdTargetType = testdataFactory.findOrCreateTargetType("targettype");
+        final TargetType createdTargetType = testdataFactory.findOrCreateTargetType("targettype");
         targetTypeManagement.delete(createdTargetType.getId());
 
-        TargetTypeDeletedEvent targetTypeDeletedEvent = eventListener.waitForEvent(TargetTypeDeletedEvent.class);
+        final TargetTypeDeletedEvent targetTypeDeletedEvent = eventListener.waitForEvent(TargetTypeDeletedEvent.class);
         assertThat(targetTypeDeletedEvent).isNotNull();
         assertThat(targetTypeDeletedEvent.getEntityId()).isEqualTo(createdTargetType.getId());
     }
@@ -156,7 +157,7 @@ public class RepositoryEntityEventTest extends AbstractJpaIntegrationTest {
         final DistributionSetCreatedEvent dsCreatedEvent = eventListener
                 .waitForEvent(DistributionSetCreatedEvent.class);
         assertThat(dsCreatedEvent).isNotNull();
-        assertThat(dsCreatedEvent.getEntity().getId()).isEqualTo(createDistributionSet.getId());
+        assertThat(getIdOfEntity(dsCreatedEvent)).isEqualTo(createDistributionSet.getId());
     }
 
     @Test
@@ -180,7 +181,7 @@ public class RepositoryEntityEventTest extends AbstractJpaIntegrationTest {
         final SoftwareModuleCreatedEvent softwareModuleCreatedEvent = eventListener
                 .waitForEvent(SoftwareModuleCreatedEvent.class);
         assertThat(softwareModuleCreatedEvent).isNotNull();
-        assertThat(softwareModuleCreatedEvent.getEntity().getId()).isEqualTo(softwareModule.getId());
+        assertThat(getIdOfEntity(softwareModuleCreatedEvent)).isEqualTo(softwareModule.getId());
     }
 
     @Test
@@ -193,7 +194,7 @@ public class RepositoryEntityEventTest extends AbstractJpaIntegrationTest {
         final SoftwareModuleUpdatedEvent softwareModuleUpdatedEvent = eventListener
                 .waitForEvent(SoftwareModuleUpdatedEvent.class);
         assertThat(softwareModuleUpdatedEvent).isNotNull();
-        assertThat(softwareModuleUpdatedEvent.getEntity().getId()).isEqualTo(softwareModule.getId());
+        assertThat(getIdOfEntity(softwareModuleUpdatedEvent)).isEqualTo(softwareModule.getId());
     }
 
     @Test
@@ -206,6 +207,11 @@ public class RepositoryEntityEventTest extends AbstractJpaIntegrationTest {
                 .waitForEvent(SoftwareModuleDeletedEvent.class);
         assertThat(softwareModuleDeletedEvent).isNotNull();
         assertThat(softwareModuleDeletedEvent.getEntityId()).isEqualTo(softwareModule.getId());
+    }
+
+    private static Long getIdOfEntity(final RemoteEntityEvent<?> event) {
+        event.getEntityId();
+        return event.getEntity().get().getId();
     }
 
     public static class RepositoryTestConfiguration {


### PR DESCRIPTION
A RemoteEntityEvent provides the entity that caused the event. By the time the event is consumed, the entity might already be deleted. This should be made explicit by returning an Optional to avoid NullPointerExceptions.

Signed-off-by: Stefan Klotz <stefan.klotz@bosch.io>