### PR TITLE
Fixed typographical error in SpServerError enum

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/exception/SpServerError.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/exception/SpServerError.java
@@ -22,7 +22,7 @@ public enum SpServerError {
     /**
     *
     */
-    SP_REPO_ENTITY_ALREADY_EXISTS("hawkbit.server.error.repo.entitiyAlreayExists",
+    SP_REPO_ENTITY_ALREADY_EXISTS("hawkbit.server.error.repo.entitiyAlreadyExists",
             "The given entity already exists in database"),
 
     /**


### PR DESCRIPTION
"hawkbit.server.error.repo.entitiyAlreayExists" -> "hawkbit.server.error.repo.entitiyAlreadyExists"