### PR TITLE
Add springdoc to management rest API

### DIFF
--- a/hawkbit-rest/hawkbit-mgmt-api/pom.xml
+++ b/hawkbit-rest/hawkbit-mgmt-api/pom.xml
@@ -49,5 +49,24 @@
          <artifactId>allure-junit5</artifactId>
          <scope>test</scope>
       </dependency>
+
+      <dependency>
+         <groupId>org.springdoc</groupId>
+         <artifactId>springdoc-openapi-ui</artifactId>
+         <version>${springdoc.version}</version>
+      </dependency>
+
+      <dependency>
+         <groupId>org.springdoc</groupId>
+         <artifactId>springdoc-openapi-webmvc-core</artifactId>
+         <version>${springdoc.version}</version>
+      </dependency>
+
+      <dependency>
+         <groupId>org.springdoc</groupId>
+         <artifactId>springdoc-openapi-security</artifactId>
+         <version>${springdoc.version}</version>
+      </dependency>
+
    </dependencies>
 </project>

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtOpenApi30Config.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtOpenApi30Config.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2022 Bosch.IO GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.rest.api;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MgmtOpenApi30Config
+{
+    @Bean
+    public OpenAPI customOpenAPI()
+    {
+        // Globally add the basicAuth security scheme.
+        // This ensures that it gets added to the OpenAPI specification file and add
+        // the "Authorize" button in swagger-ui.
+        // Without this, there is no defined security scheme.
+        final String securitySchemeName = "basicAuth";
+        final String apiTitle = "hawkBit Management REST API";
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(
+                        new Components()
+                                .addSecuritySchemes(securitySchemeName,
+                                                    new SecurityScheme()
+                                                            .name(securitySchemeName)
+                                                            .type(SecurityScheme.Type.HTTP)
+                                                            .in(SecurityScheme.In.HEADER)
+                                                            .scheme("basic")
+                                )
+                )
+                .info(new Info().title(apiTitle).version(MgmtRestConstants.API_VERSION));
+    }
+}

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtApiConfiguration.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtApiConfiguration.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.mgmt.rest.resource;
 
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtOpenApi30Config;
 import org.eclipse.hawkbit.rest.RestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -22,7 +23,7 @@ import org.springframework.stereotype.Controller;
  */
 @Configuration
 @ComponentScan
-@Import(RestConfiguration.class)
+@Import({MgmtOpenApi30Config.class, RestConfiguration.class})
 @PropertySource("classpath:/hawkbit-mgmt-api-defaults.properties")
 public class MgmtApiConfiguration {
 

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@
       <rsql-parser.version>2.1.0</rsql-parser.version>
       <awaitility.version>3.1.2</awaitility.version>
       <io-protostuff.version>1.5.6</io-protostuff.version>
+      <springdoc.version>1.6.14</springdoc.version>
 
       <!-- SONATYPE-2021-1175 -->
       <logback.version>1.2.9</logback.version>


### PR DESCRIPTION
This enables a swagger-ui interface to test and discover the API.
And it also notably generates an OpenAPI specification file which could
then be used to generate API clients in multiple languages to interact
with hawkBit.

Compared to https://github.com/kokuwaio/hawkbit-specs , this approach
has the advantage that the specification file can be easily updated
whenever the API is updated.
Also the generated specification is complete.

A similar approach could be used to generate the OpenAPI specification
for the other APIs as asked
[here](https://gitter.im/eclipse/hawkbit?at=5e1c2db3b720fa5b3c06a101).

Signed-off-by: Vladimir Svoboda <vsvoboda@forkoder.eu>