### PR TITLE
Management API: Expose lastStatusCode property of action entities

### DIFF
--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtAction.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtAction.java
@@ -75,6 +75,9 @@ public class MgmtAction extends MgmtBaseEntity {
     @JsonProperty
     private String rolloutName;
 
+    @JsonProperty
+    private Integer lastStatusCode;
+
     public MgmtMaintenanceWindow getMaintenanceWindow() {
         return maintenanceWindow;
     }
@@ -153,6 +156,14 @@ public class MgmtAction extends MgmtBaseEntity {
 
     public void setDetailStatus(final String detailStatus) {
         this.detailStatus = detailStatus;
+    }
+
+    public Integer getLastStatusCode() {
+        return lastStatusCode;
+    }
+
+    public void setLastStatusCode(final Integer lastStatusCode) {
+        this.lastStatusCode = lastStatusCode;
     }
 
 }

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
@@ -40,8 +40,8 @@ import org.eclipse.hawkbit.repository.builder.TargetCreate;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.ActionType;
 import org.eclipse.hawkbit.repository.model.ActionStatus;
-import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.AutoConfirmationStatus;
+import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.MetaData;
 import org.eclipse.hawkbit.repository.model.PollStatus;
 import org.eclipse.hawkbit.repository.model.Rollout;
@@ -257,6 +257,10 @@ public final class MgmtTargetMapper {
 
         result.setDetailStatus(action.getStatus().toString().toLowerCase());
 
+        action.getLastActionStatusCode().ifPresent(statusCode -> {
+            result.setLastStatusCode(statusCode);
+        });
+        
         final Rollout rollout = action.getRollout();
         if (rollout != null) {
             result.setRollout(rollout.getId());

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/documentation/MgmtApiModelProperties.java
@@ -162,6 +162,8 @@ public final class MgmtApiModelProperties {
 
     public static final String ACTION_STATUS_CODE = "(Optional) Code provided by the device related to the status.";
 
+    public static final String ACTION_LAST_STATUS_CODE = "(Optional) Code provided as part of the last status update that was sent by the device.";
+
     public static final String ACTION_STATUS_LIST = "List of action status.";
 
     public static final String ACTION_EXECUTION_STATUS = "Status of action.";

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/ActionResourceDocumentationTest.java
@@ -52,7 +52,8 @@ public class ActionResourceDocumentationTest extends AbstractApiRestDocumentatio
     @Description("Handles the GET request of retrieving all actions. Required Permission: READ_TARGET.")
     public void getActions() throws Exception {
         enableMultiAssignments();
-        generateRolloutActionForTarget(targetId);
+        final Action action = generateRolloutActionForTarget(targetId);
+        provideCodeFeedback(action, 200);
 
         mockMvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)).andExpect(status().isOk())
                 .andDo(MockMvcResultPrinter.print())
@@ -74,6 +75,8 @@ public class ActionResourceDocumentationTest extends AbstractApiRestDocumentatio
                         fieldWithPath("content[].detailStatus").description(MgmtApiModelProperties.ACTION_DETAIL_STATUS)
                                 .attributes(key("value").value(
                                         "['finished', 'error', 'running', 'warning', 'scheduled', 'canceling', 'canceled', 'download', 'downloaded', 'retrieved', 'cancel_rejected']")),
+                        optionalRequestFieldWithPath("content[].lastStatusCode")
+                                .description(MgmtApiModelProperties.ACTION_LAST_STATUS_CODE).type("Integer"),
                         fieldWithPath("content[]._links").description(MgmtApiModelProperties.LINK_TO_ACTION),
                         fieldWithPath("content[].id").description(MgmtApiModelProperties.ACTION_ID),
                         fieldWithPath("content[].weight").description(MgmtApiModelProperties.ACTION_WEIGHT),

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/TargetResourceDocumentationTest.java
@@ -107,8 +107,8 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                         fieldWithPath("content[].autoConfirmActive")
                                 .description(MgmtApiModelProperties.AUTO_CONFIRM_ACTIVE),
                         fieldWithPath("content[].installedAt").description(MgmtApiModelProperties.INSTALLED_AT),
-                        fieldWithPath("content[].lastModifiedAt").description(
-                                ApiModelPropertiesGeneric.LAST_MODIFIED_AT).type("Number"),
+                        fieldWithPath("content[].lastModifiedAt")
+                                .description(ApiModelPropertiesGeneric.LAST_MODIFIED_AT).type("Number"),
                         fieldWithPath("content[].lastModifiedBy")
                                 .description(ApiModelPropertiesGeneric.LAST_MODIFIED_BY).type("String"),
                         fieldWithPath("content[].ipAddress").description(MgmtApiModelProperties.IP_ADDRESS)
@@ -362,6 +362,8 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
     public void getActionFromTarget() throws Exception {
         enableMultiAssignments();
         final Action action = generateRolloutActionForTarget(targetId, true, true);
+        provideCodeFeedback(action, 200);
+        
         assertThat(deploymentManagement.findAction(action.getId()).get().getActionType())
                 .isEqualTo(ActionType.TIMEFORCED);
 
@@ -390,6 +392,8 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 fieldWithPath("detailStatus").description(MgmtApiModelProperties.ACTION_DETAIL_STATUS)
                                         .attributes(key("value").value(
                                                 "['finished', 'error', 'running', 'warning', 'scheduled', 'canceling', 'canceled', 'download', 'downloaded', 'retrieved', 'cancel_rejected']")),
+                                optionalRequestFieldWithPath("lastStatusCode")
+                                        .description(MgmtApiModelProperties.ACTION_LAST_STATUS_CODE).type("Integer"),
                                 fieldWithPath("rollout").description(MgmtApiModelProperties.ACTION_ROLLOUT),
                                 fieldWithPath("rolloutName").description(MgmtApiModelProperties.ACTION_ROLLOUT_NAME),
                                 fieldWithPath("_links.self").ignored(),
@@ -406,6 +410,7 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
         enableMultiAssignments();
         final Action action = generateActionForTarget(targetId, true, true, getTestSchedule(2), getTestDuration(1),
                 getTestTimeZone());
+        provideCodeFeedback(action, 200);
 
         mockMvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/"
                 + MgmtRestConstants.TARGET_V1_ACTIONS + "/{actionId}", targetId, action.getId()))
@@ -432,6 +437,8 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
                                 fieldWithPath("detailStatus").description(MgmtApiModelProperties.ACTION_DETAIL_STATUS)
                                         .attributes(key("value").value(
                                                 "['finished', 'error', 'running', 'warning', 'scheduled', 'canceling', 'canceled', 'download', 'downloaded', 'retrieved', 'cancel_rejected']")),
+                                optionalRequestFieldWithPath("lastStatusCode")
+                                        .description(MgmtApiModelProperties.ACTION_LAST_STATUS_CODE).type("Integer"),
                                 fieldWithPath("maintenanceWindow")
                                         .description(MgmtApiModelProperties.MAINTENANCE_WINDOW),
                                 fieldWithPath("maintenanceWindow.schedule")
@@ -1003,11 +1010,6 @@ public class TargetResourceDocumentationTest extends AbstractApiRestDocumentatio
     private Action generateRolloutActionForTarget(final String knownControllerId, final boolean inSync,
             final boolean timeforced) throws Exception {
         return generateActionForTarget(knownControllerId, inSync, timeforced, null, null, null, true);
-    }
-
-    private Action generateActionForTarget(final String knownControllerId, final boolean inSync,
-            final boolean timeforced) throws Exception {
-        return generateActionForTarget(knownControllerId, inSync, timeforced, null, null, null);
     }
 
     private Action generateActionForTarget(final String knownControllerId, final boolean inSync,


### PR DESCRIPTION
With this pull request, the lastStatusCode property of action entities is also exposed via Management REST API, in particular via the endpoint "/rest/v1/targets/target-id/actions/action-id".