### PR TITLE
hawkBit::REST:Documentation: fix build with openjdk 17

### DIFF
--- a/hawkbit-rest/hawkbit-rest-docs/pom.xml
+++ b/hawkbit-rest/hawkbit-rest-docs/pom.xml
@@ -128,6 +128,13 @@
                   </configuration>
                </execution>
             </executions>
+            <dependencies>
+               <dependency>
+                  <groupId>org.jruby</groupId>
+                  <artifactId>jruby-complete</artifactId>
+                  <version>9.3.4.0</version>
+               </dependency>
+            </dependencies>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
hawkBit no longer built after upgrading the jvm from openjdk 11 to 17:
[ERROR] Failed to execute goal org.asciidoctor:asciidoctor-maven-plugin:1.5.2:process-asciidoc (generate-docs) on project hawkbit-rest-docs: Execution generate-docs of goal org.asciidoctor:asciidoctor-maven-plugin:1.5.2:process-asciidoc failed: (LoadError) load error: jruby/java/java_ext/java.lang -- java.lang.reflect.InaccessibleObjectException: Unable to make protected native java.lang.Object java.lang.Object.clone() throws java.lang.CloneNotSupportedException accessible: module java.base does not "opens java.lang" to unnamed module @fefbafd -> [Help 1]

Explicitely adding the jruby dependency to the asciidoctor plugin seems
to make this work, and does not break compilation with older jdk