### PR TITLE
Add resource collection /rest/v1/actions to Management REST API

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionFields.java
@@ -21,6 +21,11 @@ public enum ActionFields implements FieldNameProvider, FieldValueConverter<Actio
      * The status field.
      */
     STATUS("active"),
+    
+    /**
+     * The detailed action status
+     */
+    ACTIONSTATUS("status"),
 
     /**
      * The id field.

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionFields.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 /**
  * Sort fields for {@link ActionRest}.
- *
  */
 public enum ActionFields implements FieldNameProvider, FieldValueConverter<ActionFields> {
 
@@ -22,32 +21,35 @@ public enum ActionFields implements FieldNameProvider, FieldValueConverter<Actio
      * The status field.
      */
     STATUS("active"),
-    
+
     /**
      * The id field.
      */
     ID("id"),
-    
+
     /**
      * The weight field.
      */
     WEIGHT("weight"),
-    
+
     /**
      * The target field
      */
-    TARGET("target", TargetFields.ID.getFieldName(), TargetFields.NAME.getFieldName(), TargetFields.UPDATESTATUS.getFieldName(), TargetFields.IPADDRESS.getFieldName()),
-    
+    TARGET("target", TargetFields.ID.getFieldName(), TargetFields.NAME.getFieldName(),
+            TargetFields.UPDATESTATUS.getFieldName(), TargetFields.IPADDRESS.getFieldName()),
+
     /**
      * The distribution set field
      */
-    DISTRIBUTIONSET("distributionSet", DistributionSetFields.ID.getFieldName(), DistributionSetFields.NAME.getFieldName(), DistributionSetFields.VERSION.getFieldName(), DistributionSetFields.TYPE.getFieldName()),
-    
+    DISTRIBUTIONSET("distributionSet", DistributionSetFields.ID.getFieldName(),
+            DistributionSetFields.NAME.getFieldName(), DistributionSetFields.VERSION.getFieldName(),
+            DistributionSetFields.TYPE.getFieldName()),
+
     /**
      * The rollout field
      */
     ROLLOUT("rollout", RolloutFields.ID.getFieldName(), RolloutFields.NAME.getFieldName()),
-    
+
     /**
      * The rollout field
      */

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionFields.java
@@ -21,11 +21,11 @@ public enum ActionFields implements FieldNameProvider, FieldValueConverter<Actio
      * The status field.
      */
     STATUS("active"),
-    
+
     /**
      * The detailed action status
      */
-    ACTIONSTATUS("status"),
+    DETAILSTATUS("status"),
 
     /**
      * The id field.

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionFields.java
@@ -8,6 +8,10 @@
  */
 package org.eclipse.hawkbit.repository;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Sort fields for {@link ActionRest}.
  *
@@ -18,22 +22,57 @@ public enum ActionFields implements FieldNameProvider, FieldValueConverter<Actio
      * The status field.
      */
     STATUS("active"),
+    
     /**
      * The id field.
      */
     ID("id"),
+    
     /**
      * The weight field.
      */
-    WEIGHT("weight");
+    WEIGHT("weight"),
+    
+    /**
+     * The target field
+     */
+    TARGET("target", TargetFields.ID.getFieldName(), TargetFields.NAME.getFieldName(), TargetFields.UPDATESTATUS.getFieldName(), TargetFields.IPADDRESS.getFieldName()),
+    
+    /**
+     * The distribution set field
+     */
+    DISTRIBUTIONSET("distributionSet", DistributionSetFields.ID.getFieldName(), DistributionSetFields.NAME.getFieldName(), DistributionSetFields.VERSION.getFieldName(), DistributionSetFields.TYPE.getFieldName()),
+    
+    /**
+     * The rollout field
+     */
+    ROLLOUT("rollout", RolloutFields.ID.getFieldName(), RolloutFields.NAME.getFieldName()),
+    
+    /**
+     * The rollout field
+     */
+    ROLLOUTGROUP("rolloutGroup", RolloutGroupFields.ID.getFieldName(), RolloutGroupFields.NAME.getFieldName());
 
     private static final String ACTIVE = "pending";
     private static final String INACTIVE = "finished";
 
     private final String fieldName;
 
+    private List<String> subEntityAttributes;
+
     private ActionFields(final String fieldName) {
         this.fieldName = fieldName;
+        this.subEntityAttributes = Collections.emptyList();
+    }
+
+    private ActionFields(final String fieldName, final String... subEntityAttributes) {
+        this.fieldName = fieldName;
+        this.subEntityAttributes = Arrays.asList(subEntityAttributes);
+    }
+
+    @Override
+    public List<String> getSubEntityAttributes() {
+        return subEntityAttributes;
     }
 
     @Override
@@ -49,6 +88,14 @@ public enum ActionFields implements FieldNameProvider, FieldValueConverter<Actio
         return value;
     }
 
+    @Override
+    public String[] possibleValues(final ActionFields e) {
+        if (STATUS == e) {
+            return new String[] { ACTIVE, INACTIVE };
+        }
+        return new String[0];
+    }
+
     private static Object convertStatusValue(final String value) {
         final String trimmedValue = value.trim();
         if (trimmedValue.equalsIgnoreCase(ACTIVE)) {
@@ -60,11 +107,4 @@ public enum ActionFields implements FieldNameProvider, FieldValueConverter<Actio
         }
     }
 
-    @Override
-    public String[] possibleValues(final ActionFields e) {
-        if (STATUS == e) {
-            return new String[] { ACTIVE, INACTIVE };
-        }
-        return new String[0];
-    }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
@@ -218,6 +218,16 @@ public interface DeploymentManagement {
     long countActionsAll();
 
     /**
+     * Counts the actions which match the given query.
+     * 
+     * @param rsqlParam
+     *            RSQL query.
+     * @return the total number of actions matching the given RSQL query.
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    long countActions(@NotNull String rsqlParam);
+
+    /**
      * Counts all actions associated to a specific target.
      *
      * @param controllerId
@@ -273,6 +283,19 @@ public interface DeploymentManagement {
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
     Slice<Action> findActionsAll(@NotNull Pageable pageable);
+
+    /**
+     * Retrieves all {@link Action} entities which match the given RSQL query.
+     * 
+     * @param rsqlParam
+     *            RSQL query string
+     * @param pageable
+     *            the page request parameter for paging and sorting the result
+     * 
+     * @return a paged list of {@link Action}s.
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    Slice<Action> findActions(@NotNull String rsqlParam, @NotNull Pageable pageable);
 
     /**
      * Retrieves all {@link Action} which assigned to a specific

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaDeploymentManagement.java
@@ -72,8 +72,6 @@ import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetAssignmentResult;
 import org.eclipse.hawkbit.repository.model.DistributionSetInvalidation.CancelationType;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
-import org.eclipse.hawkbit.repository.model.Rollout;
-import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetType;
@@ -582,7 +580,7 @@ public class JpaDeploymentManagement extends JpaActionManagement implements Depl
             if (rolloutGroupActions.getContent().isEmpty()) {
                 return 0L;
             }
-            
+
             final List<Action> newTargetAssignments = handleTargetAssignments(rolloutGroupActions);
 
             if (!newTargetAssignments.isEmpty()) {
@@ -592,7 +590,7 @@ public class JpaDeploymentManagement extends JpaActionManagement implements Depl
             return rolloutGroupActions.getTotalElements();
         });
     }
-    
+
     private List<Action> handleTargetAssignments(final Page<Action> rolloutGroupActions) {
         // Close actions already assigned and collect pending assignments
         final List<JpaAction> pendingTargetAssignments = rolloutGroupActions.getContent().stream()
@@ -651,9 +649,9 @@ public class JpaDeploymentManagement extends JpaActionManagement implements Depl
         return Collections.unmodifiableList(savedActions);
     }
 
-    private void closeOrCancelOpenDeviceActions(final List<JpaAction> actions){
+    private void closeOrCancelOpenDeviceActions(final List<JpaAction> actions) {
         final List<Long> targetIds = actions.stream().map(JpaAction::getTarget).map(Target::getId)
-              .collect(Collectors.toList());
+                .collect(Collectors.toList());
         if (isActionsAutocloseEnabled()) {
             onlineDsAssignmentStrategy.closeObsoleteUpdateActions(targetIds);
         } else {
@@ -661,7 +659,7 @@ public class JpaDeploymentManagement extends JpaActionManagement implements Depl
         }
     }
 
-    private List<JpaAction> activateActions(final List<JpaAction> actions){
+    private List<JpaAction> activateActions(final List<JpaAction> actions) {
         actions.forEach(action -> {
             action.setActive(true);
             action.setStatus(Status.RUNNING);
@@ -861,6 +859,13 @@ public class JpaDeploymentManagement extends JpaActionManagement implements Depl
     }
 
     @Override
+    public long countActions(final String rsqlParam) {
+        final List<Specification<JpaAction>> specList = Arrays.asList(
+                RSQLUtility.buildRsqlSpecification(rsqlParam, ActionFields.class, virtualPropertyReplacer, database));
+        return JpaManagementHelper.countBySpec(actionRepository, specList);
+    }
+
+    @Override
     public long countActionsByDistributionSetIdAndActiveIsTrue(final Long distributionSet) {
         return actionRepository.countByDistributionSetIdAndActiveIsTrue(distributionSet);
     }
@@ -880,6 +885,13 @@ public class JpaDeploymentManagement extends JpaActionManagement implements Depl
     @Override
     public Slice<Action> findActionsAll(final Pageable pageable) {
         return JpaManagementHelper.findAllWithoutCountBySpec(actionRepository, pageable, null);
+    }
+
+    @Override
+    public Slice<Action> findActions(final String rsqlParam, final Pageable pageable) {
+        final List<Specification<JpaAction>> specList = Arrays.asList(
+                RSQLUtility.buildRsqlSpecification(rsqlParam, ActionFields.class, virtualPropertyReplacer, database));
+        return JpaManagementHelper.findAllWithoutCountBySpec(actionRepository, pageable, specList);
     }
 
     @Override
@@ -990,4 +1002,5 @@ public class JpaDeploymentManagement extends JpaActionManagement implements Depl
             });
         }
     }
+
 }

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtAction.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtAction.java
@@ -55,6 +55,9 @@ public class MgmtAction extends MgmtBaseEntity {
     private String status;
 
     @JsonProperty
+    private String detailStatus;
+
+    @JsonProperty
     private Long forceTime;
 
     @JsonProperty(value = "forceType")
@@ -65,7 +68,7 @@ public class MgmtAction extends MgmtBaseEntity {
 
     @JsonProperty
     private MgmtMaintenanceWindow maintenanceWindow;
-    
+
     @JsonProperty
     private Long rollout;
 
@@ -132,7 +135,7 @@ public class MgmtAction extends MgmtBaseEntity {
         return rollout;
     }
 
-    public void setRollout(Long rollout) {
+    public void setRollout(final Long rollout) {
         this.rollout = rollout;
     }
 
@@ -140,8 +143,16 @@ public class MgmtAction extends MgmtBaseEntity {
         return rolloutName;
     }
 
-    public void setRolloutName(String rolloutName) {
+    public void setRolloutName(final String rolloutName) {
         this.rolloutName = rolloutName;
+    }
+
+    public String getDetailStatus() {
+        return detailStatus;
+    }
+
+    public void setDetailStatus(final String detailStatus) {
+        this.detailStatus = detailStatus;
     }
 
 }

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtActionRestApi.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtActionRestApi.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2022 Bosch.IO GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.rest.api;
+
+import org.eclipse.hawkbit.mgmt.json.model.PagedList;
+import org.eclipse.hawkbit.mgmt.json.model.action.MgmtAction;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * REST API providing (read-only) access to actions.
+ */
+@RequestMapping(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)
+public interface MgmtActionRestApi {
+
+    /**
+     * Handles the GET request of retrieving all actions.
+     *
+     * @param pagingOffsetParam
+     *            the offset of list of actions for pagination, might not be
+     *            present in the rest request then default value will be applied
+     * @param pagingLimitParam
+     *            the limit of the paged request, might not be present in the
+     *            rest request then default value will be applied
+     * @param sortParam
+     *            the sorting parameter in the request URL, syntax
+     *            {@code field:direction, field:direction}
+     * @param rsqlParam
+     *            the search parameter in the request URL, syntax
+     *            {@code q=name==abc}
+     * @return a list of all actions for a defined or default page request with
+     *         status OK. The response is always paged. In any failure the
+     *         JsonResponseExceptionHandler is handling the response.
+     */
+
+    @GetMapping(produces = { MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE })
+    ResponseEntity<PagedList<MgmtAction>> getActions(
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET) int pagingOffsetParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT) int pagingLimitParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SORTING, required = false) String sortParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SEARCH, required = false) String rsqlParam);
+
+}

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtActionRestApi.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtActionRestApi.java
@@ -37,7 +37,10 @@ public interface MgmtActionRestApi {
      *            {@code field:direction, field:direction}
      * @param rsqlParam
      *            the search parameter in the request URL, syntax
-     *            {@code q=name==abc}
+     *            {@code q=distributionSet.id==1}
+     * @param representationModeParam
+     *            the representation mode parameter specifying whether a compact
+     *            or a full representation shall be returned
      * @return a list of all actions for a defined or default page request with
      *         status OK. The response is always paged. In any failure the
      *         JsonResponseExceptionHandler is handling the response.
@@ -49,6 +52,6 @@ public interface MgmtActionRestApi {
             @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT) int pagingLimitParam,
             @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SORTING, required = false) String sortParam,
             @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SEARCH, required = false) String rsqlParam,
-            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE_DEFAULT) String representationMode);
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE_DEFAULT) String representationModeParam);
 
 }

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtActionRestApi.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtActionRestApi.java
@@ -48,6 +48,7 @@ public interface MgmtActionRestApi {
             @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET) int pagingOffsetParam,
             @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT) int pagingLimitParam,
             @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SORTING, required = false) String sortParam,
-            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SEARCH, required = false) String rsqlParam);
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SEARCH, required = false) String rsqlParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE_DEFAULT) String representationMode);
 
 }

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRepresentationMode.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRepresentationMode.java
@@ -9,6 +9,7 @@
 package org.eclipse.hawkbit.mgmt.rest.api;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * Enumeration of the supported representation modes.
@@ -16,23 +17,22 @@ import java.util.Arrays;
 public enum MgmtRepresentationMode {
 
     FULL("full"),
-    
+
     COMPACT("compact");
-    
+
     private final String mode;
-    
+
     private MgmtRepresentationMode(final String mode) {
         this.mode = mode;
     }
-    
+
     @Override
     public String toString() {
         return mode;
     }
-    
-    public static MgmtRepresentationMode fromValue(final String value) {
-        return Arrays.stream(MgmtRepresentationMode.values()).filter(v -> v.mode.equalsIgnoreCase(value)).findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Unknown representation mode: " + value));
+
+    public static Optional<MgmtRepresentationMode> fromValue(final String value) {
+        return Arrays.stream(MgmtRepresentationMode.values()).filter(v -> v.mode.equalsIgnoreCase(value)).findFirst();
     }
-    
+
 }

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRepresentationMode.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRepresentationMode.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2022 Bosch.IO GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.rest.api;
+
+import java.util.Arrays;
+
+/**
+ * Enumeration of the supported representation modes.
+ */
+public enum MgmtRepresentationMode {
+
+    FULL("full"),
+    
+    COMPACT("compact");
+    
+    private final String mode;
+    
+    private MgmtRepresentationMode(final String mode) {
+        this.mode = mode;
+    }
+    
+    @Override
+    public String toString() {
+        return mode;
+    }
+    
+    public static MgmtRepresentationMode fromValue(final String value) {
+        return Arrays.stream(MgmtRepresentationMode.values()).filter(v -> v.mode.equalsIgnoreCase(value)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown representation mode: " + value));
+    }
+    
+}

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
@@ -63,7 +63,7 @@ public final class MgmtRestConstants {
     /**
      * The target URL mapping, href link for assigned target type.
      */
-    public static final String TARGET_V1_ASSIGNED_TARGET_TYPE= "targetType";
+    public static final String TARGET_V1_ASSIGNED_TARGET_TYPE = "targetType";
 
     /**
      * The target URL mapping, href link for assigned distribution set.
@@ -190,6 +190,17 @@ public final class MgmtRestConstants {
      * must be in the FIQL syntax.
      */
     public static final String REQUEST_PARAMETER_SEARCH = "q";
+
+    /**
+     * The request parameter for specifying the representation mode. The value
+     * of this parameter can either be "full" or "compact".
+     */
+    public static final String REQUEST_PARAMETER_REPRESENTATION_MODE = "representation";
+
+    /**
+     * The default representation mode.
+     */
+    public static final String REQUEST_PARAMETER_REPRESENTATION_MODE_DEFAULT = "compact";
 
     /**
      * The software module type URL mapping rest resource.

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
@@ -141,6 +141,11 @@ public final class MgmtRestConstants {
     public static final String DISTRIBUTIONSET_TAG_DISTRIBUTIONSETS_REQUEST_MAPPING = "/{distributionsetTagId}/assigned";
 
     /**
+     * The action URL mapping rest resource.
+     */
+    public static final String ACTION_V1_REQUEST_MAPPING = BASE_V1_REQUEST_MAPPING + "/actions";
+
+    /**
      * The default offset parameter in case the offset parameter is not present
      * in the request.
      *

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRolloutRestApi.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRolloutRestApi.java
@@ -45,16 +45,20 @@ public interface MgmtRolloutRestApi {
      * @param rsqlParam
      *            the search parameter in the request URL, syntax
      *            {@code q=name==abc}
+     * @param representationModeParam
+     *            the representation mode parameter specifying whether a compact
+     *            or a full representation shall be returned
      * @return a list of all rollouts for a defined or default page request with
      *         status OK. The response is always paged. In any failure the
      *         JsonResponseExceptionHandler is handling the response.
      */
     @GetMapping(produces = { MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE })
     ResponseEntity<PagedList<MgmtRolloutResponseBody>> getRollouts(
-            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET) int pagingOffsetParam,
-            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT) int pagingLimitParam,
-            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SORTING, required = false) String sortParam,
-            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SEARCH, required = false) String rsqlParam);
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET) final int pagingOffsetParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT) final int pagingLimitParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SORTING, required = false) final String sortParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SEARCH, required = false) final String rsqlParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE_DEFAULT) String representationModeParam);
 
     /**
      * Handles the GET request of retrieving a single rollout.

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionMapper.java
@@ -51,7 +51,7 @@ public final class MgmtActionMapper {
         if (repMode == MgmtRepresentationMode.COMPACT) {
             return MgmtTargetMapper.toResponse(controllerId, action);
         }
-        return MgmtTargetMapper.toResponseWithLinks(controllerId, action, repMode);
+        return MgmtTargetMapper.toResponseWithLinks(controllerId, action);
     }
 
 }

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionMapper.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2022 Bosch.IO GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.rest.resource;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.hawkbit.mgmt.json.model.action.MgmtAction;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.rest.data.ResponseList;
+
+/**
+ * A mapper which maps repository model to RESTful model representation and
+ * back.
+ */
+public final class MgmtActionMapper {
+
+    private MgmtActionMapper() {
+        // Utility class
+    }
+
+    /**
+     * Create a response for actions.
+     *
+     * @param actions
+     *            list of actions
+     * 
+     * @return the response
+     */
+    public static List<MgmtAction> toResponse(final Collection<Action> actions) {
+        if (actions == null) {
+            return Collections.emptyList();
+        }
+        return new ResponseList<>(actions.stream().map(MgmtActionMapper::toResponse).collect(Collectors.toList()));
+    }
+
+    static MgmtAction toResponse(final Action action) {
+        // dispatch
+        return MgmtTargetMapper.toResponse(action.getTarget().getControllerId(), action);
+    }
+
+}

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionMapper.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.mgmt.json.model.action.MgmtAction;
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtRepresentationMode;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.rest.data.ResponseList;
 
@@ -32,19 +33,25 @@ public final class MgmtActionMapper {
      *
      * @param actions
      *            list of actions
+     * @param repMode
+     *            the representation mode
      * 
      * @return the response
      */
-    public static List<MgmtAction> toResponse(final Collection<Action> actions) {
+    public static List<MgmtAction> toResponse(final Collection<Action> actions, final MgmtRepresentationMode repMode) {
         if (actions == null) {
             return Collections.emptyList();
         }
-        return new ResponseList<>(actions.stream().map(MgmtActionMapper::toResponse).collect(Collectors.toList()));
+        return new ResponseList<>(actions.stream().map(action -> MgmtActionMapper.toResponse(action, repMode))
+                .collect(Collectors.toList()));
     }
 
-    static MgmtAction toResponse(final Action action) {
-        // dispatch
-        return MgmtTargetMapper.toResponse(action.getTarget().getControllerId(), action);
+    static MgmtAction toResponse(final Action action, final MgmtRepresentationMode repMode) {
+        final String controllerId = action.getTarget().getControllerId();
+        if (repMode == MgmtRepresentationMode.COMPACT) {
+            return MgmtTargetMapper.toResponse(controllerId, action);
+        }
+        return MgmtTargetMapper.toResponseWithLinks(controllerId, action, repMode);
     }
 
 }

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResource.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResource.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2022 Bosch.IO GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.rest.resource;
+
+import org.eclipse.hawkbit.mgmt.json.model.PagedList;
+import org.eclipse.hawkbit.mgmt.json.model.action.MgmtAction;
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtActionRestApi;
+import org.eclipse.hawkbit.repository.DeploymentManagement;
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MgmtActionResource implements MgmtActionRestApi {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MgmtActionResource.class);
+
+    private final DeploymentManagement deploymentManagement;
+
+    MgmtActionResource(final DeploymentManagement deploymentManagement) {
+        this.deploymentManagement = deploymentManagement;
+    }
+
+    @Override
+    public ResponseEntity<PagedList<MgmtAction>> getActions(final int pagingOffsetParam, final int pagingLimitParam,
+            final String sortParam, final String rsqlParam) {
+
+        final int sanitizedOffsetParam = PagingUtility.sanitizeOffsetParam(pagingOffsetParam);
+        final int sanitizedLimitParam = PagingUtility.sanitizePageLimitParam(pagingLimitParam);
+        final Sort sorting = PagingUtility.sanitizeActionSortParam(sortParam);
+        final Pageable pageable = new OffsetBasedPageRequest(sanitizedOffsetParam, sanitizedLimitParam, sorting);
+
+        final Slice<Action> actions;
+        final Long totalActionCount;
+        if (rsqlParam != null) {
+            actions = this.deploymentManagement.findActionsAll(pageable);
+            totalActionCount = this.deploymentManagement.countActionsAll();
+        } else {
+            actions = this.deploymentManagement.findActionsAll(pageable);
+            totalActionCount = this.deploymentManagement.countActionsAll();
+        }
+
+        return ResponseEntity.ok(new PagedList<>(MgmtActionMapper.toResponse(actions.getContent()), totalActionCount));
+    }
+
+}

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResource.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResource.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.mgmt.rest.resource;
 import org.eclipse.hawkbit.mgmt.json.model.PagedList;
 import org.eclipse.hawkbit.mgmt.json.model.action.MgmtAction;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtActionRestApi;
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtRepresentationMode;
 import org.eclipse.hawkbit.repository.DeploymentManagement;
 import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.model.Action;
@@ -33,13 +34,15 @@ public class MgmtActionResource implements MgmtActionRestApi {
 
     @Override
     public ResponseEntity<PagedList<MgmtAction>> getActions(final int pagingOffsetParam, final int pagingLimitParam,
-            final String sortParam, final String rsqlParam) {
+            final String sortParam, final String rsqlParam, final String representationMode) {
 
         final int sanitizedOffsetParam = PagingUtility.sanitizeOffsetParam(pagingOffsetParam);
         final int sanitizedLimitParam = PagingUtility.sanitizePageLimitParam(pagingLimitParam);
         final Sort sorting = PagingUtility.sanitizeActionSortParam(sortParam);
         final Pageable pageable = new OffsetBasedPageRequest(sanitizedOffsetParam, sanitizedLimitParam, sorting);
 
+        final MgmtRepresentationMode repMode = MgmtRepresentationMode.fromValue(representationMode);
+        
         final Slice<Action> actions;
         final Long totalActionCount;
         if (rsqlParam != null) {
@@ -50,7 +53,7 @@ public class MgmtActionResource implements MgmtActionRestApi {
             totalActionCount = this.deploymentManagement.countActionsAll();
         }
 
-        return ResponseEntity.ok(new PagedList<>(MgmtActionMapper.toResponse(actions.getContent()), totalActionCount));
+        return ResponseEntity.ok(new PagedList<>(MgmtActionMapper.toResponse(actions.getContent(), repMode), totalActionCount));
     }
 
 }

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResource.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResource.java
@@ -14,8 +14,6 @@ import org.eclipse.hawkbit.mgmt.rest.api.MgmtActionRestApi;
 import org.eclipse.hawkbit.repository.DeploymentManagement;
 import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.model.Action;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -24,8 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class MgmtActionResource implements MgmtActionRestApi {
-
-    private static final Logger LOG = LoggerFactory.getLogger(MgmtActionResource.class);
 
     private final DeploymentManagement deploymentManagement;
 
@@ -45,8 +41,8 @@ public class MgmtActionResource implements MgmtActionRestApi {
         final Slice<Action> actions;
         final Long totalActionCount;
         if (rsqlParam != null) {
-            actions = this.deploymentManagement.findActionsAll(pageable);
-            totalActionCount = this.deploymentManagement.countActionsAll();
+            actions = this.deploymentManagement.findActions(rsqlParam, pageable);
+            totalActionCount = this.deploymentManagement.countActions(rsqlParam);
         } else {
             actions = this.deploymentManagement.findActionsAll(pageable);
             totalActionCount = this.deploymentManagement.countActionsAll();

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResource.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResource.java
@@ -14,6 +14,7 @@ import org.eclipse.hawkbit.mgmt.rest.api.MgmtActionRestApi;
 import org.eclipse.hawkbit.repository.DeploymentManagement;
 import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.model.Action;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -21,6 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@ConditionalOnProperty(name = "hawkbit.rest.MgmtActionResource.enabled", matchIfMissing = true)
 public class MgmtActionResource implements MgmtActionRestApi {
 
     private final DeploymentManagement deploymentManagement;

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
@@ -26,6 +26,7 @@ import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutSuccessAction;
 import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutSuccessAction.SuccessAction;
 import org.eclipse.hawkbit.mgmt.json.model.rolloutgroup.MgmtRolloutGroup;
 import org.eclipse.hawkbit.mgmt.json.model.rolloutgroup.MgmtRolloutGroupResponseBody;
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtDistributionSetRestApi;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRolloutRestApi;
 import org.eclipse.hawkbit.repository.EntityFactory;
@@ -57,11 +58,15 @@ final class MgmtRolloutMapper {
     }
 
     static List<MgmtRolloutResponseBody> toResponseRollout(final List<Rollout> rollouts) {
+        return toResponseRollout(rollouts, false);
+    }
+
+    static List<MgmtRolloutResponseBody> toResponseRollout(final List<Rollout> rollouts, final boolean withDetails) {
         if (rollouts == null) {
             return Collections.emptyList();
         }
 
-        return rollouts.stream().map(rollout -> toResponseRollout(rollout, false)).collect(Collectors.toList());
+        return rollouts.stream().map(rollout -> toResponseRollout(rollout, withDetails)).collect(Collectors.toList());
     }
 
     static MgmtRolloutResponseBody toResponseRollout(final Rollout rollout, final boolean withDetails) {
@@ -95,6 +100,10 @@ final class MgmtRolloutMapper {
             body.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRolloutGroups(rollout.getId(),
                     MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
                     MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null)).withRel("groups"));
+
+            final DistributionSet distributionSet = rollout.getDistributionSet();
+            body.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getDistributionSet(distributionSet.getId()))
+                    .withRel("distributionset").withName(distributionSet.getName() + ":" + distributionSet.getVersion()));
         }
 
         body.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRollout(rollout.getId())).withSelfRel());

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
@@ -130,8 +130,8 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         final String rsqlDsVersion = "distributionSet.version==" + ds.getVersion();
         final String rsqlDsId = "distributionSet.id==" + ds.getId();
 
-        mvc.perform(
-                get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlDsName).param("representation", "full"))
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlDsName)
+                .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, MgmtRepresentationMode.FULL.toString()))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk()).andExpect(jsonPath("total", equalTo(1)))
                 .andExpect(jsonPath("size", equalTo(1))).andExpect(jsonPath("content.[0]._links.distributionset.name",
                         equalTo(ds.getName() + ":" + ds.getVersion())));
@@ -174,15 +174,17 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         final String rsqlRolloutName = "rollout.name==" + rollout.getName() + "*";
         final String rsqlRolloutId = "rollout.id==" + rollout.getId();
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlRolloutName).param("representation",
-                "full")).andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
-                .andExpect(jsonPath("total", equalTo(1))).andExpect(jsonPath("size", equalTo(1)))
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlRolloutName)
+                .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, MgmtRepresentationMode.FULL.toString()))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk()).andExpect(jsonPath("total", equalTo(1)))
+                .andExpect(jsonPath("size", equalTo(1)))
                 .andExpect(jsonPath("content.[0]._links.target.name", equalTo(target1.getName()))).andExpect(jsonPath(
                         "content.[0]._links.distributionset.name", equalTo(ds.getName() + ":" + ds.getVersion())));
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlRolloutId).param("representation",
-                "full")).andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
-                .andExpect(jsonPath("total", equalTo(1))).andExpect(jsonPath("size", equalTo(1)))
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlRolloutId)
+                .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, MgmtRepresentationMode.FULL.toString()))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk()).andExpect(jsonPath("total", equalTo(1)))
+                .andExpect(jsonPath("size", equalTo(1)))
                 .andExpect(jsonPath("content.[0]._links.target.name", equalTo(target1.getName()))).andExpect(jsonPath(
                         "content.[0]._links.distributionset.name", equalTo(ds.getName() + ":" + ds.getVersion())));
     }
@@ -199,9 +201,10 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         final String rsqlTargetName = "target.name==knownTargetId";
 
         // pending status one result
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlTargetName).param("representation",
-                "full")).andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
-                .andExpect(jsonPath("total", equalTo(1))).andExpect(jsonPath("size", equalTo(1)))
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlTargetName)
+                .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, MgmtRepresentationMode.FULL.toString()))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk()).andExpect(jsonPath("total", equalTo(1)))
+                .andExpect(jsonPath("size", equalTo(1)))
                 .andExpect(jsonPath("content.[0]._links.target.name", equalTo(target.getName()))).andExpect(jsonPath(
                         "content.[0]._links.distributionset.name", equalTo(ds.getName() + ":" + ds.getVersion())));
     }

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import org.awaitility.Awaitility;
 import org.awaitility.Duration;
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtActionRestApi;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
@@ -37,6 +38,9 @@ import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
+/**
+ * Integration test for the {@link MgmtActionRestApi}.
+ */
 @Feature("Component Tests - Management API")
 @Story("Action Resource")
 class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
@@ -171,7 +171,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         rolloutManagement.start(rollout.getId());
         rolloutManagement.handleRollouts();
 
-        final String rsqlRolloutName = "rollout.name==" + rollout.getName() + "*";
+        final String rsqlRolloutName = "rollout.name==" + rollout.getName();
         final String rsqlRolloutId = "rollout.id==" + rollout.getId();
 
         mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlRolloutName)

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
@@ -50,8 +50,8 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
     private static final String JSON_PATH_PAGED_LIST_SIZE = JSON_PATH_ROOT + JSON_PATH_FIELD_SIZE;
     private static final String JSON_PATH_PAGED_LIST_TOTAL = JSON_PATH_ROOT + JSON_PATH_FIELD_TOTAL;
 
-    //@Test
-    //@Description("Verifies that actions history is returned as defined by filter status==pending,status==finished.")
+    @Test
+    @Description("Verifies that actions history is returned as defined by filter status==pending,status==finished.")
     void searchActionsRsql() throws Exception {
 
         // prepare test

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2022 Bosch.IO GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.mgmt.rest.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.awaitility.Awaitility;
+import org.awaitility.Duration;
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.rest.util.MockMvcResultPrinter;
+import org.junit.jupiter.api.Test;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+@Feature("Component Tests - Management API")
+@Story("Action Resource")
+class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
+
+    private static final String JSON_PATH_ROOT = "$";
+    private static final String JSON_PATH_FIELD_CONTENT = ".content";
+    private static final String JSON_PATH_FIELD_SIZE = ".size";
+    private static final String JSON_PATH_FIELD_TOTAL = ".total";
+
+    private static final String JSON_PATH_PAGED_LIST_CONTENT = JSON_PATH_ROOT + JSON_PATH_FIELD_CONTENT;
+    private static final String JSON_PATH_PAGED_LIST_SIZE = JSON_PATH_ROOT + JSON_PATH_FIELD_SIZE;
+    private static final String JSON_PATH_PAGED_LIST_TOTAL = JSON_PATH_ROOT + JSON_PATH_FIELD_TOTAL;
+
+    //@Test
+    //@Description("Verifies that actions history is returned as defined by filter status==pending,status==finished.")
+    void searchActionsRsql() throws Exception {
+
+        // prepare test
+        final DistributionSet dsA = testdataFactory.createDistributionSet("");
+        final Target createTarget = testdataFactory.createTarget("knownTargetId");
+
+        assignDistributionSet(dsA, Collections.singletonList(createTarget));
+
+        final String rsqlPendingStatus = "status==pending";
+        final String rsqlFinishedStatus = "status==finished";
+        final String rsqlPendingOrFinishedStatus = rsqlFinishedStatus + "," + rsqlPendingStatus;
+        // pending status one result
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlPendingStatus,
+                createTarget.getControllerId())).andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(jsonPath("total", equalTo(1))).andExpect(jsonPath("size", equalTo(1)))
+                .andExpect(jsonPath("content[0].status", equalTo("pending")));
+
+        // finished status none result
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlFinishedStatus,
+                createTarget.getControllerId())).andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(jsonPath("total", equalTo(0))).andExpect(jsonPath("size", equalTo(0)));
+
+        // pending or finished status one result
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlPendingOrFinishedStatus,
+                createTarget.getControllerId())).andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(jsonPath("total", equalTo(1))).andExpect(jsonPath("size", equalTo(1)))
+                .andExpect(jsonPath("content[0].status", equalTo("pending")));
+    }
+
+    @Test
+    @Description("Verifies that all available actions are returned if the complete collection is requested.")
+    void getActions() throws Exception {
+        final String knownTargetId = "targetId";
+        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
+
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING).param(MgmtRestConstants.REQUEST_PARAMETER_SORTING,
+                "ID:ASC")).andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(jsonPath("content.[1].id", equalTo(actions.get(1).getId().intValue())))
+                .andExpect(jsonPath("content.[1].type", equalTo("update")))
+                .andExpect(jsonPath("content.[1].status", equalTo("pending")))
+                .andExpect(jsonPath("content.[1]._links.self.href",
+                        equalTo(generateActionSelfLink(knownTargetId, actions.get(1).getId()))))
+                .andExpect(jsonPath("content.[0].id", equalTo(actions.get(0).getId().intValue())))
+                .andExpect(jsonPath("content.[0].type", equalTo("cancel")))
+                .andExpect(jsonPath("content.[0].status", equalTo("pending")))
+                .andExpect(jsonPath("content.[0]._links.self.href",
+                        equalTo(generateActionSelfLink(knownTargetId, actions.get(0).getId()))))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)));
+    }
+
+    @Test
+    @Description("Verifies that the get request for actions returns an empty collection if no assignments have been done yet.")
+    void getActionsWithEmptyResult() throws Exception {
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)).andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk()).andExpect(jsonPath("size", equalTo(0)))
+                .andExpect(jsonPath("content", hasSize(0))).andExpect(jsonPath("total", equalTo(0)));
+    }
+
+    @Test
+    @Description("Verifies paging is respected as expected.")
+    void getMultipleActionsWithPagingLimitRequestParameter() throws Exception {
+        final String knownTargetId = "targetId";
+        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
+
+        // page 1: one entry
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)
+                .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
+                .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC")).andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content.[0].id", equalTo(actions.get(0).getId().intValue())))
+                .andExpect(jsonPath("content.[0].type", equalTo("cancel")))
+                .andExpect(jsonPath("content.[0].status", equalTo("pending")))
+                .andExpect(jsonPath("content.[0]._links.self.href",
+                        equalTo(generateActionSelfLink(knownTargetId, actions.get(0).getId()))))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(1)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(1)));
+
+        // page 2: one entry
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)
+                .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
+                .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1))
+                .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1))
+                .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC")).andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content.[0].id", equalTo(actions.get(1).getId().intValue())))
+                .andExpect(jsonPath("content.[0].type", equalTo("update")))
+                .andExpect(jsonPath("content.[0].status", equalTo("pending")))
+                .andExpect(jsonPath("content.[0]._links.self.href",
+                        equalTo(generateActionSelfLink(knownTargetId, actions.get(1).getId()))))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(1)))
+                .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(1)));
+    }
+
+    @Test
+    @Description("Verifies that the actions resource is read-only.")
+    void invalidRequestsOnActionResource() throws Exception {
+        final String knownTargetId = "targetId";
+
+        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
+        final Long actionId = actions.get(0).getId();
+
+        // ensure specific action cannot be accessed via the actions resource
+        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "/" + actionId))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isNotFound());
+
+        // not allowed methods
+        mvc.perform(post(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)).andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isMethodNotAllowed());
+        mvc.perform(put(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)).andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isMethodNotAllowed());
+        mvc.perform(delete(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)).andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    private String generateActionSelfLink(final String knownTargetId, final Long actionId) {
+        return "http://localhost" + MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+                + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId;
+    }
+
+    private List<Action> generateTargetWithTwoUpdatesWithOneOverride(final String knownTargetId) {
+        return generateTargetWithTwoUpdatesWithOneOverrideWithMaintenanceWindow(knownTargetId, null, null, null);
+    }
+
+    private List<Action> generateTargetWithTwoUpdatesWithOneOverrideWithMaintenanceWindow(final String knownTargetId,
+            final String schedule, final String duration, final String timezone) {
+        final Target target = testdataFactory.createTarget(knownTargetId);
+
+        final Iterator<DistributionSet> sets = testdataFactory.createDistributionSets(2).iterator();
+        final DistributionSet one = sets.next();
+        final DistributionSet two = sets.next();
+
+        // Update
+        if (schedule == null) {
+            final List<Target> updatedTargets = assignDistributionSet(one, Collections.singletonList(target))
+                    .getAssignedEntity().stream().map(Action::getTarget).collect(Collectors.toList());
+            // 2nd update
+            // sleep 10ms to ensure that we can sort by reportedAt
+            Awaitility.await().atMost(Duration.ONE_HUNDRED_MILLISECONDS).atLeast(5, TimeUnit.MILLISECONDS)
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .until(() -> updatedTargets.stream().allMatch(t -> t.getLastModifiedAt() > 0L));
+            assignDistributionSet(two, updatedTargets);
+        } else {
+            final List<Target> updatedTargets = assignDistributionSetWithMaintenanceWindow(one.getId(),
+                    target.getControllerId(), schedule, duration, timezone).getAssignedEntity().stream()
+                            .map(Action::getTarget).collect(Collectors.toList());
+            // 2nd update
+            // sleep 10ms to ensure that we can sort by reportedAt
+            Awaitility.await().atMost(Duration.ONE_HUNDRED_MILLISECONDS).atLeast(5, TimeUnit.MILLISECONDS)
+                    .pollInterval(10, TimeUnit.MILLISECONDS)
+                    .until(() -> updatedTargets.stream().allMatch(t -> t.getLastModifiedAt() > 0L));
+            assignDistributionSetWithMaintenanceWindow(two.getId(), updatedTargets.get(0).getControllerId(), schedule,
+                    duration, timezone);
+        }
+
+        // two updates, one cancellation
+        final List<Action> actions = deploymentManagement.findActionsByTarget(target.getControllerId(), PAGE)
+                .getContent();
+
+        assertThat(actions).hasSize(2);
+        return actions;
+    }
+
+}

--- a/hawkbit-rest/hawkbit-rest-docs/src/main/asciidoc/actions-api-guide.adoc
+++ b/hawkbit-rest/hawkbit-rest-docs/src/main/asciidoc/actions-api-guide.adoc
@@ -1,0 +1,73 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: macro
+:toclevels: 1
+:sectlinks:
+:linkattrs:
+
+[[actions]]
+= Actions
+
+toc::[]
+
+== GET /rest/v1/actions
+
+=== Implementation notes
+
+Handles the GET request of retrieving all actions within Hawkbit. Required permission: READ_TARGET
+
+=== Get paged list of actions
+
+==== CURL
+
+include::{snippets}/actions/get-actions/curl-request.adoc[]
+
+==== Request URL
+
+A `GET` request is used to access the actions
+
+include::{snippets}/actions/get-actions/http-request.adoc[]
+
+==== Request query parameter
+
+include::{snippets}/actions/get-actions-with-parameters/request-parameters.adoc[]
+
+==== Request parameter example
+
+include::{snippets}/actions/get-actions-with-parameters/http-request.adoc[]
+
+=== Response (Status 200)
+
+==== Response fields 
+
+include::{snippets}/actions/get-actions/response-fields.adoc[]
+
+==== Response example 
+
+include::{snippets}/actions/get-actions/http-response.adoc[]
+
+==== Response example for representation mode 'full'
+
+include::{snippets}/actions/get-actions-with-parameters/http-response.adoc[]
+
+
+=== Error responses
+
+|===
+| HTTP Status Code | Reason | Response Model
+
+include::../errors/400.adoc[]
+include::../errors/401.adoc[]
+include::../errors/403.adoc[]
+include::../errors/405.adoc[]
+include::../errors/406.adoc[]
+include::../errors/429.adoc[]
+|===
+
+== Additional content
+
+[[error-body]]
+=== Error body
+
+include::../errors/error-response-body.adoc[]

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
@@ -241,4 +241,7 @@ public final class MgmtApiModelProperties {
     public static final String CONFIG_PARAM = "The name of the configuration parameter.";
 
     public static final String DS_NEW_ASSIGNED_ACTIONS = "The newly created actions as a result of this assignment";
+
+    public static final String REPRESENTATION_MODE = "The representation mode. Can be \"full\" or \"compact\". Defaults to \"compact\"";
+
 }

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
@@ -156,6 +156,8 @@ public final class MgmtApiModelProperties {
 
     public static final String ACTION_EXECUTION_STATUS = "Status of action.";
 
+    public static final String ACTION_DETAIL_STATUS = "Detailed status of action.";
+
     public static final String ACTION_LIST = "List of actions.";
 
     public static final String ACTION_WEIGHT = "Weight of the action showing the importance of the update.";

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
@@ -33,6 +33,7 @@ public final class MgmtApiModelProperties {
     public static final String LINK_TO_OPTIONAL_SMT = "Link to optional software modules types in this distribution set type.";
     public static final String LINK_TO_ROLLOUT = "The link to the rollout.";
     public static final String LINK_TO_TARGET_TYPE = "The link to the target type.";
+    public static final String LINK_TO_TARGET = "The link to the target.";
 
     // software module types
     public static final String SMT_TYPE = "The type of the software module identified by its key.";

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
@@ -81,7 +81,7 @@ public class ActionResourceDocumentationTest extends AbstractApiRestDocumentatio
 
     @Test
     @Description("Handles the GET request of retrieving all actions based on parameters. Required Permission: READ_TARGET.")
-    public void getActionsFromTargetWithParameters() throws Exception {
+    public void getActionsWithParameters() throws Exception {
         generateActionForTarget(targetId);
 
         mockMvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
@@ -82,32 +82,22 @@ public class ActionResourceDocumentationTest extends AbstractApiRestDocumentatio
     @Test
     @Description("Handles the GET request of retrieving all actions based on parameters. Required Permission: READ_TARGET.")
     public void getActionsWithParameters() throws Exception {
-        generateActionForTarget(targetId);
+        generateRolloutActionForTarget(targetId);
 
         mockMvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING
-                + "?limit=10&sort=id:ASC&offset=0&q=target.name==" + targetId)).andExpect(status().isOk())
+                + "?limit=10&sort=id:ASC&offset=0&q=target.name==" + targetId + "&representation=full")).andExpect(status().isOk())
                 .andDo(MockMvcResultPrinter.print())
                 .andDo(this.document.document(requestParameters(
                         parameterWithName("limit").attributes(key("type").value("query"))
                                 .description(ApiModelPropertiesGeneric.LIMIT),
                         parameterWithName("sort").description(ApiModelPropertiesGeneric.SORT),
                         parameterWithName("offset").description(ApiModelPropertiesGeneric.OFFSET),
-                        parameterWithName("q").description(ApiModelPropertiesGeneric.FIQL))));
-    }
-
-    private Action generateActionForTarget(final String knownControllerId) throws Exception {
-        return generateActionForTarget(knownControllerId, true, false, null, null, null);
+                        parameterWithName("q").description(ApiModelPropertiesGeneric.FIQL),
+                        parameterWithName("representation").description(MgmtApiModelProperties.REPRESENTATION_MODE))));
     }
 
     private Action generateRolloutActionForTarget(final String knownControllerId) throws Exception {
         return generateActionForTarget(knownControllerId, true, false, null, null, null, true);
-    }
-
-    private Action generateActionForTarget(final String knownControllerId, final boolean inSync,
-            final boolean timeforced, final String maintenanceWindowSchedule, final String maintenanceWindowDuration,
-            final String maintenanceWindowTimeZone) throws Exception {
-        return generateActionForTarget(knownControllerId, inSync, timeforced, maintenanceWindowSchedule,
-                maintenanceWindowDuration, maintenanceWindowTimeZone, false);
     }
 
     private Action generateActionForTarget(final String knownControllerId, final boolean inSync,

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
@@ -41,7 +41,7 @@ import io.qameta.allure.Story;
 @Story("Action Resource")
 public class ActionResourceDocumentationTest extends AbstractApiRestDocumentation {
 
-    private final String targetId = "137";
+    private final String targetId = "target137";
 
     @Override
     public String getResourceName() {
@@ -85,10 +85,11 @@ public class ActionResourceDocumentationTest extends AbstractApiRestDocumentatio
     @Test
     @Description("Handles the GET request of retrieving all actions based on parameters. Required Permission: READ_TARGET.")
     public void getActionsWithParameters() throws Exception {
-        generateRolloutActionForTarget(targetId);
+        final Action action = generateRolloutActionForTarget(targetId);
 
-        mockMvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING
-                + "?limit=10&sort=id:ASC&offset=0&q=target.name==" + targetId + "&representation=full"))
+        mockMvc.perform(
+                get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?limit=10&sort=id:ASC&offset=0&q=rollout.id=="
+                        + action.getRollout().getId() + "&representation=full"))
                 .andExpect(status().isOk()).andDo(MockMvcResultPrinter.print())
                 .andDo(this.document.document(requestParameters(
                         parameterWithName("limit").attributes(key("type").value("query"))

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
@@ -71,6 +71,9 @@ public class ActionResourceDocumentationTest extends AbstractApiRestDocumentatio
 
                         fieldWithPath("content[].status").description(MgmtApiModelProperties.ACTION_EXECUTION_STATUS)
                                 .attributes(key("value").value("['finished', 'pending']")),
+                        fieldWithPath("content[].detailStatus").description(MgmtApiModelProperties.ACTION_DETAIL_STATUS)
+                                .attributes(key("value").value(
+                                        "['finished', 'error', 'running', 'warning', 'scheduled', 'canceling', 'canceled', 'download', 'downloaded', 'retrieved', 'cancel_rejected']")),
                         fieldWithPath("content[]._links").description(MgmtApiModelProperties.LINK_TO_ACTION),
                         fieldWithPath("content[].id").description(MgmtApiModelProperties.ACTION_ID),
                         fieldWithPath("content[].weight").description(MgmtApiModelProperties.ACTION_WEIGHT),
@@ -85,8 +88,8 @@ public class ActionResourceDocumentationTest extends AbstractApiRestDocumentatio
         generateRolloutActionForTarget(targetId);
 
         mockMvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING
-                + "?limit=10&sort=id:ASC&offset=0&q=target.name==" + targetId + "&representation=full")).andExpect(status().isOk())
-                .andDo(MockMvcResultPrinter.print())
+                + "?limit=10&sort=id:ASC&offset=0&q=target.name==" + targetId + "&representation=full"))
+                .andExpect(status().isOk()).andDo(MockMvcResultPrinter.print())
                 .andDo(this.document.document(requestParameters(
                         parameterWithName("limit").attributes(key("type").value("query"))
                                 .description(ApiModelPropertiesGeneric.LIMIT),

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.rest.mgmt.documentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
+import org.eclipse.hawkbit.repository.ActionStatusFields;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.rest.documentation.AbstractApiRestDocumentation;
+import org.eclipse.hawkbit.rest.documentation.ApiModelPropertiesGeneric;
+import org.eclipse.hawkbit.rest.documentation.MgmtApiModelProperties;
+import org.eclipse.hawkbit.rest.util.MockMvcResultPrinter;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+
+/**
+ * Documentation generation for Management API for {@link Action}.
+ */
+@Feature("Spring Rest Docs Tests - Action")
+@Story("Action Resource")
+public class ActionResourceDocumentationTest extends AbstractApiRestDocumentation {
+
+    private final String targetId = "137";
+
+    @Override
+    public String getResourceName() {
+        return "actions";
+    }
+
+    @Test
+    @Description("Handles the GET request of retrieving all actions. Required Permission: READ_TARGET.")
+    public void getActions() throws Exception {
+        enableMultiAssignments();
+        generateRolloutActionForTarget(targetId);
+
+        mockMvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)).andExpect(status().isOk())
+                .andDo(MockMvcResultPrinter.print())
+                .andDo(this.document.document(responseFields(
+                        fieldWithPath("size").type(JsonFieldType.NUMBER).description(ApiModelPropertiesGeneric.SIZE),
+                        fieldWithPath("total").description(ApiModelPropertiesGeneric.TOTAL_ELEMENTS),
+                        fieldWithPath("content[]").description(MgmtApiModelProperties.ACTION_LIST),
+                        fieldWithPath("content[].createdBy").description(ApiModelPropertiesGeneric.CREATED_BY),
+                        fieldWithPath("content[].createdAt").description(ApiModelPropertiesGeneric.CREATED_AT),
+                        fieldWithPath("content[].lastModifiedBy")
+                                .description(ApiModelPropertiesGeneric.LAST_MODIFIED_BY).type("String"),
+                        fieldWithPath("content[].lastModifiedAt")
+                                .description(ApiModelPropertiesGeneric.LAST_MODIFIED_AT).type("String"),
+                        fieldWithPath("content[].type").description(MgmtApiModelProperties.ACTION_TYPE)
+                                .attributes(key("value").value("['update', 'cancel']")),
+
+                        fieldWithPath("content[].status").description(MgmtApiModelProperties.ACTION_EXECUTION_STATUS)
+                                .attributes(key("value").value("['finished', 'pending']")),
+                        fieldWithPath("content[]._links").description(MgmtApiModelProperties.LINK_TO_ACTION),
+                        fieldWithPath("content[].id").description(MgmtApiModelProperties.ACTION_ID),
+                        fieldWithPath("content[].weight").description(MgmtApiModelProperties.ACTION_WEIGHT),
+                        fieldWithPath("content[].rollout").description(MgmtApiModelProperties.ACTION_ROLLOUT),
+                        fieldWithPath("content[].rolloutName")
+                                .description(MgmtApiModelProperties.ACTION_ROLLOUT_NAME))));
+    }
+
+    @Test
+    @Description("Handles the GET request of retrieving all actions based on parameters. Required Permission: READ_TARGET.")
+    public void getActionsFromTargetWithParameters() throws Exception {
+        generateActionForTarget(targetId);
+
+        mockMvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING
+                + "?limit=10&sort=id:ASC&offset=0&q=target.name==" + targetId)).andExpect(status().isOk())
+                .andDo(MockMvcResultPrinter.print())
+                .andDo(this.document.document(requestParameters(
+                        parameterWithName("limit").attributes(key("type").value("query"))
+                                .description(ApiModelPropertiesGeneric.LIMIT),
+                        parameterWithName("sort").description(ApiModelPropertiesGeneric.SORT),
+                        parameterWithName("offset").description(ApiModelPropertiesGeneric.OFFSET),
+                        parameterWithName("q").description(ApiModelPropertiesGeneric.FIQL))));
+    }
+
+    private Action generateActionForTarget(final String knownControllerId) throws Exception {
+        return generateActionForTarget(knownControllerId, true, false, null, null, null);
+    }
+
+    private Action generateRolloutActionForTarget(final String knownControllerId) throws Exception {
+        return generateActionForTarget(knownControllerId, true, false, null, null, null, true);
+    }
+
+    private Action generateActionForTarget(final String knownControllerId, final boolean inSync,
+            final boolean timeforced, final String maintenanceWindowSchedule, final String maintenanceWindowDuration,
+            final String maintenanceWindowTimeZone) throws Exception {
+        return generateActionForTarget(knownControllerId, inSync, timeforced, maintenanceWindowSchedule,
+                maintenanceWindowDuration, maintenanceWindowTimeZone, false);
+    }
+
+    private Action generateActionForTarget(final String knownControllerId, final boolean inSync,
+            final boolean timeforced, final String maintenanceWindowSchedule, final String maintenanceWindowDuration,
+            final String maintenanceWindowTimeZone, final boolean createRollout) throws Exception {
+        final PageRequest pageRequest = PageRequest.of(0, 1, Direction.ASC, ActionStatusFields.ID.getFieldName());
+
+        createTargetByGivenNameWithAttributes(knownControllerId, inSync, timeforced, createDistributionSet(),
+                maintenanceWindowSchedule, maintenanceWindowDuration, maintenanceWindowTimeZone, createRollout);
+
+        final List<Action> actions = deploymentManagement.findActionsAll(pageRequest).getContent();
+
+        assertThat(actions).hasSize(1);
+        return actions.get(0);
+    }
+
+}

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/RolloutResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/RolloutResourceDocumentationTest.java
@@ -155,6 +155,8 @@ public class RolloutResourceDocumentationTest extends AbstractApiRestDocumentati
                     .description(MgmtApiModelProperties.ROLLOUT_LINKS_APPROVE));
             allFieldDescriptor.add(
                     fieldWithPath(arrayPrefix + "_links.deny").description(MgmtApiModelProperties.ROLLOUT_LINKS_DENY));
+            allFieldDescriptor.add(fieldWithPath(arrayPrefix + "_links.distributionset")
+                    .description(MgmtApiModelProperties.LINK_TO_DS));
         }
 
         return new DocumenationResponseFieldsSnippet(allFieldDescriptor);

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
@@ -107,8 +107,8 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 .type("String"),
                         fieldWithPath("content[].lastControllerRequestAt")
                                 .description(MgmtApiModelProperties.LAST_REQUEST_AT).type("Number"),
-                        fieldWithPath("content[].targetType")
-                                .description(MgmtApiModelProperties.TARGETTYPE_ID).type("Number"),
+                        fieldWithPath("content[].targetType").description(MgmtApiModelProperties.TARGETTYPE_ID)
+                                .type("Number"),
                         fieldWithPath("content[]._links.self").ignored())));
     }
 
@@ -138,8 +138,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 .description(MgmtApiModelProperties.SECURITY_TOKEN),
                         optionalRequestFieldWithPath("[]targetType").description(MgmtApiModelProperties.TARGETTYPE_ID)),
                         responseFields(fieldWithPath("[]controllerId").description(ApiModelPropertiesGeneric.ITEM_ID),
-                                fieldWithPath(
-                                        "[]name").description(ApiModelPropertiesGeneric.NAME),
+                                fieldWithPath("[]name").description(ApiModelPropertiesGeneric.NAME),
                                 fieldWithPath("[]description").description(ApiModelPropertiesGeneric.DESCRPTION),
                                 fieldWithPath("[]address").description(MgmtApiModelProperties.ADDRESS),
                                 fieldWithPath("[]createdBy").description(ApiModelPropertiesGeneric.CREATED_BY),
@@ -156,8 +155,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 fieldWithPath("[]securityToken").description(MgmtApiModelProperties.SECURITY_TOKEN),
                                 fieldWithPath("[]requestAttributes")
                                         .description(MgmtApiModelProperties.REQUEST_ATTRIBUTES),
-                                fieldWithPath("[]targetType")
-                                        .description(MgmtApiModelProperties.TARGETTYPE_ID),
+                                fieldWithPath("[]targetType").description(MgmtApiModelProperties.TARGETTYPE_ID),
                                 fieldWithPath("[]_links.self").ignored())));
     }
 
@@ -236,6 +234,10 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 fieldWithPath("content[].status")
                                         .description(MgmtApiModelProperties.ACTION_EXECUTION_STATUS)
                                         .attributes(key("value").value("['finished', 'pending']")),
+                                fieldWithPath("content[].detailStatus")
+                                        .description(MgmtApiModelProperties.ACTION_DETAIL_STATUS)
+                                        .attributes(key("value").value(
+                                                "['finished', 'error', 'running', 'warning', 'scheduled', 'canceling', 'canceled', 'download', 'downloaded', 'retrieved', 'cancel_rejected']")),
                                 fieldWithPath("content[]._links").description(MgmtApiModelProperties.LINK_TO_ACTION),
                                 fieldWithPath("content[].id").description(MgmtApiModelProperties.ACTION_ID),
                                 fieldWithPath("content[].weight").description(MgmtApiModelProperties.ACTION_WEIGHT),
@@ -273,6 +275,10 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 fieldWithPath("content[].status")
                                         .description(MgmtApiModelProperties.ACTION_EXECUTION_STATUS)
                                         .attributes(key("value").value("['finished', 'pending']")),
+                                fieldWithPath("content[].detailStatus")
+                                        .description(MgmtApiModelProperties.ACTION_DETAIL_STATUS)
+                                        .attributes(key("value").value(
+                                                "['finished', 'error', 'running', 'warning', 'scheduled', 'canceling', 'canceled', 'download', 'downloaded', 'retrieved', 'cancel_rejected']")),
                                 fieldWithPath("content[]._links").description(MgmtApiModelProperties.LINK_TO_ACTION),
                                 fieldWithPath("content[].id").description(MgmtApiModelProperties.ACTION_ID),
                                 fieldWithPath("content[].weight").description(MgmtApiModelProperties.ACTION_WEIGHT),
@@ -322,7 +328,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
     public void deleteActionFromTargetWithParameters() throws Exception {
         final Action action = generateActionForTarget(targetId, false);
         deploymentManagement.cancelAction(action.getId());
-        
+
         mockMvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/"
                 + MgmtRestConstants.TARGET_V1_ACTIONS + "/{actionId}?force=true", targetId, action.getId()))
                 .andExpect(status().isNoContent()).andDo(MockMvcResultPrinter.print())
@@ -362,15 +368,13 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                         .type("String"),
                                 fieldWithPath("status").description(MgmtApiModelProperties.ACTION_EXECUTION_STATUS)
                                         .attributes(key("value").value("['finished', 'pending']")),
-                               fieldWithPath("rollout").description(MgmtApiModelProperties.ACTION_ROLLOUT),
-                               fieldWithPath("rolloutName")
-                                                .description(MgmtApiModelProperties.ACTION_ROLLOUT_NAME),
+                                fieldWithPath("rollout").description(MgmtApiModelProperties.ACTION_ROLLOUT),
+                                fieldWithPath("rolloutName").description(MgmtApiModelProperties.ACTION_ROLLOUT_NAME),
                                 fieldWithPath("_links.self").ignored(),
                                 fieldWithPath("_links.distributionset").description(MgmtApiModelProperties.LINK_TO_DS),
                                 fieldWithPath("_links.status")
                                         .description(MgmtApiModelProperties.LINKS_ACTION_STATUSES),
-                                fieldWithPath("_links.rollout")
-                                        .description(MgmtApiModelProperties.LINK_TO_ROLLOUT))));
+                                fieldWithPath("_links.rollout").description(MgmtApiModelProperties.LINK_TO_ROLLOUT))));
     }
 
     @Test
@@ -430,10 +434,9 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
         final Map<String, Object> body = new HashMap<>();
         body.put("forceType", "forced");
 
-        mockMvc.perform(
-                put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + MgmtRestConstants.TARGET_V1_ACTIONS
-                        + "/{actionId}", targetId, actionId).content(this.objectMapper.writeValueAsString(body))
-                                .contentType(MediaType.APPLICATION_JSON))
+        mockMvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/"
+                + MgmtRestConstants.TARGET_V1_ACTIONS + "/{actionId}", targetId, actionId)
+                        .content(this.objectMapper.writeValueAsString(body)).contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andDo(this.document.document(
                         pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID),
@@ -484,8 +487,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                         .description(MgmtApiModelProperties.ACTION_STATUS_REPORTED_AT).type("String"),
                                 optionalRequestFieldWithPath("content[].code")
                                         .description(MgmtApiModelProperties.ACTION_STATUS_CODE).type("Integer"),
-                                fieldWithPath(
-                                        "content[].type").description(MgmtApiModelProperties.ACTION_STATUS_TYPE)
+                                fieldWithPath("content[].type").description(MgmtApiModelProperties.ACTION_STATUS_TYPE)
                                         .attributes(key("value").value(
                                                 "['finished', 'error', 'warning', 'pending', 'running', 'canceled', 'retrieved', 'canceling']")))));
     }
@@ -517,7 +519,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                         pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID)),
                         getResponseFieldsDistributionSet(false)));
     }
-    
+
     @Test
     @Description("Handles the POST request for assigning a distribution set to a specific target. Required Permission: READ_REPOSITORY and UPDATE_TARGET.")
     public void postAssignDistributionSetToTarget() throws Exception {
@@ -537,14 +539,13 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
 
         mockMvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/"
                 + MgmtRestConstants.TARGET_V1_ASSIGNED_DISTRIBUTION_SET, targetId).content(body)
-                .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andDo(this.document.document(
                         pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID)),
                         requestParameters(parameterWithName("offline")
                                 .description(MgmtApiModelProperties.OFFLINE_UPDATE).optional()),
-                        requestFields(
-                                requestFieldWithPath("id").description(ApiModelPropertiesGeneric.ITEM_ID),
+                        requestFields(requestFieldWithPath("id").description(ApiModelPropertiesGeneric.ITEM_ID),
                                 requestFieldWithPathMandatoryInMultiAssignMode("weight")
                                         .description(MgmtApiModelProperties.ASSIGNMENT_WEIGHT)
                                         .type(JsonFieldType.NUMBER).attributes(key("value").value("0 - 1000")),
@@ -558,7 +559,8 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 optionalRequestFieldWithPath("maintenanceWindow.timezone")
                                         .description(MgmtApiModelProperties.MAINTENANCE_WINDOW_TIMEZONE),
                                 optionalRequestFieldWithPath("type").description(MgmtApiModelProperties.ASSIGNMENT_TYPE)
-                                        .attributes(key("value").value("['soft', 'forced','timeforced', 'downloadonly']"))),
+                                        .attributes(
+                                                key("value").value("['soft', 'forced','timeforced', 'downloadonly']"))),
                         responseFields(getDsAssignmentResponseFieldDescriptors())));
     }
 
@@ -571,24 +573,24 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
 
         final long forceTime = System.currentTimeMillis();
         final JSONArray body = new JSONArray();
-        body.put(new JSONObject().put("id", sets.get(1).getId()).put("weight", 500).put("type", "timeforced")
-                .put("forcetime", forceTime)
-                .put("maintenanceWindow", new JSONObject().put("schedule", getTestSchedule(100))
-                        .put("duration", getTestDuration(10)).put("timezone", getTestTimeZone())))
+        body.put(
+                new JSONObject().put("id", sets.get(1).getId()).put("weight", 500).put("type", "timeforced")
+                        .put("forcetime", forceTime).put("maintenanceWindow",
+                                new JSONObject().put("schedule", getTestSchedule(100))
+                                        .put("duration", getTestDuration(10)).put("timezone", getTestTimeZone())))
                 .toString();
         body.put(new JSONObject().put("id", sets.get(0).getId()).put("type", "forced").put("weight", 800));
 
         enableMultiAssignments();
         mockMvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/"
                 + MgmtRestConstants.TARGET_V1_ASSIGNED_DISTRIBUTION_SET, targetId).content(body.toString())
-                .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andDo(this.document.document(
                         pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID)),
                         requestParameters(parameterWithName("offline")
                                 .description(MgmtApiModelProperties.OFFLINE_UPDATE).optional()),
-                        requestFields(
-                                requestFieldWithPath("[].id").description(ApiModelPropertiesGeneric.ITEM_ID),
+                        requestFields(requestFieldWithPath("[].id").description(ApiModelPropertiesGeneric.ITEM_ID),
                                 requestFieldWithPathMandatoryInMultiAssignMode("[].weight")
                                         .description(MgmtApiModelProperties.ASSIGNMENT_WEIGHT)
                                         .attributes(key("value").value("0 - 1000")),
@@ -612,15 +614,15 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
     private static FieldDescriptor[] getDsAssignmentResponseFieldDescriptors() {
         final FieldDescriptor[] descriptors = {
                 fieldWithPath("assigned").description(MgmtApiModelProperties.DS_NEW_ASSIGNED_TARGETS),
-            fieldWithPath("alreadyAssigned").type(JsonFieldType.NUMBER)
-            .description(MgmtApiModelProperties.DS_ALREADY_ASSIGNED_TARGETS),
-    fieldWithPath("assignedActions").type(JsonFieldType.ARRAY)
-            .description(MgmtApiModelProperties.DS_NEW_ASSIGNED_ACTIONS),
-    fieldWithPath("assignedActions.[].id").type(JsonFieldType.NUMBER)
-            .description(MgmtApiModelProperties.ACTION_ID),
-    fieldWithPath("assignedActions.[]._links.self").type(JsonFieldType.OBJECT)
-            .description(MgmtApiModelProperties.LINK_TO_ACTION),
-    fieldWithPath("total").type(JsonFieldType.NUMBER)
+                fieldWithPath("alreadyAssigned").type(JsonFieldType.NUMBER)
+                        .description(MgmtApiModelProperties.DS_ALREADY_ASSIGNED_TARGETS),
+                fieldWithPath("assignedActions").type(JsonFieldType.ARRAY)
+                        .description(MgmtApiModelProperties.DS_NEW_ASSIGNED_ACTIONS),
+                fieldWithPath("assignedActions.[].id").type(JsonFieldType.NUMBER)
+                        .description(MgmtApiModelProperties.ACTION_ID),
+                fieldWithPath("assignedActions.[]._links.self").type(JsonFieldType.OBJECT)
+                        .description(MgmtApiModelProperties.LINK_TO_ACTION),
+                fieldWithPath("total").type(JsonFieldType.NUMBER)
                         .description(MgmtApiModelProperties.DS_TOTAL_ASSIGNED_TARGETS) };
         return descriptors;
     }
@@ -847,11 +849,9 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
         targetManagement.assignType(testTarget.getControllerId(), targetType.getId());
 
         mockMvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/targettype",
-                        testTarget.getControllerId()).contentType(MediaType.APPLICATION_JSON))
-                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
-                .andDo(this.document.document(
-                        pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID))
-                        ));
+                testTarget.getControllerId()).contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk()).andDo(this.document.document(
+                        pathParameters(parameterWithName("targetId").description(ApiModelPropertiesGeneric.ITEM_ID))));
     }
 
     private String createTargetJsonForPostRequest(final String controllerId, final String name,

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
@@ -280,8 +280,6 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                                 "['finished', 'error', 'running', 'warning', 'scheduled', 'canceling', 'canceled', 'download', 'downloaded', 'retrieved', 'cancel_rejected']")),
                                 fieldWithPath("content[]._links.self")
                                         .description(MgmtApiModelProperties.LINK_TO_ACTION),
-                                fieldWithPath("content[]._links.target")
-                                        .description(MgmtApiModelProperties.LINK_TO_TARGET),
                                 fieldWithPath("content[].id").description(MgmtApiModelProperties.ACTION_ID),
                                 fieldWithPath("content[].weight").description(MgmtApiModelProperties.ACTION_WEIGHT),
                                 fieldWithPath("content[].maintenanceWindow")
@@ -412,6 +410,9 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                         .type("String"),
                                 fieldWithPath("status").description(MgmtApiModelProperties.ACTION_EXECUTION_STATUS)
                                         .attributes(key("value").value("['finished', 'pending']")),
+                                fieldWithPath("detailStatus").description(MgmtApiModelProperties.ACTION_DETAIL_STATUS)
+                                        .attributes(key("value").value(
+                                                "['finished', 'error', 'running', 'warning', 'scheduled', 'canceling', 'canceled', 'download', 'downloaded', 'retrieved', 'cancel_rejected']")),
                                 fieldWithPath("maintenanceWindow")
                                         .description(MgmtApiModelProperties.MAINTENANCE_WINDOW),
                                 fieldWithPath("maintenanceWindow.schedule")
@@ -425,7 +426,8 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 fieldWithPath("_links.self").ignored(),
                                 fieldWithPath("_links.distributionset").description(MgmtApiModelProperties.LINK_TO_DS),
                                 fieldWithPath("_links.status")
-                                        .description(MgmtApiModelProperties.LINKS_ACTION_STATUSES))));
+                                        .description(MgmtApiModelProperties.LINKS_ACTION_STATUSES),
+                                fieldWithPath("_links.target").description(MgmtApiModelProperties.LINK_TO_TARGET))));
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
@@ -271,7 +271,6 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                         .description(ApiModelPropertiesGeneric.LAST_MODIFIED_AT).type("String"),
                                 fieldWithPath("content[].type").description(MgmtApiModelProperties.ACTION_TYPE)
                                         .attributes(key("value").value("['update', 'cancel']")),
-
                                 fieldWithPath("content[].status")
                                         .description(MgmtApiModelProperties.ACTION_EXECUTION_STATUS)
                                         .attributes(key("value").value("['finished', 'pending']")),
@@ -279,7 +278,10 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                         .description(MgmtApiModelProperties.ACTION_DETAIL_STATUS)
                                         .attributes(key("value").value(
                                                 "['finished', 'error', 'running', 'warning', 'scheduled', 'canceling', 'canceled', 'download', 'downloaded', 'retrieved', 'cancel_rejected']")),
-                                fieldWithPath("content[]._links").description(MgmtApiModelProperties.LINK_TO_ACTION),
+                                fieldWithPath("content[]._links.self")
+                                        .description(MgmtApiModelProperties.LINK_TO_ACTION),
+                                fieldWithPath("content[]._links.target")
+                                        .description(MgmtApiModelProperties.LINK_TO_TARGET),
                                 fieldWithPath("content[].id").description(MgmtApiModelProperties.ACTION_ID),
                                 fieldWithPath("content[].weight").description(MgmtApiModelProperties.ACTION_WEIGHT),
                                 fieldWithPath("content[].maintenanceWindow")
@@ -368,13 +370,17 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                         .type("String"),
                                 fieldWithPath("status").description(MgmtApiModelProperties.ACTION_EXECUTION_STATUS)
                                         .attributes(key("value").value("['finished', 'pending']")),
+                                fieldWithPath("detailStatus").description(MgmtApiModelProperties.ACTION_DETAIL_STATUS)
+                                        .attributes(key("value").value(
+                                                "['finished', 'error', 'running', 'warning', 'scheduled', 'canceling', 'canceled', 'download', 'downloaded', 'retrieved', 'cancel_rejected']")),
                                 fieldWithPath("rollout").description(MgmtApiModelProperties.ACTION_ROLLOUT),
                                 fieldWithPath("rolloutName").description(MgmtApiModelProperties.ACTION_ROLLOUT_NAME),
                                 fieldWithPath("_links.self").ignored(),
                                 fieldWithPath("_links.distributionset").description(MgmtApiModelProperties.LINK_TO_DS),
                                 fieldWithPath("_links.status")
                                         .description(MgmtApiModelProperties.LINKS_ACTION_STATUSES),
-                                fieldWithPath("_links.rollout").description(MgmtApiModelProperties.LINK_TO_ROLLOUT))));
+                                fieldWithPath("_links.rollout").description(MgmtApiModelProperties.LINK_TO_ROLLOUT),
+                                fieldWithPath("_links.target").description(MgmtApiModelProperties.LINK_TO_TARGET))));
     }
 
     @Test
@@ -456,10 +462,14 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                         .attributes(key("value").value("['forced', 'soft', 'timeforced']")),
                                 fieldWithPath("status").description(MgmtApiModelProperties.ACTION_EXECUTION_STATUS)
                                         .attributes(key("value").value("['finished', 'pending']")),
+                                fieldWithPath("detailStatus").description(MgmtApiModelProperties.ACTION_DETAIL_STATUS)
+                                        .attributes(key("value").value(
+                                                "['finished', 'error', 'running', 'warning', 'scheduled', 'canceling', 'canceled', 'download', 'downloaded', 'retrieved', 'cancel_rejected']")),
                                 fieldWithPath("_links.self").ignored(),
                                 fieldWithPath("_links.distributionset").description(MgmtApiModelProperties.LINK_TO_DS),
                                 fieldWithPath("_links.status")
-                                        .description(MgmtApiModelProperties.LINKS_ACTION_STATUSES))));
+                                        .description(MgmtApiModelProperties.LINKS_ACTION_STATUSES),
+                                fieldWithPath("_links.target").description(MgmtApiModelProperties.LINK_TO_TARGET))));
     }
 
     @Test


### PR DESCRIPTION
This pull request enhances the Management REST API with a new primary resource collection for deployment actions. It will be available under the context path `/rest/v1/actions`. So far, actions are only exposed as part of the `/rest/v1/targets` resource collection, e.g. by requesting them for a specific target (`/rest/v1/targets/<controller-id>/actions`).

The actions resource collection is read-only and allows to filter and sort the list of actions based on different criteria, such as the associated target, distribution set, and /or rollout. As usual, the filter needs to be specified as a RSQL query. Example requests:
- `/rest/v1/actions?q=target.name==Target123`
- `/rest/v1/actions?q=distributionSet.name==MyDS,distributionSet.version==1.0.0`
- `/rest/v1/actions?q=rollout.id==123`
etc.

Note that the resource links which are exposed in the JSON representation of an Action point to the corresponding REST entry points of the target resource collection (`/rest/v1/targets/<controller-id>/actions/<action-id>`).