### PR TITLE
Bump several dependencies to address some known CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
       <allure.version>2.13.6</allure.version>
       <eclipselink.version>2.7.11</eclipselink.version>
       <eclipselink.maven.plugin.version>2.7.9.1</eclipselink.maven.plugin.version>
-      <jaxb-api.version>2.3.0</jaxb-api.version>
+      <jaxb-api.version>2.3.1</jaxb-api.version>
       <gwtmockito.version>1.1.8</gwtmockito.version>
       <guava.version>30.1.1-jre</guava.version>
       <javax.el-api.version>2.2.4</javax.el-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
       <!-- Spring boot version overrides - END -->
 
       <!-- Vaadin versions - START -->
-      <vaadin.version>8.14.1</vaadin.version>
+      <vaadin.version>8.19.0</vaadin.version>
       <vaadin.spring.version>3.2.1</vaadin.spring.version>
       <vaadin.spring.addon.version>2.0.0.RELEASE</vaadin.spring.addon.version>
       <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
       <!-- Misc libraries versions - START -->
       <cron-utils.version>9.1.6</cron-utils.version>
       <jsoup.version>1.15.3</jsoup.version>
-      <allure.version>2.13.6</allure.version>
+      <allure.version>2.13.10</allure.version>
       <eclipselink.version>2.7.11</eclipselink.version>
       <eclipselink.maven.plugin.version>2.7.9.1</eclipselink.maven.plugin.version>
       <jaxb-api.version>2.3.1</jaxb-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
       <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
       <vaadin.addon.dbar-addon.version>3.0.1</vaadin.addon.dbar-addon.version>
       <vaadin.gwt-api.version>1.3.0</vaadin.gwt-api.version>
-      <vaadin.gwt-user.version>2.8.2</vaadin.gwt-user.version>
+      <vaadin.gwt-user.version>2.9.0</vaadin.gwt-user.version>
       <!-- Vaadin versions - END -->
 
       <!-- ************************ -->

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 
       <java.version>11</java.version>
 
-      <spring.boot.version>2.3.12.RELEASE</spring.boot.version>
+      <spring.boot.version>2.7.8</spring.boot.version>
       <spring-framework.version>5.2.22.RELEASE</spring-framework.version>
       <spring.cloud.version>Hoxton.SR12</spring.cloud.version>
       <spring.plugin.core.version>2.0.0.RELEASE</spring.plugin.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
          upgrade) - START -->
       <!-- Newer versions needed than defined in Boot -->
       <!-- Fixed dependencies -->
-      <rabbitmq.http-client.version>3.5.0.RELEASE</rabbitmq.http-client.version>
+      <rabbitmq.http-client.version>3.12.1</rabbitmq.http-client.version>
       <!-- Spring boot version overrides - END -->
 
       <!-- Vaadin versions - START -->

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
       <java.version>11</java.version>
 
       <spring.boot.version>2.7.8</spring.boot.version>
-      <spring-framework.version>5.2.22.RELEASE</spring-framework.version>
+      <spring-framework.version>5.3.25</spring-framework.version>
       <spring.cloud.version>Hoxton.SR12</spring.cloud.version>
       <spring.plugin.core.version>2.0.0.RELEASE</spring.plugin.core.version>
 


### PR DESCRIPTION
This is a far cry from the overall situation, as there are plenty of dependencies that are still not up-to-date, but this set is, while conservative, still useful and, most importantly, compatible.

The change passes all tests and also seems to work in practice on my local installation.