### PR TITLE
Fix DistributionSet Tag API docs

### DIFF
--- a/hawkbit-rest/hawkbit-rest-docs/src/main/asciidoc/distributionsettag-api-guide.adoc
+++ b/hawkbit-rest/hawkbit-rest-docs/src/main/asciidoc/distributionsettag-api-guide.adoc
@@ -26,7 +26,7 @@ include::{snippets}/distributionsettag/get-distribution-set-tags/curl-request.ad
 
 ==== Request URL
 
-A `GET` request is used to access the distribution set tags
+A `GET` request is used to access the distribution set tags.
 
 include::{snippets}/distributionsettag/get-distribution-set-tags/http-request.adoc[]
 
@@ -76,7 +76,7 @@ include::{snippets}/distributionsettag/get-distribution-set-tag/curl-request.ado
 
 ==== Request URL
 
-A `GET` request is used to access the distribution set tag
+A `GET` request is used to access the distribution set tag.
 
 include::{snippets}/distributionsettag/get-distribution-set-tag/http-request.adoc[]
 
@@ -152,6 +152,7 @@ include::../errors/409.adoc[]
 include::../errors/415.adoc[]
 include::../errors/429.adoc[]
 |===
+
 
 == PUT /rest/v1/distributionsettags/{distributionsetTagId}
 
@@ -247,7 +248,7 @@ include::../errors/429.adoc[]
 |===
 
 
-== GET /rest/v1/distributionsettags/{distributionsetTagId}/distributionsets
+== GET /rest/v1/distributionsettags/{distributionsetTagId}/assigned
 
 === Implementation Notes
 
@@ -292,13 +293,14 @@ include::../errors/429.adoc[]
 |===
 
 
-== POST /rest/v1/distributionsettags/{distributionsetTagId}/distributionsets/toggleTagAssignment
+== POST /rest/v1/distributionsettags/{distributionsetTagId}/assigned/toggleTagAssignment
 
 === Implementation Notes
 
-Handles the POST request of toogle distribution assignment. The request body must always be a list of controller ids.
+Handles the POST request of toggle distribution assignment.
+The request body must always be a list of distribution set ids.
 
-=== Toogle distribution assignment
+=== Toggle distribution assignment
 
 ==== CURL
 
@@ -337,7 +339,8 @@ include::../errors/415.adoc[]
 include::../errors/429.adoc[]
 |===
 
-== POST /rest/v1/distributionsettags/{distributionsetTagId}/distributionsets
+
+== POST /rest/v1/distributionsettags/{distributionsetTagId}/assigned
 
 === Implementation Notes
 
@@ -382,11 +385,12 @@ include::../errors/415.adoc[]
 include::../errors/429.adoc[]
 |===
 
-== DELETE /rest/v1/distributionsettags/{distributionsetTagId}/distributionsets/{distributionsetId}
+
+== DELETE /rest/v1/distributionsettags/{distributionsetTagId}/assigned/{distributionsetId}
 
 === Implementation Notes
 
-Handles the DELETE request of unassign the given distribution. 
+Handles the DELETE request of unassign the given distribution.
 
 === Unassign a distribution
 
@@ -421,6 +425,7 @@ include::../errors/405.adoc[]
 include::../errors/406.adoc[]
 include::../errors/429.adoc[]
 |===
+
 
 == Additional content
 

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
@@ -65,6 +65,7 @@ public final class MgmtApiModelProperties {
     public static final String DS_ASSIGNED_TARGETS = "Targets that have this distribution set assigned.";
     public static final String DS_INSTALLED_TARGETS = "Targets that have this distribution set installed.";
     public static final String DS_LIST = "List of distribution sets.";
+    public static final String DS_TAG_LIST = "List of distribution set tags";
     public static final String DS_NEW_ASSIGNED_TARGETS = "Targets that now have this distribution set assigned.";
     public static final String DS_ALREADY_ASSIGNED_TARGETS = "Targets that had this distribution set already assigned (in \"offline\" case this includes targets that have arbitrary updates running)";
     public static final String DS_TOTAL_ASSIGNED_TARGETS = "Overall assigned as part of this request.";
@@ -126,6 +127,8 @@ public final class MgmtApiModelProperties {
     public static final String TARGET_ATTRIBUTES = "Target attributes.";
 
     public static final String TARGET_LIST = "List of provisioning targets.";
+
+    public static final String TARGET_TAG_LIST = "List of target tags";
 
     public static final String TARGET_TYPE_LIST = "List of target types";
 

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/DistributionSetTagResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/DistributionSetTagResourceDocumentationTest.java
@@ -76,7 +76,7 @@ public class DistributionSetTagResourceDocumentationTest extends AbstractApiRest
                 .andDo(this.document.document(getResponseFieldsTag(true,
                         fieldWithPath("size").type(JsonFieldType.NUMBER).description(ApiModelPropertiesGeneric.SIZE),
                         fieldWithPath("total").description(ApiModelPropertiesGeneric.TOTAL_ELEMENTS),
-                        fieldWithPath("content").description(MgmtApiModelProperties.TARGET_LIST))));
+                        fieldWithPath("content").description(MgmtApiModelProperties.DS_TAG_LIST))));
     }
 
     @Test
@@ -173,7 +173,7 @@ public class DistributionSetTagResourceDocumentationTest extends AbstractApiRest
                                 fieldWithPath("size").type(JsonFieldType.NUMBER)
                                         .description(ApiModelPropertiesGeneric.SIZE),
                                 fieldWithPath("total").description(ApiModelPropertiesGeneric.TOTAL_ELEMENTS),
-                                fieldWithPath("content").description(MgmtApiModelProperties.TARGET_LIST))));
+                                fieldWithPath("content").description(MgmtApiModelProperties.DS_TAG_LIST))));
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetTagResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetTagResourceDocumentationTest.java
@@ -77,7 +77,7 @@ public class TargetTagResourceDocumentationTest extends AbstractApiRestDocumenta
                 .andDo(this.document.document(getResponseFieldTargetTag(true,
                         fieldWithPath("size").type(JsonFieldType.NUMBER).description(ApiModelPropertiesGeneric.SIZE),
                         fieldWithPath("total").description(ApiModelPropertiesGeneric.TOTAL_ELEMENTS),
-                        fieldWithPath("content").description(MgmtApiModelProperties.TARGET_LIST))));
+                        fieldWithPath("content").description(MgmtApiModelProperties.TARGET_TAG_LIST))));
     }
 
     @Test
@@ -169,7 +169,7 @@ public class TargetTagResourceDocumentationTest extends AbstractApiRestDocumenta
                                 fieldWithPath("size").type(JsonFieldType.NUMBER)
                                         .description(ApiModelPropertiesGeneric.SIZE),
                                 fieldWithPath("total").description(ApiModelPropertiesGeneric.TOTAL_ELEMENTS),
-                                fieldWithPath("content").description(MgmtApiModelProperties.TARGET_LIST))));
+                                fieldWithPath("content").description(MgmtApiModelProperties.TARGET_TAG_LIST))));
     }
 
     @Test


### PR DESCRIPTION
In the Mgmt API docs, the headlines of the DistributionSet Tag assignment to DistributionSets were named after the already deprecated endpoints.  
The headlines are now renamed to the endpoint that they represent, e.g. `/rest/v1/distributionsettags/{distributionsetTagId}/assigned`.