### PR TITLE
jpa/tests: fix flaky findMessagesByActionStatusId test

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
@@ -1094,9 +1094,11 @@ class ControllerManagementTest extends AbstractJpaIntegrationTest {
         final Long actionId = getFirstAssignedActionId(assignDistributionSet(testDs, testTarget));
 
         controllerManagement.addUpdateActionStatus(entityFactory.actionStatus().create(actionId)
-                .status(Action.Status.RUNNING).messages(Lists.newArrayList("proceeding message 1")));
+                .status(Action.Status.RUNNING).occurredAt(System.currentTimeMillis())
+                .messages(Lists.newArrayList("proceeding message 1")));
         controllerManagement.addUpdateActionStatus(entityFactory.actionStatus().create(actionId)
-                .status(Action.Status.RUNNING).messages(Lists.newArrayList("proceeding message 2")));
+                .status(Action.Status.RUNNING).occurredAt(System.currentTimeMillis())
+                .messages(Lists.newArrayList("proceeding message 2")));
 
         final List<String> messages = controllerManagement.getActionHistoryMessages(actionId, 2);
 


### PR DESCRIPTION
This test was missing the proper occuredAt time, making the retrieval not consistent and leading to test failures like seen in https://github.com/eclipse/hawkbit/pull/1320#issuecomment-1442145903