### PR TITLE
Add license header for Bosch.IO 2022

### DIFF
--- a/licenses/LICENSE_HEADER_TEMPLATE_BOSCH_22.txt
+++ b/licenses/LICENSE_HEADER_TEMPLATE_BOSCH_22.txt
@@ -1,0 +1,6 @@
+Copyright (c) 2022 Bosch.IO GmbH and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html

--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
                <artifactId>license-maven-plugin</artifactId>
                <version>2.11</version>
                <configuration>
-                  <header>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_20.txt</header>
+                  <header>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_22.txt</header>
                   <validHeaders>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_SIEMENS.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_SIEMENS_18.txt</validHeader>
@@ -329,6 +329,7 @@
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_19.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_20.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_21.txt</validHeader>
+                     <validHeader>licenses/LICENSE_HEADER_TEMPLATE_BOSCH_22.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_MICROSOFT_18.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_MICROSOFT_20.txt</validHeader>
                      <validHeader>licenses/LICENSE_HEADER_TEMPLATE_DEVOLO_19.txt</validHeader>


### PR DESCRIPTION
Adds a new license header template for Bosch.IO
