### PR TITLE
Bump log4j version to mitigate CVE-2021-44228

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,8 @@
       <rsql-parser.version>2.1.0</rsql-parser.version>
       <awaitility.version>3.1.2</awaitility.version>
       <io-protostuff.version>1.5.6</io-protostuff.version>
+      <!-- CVE-2021-44228 -->
+      <log4j.version>2.15.0</log4j.version>
       <!-- Misc libraries versions - END -->
 
       <!-- Release - START -->
@@ -750,6 +752,22 @@
             <groupId>org.springframework.plugin</groupId>
             <artifactId>spring-plugin-core</artifactId>
             <version>${spring.plugin.core.version}</version>
+         </dependency>
+         <!-- CVE-2021-44228 -->
+         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>${log4j.version}</version>
          </dependency>
 
          <!-- Protostuff Io -->


### PR DESCRIPTION
Alternatively it can be mitigated by running hawkbit with property `log4j2.formatMsgNoLookups=true`