### PR TITLE
docs: switch to goldmark markdown handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ docs/themes/**
 docs/public/**
 docs/content/rest-api/*.html
 .gitmodules
+docs/.hugo_build.lock

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -15,7 +15,9 @@ metadataformat = "toml"
 canonifyurls = false
 
 [markup]
-  defaultMarkdownHandler = "blackfriday"
+	[markup.goldmark]
+		[markup.goldmark.extensions]
+			typographer = true
 
 [markup.highlight]
 	codeFences = false
@@ -103,9 +105,3 @@ canonifyurls = false
 	name   = "Release notes"
 	url    = "/release-notes/"
 	weight = 100
-
-[blackfriday]
-	smartypants	= true
-	fractions = false
-	smartDashes = true
-	plainIDAnchors = true


### PR DESCRIPTION
Abandon no longer supported blackfriday markdown handler and switch to default goldmark markdown handler. Enabled typographer extension to handle quotes and dashes.

Website is now building with hugo > 0.100 as well.

Build tested with hugo 0.101.0:
$ docker run --rm -it -v $(pwd):/src:Z -p 1313:1313 klakegg/hugo:0.101.0 server

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>