### PR TITLE
Extend event for entity events

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
@@ -219,7 +219,7 @@ class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTest {
     void sendUpdateAttributesRequest() {
         final String amqpUri = "amqp://anyhost";
         final TargetAttributesRequestedEvent targetAttributesRequestedEvent = new TargetAttributesRequestedEvent(TENANT,
-                1L, CONTROLLER_ID, amqpUri, Target.class.getName(), serviceMatcher.getServiceId());
+                1L, CONTROLLER_ID, amqpUri, Target.class, serviceMatcher.getServiceId());
 
         amqpMessageDispatcherService.targetTriggerUpdateAttributes(targetAttributesRequestedEvent);
 
@@ -247,7 +247,7 @@ class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTest {
         // setup
         final String amqpUri = "amqp://anyhost";
         final TargetDeletedEvent targetDeletedEvent = new TargetDeletedEvent(TENANT, 1L, CONTROLLER_ID, amqpUri,
-                Target.class.getName(), serviceMatcher.getServiceId());
+                Target.class, serviceMatcher.getServiceId());
 
         // test
         amqpMessageDispatcherService.targetDelete(targetDeletedEvent);
@@ -264,7 +264,7 @@ class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTest {
         // setup
         final String noAmqpUri = "http://anyhost";
         final TargetDeletedEvent targetDeletedEvent = new TargetDeletedEvent(TENANT, 1L, CONTROLLER_ID, noAmqpUri,
-                Target.class.getName(), serviceMatcher.getServiceId());
+                Target.class, serviceMatcher.getServiceId());
 
         // test
         amqpMessageDispatcherService.targetDelete(targetDeletedEvent);
@@ -280,7 +280,7 @@ class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTest {
         // setup
         final String noAmqpUri = null;
         final TargetDeletedEvent targetDeletedEvent = new TargetDeletedEvent(TENANT, 1L, CONTROLLER_ID, noAmqpUri,
-                Target.class.getName(), serviceMatcher.getServiceId());
+                Target.class, serviceMatcher.getServiceId());
 
         // test
         amqpMessageDispatcherService.targetDelete(targetDeletedEvent);

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entity/EntityIdEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/entity/EntityIdEvent.java
@@ -21,6 +21,11 @@ public interface EntityIdEvent extends TenantAwareEvent {
     String getEntityClass();
 
     /**
+     * @return the class of entities interface
+     */
+    String getInterfaceClass();
+
+    /**
      * @return the ID of the entity of this event.
      */
     Long getEntityId();

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetDeletedEvent.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  * Defines the remote event for deletion of {@link DistributionSet}.
@@ -35,8 +36,8 @@ public class DistributionSetDeletedEvent extends RemoteIdEvent implements Entity
      * @param applicationId
      *            the origin application id
      */
-    public DistributionSetDeletedEvent(final String tenant, final Long entityId, final String entityClass,
-            final String applicationId) {
+    public DistributionSetDeletedEvent(final String tenant, final Long entityId,
+            final Class<? extends TenantAwareBaseEntity> entityClass, final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetTagDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetTagDeletedEvent.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.DistributionSetTag;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  * Defines the the remote event of delete a {@link DistributionSetTag}.
@@ -38,8 +39,8 @@ public class DistributionSetTagDeletedEvent extends RemoteIdEvent implements Ent
      *            the origin application id
      */
 
-    public DistributionSetTagDeletedEvent(final String tenant, final Long entityId, final String entityClass,
-            final String applicationId) {
+    public DistributionSetTagDeletedEvent(final String tenant, final Long entityId,
+            final Class<? extends TenantAwareBaseEntity> entityClass, final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetTypeDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/DistributionSetTypeDeletedEvent.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  *
@@ -38,8 +39,8 @@ public class DistributionSetTypeDeletedEvent extends RemoteIdEvent implements En
      * @param applicationId
      *            the origin application id
      */
-    public DistributionSetTypeDeletedEvent(final String tenant, final Long entityId, final String entityClass,
-            final String applicationId) {
+    public DistributionSetTypeDeletedEvent(final String tenant, final Long entityId,
+            final Class<? extends TenantAwareBaseEntity> entityClass, final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RemoteIdEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RemoteIdEvent.java
@@ -8,6 +8,9 @@
  */
 package org.eclipse.hawkbit.repository.event.remote;
 
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
+import org.springframework.util.ObjectUtils;
+
 /**
  * An base definition class for an event which contains an id.
  *
@@ -19,6 +22,8 @@ public class RemoteIdEvent extends RemoteTenantAwareEvent {
     private Long entityId;
 
     private String entityClass;
+    
+    private String interfaceClass;
 
     /**
      * Default constructor.
@@ -39,11 +44,18 @@ public class RemoteIdEvent extends RemoteTenantAwareEvent {
      * @param applicationId
      *            the origin application id
      */
-    protected RemoteIdEvent(final Long entityId, final String tenant, final String entityClass,
-            final String applicationId) {
+    protected RemoteIdEvent(final Long entityId, final String tenant,
+            final Class<? extends TenantAwareBaseEntity> entityClass, final String applicationId) {
         super(entityId, tenant, applicationId);
-        this.entityClass = entityClass;
+        this.entityClass = entityClass.getName();
+        this.interfaceClass = entityClass.isInterface() ? entityClass.getName()
+                : getFirstInterfaceEntity(entityClass).getName();
         this.entityId = entityId;
+    }
+
+    private static Class<?> getFirstInterfaceEntity(final Class<? extends TenantAwareBaseEntity> baseEntity) {
+        final Class<?>[] interfaces = baseEntity.getInterfaces();
+        return ObjectUtils.isEmpty(interfaces) ? baseEntity : interfaces[0];
     }
 
     /**
@@ -57,4 +69,7 @@ public class RemoteIdEvent extends RemoteTenantAwareEvent {
         return entityId;
     }
 
+    public String getInterfaceClass() {
+        return interfaceClass;
+    }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RemoteIdEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RemoteIdEvent.java
@@ -9,7 +9,8 @@
 package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
-import org.springframework.util.ObjectUtils;
+
+import java.util.Arrays;
 
 /**
  * An base definition class for an event which contains an id.
@@ -22,7 +23,7 @@ public class RemoteIdEvent extends RemoteTenantAwareEvent {
     private Long entityId;
 
     private String entityClass;
-    
+
     private String interfaceClass;
 
     /**
@@ -49,13 +50,14 @@ public class RemoteIdEvent extends RemoteTenantAwareEvent {
         super(entityId, tenant, applicationId);
         this.entityClass = entityClass.getName();
         this.interfaceClass = entityClass.isInterface() ? entityClass.getName()
-                : getFirstInterfaceEntity(entityClass).getName();
+                : getInterfaceEntity(entityClass).getName();
         this.entityId = entityId;
     }
 
-    private static Class<?> getFirstInterfaceEntity(final Class<? extends TenantAwareBaseEntity> baseEntity) {
+    private static Class<?> getInterfaceEntity(final Class<? extends TenantAwareBaseEntity> baseEntity) {
         final Class<?>[] interfaces = baseEntity.getInterfaces();
-        return ObjectUtils.isEmpty(interfaces) ? baseEntity : interfaces[0];
+        return Arrays.stream(interfaces).filter(TenantAwareBaseEntity.class::isAssignableFrom).findFirst()
+                .orElse(baseEntity);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RolloutDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RolloutDeletedEvent.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.Rollout;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  *
@@ -38,8 +39,8 @@ public class RolloutDeletedEvent extends RemoteIdEvent implements EntityDeletedE
      * @param applicationId
      *            the origin application id
      */
-    public RolloutDeletedEvent(final String tenant, final Long entityId, final String entityClass,
-            final String applicationId) {
+    public RolloutDeletedEvent(final String tenant, final Long entityId,
+            final Class<? extends TenantAwareBaseEntity> entityClass, final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RolloutGroupDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/RolloutGroupDeletedEvent.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  *
@@ -38,8 +39,8 @@ public class RolloutGroupDeletedEvent extends RemoteIdEvent implements EntityDel
      * @param applicationId
      *            the origin application id
      */
-    public RolloutGroupDeletedEvent(final String tenant, final Long entityId, final String entityClass,
-            final String applicationId) {
+    public RolloutGroupDeletedEvent(final String tenant, final Long entityId,
+            final Class<? extends TenantAwareBaseEntity> entityClass, final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/SoftwareModuleDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/SoftwareModuleDeletedEvent.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  *
@@ -38,8 +39,8 @@ public class SoftwareModuleDeletedEvent extends RemoteIdEvent implements EntityD
      * @param applicationId
      *            the origin application id
      */
-    public SoftwareModuleDeletedEvent(final String tenant, final Long entityId, final String entityClass,
-            final String applicationId) {
+    public SoftwareModuleDeletedEvent(final String tenant, final Long entityId,
+            final Class<? extends TenantAwareBaseEntity> entityClass, final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/SoftwareModuleTypeDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/SoftwareModuleTypeDeletedEvent.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  *
@@ -38,8 +39,8 @@ public class SoftwareModuleTypeDeletedEvent extends RemoteIdEvent implements Ent
      * @param applicationId
      *            the origin application id
      */
-    public SoftwareModuleTypeDeletedEvent(final String tenant, final Long entityId, final String entityClass,
-            final String applicationId) {
+    public SoftwareModuleTypeDeletedEvent(final String tenant, final Long entityId,
+            final Class<? extends TenantAwareBaseEntity> entityClass, final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetAttributesRequestedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetAttributesRequestedEvent.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  * Defines the remote event of triggering attribute updates of a {@link Target}.
@@ -42,7 +43,8 @@ public class TargetAttributesRequestedEvent extends RemoteIdEvent {
      *            the origin application id
      */
     public TargetAttributesRequestedEvent(final String tenant, final Long entityId, final String controllerId,
-            final String targetAddress, final String entityClass, final String applicationId) {
+            final String targetAddress, final Class<? extends TenantAwareBaseEntity> entityClass,
+            final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
         this.controllerId = controllerId;
         this.targetAddress = targetAddress;

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetDeletedEvent.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  *
@@ -44,7 +45,8 @@ public class TargetDeletedEvent extends RemoteIdEvent implements EntityDeletedEv
      *            the origin application id
      */
     public TargetDeletedEvent(final String tenant, final Long entityId, final String controllerId,
-            final String targetAddress, final String entityClass, final String applicationId) {
+            final String targetAddress, final Class<? extends TenantAwareBaseEntity> entityClass,
+            final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
         this.controllerId = controllerId;
         this.targetAddress = targetAddress;

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetFilterQueryDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetFilterQueryDeletedEvent.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  *
@@ -37,8 +38,8 @@ public class TargetFilterQueryDeletedEvent extends RemoteIdEvent implements Enti
      * @param applicationId
      *            the origin application id
      */
-    public TargetFilterQueryDeletedEvent(final String tenant, final Long entityId, final String entityClass,
-            final String applicationId) {
+    public TargetFilterQueryDeletedEvent(final String tenant, final Long entityId,
+            final Class<? extends TenantAwareBaseEntity> entityClass, final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetTagDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetTagDeletedEvent.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.TargetTag;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  * Defines the remote event of delete a {@link TargetTag}.
@@ -38,8 +39,8 @@ public class TargetTagDeletedEvent extends RemoteIdEvent implements EntityDelete
      * @param applicationId
      *            the origin application id
      */
-    public TargetTagDeletedEvent(final String tenant, final Long entityId, final String entityClass,
-            final String applicationId) {
+    public TargetTagDeletedEvent(final String tenant, final Long entityId,
+            final Class<? extends TenantAwareBaseEntity> entityClass, final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetTypeDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TargetTypeDeletedEvent.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
 import org.eclipse.hawkbit.repository.model.TargetType;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  *
@@ -38,8 +39,8 @@ public class TargetTypeDeletedEvent extends RemoteIdEvent implements EntityDelet
      * @param applicationId
      *            the origin application id
      */
-    public TargetTypeDeletedEvent(final String tenant, final Long entityId, final String entityClass,
-                                  final String applicationId) {
+    public TargetTypeDeletedEvent(final String tenant, final Long entityId,
+            final Class<? extends TenantAwareBaseEntity> entityClass, final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
     }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TenantConfigurationDeletedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/TenantConfigurationDeletedEvent.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.repository.event.remote;
 
 import org.eclipse.hawkbit.repository.event.entity.EntityDeletedEvent;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 
 /**
  *
@@ -43,7 +44,8 @@ public class TenantConfigurationDeletedEvent extends RemoteIdEvent implements En
      *            the origin application id
      */
     public TenantConfigurationDeletedEvent(final String tenant, final Long entityId, final String configKey,
-            final String configValue, final String entityClass, final String applicationId) {
+            final String configValue, final Class<? extends TenantAwareBaseEntity> entityClass,
+            final String applicationId) {
         super(entityId, tenant, entityClass, applicationId);
         this.configKey = configKey;
         this.configValue = configValue;

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RemoteEntityEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/RemoteEntityEvent.java
@@ -49,7 +49,7 @@ public class RemoteEntityEvent<E extends TenantAwareBaseEntity> extends RemoteId
      *            the origin application id
      */
     protected RemoteEntityEvent(final E baseEntity, final String applicationId) {
-        super(baseEntity.getId(), baseEntity.getTenant(), baseEntity.getClass().getName(), applicationId);
+        super(baseEntity.getId(), baseEntity.getTenant(), baseEntity.getClass(), applicationId);
         this.entity = baseEntity;
     }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/test/java/org/eclipse/hawkbit/repository/RepositoryManagementMethodPreAuthorizeAnnotatedTest.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/test/java/org/eclipse/hawkbit/repository/RepositoryManagementMethodPreAuthorizeAnnotatedTest.java
@@ -76,7 +76,7 @@ public class RepositoryManagementMethodPreAuthorizeAnnotatedTest {
             }
             final PreAuthorize annotation = method.getAnnotation(PreAuthorize.class);
             assertThat(annotation).as("The public method " + method.getName() + " in class " + clazz.getName()
-                    + " is not annoated with @PreAuthorize, security leak?").isNotNull();
+                    + " is not annotated with @PreAuthorize, security leak?").isNotNull();
         }
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -682,7 +682,7 @@ public class JpaControllerManagement extends JpaActionManagement implements Cont
         eventPublisherHolder.getEventPublisher()
                 .publishEvent(new TargetAttributesRequestedEvent(tenantAware.getCurrentTenant(), target.getId(),
                         target.getControllerId(), target.getAddress() != null ? target.getAddress().toString() : null,
-                        JpaTarget.class.getName(), eventPublisherHolder.getApplicationId()));
+                        JpaTarget.class, eventPublisherHolder.getApplicationId()));
     }
 
     private void handleErrorOnAction(final JpaAction mergedAction, final JpaTarget mergedTarget) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDistributionSetManagement.java
@@ -273,7 +273,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
 
         afterCommit.afterCommit(() -> distributionSetIDs.forEach(dsId -> eventPublisherHolder.getEventPublisher()
                 .publishEvent(new DistributionSetDeletedEvent(tenantAware.getCurrentTenant(), dsId,
-                        JpaDistributionSet.class.getName(), eventPublisherHolder.getApplicationId()))));
+                        JpaDistributionSet.class, eventPublisherHolder.getApplicationId()))));
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutExecutor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutExecutor.java
@@ -354,7 +354,7 @@ public class JpaRolloutExecutor implements RolloutExecutor {
 
         afterCommit.afterCommit(() -> groupIds.forEach(rolloutGroupId -> eventPublisherHolder.getEventPublisher()
                 .publishEvent(new RolloutGroupDeletedEvent(tenantAware.getCurrentTenant(), rolloutGroupId,
-                        JpaRolloutGroup.class.getName(), eventPublisherHolder.getApplicationId()))));
+                        JpaRolloutGroup.class, eventPublisherHolder.getApplicationId()))));
     }
 
     private boolean isRolloutComplete(final JpaRollout rollout) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -352,7 +352,7 @@ public class JpaTargetManagement implements TargetManagement {
                         .publishEvent(new TargetDeletedEvent(tenantAware.getCurrentTenant(), target.getId(),
                                 target.getControllerId(),
                                 Optional.ofNullable(target.getAddress()).map(URI::toString).orElse(null),
-                                JpaTarget.class.getName(), eventPublisherHolder.getApplicationId()))));
+                                JpaTarget.class, eventPublisherHolder.getApplicationId()))));
     }
 
     @Override
@@ -836,7 +836,7 @@ public class JpaTargetManagement implements TargetManagement {
         eventPublisherHolder.getEventPublisher()
                 .publishEvent(new TargetAttributesRequestedEvent(tenantAware.getCurrentTenant(), target.getId(),
                         target.getControllerId(), target.getAddress() != null ? target.getAddress().toString() : null,
-                        JpaTarget.class.getName(), eventPublisherHolder.getApplicationId()));
+                        JpaTarget.class, eventPublisherHolder.getApplicationId()));
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSet.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSet.java
@@ -341,14 +341,14 @@ public class JpaDistributionSet extends AbstractJpaNamedVersionedEntity implemen
                 new DistributionSetUpdatedEvent(this, EventPublisherHolder.getInstance().getApplicationId(), complete));
 
         if (isSoftDeleted(descriptorEvent)) {
-            publishEventWithEventPublisher(new DistributionSetDeletedEvent(getTenant(), getId(), getClass().getName(),
+            publishEventWithEventPublisher(new DistributionSetDeletedEvent(getTenant(), getId(), getClass(),
                     EventPublisherHolder.getInstance().getApplicationId()));
         }
     }
 
     @Override
     public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
-        publishEventWithEventPublisher(new DistributionSetDeletedEvent(getTenant(), getId(), getClass().getName(),
+        publishEventWithEventPublisher(new DistributionSetDeletedEvent(getTenant(), getId(), getClass(),
                 EventPublisherHolder.getInstance().getApplicationId()));
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetTag.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetTag.java
@@ -89,7 +89,7 @@ public class JpaDistributionSetTag extends JpaTag implements DistributionSetTag,
     @Override
     public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new DistributionSetTagDeletedEvent(
-                getTenant(), getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                getTenant(), getId(), getClass(), EventPublisherHolder.getInstance().getApplicationId()));
 
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
@@ -260,6 +260,6 @@ public class JpaDistributionSetType extends AbstractJpaNamedEntity implements Di
     @Override
     public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new DistributionSetTypeDeletedEvent(
-                getTenant(), getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                getTenant(), getId(), getClass(), EventPublisherHolder.getInstance().getApplicationId()));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
@@ -271,7 +271,7 @@ public class JpaRollout extends AbstractJpaNamedEntity implements Rollout, Event
 
         if (isSoftDeleted(descriptorEvent)) {
             EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new RolloutDeletedEvent(getTenant(),
-                    getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                    getId(), getClass(), EventPublisherHolder.getInstance().getApplicationId()));
         }
     }
 
@@ -288,7 +288,7 @@ public class JpaRollout extends AbstractJpaNamedEntity implements Rollout, Event
     @Override
     public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new RolloutDeletedEvent(getTenant(),
-                getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                getId(), getClass(), EventPublisherHolder.getInstance().getApplicationId()));
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRolloutGroup.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRolloutGroup.java
@@ -296,6 +296,6 @@ public class JpaRolloutGroup extends AbstractJpaNamedEntity implements RolloutGr
     @Override
     public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new RolloutGroupDeletedEvent(getTenant(),
-                getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                getId(), getClass(), EventPublisherHolder.getInstance().getApplicationId()));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModule.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModule.java
@@ -251,7 +251,7 @@ public class JpaSoftwareModule extends AbstractJpaNamedVersionedEntity implement
 
         if (isSoftDeleted(descriptorEvent)) {
             EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new SoftwareModuleDeletedEvent(
-                    getTenant(), getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                    getTenant(), getId(), getClass(), EventPublisherHolder.getInstance().getApplicationId()));
         }
     }
 
@@ -268,7 +268,7 @@ public class JpaSoftwareModule extends AbstractJpaNamedVersionedEntity implement
     @Override
     public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new SoftwareModuleDeletedEvent(getTenant(),
-                getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                getId(), getClass(), EventPublisherHolder.getInstance().getApplicationId()));
     }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModuleType.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModuleType.java
@@ -159,6 +159,6 @@ public class JpaSoftwareModuleType extends AbstractJpaNamedEntity implements Sof
     @Override
     public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new SoftwareModuleTypeDeletedEvent(
-                getTenant(), getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                getTenant(), getId(), getClass(), EventPublisherHolder.getInstance().getApplicationId()));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -505,6 +505,6 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
     public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher()
                 .publishEvent(new TargetDeletedEvent(getTenant(), getId(), getControllerId(), address,
-                        getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                        getClass(), EventPublisherHolder.getInstance().getApplicationId()));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetFilterQuery.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetFilterQuery.java
@@ -175,6 +175,6 @@ public class JpaTargetFilterQuery extends AbstractJpaTenantAwareBaseEntity
     @Override
     public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new TargetFilterQueryDeletedEvent(
-                getTenant(), getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                getTenant(), getId(), getClass(), EventPublisherHolder.getInstance().getApplicationId()));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetTag.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetTag.java
@@ -85,7 +85,7 @@ public class JpaTargetTag extends JpaTag implements TargetTag, EventAwareEntity 
     @Override
     public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new TargetTagDeletedEvent(getTenant(),
-                getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                getId(), getClass(), EventPublisherHolder.getInstance().getApplicationId()));
 
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetType.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetType.java
@@ -151,6 +151,6 @@ public class JpaTargetType extends AbstractJpaNamedEntity implements TargetType,
     @Override
     public void fireDeleteEvent(DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher().publishEvent(new TargetTypeDeletedEvent(
-                getTenant(), getId(), getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                getTenant(), getId(), getClass(), EventPublisherHolder.getInstance().getApplicationId()));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTenantConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTenantConfiguration.java
@@ -101,6 +101,6 @@ public class JpaTenantConfiguration extends AbstractJpaTenantAwareBaseEntity
     public void fireDeleteEvent(final DescriptorEvent descriptorEvent) {
         EventPublisherHolder.getInstance().getEventPublisher()
                 .publishEvent(new TenantConfigurationDeletedEvent(getTenant(), getId(), getKey(), getValue(),
-                        getClass().getName(), EventPublisherHolder.getInstance().getApplicationId()));
+                        getClass(), EventPublisherHolder.getInstance().getApplicationId()));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/RemoteIdEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/RemoteIdEventTest.java
@@ -18,6 +18,8 @@ import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
+import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
+import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +34,7 @@ public class RemoteIdEventTest extends AbstractRemoteEventTest {
 
     private static String TENANT = "tenant";
 
-    private static String ENTIY_CLASS = "EntityClass";
+    private static Class<? extends TenantAwareBaseEntity> ENTITY_CLASS = JpaAction.class;
 
     private static String NODE = "Node";
 
@@ -56,7 +58,7 @@ public class RemoteIdEventTest extends AbstractRemoteEventTest {
     @Description("Verifies that the target id is correct reloaded")
     public void testTargetDeletedEvent() {
         final TargetDeletedEvent deletedEvent = new TargetDeletedEvent(TENANT, ENTITY_ID, CONTROLLER_ID, ADDRESS,
-                ENTIY_CLASS, NODE);
+                ENTITY_CLASS, NODE);
         assertEntity(deletedEvent);
     }
 
@@ -85,7 +87,7 @@ public class RemoteIdEventTest extends AbstractRemoteEventTest {
                 .orElseThrow(() -> new IllegalArgumentException("Given event is not RemoteIdEvent compatible"));
 
         try {
-            final RemoteIdEvent event = (RemoteIdEvent) constructor.newInstance(TENANT, ENTITY_ID, ENTIY_CLASS, NODE);
+            final RemoteIdEvent event = (RemoteIdEvent) constructor.newInstance(TENANT, ENTITY_ID, ENTITY_CLASS, NODE);
             assertEntity(event);
         } catch (final ReflectiveOperationException e) {
             fail("Exception should not happen " + e.getMessage());

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/push/event/ActionChangedEvent.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/push/event/ActionChangedEvent.java
@@ -43,7 +43,7 @@ public class ActionChangedEvent extends RemoteIdEvent implements EntityUpdatedEv
      */
     public ActionChangedEvent(final String tenant, final Long targetId, final Long entityId) {
         // application id is not needed, because we compose the event ourselves
-        super(entityId, tenant, Action.class.getName(), null);
+        super(entityId, tenant, Action.class, null);
 
         this.targetId = targetId;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/push/event/RolloutChangedEvent.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/push/event/RolloutChangedEvent.java
@@ -37,6 +37,6 @@ public class RolloutChangedEvent extends RemoteIdEvent implements EntityUpdatedE
      */
     public RolloutChangedEvent(final String tenant, final Long entityId) {
         // application id is not needed, because we compose the event ourselves
-        super(entityId, tenant, Rollout.class.getName(), null);
+        super(entityId, tenant, Rollout.class, null);
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/push/event/RolloutGroupChangedEvent.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/push/event/RolloutGroupChangedEvent.java
@@ -43,7 +43,7 @@ public class RolloutGroupChangedEvent extends RemoteIdEvent implements EntityUpd
      */
     public RolloutGroupChangedEvent(final String tenant, final Long rolloutId, final Long entityId) {
         // application id is not needed, because we compose the event ourselves
-        super(entityId, tenant, RolloutGroup.class.getName(), null);
+        super(entityId, tenant, RolloutGroup.class, null);
 
         this.rolloutId = rolloutId;
     }


### PR DESCRIPTION
Extend the EntityId event so that the interface of the entity is also provided. This allows the event to be interpreted for different implementations even if they are not in the same classpath. 

Signed-off-by: Michael Herdt <Michael.Herdt@bosch.io>