### PR TITLE
Avoid using RegexRequestMatcher due to [CVE-2022-22978]

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
@@ -455,7 +455,7 @@ public class SecurityManagedConfiguration {
             http.csrf().disable();
             http.anonymous().disable();
 
-            http.antMatcher("**/controller/**")
+            http.antMatcher("/**/downloadId/**")
                     .addFilterBefore(downloadIdAuthenticationFilter, FilterSecurityInterceptor.class);
             http.authorizeRequests().anyRequest().authenticated().and().sessionManagement()
                     .sessionCreationPolicy(SessionCreationPolicy.STATELESS);

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
@@ -455,7 +455,7 @@ public class SecurityManagedConfiguration {
             http.csrf().disable();
             http.anonymous().disable();
 
-            http.regexMatcher(HttpDownloadAuthenticationFilter.REQUEST_ID_REGEX_PATTERN)
+            http.antMatcher("**/controller/**")
                     .addFilterBefore(downloadIdAuthenticationFilter, FilterSecurityInterceptor.class);
             http.authorizeRequests().anyRequest().authenticated().and().sessionManagement()
                     .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
@@ -521,7 +521,8 @@ public class SecurityManagedConfiguration {
         @Override
         protected void configure(final HttpSecurity http) throws Exception {
 
-            HttpSecurity httpSec = http.regexMatcher("\\/rest.*|\\/system/admin.*").csrf().disable();
+            HttpSecurity httpSec = http.requestMatchers().antMatchers("/rest/**", "/system/admin/**").and().csrf()
+                    .disable();
 
             if (securityProperties.getCors().isEnabled()) {
                 httpSec = httpSec.cors().and();
@@ -693,9 +694,11 @@ public class SecurityManagedConfiguration {
             // https://vaadin.com/forum#!/thread/3200565.
             HttpSecurity httpSec;
             if (enableOidc) {
-                httpSec = http.regexMatcher("(?!.*HEARTBEAT)^.*\\/(UI|oauth2).*$");
+                //httpSec = http.regexMatcher("(?!.*HEARTBEAT)^.*\\/(UI|oauth2).*$");
+                httpSec = http.requestMatchers().antMatchers("/**/UI/**", "/**/oauth2/**").and();
             } else {
-                httpSec = http.regexMatcher("(?!.*HEARTBEAT)^.*\\/UI.*$");
+                //httpSec = http.regexMatcher("(?!.*HEARTBEAT)^.*\\/UI.*$");
+                httpSec = http.antMatcher("/**/UI/**");
             }
             // disable as CSRF is handled by Vaadin
             httpSec.csrf().disable();

--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/SecurityManagedConfiguration.java
@@ -694,10 +694,8 @@ public class SecurityManagedConfiguration {
             // https://vaadin.com/forum#!/thread/3200565.
             HttpSecurity httpSec;
             if (enableOidc) {
-                //httpSec = http.regexMatcher("(?!.*HEARTBEAT)^.*\\/(UI|oauth2).*$");
                 httpSec = http.requestMatchers().antMatchers("/**/UI/**", "/**/oauth2/**").and();
             } else {
-                //httpSec = http.regexMatcher("(?!.*HEARTBEAT)^.*\\/UI.*$");
                 httpSec = http.antMatcher("/**/UI/**");
             }
             // disable as CSRF is handled by Vaadin

--- a/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/HttpDownloadAuthenticationFilter.java
+++ b/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/HttpDownloadAuthenticationFilter.java
@@ -8,15 +8,13 @@
  */
 package org.eclipse.hawkbit.security;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import javax.servlet.http.HttpServletRequest;
 
 import org.eclipse.hawkbit.cache.DownloadIdCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+import org.springframework.util.AntPathMatcher;
 
 /**
  * Extracts download or upload id from the request URI secruity token and set
@@ -27,10 +25,10 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
  */
 public class HttpDownloadAuthenticationFilter extends AbstractPreAuthenticatedProcessingFilter {
 
-    public static final String REQUEST_ID_REGEX_PATTERN = ".*\\/downloadId\\/.*";
     private static final Logger LOG = LoggerFactory.getLogger(HttpDownloadAuthenticationFilter.class);
 
-    private final Pattern pattern;
+    private static final AntPathMatcher MATCHER = new AntPathMatcher();
+
     private final DownloadIdCache downloadIdCache;
 
     /**
@@ -41,13 +39,10 @@ public class HttpDownloadAuthenticationFilter extends AbstractPreAuthenticatedPr
      */
     public HttpDownloadAuthenticationFilter(final DownloadIdCache downloadIdCache) {
         this.downloadIdCache = downloadIdCache;
-        this.pattern = Pattern.compile(REQUEST_ID_REGEX_PATTERN);
-
     }
 
     private Object getDownloadByUri(final String requestURI) {
-        final Matcher matcher = pattern.matcher(requestURI);
-        if (!matcher.matches()) {
+        if (!MATCHER.match("**/downloadId/**",requestURI)) {
             return null;
         }
         LOG.debug("retrieving id from URI request {}", requestURI);

--- a/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/HttpDownloadAuthenticationFilter.java
+++ b/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/HttpDownloadAuthenticationFilter.java
@@ -42,7 +42,7 @@ public class HttpDownloadAuthenticationFilter extends AbstractPreAuthenticatedPr
     }
 
     private Object getDownloadByUri(final String requestURI) {
-        if (!MATCHER.match("**/downloadId/**",requestURI)) {
+        if (!MATCHER.match("/**/downloadId/**",requestURI)) {
             return null;
         }
         LOG.debug("retrieving id from URI request {}", requestURI);

--- a/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/HttpDownloadAuthenticationFilter.java
+++ b/hawkbit-http-security/src/main/java/org/eclipse/hawkbit/security/HttpDownloadAuthenticationFilter.java
@@ -8,13 +8,15 @@
  */
 package org.eclipse.hawkbit.security;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.eclipse.hawkbit.cache.DownloadIdCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
-import org.springframework.util.AntPathMatcher;
 
 /**
  * Extracts download or upload id from the request URI secruity token and set
@@ -25,10 +27,10 @@ import org.springframework.util.AntPathMatcher;
  */
 public class HttpDownloadAuthenticationFilter extends AbstractPreAuthenticatedProcessingFilter {
 
+    public static final String REQUEST_ID_REGEX_PATTERN = ".*\\/downloadId\\/.*";
     private static final Logger LOG = LoggerFactory.getLogger(HttpDownloadAuthenticationFilter.class);
 
-    private static final AntPathMatcher MATCHER = new AntPathMatcher();
-
+    private final Pattern pattern;
     private final DownloadIdCache downloadIdCache;
 
     /**
@@ -39,10 +41,13 @@ public class HttpDownloadAuthenticationFilter extends AbstractPreAuthenticatedPr
      */
     public HttpDownloadAuthenticationFilter(final DownloadIdCache downloadIdCache) {
         this.downloadIdCache = downloadIdCache;
+        this.pattern = Pattern.compile(REQUEST_ID_REGEX_PATTERN);
+
     }
 
     private Object getDownloadByUri(final String requestURI) {
-        if (!MATCHER.match("/**/downloadId/**",requestURI)) {
+        final Matcher matcher = pattern.matcher(requestURI);
+        if (!matcher.matches()) {
             return null;
         }
         LOG.debug("retrieving id from URI request {}", requestURI);


### PR DESCRIPTION
The spring-security-web package is vulnerable to Authorization Bypass. The RegexRequestMatcher() function in the RegexRequestMatcher class and the addSecureUrl() function in the DefaultFilterInvocationSecurityMetadataSource class can return an unexpected match when a . character is used in a regular expression.
Therefore, the security configuration was adapted to make use of an AntPathRequestMatcher matcher instead of RegexRequestMatcher. 