### PR TITLE
Fix sub entity attribute formatting

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/AbstractFieldNameRSQLVisitor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/AbstractFieldNameRSQLVisitor.java
@@ -60,7 +60,7 @@ public abstract class AbstractFieldNameRSQLVisitor<A extends Enum<A> & FieldName
 
         for (int i = 1; i < graph.length; i++) {
 
-            final String propertyField = graph[i];
+            final String propertyField = getFormattedSubEntityAttribute(propertyEnum ,graph[i]);
             fieldNameBuilder.append(FieldNameProvider.SUB_ATTRIBUTE_SEPARATOR).append(propertyField);
 
             // the key of map is not in the graph
@@ -108,6 +108,11 @@ public abstract class AbstractFieldNameRSQLVisitor<A extends Enum<A> & FieldName
         return new RSQLParameterUnsupportedFieldException(String.format(
                 "The given search parameter field {%s} does not exist, must be one of the following fields %s",
                 node.getSelector(), getExpectedFieldList()), rootException);
+    }
+
+    private String getFormattedSubEntityAttribute(final A propertyEnum, final String propertyField) {
+        return propertyEnum.getSubEntityAttributes().stream().filter(attr -> attr.equalsIgnoreCase(propertyField))
+              .findFirst().orElse(propertyField);
     }
 
     private List<String> getExpectedFieldList() {

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/TestdataFactory.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/TestdataFactory.java
@@ -647,7 +647,14 @@ public class TestdataFactory {
      */
     public Target createTarget(final String controllerId, final String targetName) {
         final Target target = targetManagement
-                .create(entityFactory.target().create().controllerId(controllerId).name(targetName));
+              .create(entityFactory.target().create().controllerId(controllerId).name(targetName));
+        assertTargetProperlyCreated(target);
+        return target;
+    }
+
+    public Target createTarget(final String controllerId, final String targetName, final String address) {
+        final Target target = targetManagement
+                .create(entityFactory.target().create().controllerId(controllerId).name(targetName).address(address));
         assertTargetProperlyCreated(target);
         return target;
     }


### PR DESCRIPTION
Fix formatting of the sub entity attribute by verifying the formatting against the sub entity attributes list of the related parent property enum.