### PR TITLE
Make DdiActionFeedback#time value an optional property

### DIFF
--- a/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedback.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedback.java
@@ -53,7 +53,7 @@ public class DdiActionFeedback {
      *            status to be appended to the action
      */
     @JsonCreator
-    public DdiActionFeedback(@JsonProperty(value = "time", required = true) final String time,
+    public DdiActionFeedback(@JsonProperty(value = "time") final String time,
             @JsonProperty(value = "status", required = true) final DdiStatus status) {
         this.time = time;
         this.status = status;

--- a/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedbackTest.java
+++ b/hawkbit-rest/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedbackTest.java
@@ -14,7 +14,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Collections;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 
@@ -30,22 +32,38 @@ import io.qameta.allure.Story;
  */
 @Feature("Unit Tests - Direct Device Integration API")
 @Story("Serialization of DDI api Models")
-public class DdiActionFeedbackTest {
+class DdiActionFeedbackTest {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
-    @Description("Verify the correct serialization and deserialization of the model")
-    public void shouldSerializeAndDeserializeObject() throws IOException {
+    @Description("Verify the correct serialization and deserialization of the model with minimal payload")
+    void shouldSerializeAndDeserializeObjectWithoutOptionalValues() throws IOException {
         // Setup
-        final String time = Instant.now().toString();
         final DdiStatus ddiStatus = new DdiStatus(DdiStatus.ExecutionStatus.CLOSED, null, null, Lists.emptyList());
-        final DdiActionFeedback ddiActionFeedback = new DdiActionFeedback(time, ddiStatus);
+        final DdiActionFeedback ddiActionFeedback = new DdiActionFeedback(null, ddiStatus);
 
         // Test
         final String serializedDdiActionFeedback = mapper.writeValueAsString(ddiActionFeedback);
         final DdiActionFeedback deserializedDdiActionFeedback = mapper.readValue(serializedDdiActionFeedback,
                 DdiActionFeedback.class);
+
+        assertThat(deserializedDdiActionFeedback.getStatus()).hasToString(ddiStatus.toString());
+    }
+
+    @Test
+    @Description("Verify the correct serialization and deserialization of the model with all values provided")
+    void shouldSerializeAndDeserializeObjectWithOptionalValues() throws IOException {
+        // Setup
+        final String time = Instant.now().toString();
+        final DdiResult ddiResult = new DdiResult(DdiResult.FinalResult.SUCCESS, new DdiProgress(10,10));
+        final DdiStatus ddiStatus = new DdiStatus(DdiStatus.ExecutionStatus.CLOSED, ddiResult, 200, Collections.singletonList("myMessage"));
+        final DdiActionFeedback ddiActionFeedback = new DdiActionFeedback(time, ddiStatus);
+
+        // Test
+        final String serializedDdiActionFeedback = mapper.writeValueAsString(ddiActionFeedback);
+        final DdiActionFeedback deserializedDdiActionFeedback = mapper.readValue(serializedDdiActionFeedback,
+              DdiActionFeedback.class);
 
         assertThat(serializedDdiActionFeedback).contains(time);
         assertThat(deserializedDdiActionFeedback.getTime()).isEqualTo(time);
@@ -54,11 +72,38 @@ public class DdiActionFeedbackTest {
 
     @Test
     @Description("Verify that deserialization fails for known properties with a wrong datatype")
-    public void shouldFailForObjectWithWrongDataTypes() throws IOException {
+    void shouldFailForObjectWithWrongDataTypes() throws IOException {
         // Setup
         final String serializedDdiActionFeedback = "{\"time\":\"20190809T121314\",\"status\":{\"execution\": [closed],\"result\":null,\"details\":[]}}";
 
         assertThatExceptionOfType(MismatchedInputException.class).isThrownBy(
-                () -> mapper.readValue(serializedDdiActionFeedback, DdiActionFeedback.class));
+              () -> mapper.readValue(serializedDdiActionFeedback, DdiActionFeedback.class));
     }
+
+    @Test
+    @Description("Verify that deserialization works if optional fields are not parsed")
+    void shouldConvertItWithoutOptionalFieldTime() throws JsonProcessingException {
+        // Setup
+        final String serializedDdiActionFeedback = "{\n" + //
+                "  \"status\" : {\n" + //
+                "    \"result\" : {\n" + //
+                "      \"finished\" : \"none\"\n" + //
+                "    },\n" + //
+                "    \"execution\" : \"download\",\n" + //
+                "    \"details\" : [ \"Some message\" ]\n" + //
+                "  }\n" + //
+                "}";//
+
+        assertThat(mapper.readValue(serializedDdiActionFeedback, DdiActionFeedback.class)).satisfies(deserializedDdiActionFeedback ->  {
+            assertThat(deserializedDdiActionFeedback.getTime()).isNull();
+            assertThat(deserializedDdiActionFeedback.getStatus()).isNotNull();
+            assertThat(deserializedDdiActionFeedback.getStatus().getResult()).isNotNull();
+            assertThat(deserializedDdiActionFeedback.getStatus().getResult().getFinished()).isEqualTo(DdiResult.FinalResult.NONE);
+            assertThat(deserializedDdiActionFeedback.getStatus().getResult().getProgress()).isNull();
+            assertThat(deserializedDdiActionFeedback.getStatus().getCode()).isNull();
+            assertThat(deserializedDdiActionFeedback.getStatus().getExecution()).isEqualTo(DdiStatus.ExecutionStatus.DOWNLOAD);
+            assertThat(deserializedDdiActionFeedback.getStatus().getDetails()).hasSize(1);
+        });
+    }
+
 }


### PR DESCRIPTION
With [a previous PR ](https://github.com/eclipse/hawkbit/pull/1280) a minor change was introduced which leads to the problem, that the "time" value is required when providing an action feedback against the DDI API. This will lead to an API break and needs to be fixed by making this value optional again. This PR restores the old behaviour and extends the tests to identify such cases in the future.

Signed-off-by: Michael Herdt <Michael.Herdt@bosch.io>