### PR TITLE
Fix website build with recent Hugo

### DIFF
--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -24,7 +24,7 @@
 
 	<article class="article">
 		<div class="wrapper">
-			<h1>{{ .Title }} {{ if .IsDraft }} (Draft){{ end }}</h1>
+			<h1>{{ .Title }} {{ if .Draft }} (Draft){{ end }}</h1>
 
 			{{ .Content }}
 

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>{{ .Title }}{{ if not .IsHome }} - {{ .Site.Title }}{{ end }}</title>
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
 
     {{ with .Site.Params.description }}
     <meta name="description" content="{{ . }}">
@@ -73,7 +73,7 @@
     <script src="{{ "javascripts/modernizr.js" | absURL }}"></script>
     <script src="//www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/vendor/cookieconsent/default.min.js"></script>
 
-    {{ with .RSSLink }}
+    {{ with .OutputFormats.Get "RSS" }}
     <link href="{{ . }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
     <link href="{{ . }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
     {{ end }}


### PR DESCRIPTION
The website currently fails to build with recent versions of Hugo. Apply some minimal changes to allow the website to build with hugo v0.93.3.

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>