### PR TITLE
Add type name to mgmt api responses

### DIFF
--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSet.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSet.java
@@ -44,6 +44,9 @@ public class MgmtDistributionSet extends MgmtNamedEntity {
     private String type;
 
     @JsonProperty
+    private String typeName;
+
+    @JsonProperty
     private Boolean complete;
 
     @JsonProperty
@@ -107,6 +110,14 @@ public class MgmtDistributionSet extends MgmtNamedEntity {
 
     public void setType(final String type) {
         this.type = type;
+    }
+
+    public String getTypeName() {
+        return typeName;
+    }
+
+    public void setTypeName(final String typeName) {
+        this.typeName = typeName;
     }
 
     public Boolean getComplete() {

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModule.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModule.java
@@ -32,6 +32,8 @@ public class MgmtSoftwareModule extends MgmtNamedEntity {
     @JsonProperty(required = true)
     private String type;
 
+    private String typeName;
+
     @JsonProperty
     private String vendor;
 
@@ -72,6 +74,14 @@ public class MgmtSoftwareModule extends MgmtNamedEntity {
 
     public void setType(final String type) {
         this.type = type;
+    }
+
+    public String getTypeName() {
+        return typeName;
+    }
+
+    public void setTypeName(final String typeName) {
+        this.typeName = typeName;
     }
 
     public String getVendor() {

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTarget.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTarget.java
@@ -52,6 +52,9 @@ public class MgmtTarget extends MgmtNamedEntity {
     @JsonProperty
     private Long targetType;
 
+    @JsonProperty
+    private String targetTypeName;
+
     /**
      * @return Target type ID
      */
@@ -61,10 +64,25 @@ public class MgmtTarget extends MgmtNamedEntity {
 
     /**
      * @param targetType
-     *          Target type ID
+     *            Target type ID
      */
-    public void setTargetType(Long targetType) {
+    public void setTargetType(final Long targetType) {
         this.targetType = targetType;
+    }
+
+    /**
+     * @return Target type name
+     */
+    public String getTargetTypeName() {
+        return targetTypeName;
+    }
+
+    /**
+     * @param targetTypeName
+     *            Target type name
+     */
+    public void setTargetTypeName(final String targetTypeName) {
+        this.targetTypeName = targetTypeName;
     }
 
     /**

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetMapper.java
@@ -109,6 +109,7 @@ public final class MgmtDistributionSetMapper {
         response.setVersion(distributionSet.getVersion());
         response.setComplete(distributionSet.isComplete());
         response.setType(distributionSet.getType().getKey());
+        response.setTypeName(distributionSet.getType().getName());
         response.setDeleted(distributionSet.isDeleted());
         response.setValid(distributionSet.isValid());
 

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleMapper.java
@@ -106,6 +106,7 @@ public final class MgmtSoftwareModuleMapper {
         response.setModuleId(softwareModule.getId());
         response.setVersion(softwareModule.getVersion());
         response.setType(softwareModule.getType().getKey());
+        response.setTypeName(softwareModule.getType().getName());
         response.setVendor(softwareModule.getVendor());
         response.setDeleted(softwareModule.isDeleted());
         response.setEncrypted(softwareModule.isEncrypted());

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.mgmt.json.model.MgmtMaintenanceWindow;
@@ -82,8 +81,8 @@ public final class MgmtTargetMapper {
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null)).withRel("metadata"));
         if (response.getTargetType() != null) {
-            response.add(linkTo(methodOn(MgmtTargetTypeRestApi.class)
-                    .getTargetType(response.getTargetType())).withRel(MgmtRestConstants.TARGET_V1_ASSIGNED_TARGET_TYPE));
+            response.add(linkTo(methodOn(MgmtTargetTypeRestApi.class).getTargetType(response.getTargetType()))
+                    .withRel(MgmtRestConstants.TARGET_V1_ASSIGNED_TARGET_TYPE));
         }
     }
 
@@ -159,8 +158,9 @@ public final class MgmtTargetMapper {
         if (installationDate != null) {
             targetRest.setInstalledAt(installationDate);
         }
-        if (target.getTargetType() != null){
+        if (target.getTargetType() != null) {
             targetRest.setTargetType(target.getTargetType().getId());
+            targetRest.setTargetTypeName(target.getTargetType().getName());
         }
 
         targetRest.add(linkTo(methodOn(MgmtTargetRestApi.class).getTarget(target.getControllerId())).withSelfRel());
@@ -226,12 +226,12 @@ public final class MgmtTargetMapper {
             result.setStatus(MgmtAction.ACTION_FINISHED);
         }
 
-        Rollout rollout = action.getRollout();
+        final Rollout rollout = action.getRollout();
         if (rollout != null) {
             result.setRollout(rollout.getId());
             result.setRolloutName(rollout.getName());
         }
-        
+
         if (action.hasMaintenanceSchedule()) {
             final MgmtMaintenanceWindow maintenanceWindow = new MgmtMaintenanceWindow();
             maintenanceWindow.setSchedule(action.getMaintenanceWindowSchedule());
@@ -270,7 +270,7 @@ public final class MgmtTargetMapper {
             result.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRollout(rollout.getId()))
                     .withRel(MgmtRestConstants.TARGET_V1_ROLLOUT));
         }
-        
+
         return result;
     }
 

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/AbstractApiRestDocumentation.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/AbstractApiRestDocumentation.java
@@ -255,7 +255,7 @@ public abstract class AbstractApiRestDocumentation extends AbstractRestIntegrati
         controllerManagement.addUpdateActionStatus(
                 entityFactory.actionStatus().create(action.getId()).code(code).status(Status.RUNNING));
     }
-    
+
     protected Target createTargetByGivenNameWithAttributes(final String name, final DistributionSet distributionSet) {
         return createTargetByGivenNameWithAttributes(name, true, false, distributionSet);
     }
@@ -289,8 +289,10 @@ public abstract class AbstractApiRestDocumentation extends AbstractRestIntegrati
                         .type("String"),
                 fieldWithPath(fieldArrayPrefix + "lastControllerRequestAt")
                         .description(MgmtApiModelProperties.LAST_REQUEST_AT).type("Number"),
-                fieldWithPath(fieldArrayPrefix + "targetType")
-                        .description(MgmtApiModelProperties.TARGETTYPE_ID).type("Number"),
+                fieldWithPath(fieldArrayPrefix + "targetType").description(MgmtApiModelProperties.TARGETTYPE_ID)
+                        .type("Number"),
+                fieldWithPath(fieldArrayPrefix + "targetTypeName").description(MgmtApiModelProperties.TARGETTYPE_NAME)
+                        .type("String"),
                 fieldWithPath(fieldArrayPrefix + "_links.self").ignored());
 
         if (!isArray) {
@@ -331,6 +333,7 @@ public abstract class AbstractApiRestDocumentation extends AbstractRestIntegrati
                 fieldWithPath(arrayPrefix + "lastModifiedBy").description(ApiModelPropertiesGeneric.LAST_MODIFIED_BY),
                 fieldWithPath(arrayPrefix + "lastModifiedAt").description(ApiModelPropertiesGeneric.LAST_MODIFIED_AT),
                 fieldWithPath(arrayPrefix + "type").description(MgmtApiModelProperties.DS_TYPE),
+                fieldWithPath(arrayPrefix + "typeName").description(MgmtApiModelProperties.DS_TYPE_NAME),
                 fieldWithPath(arrayPrefix + "requiredMigrationStep")
                         .description(MgmtApiModelProperties.DS_REQUIRED_STEP),
                 fieldWithPath(arrayPrefix + "complete").description(MgmtApiModelProperties.DS_COMPLETE),

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
@@ -43,6 +43,7 @@ public final class MgmtApiModelProperties {
 
     // software module
     public static final String SM_TYPE = "The software module type " + ApiModelPropertiesGeneric.ENDING;
+    public static final String SM_TYPE_NAME = "The software module type name " + ApiModelPropertiesGeneric.ENDING;
     public static final String ENCRYPTED = "Encryption flag, used to identify that artifacts should be encrypted upon upload.";
     public static final String ARTIFACT_HASHES = "Hashes of the artifact.";
     public static final String ARTIFACT_SIZE = "Size of the artifact.";
@@ -85,6 +86,7 @@ public final class MgmtApiModelProperties {
 
     // Target type
     public static final String TARGETTYPE_ID = "ID of the target type";
+    public static final String TARGETTYPE_NAME = "Name of the target type";
     public static final String COMPATIBLE_DS_TYPES = "Array of distribution set types that are compatible to that target type";
     public static final String LINK_COMPATIBLE_DS_TYPES = "Link to the compatible distribution set types in this target type";
 
@@ -191,6 +193,8 @@ public final class MgmtApiModelProperties {
     public static final String DS_TYPE_LIST = "List of distribution set types.";
 
     public static final String DS_TYPE = "The type of the distribution set.";
+
+    public static final String DS_TYPE_NAME = "The type name of the distribution set.";
 
     public static final String DS_COMPLETE = "True of the distribution set software module setup is complete as defined by the distribution set type.";
 

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/DistributionSetsDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/DistributionSetsDocumentationTest.java
@@ -99,6 +99,7 @@ public class DistributionSetsDocumentationTest extends AbstractApiRestDocumentat
                         fieldWithPath("content[].lastModifiedAt")
                                 .description(ApiModelPropertiesGeneric.LAST_MODIFIED_AT),
                         fieldWithPath("content[].type").description(MgmtApiModelProperties.DS_TYPE),
+                        fieldWithPath("content[].typeName").description(MgmtApiModelProperties.DS_TYPE_NAME),
                         fieldWithPath("content[].requiredMigrationStep")
                                 .description(MgmtApiModelProperties.DS_REQUIRED_STEP),
                         fieldWithPath("content[].complete").description(MgmtApiModelProperties.DS_COMPLETE),

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/SoftwaremodulesDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/SoftwaremodulesDocumentationTest.java
@@ -92,6 +92,7 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
                         fieldWithPath("content[].lastModifiedAt")
                                 .description(ApiModelPropertiesGeneric.LAST_MODIFIED_AT),
                         fieldWithPath("content[].type").description(MgmtApiModelProperties.SM_TYPE),
+                        fieldWithPath("content[].typeName").description(MgmtApiModelProperties.SM_TYPE_NAME),
                         fieldWithPath("content[].version").description(MgmtApiModelProperties.VERSION),
                         fieldWithPath("content[]._links.self").ignored())));
     }
@@ -151,6 +152,7 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
                                 fieldWithPath("[].lastModifiedAt")
                                         .description(ApiModelPropertiesGeneric.LAST_MODIFIED_AT),
                                 fieldWithPath("[].type").description(MgmtApiModelProperties.SM_TYPE),
+                                fieldWithPath("[].typeName").description(MgmtApiModelProperties.SM_TYPE_NAME),
                                 fieldWithPath("[].version").description(MgmtApiModelProperties.VERSION),
                                 fieldWithPath("[]._links.self").ignored())));
     }
@@ -193,6 +195,7 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
                                 fieldWithPath("encrypted").description(MgmtApiModelProperties.ENCRYPTED),
                                 fieldWithPath("deleted").description(ApiModelPropertiesGeneric.DELETED),
                                 fieldWithPath("type").description(MgmtApiModelProperties.SM_TYPE),
+                                fieldWithPath("typeName").description(MgmtApiModelProperties.SM_TYPE_NAME),
                                 fieldWithPath("version").description(MgmtApiModelProperties.VERSION),
                                 fieldWithPath("_links.self").ignored(),
                                 fieldWithPath("_links.type").description(MgmtApiModelProperties.SM_TYPE),
@@ -228,6 +231,7 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
                                 fieldWithPath("lastModifiedBy").description(ApiModelPropertiesGeneric.LAST_MODIFIED_BY),
                                 fieldWithPath("lastModifiedAt").description(ApiModelPropertiesGeneric.LAST_MODIFIED_AT),
                                 fieldWithPath("type").description(MgmtApiModelProperties.SM_TYPE),
+                                fieldWithPath("typeName").description(MgmtApiModelProperties.SM_TYPE_NAME),
                                 fieldWithPath("version").description(MgmtApiModelProperties.VERSION),
                                 fieldWithPath("vendor").description(MgmtApiModelProperties.VENDOR),
                                 fieldWithPath("encrypted").description(MgmtApiModelProperties.ENCRYPTED),

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
@@ -107,8 +107,10 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 .type("String"),
                         fieldWithPath("content[].lastControllerRequestAt")
                                 .description(MgmtApiModelProperties.LAST_REQUEST_AT).type("Number"),
-                        fieldWithPath("content[].targetType")
-                                .description(MgmtApiModelProperties.TARGETTYPE_ID).type("Number"),
+                        fieldWithPath("content[].targetType").description(MgmtApiModelProperties.TARGETTYPE_ID)
+                                .type("Number"),
+                        fieldWithPath("content[].targetTypeName").description(MgmtApiModelProperties.TARGETTYPE_NAME)
+                                .type("String"),
                         fieldWithPath("content[]._links.self").ignored())));
     }
 
@@ -138,8 +140,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 .description(MgmtApiModelProperties.SECURITY_TOKEN),
                         optionalRequestFieldWithPath("[]targetType").description(MgmtApiModelProperties.TARGETTYPE_ID)),
                         responseFields(fieldWithPath("[]controllerId").description(ApiModelPropertiesGeneric.ITEM_ID),
-                                fieldWithPath(
-                                        "[]name").description(ApiModelPropertiesGeneric.NAME),
+                                fieldWithPath("[]name").description(ApiModelPropertiesGeneric.NAME),
                                 fieldWithPath("[]description").description(ApiModelPropertiesGeneric.DESCRPTION),
                                 fieldWithPath("[]address").description(MgmtApiModelProperties.ADDRESS),
                                 fieldWithPath("[]createdBy").description(ApiModelPropertiesGeneric.CREATED_BY),
@@ -156,8 +157,8 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 fieldWithPath("[]securityToken").description(MgmtApiModelProperties.SECURITY_TOKEN),
                                 fieldWithPath("[]requestAttributes")
                                         .description(MgmtApiModelProperties.REQUEST_ATTRIBUTES),
-                                fieldWithPath("[]targetType")
-                                        .description(MgmtApiModelProperties.TARGETTYPE_ID),
+                                fieldWithPath("[]targetType").description(MgmtApiModelProperties.TARGETTYPE_ID),
+                                fieldWithPath("[]targetTypeName").description(MgmtApiModelProperties.TARGETTYPE_NAME),
                                 fieldWithPath("[]_links.self").ignored())));
     }
 
@@ -322,7 +323,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
     public void deleteActionFromTargetWithParameters() throws Exception {
         final Action action = generateActionForTarget(targetId, false);
         deploymentManagement.cancelAction(action.getId());
-        
+
         mockMvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/"
                 + MgmtRestConstants.TARGET_V1_ACTIONS + "/{actionId}?force=true", targetId, action.getId()))
                 .andExpect(status().isNoContent()).andDo(MockMvcResultPrinter.print())
@@ -362,15 +363,13 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                         .type("String"),
                                 fieldWithPath("status").description(MgmtApiModelProperties.ACTION_EXECUTION_STATUS)
                                         .attributes(key("value").value("['finished', 'pending']")),
-                               fieldWithPath("rollout").description(MgmtApiModelProperties.ACTION_ROLLOUT),
-                               fieldWithPath("rolloutName")
-                                                .description(MgmtApiModelProperties.ACTION_ROLLOUT_NAME),
+                                fieldWithPath("rollout").description(MgmtApiModelProperties.ACTION_ROLLOUT),
+                                fieldWithPath("rolloutName").description(MgmtApiModelProperties.ACTION_ROLLOUT_NAME),
                                 fieldWithPath("_links.self").ignored(),
                                 fieldWithPath("_links.distributionset").description(MgmtApiModelProperties.LINK_TO_DS),
                                 fieldWithPath("_links.status")
                                         .description(MgmtApiModelProperties.LINKS_ACTION_STATUSES),
-                                fieldWithPath("_links.rollout")
-                                        .description(MgmtApiModelProperties.LINK_TO_ROLLOUT))));
+                                fieldWithPath("_links.rollout").description(MgmtApiModelProperties.LINK_TO_ROLLOUT))));
     }
 
     @Test
@@ -430,10 +429,9 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
         final Map<String, Object> body = new HashMap<>();
         body.put("forceType", "forced");
 
-        mockMvc.perform(
-                put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + MgmtRestConstants.TARGET_V1_ACTIONS
-                        + "/{actionId}", targetId, actionId).content(this.objectMapper.writeValueAsString(body))
-                                .contentType(MediaType.APPLICATION_JSON))
+        mockMvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/"
+                + MgmtRestConstants.TARGET_V1_ACTIONS + "/{actionId}", targetId, actionId)
+                        .content(this.objectMapper.writeValueAsString(body)).contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andDo(this.document.document(
                         pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID),
@@ -484,8 +482,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                         .description(MgmtApiModelProperties.ACTION_STATUS_REPORTED_AT).type("String"),
                                 optionalRequestFieldWithPath("content[].code")
                                         .description(MgmtApiModelProperties.ACTION_STATUS_CODE).type("Integer"),
-                                fieldWithPath(
-                                        "content[].type").description(MgmtApiModelProperties.ACTION_STATUS_TYPE)
+                                fieldWithPath("content[].type").description(MgmtApiModelProperties.ACTION_STATUS_TYPE)
                                         .attributes(key("value").value(
                                                 "['finished', 'error', 'warning', 'pending', 'running', 'canceled', 'retrieved', 'canceling']")))));
     }
@@ -517,7 +514,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                         pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID)),
                         getResponseFieldsDistributionSet(false)));
     }
-    
+
     @Test
     @Description("Handles the POST request for assigning a distribution set to a specific target. Required Permission: READ_REPOSITORY and UPDATE_TARGET.")
     public void postAssignDistributionSetToTarget() throws Exception {
@@ -537,14 +534,13 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
 
         mockMvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/"
                 + MgmtRestConstants.TARGET_V1_ASSIGNED_DISTRIBUTION_SET, targetId).content(body)
-                .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andDo(this.document.document(
                         pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID)),
                         requestParameters(parameterWithName("offline")
                                 .description(MgmtApiModelProperties.OFFLINE_UPDATE).optional()),
-                        requestFields(
-                                requestFieldWithPath("id").description(ApiModelPropertiesGeneric.ITEM_ID),
+                        requestFields(requestFieldWithPath("id").description(ApiModelPropertiesGeneric.ITEM_ID),
                                 requestFieldWithPathMandatoryInMultiAssignMode("weight")
                                         .description(MgmtApiModelProperties.ASSIGNMENT_WEIGHT)
                                         .type(JsonFieldType.NUMBER).attributes(key("value").value("0 - 1000")),
@@ -558,7 +554,8 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 optionalRequestFieldWithPath("maintenanceWindow.timezone")
                                         .description(MgmtApiModelProperties.MAINTENANCE_WINDOW_TIMEZONE),
                                 optionalRequestFieldWithPath("type").description(MgmtApiModelProperties.ASSIGNMENT_TYPE)
-                                        .attributes(key("value").value("['soft', 'forced','timeforced', 'downloadonly']"))),
+                                        .attributes(
+                                                key("value").value("['soft', 'forced','timeforced', 'downloadonly']"))),
                         responseFields(getDsAssignmentResponseFieldDescriptors())));
     }
 
@@ -571,24 +568,24 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
 
         final long forceTime = System.currentTimeMillis();
         final JSONArray body = new JSONArray();
-        body.put(new JSONObject().put("id", sets.get(1).getId()).put("weight", 500).put("type", "timeforced")
-                .put("forcetime", forceTime)
-                .put("maintenanceWindow", new JSONObject().put("schedule", getTestSchedule(100))
-                        .put("duration", getTestDuration(10)).put("timezone", getTestTimeZone())))
+        body.put(
+                new JSONObject().put("id", sets.get(1).getId()).put("weight", 500).put("type", "timeforced")
+                        .put("forcetime", forceTime).put("maintenanceWindow",
+                                new JSONObject().put("schedule", getTestSchedule(100))
+                                        .put("duration", getTestDuration(10)).put("timezone", getTestTimeZone())))
                 .toString();
         body.put(new JSONObject().put("id", sets.get(0).getId()).put("type", "forced").put("weight", 800));
 
         enableMultiAssignments();
         mockMvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/"
                 + MgmtRestConstants.TARGET_V1_ASSIGNED_DISTRIBUTION_SET, targetId).content(body.toString())
-                .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andDo(this.document.document(
                         pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID)),
                         requestParameters(parameterWithName("offline")
                                 .description(MgmtApiModelProperties.OFFLINE_UPDATE).optional()),
-                        requestFields(
-                                requestFieldWithPath("[].id").description(ApiModelPropertiesGeneric.ITEM_ID),
+                        requestFields(requestFieldWithPath("[].id").description(ApiModelPropertiesGeneric.ITEM_ID),
                                 requestFieldWithPathMandatoryInMultiAssignMode("[].weight")
                                         .description(MgmtApiModelProperties.ASSIGNMENT_WEIGHT)
                                         .attributes(key("value").value("0 - 1000")),
@@ -612,15 +609,15 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
     private static FieldDescriptor[] getDsAssignmentResponseFieldDescriptors() {
         final FieldDescriptor[] descriptors = {
                 fieldWithPath("assigned").description(MgmtApiModelProperties.DS_NEW_ASSIGNED_TARGETS),
-            fieldWithPath("alreadyAssigned").type(JsonFieldType.NUMBER)
-            .description(MgmtApiModelProperties.DS_ALREADY_ASSIGNED_TARGETS),
-    fieldWithPath("assignedActions").type(JsonFieldType.ARRAY)
-            .description(MgmtApiModelProperties.DS_NEW_ASSIGNED_ACTIONS),
-    fieldWithPath("assignedActions.[].id").type(JsonFieldType.NUMBER)
-            .description(MgmtApiModelProperties.ACTION_ID),
-    fieldWithPath("assignedActions.[]._links.self").type(JsonFieldType.OBJECT)
-            .description(MgmtApiModelProperties.LINK_TO_ACTION),
-    fieldWithPath("total").type(JsonFieldType.NUMBER)
+                fieldWithPath("alreadyAssigned").type(JsonFieldType.NUMBER)
+                        .description(MgmtApiModelProperties.DS_ALREADY_ASSIGNED_TARGETS),
+                fieldWithPath("assignedActions").type(JsonFieldType.ARRAY)
+                        .description(MgmtApiModelProperties.DS_NEW_ASSIGNED_ACTIONS),
+                fieldWithPath("assignedActions.[].id").type(JsonFieldType.NUMBER)
+                        .description(MgmtApiModelProperties.ACTION_ID),
+                fieldWithPath("assignedActions.[]._links.self").type(JsonFieldType.OBJECT)
+                        .description(MgmtApiModelProperties.LINK_TO_ACTION),
+                fieldWithPath("total").type(JsonFieldType.NUMBER)
                         .description(MgmtApiModelProperties.DS_TOTAL_ASSIGNED_TARGETS) };
         return descriptors;
     }
@@ -847,11 +844,9 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
         targetManagement.assignType(testTarget.getControllerId(), targetType.getId());
 
         mockMvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/targettype",
-                        testTarget.getControllerId()).contentType(MediaType.APPLICATION_JSON))
-                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
-                .andDo(this.document.document(
-                        pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID))
-                        ));
+                testTarget.getControllerId()).contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk()).andDo(this.document.document(
+                        pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID))));
     }
 
     private String createTargetJsonForPostRequest(final String controllerId, final String name,


### PR DESCRIPTION
Some entities have type property, e.g. every software module has a software module type.
When fetching these entities via mgmt api the name of their type should be included, not only the type key/id.
That way no additional rest calls to the type endpoint are needed.

Signed-off-by: Stefan Klotz <stefan.klotz@bosch.io>