### PR TITLE
Fix the wildcard search and add additional junit on software module

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/JpaQueryRsqlVisitor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/JpaQueryRsqlVisitor.java
@@ -576,7 +576,7 @@ public class JpaQueryRsqlVisitor<A extends Enum<A> & FieldNameProvider, T> exten
         final String finalizedValue;
         if (escapedValue.contains(ESCAPE_CHAR_WITH_ASTERISK)) {
             finalizedValue = escapedValue.replace(ESCAPE_CHAR_WITH_ASTERISK, "$").replace(LIKE_WILDCARD, '%')
-                    .replace("$", ESCAPE_CHAR_WITH_ASTERISK).toUpperCase();
+                    .replace("$", ESCAPE_CHAR_WITH_ASTERISK);
         } else {
             finalizedValue = escapedValue.replace(LIKE_WILDCARD, '%');
         }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/JpaQueryRsqlVisitor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/JpaQueryRsqlVisitor.java
@@ -578,9 +578,9 @@ public class JpaQueryRsqlVisitor<A extends Enum<A> & FieldNameProvider, T> exten
             finalizedValue = escapedValue.replace(ESCAPE_CHAR_WITH_ASTERISK, "$").replace(LIKE_WILDCARD, '%')
                     .replace("$", ESCAPE_CHAR_WITH_ASTERISK).toUpperCase();
         } else {
-            finalizedValue = escapedValue.replace(LIKE_WILDCARD, '%').toUpperCase();
+            finalizedValue = escapedValue.replace(LIKE_WILDCARD, '%');
         }
-        return finalizedValue;
+        return finalizedValue.toUpperCase();
     }
 
     @SuppressWarnings("unchecked")

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/JpaQueryRsqlVisitor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/JpaQueryRsqlVisitor.java
@@ -575,9 +575,8 @@ public class JpaQueryRsqlVisitor<A extends Enum<A> & FieldNameProvider, T> exten
     private String replaceIfRequired(final String escapedValue) {
         String finalizedValue;
         if (escapedValue.contains(ESCAPE_CHAR_WITH_ASTERISK)) {
-            final String temporaryReplacement = escapedValue.replace(ESCAPE_CHAR_WITH_ASTERISK, "$");
-            finalizedValue = temporaryReplacement.replace(LIKE_WILDCARD, '%').replace("$", ESCAPE_CHAR_WITH_ASTERISK)
-                    .toUpperCase();
+            finalizedValue = escapedValue.replace(ESCAPE_CHAR_WITH_ASTERISK, "$").replace(LIKE_WILDCARD, '%')
+                    .replace("$", ESCAPE_CHAR_WITH_ASTERISK).toUpperCase();
         } else {
             finalizedValue = escapedValue.replace(LIKE_WILDCARD, '%').toUpperCase();
         }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/JpaQueryRsqlVisitor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/JpaQueryRsqlVisitor.java
@@ -573,7 +573,7 @@ public class JpaQueryRsqlVisitor<A extends Enum<A> & FieldNameProvider, T> exten
     }
 
     private String replaceIfRequired(final String escapedValue) {
-        String finalizedValue;
+        final String finalizedValue;
         if (escapedValue.contains(ESCAPE_CHAR_WITH_ASTERISK)) {
             finalizedValue = escapedValue.replace(ESCAPE_CHAR_WITH_ASTERISK, "$").replace(LIKE_WILDCARD, '%')
                     .replace("$", ESCAPE_CHAR_WITH_ASTERISK).toUpperCase();

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
@@ -91,8 +91,8 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
         //wildcard entries
 //        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*$*", 1);
 //        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*§*", 1);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ö*", 1);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ä*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ö*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ä*", 1);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ü*", 1);
 //        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*@*", 1);
 //        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*/*", 1);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
@@ -58,96 +58,97 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
         softwareModuleManagement.createMetaData(softwareModuleMetadata2);
     }
 
-    @Test
-    @Description("Test filter software module by id")
-    public void testFilterByParameterId() {
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==" + ah.getId(), 1);
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + ah.getId(), 5);
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==" + -1, 0);
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + -1, 6);
-
-        // Not supported for numbers
-        if (Database.POSTGRESQL.equals(getDatabase())) {
-            return;
-        }
-
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==*", 6);
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==noexist*", 0);
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "=in=(" + ah.getId() + ",1000000)", 1);
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "=out=(" + ah.getId() + ",1000000)", 5);
-    }
+//    @Test
+//    @Description("Test filter software module by id")
+//    public void testFilterByParameterId() {
+//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==" + ah.getId(), 1);
+//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + ah.getId(), 5);
+//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==" + -1, 0);
+//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + -1, 6);
+//
+//        // Not supported for numbers
+//        if (Database.POSTGRESQL.equals(getDatabase())) {
+//            return;
+//        }
+//
+//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==*", 6);
+//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==noexist*", 0);
+//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "=in=(" + ah.getId() + ",1000000)", 1);
+//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "=out=(" + ah.getId() + ",1000000)", 5);
+//    }
 
     @Test
     @Description("Test filter software module by name")
     public void testFilterByParameterName() {
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub", 5);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub*", 2);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub*", 4);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==noExist*", 0);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=in=(agent-hub,notexist)", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=out=(agent-hub,notexist)", 5);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub", 1);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub", 5);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub*", 2);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub*", 4);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==noExist*", 0);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=in=(agent-hub,notexist)", 1);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=out=(agent-hub,notexist)", 5);
 
         //wildcard entries
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*$*", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*§*", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ö*", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ä*", 1);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*$*", 1);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*§*", 1);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ö*", 1);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ä*", 1);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ü*", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*@*", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*/*", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*&*", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==***", 6);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*\\**", 1);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*@*", 1);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*/*", 1);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*&*", 1);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==***", 6);
+//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*\\**", 1);
     }
 
-    @Test
-    @Description("Test filter software module by description")
-    public void testFilterByParameterDescription() {
-        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==''", 1);
-        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=''", 5);
-        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==agent-hub", 1);
-        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=agent-hub", 5);
-        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==noExist*", 0);
-        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=in=(agent-hub,notexist)", 1);
-        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=out=(agent-hub,notexist)", 5);
-    }
-
-    @Test
-    @Description("Test filter software module by version")
-    public void testFilterByParameterVersion() {
-        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "==1.0.1", 2);
-        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "!=v1.0", 6);
-        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=in=(1.0.1,1.0.2)", 2);
-        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=out=(1.0.1)", 4);
-    }
-
-    @Test
-    @Description("Test filter software module by type key")
-    public void testFilterByType() {
-        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==" + TestdataFactory.SM_TYPE_APP, 2);
-        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "!=" + TestdataFactory.SM_TYPE_APP, 4);
-        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==noExist*", 0);
-        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=in=(" + TestdataFactory.SM_TYPE_APP + ")", 2);
-        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=out=(" + TestdataFactory.SM_TYPE_APP + ")", 4);
-    }
-
-    @Test
-    @Description("Test filter software module by metadata")
-    public void testFilterByMetadata() {
-        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==metaValue", 1);
-        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey!=metaValue", 1);
-        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey!=notexist", 2);
-        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==*v*", 2);
-        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==noExist*", 0);
-        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey=in=(metaValue,value)", 2);
-        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey=out=(metaValue,notexist)", 1);
-        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".notExist==metaValue", 0);
-
-    }
+//    @Test
+//    @Description("Test filter software module by description")
+//    public void testFilterByParameterDescription() {
+//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==''", 1);
+//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=''", 5);
+//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==agent-hub", 1);
+//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=agent-hub", 5);
+//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==noExist*", 0);
+//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=in=(agent-hub,notexist)", 1);
+//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=out=(agent-hub,notexist)", 5);
+//    }
+//
+//    @Test
+//    @Description("Test filter software module by version")
+//    public void testFilterByParameterVersion() {
+//        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "==1.0.1", 2);
+//        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "!=v1.0", 6);
+//        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=in=(1.0.1,1.0.2)", 2);
+//        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=out=(1.0.1)", 4);
+//    }
+//
+//    @Test
+//    @Description("Test filter software module by type key")
+//    public void testFilterByType() {
+//        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==" + TestdataFactory.SM_TYPE_APP, 2);
+//        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "!=" + TestdataFactory.SM_TYPE_APP, 4);
+//        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==noExist*", 0);
+//        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=in=(" + TestdataFactory.SM_TYPE_APP + ")", 2);
+//        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=out=(" + TestdataFactory.SM_TYPE_APP + ")", 4);
+//    }
+//
+//    @Test
+//    @Description("Test filter software module by metadata")
+//    public void testFilterByMetadata() {
+//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==metaValue", 1);
+//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey!=metaValue", 1);
+//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey!=notexist", 2);
+//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==*v*", 2);
+//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==noExist*", 0);
+//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey=in=(metaValue,value)", 2);
+//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey=out=(metaValue,notexist)", 1);
+//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".notExist==metaValue", 0);
+//
+//    }
 
     private void assertRSQLQuery(final String rsqlParam, final long expectedEntity) {
         final Page<SoftwareModule> find = softwareModuleManagement.findByRsql(PageRequest.of(0, 100), rsqlParam);
+        find.getContent().stream().forEach(softwareModule -> System.out.println(softwareModule.getName()));
         final long countAll = find.getTotalElements();
         assertThat(find).isNotNull();
         assertThat(countAll).isEqualTo(expectedEntity);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
@@ -39,7 +39,7 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
         softwareModuleManagement.create(entityFactory.softwareModule().create().type(runtimeType).name("oracle-jre")
                 .version("1.7.2").description("aa"));
         softwareModuleManagement.create(
-                entityFactory.softwareModule().create().type(osType).name("poky").version("3.0.2").description("aa"));
+                entityFactory.softwareModule().create().type(osType).name("poki").version("3.0.2").description("aa"));
         softwareModuleManagement
                 .create(entityFactory.softwareModule().create().type(osType).name("*§$%&/&%ÄÜ*Ö@").version("1.0.0")
                         .description("wildcard testing"));
@@ -58,97 +58,96 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
         softwareModuleManagement.createMetaData(softwareModuleMetadata2);
     }
 
-//    @Test
-//    @Description("Test filter software module by id")
-//    public void testFilterByParameterId() {
-//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==" + ah.getId(), 1);
-//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + ah.getId(), 5);
-//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==" + -1, 0);
-//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + -1, 6);
-//
-//        // Not supported for numbers
-//        if (Database.POSTGRESQL.equals(getDatabase())) {
-//            return;
-//        }
-//
-//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==*", 6);
-//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==noexist*", 0);
-//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "=in=(" + ah.getId() + ",1000000)", 1);
-//        assertRSQLQuery(SoftwareModuleFields.ID.name() + "=out=(" + ah.getId() + ",1000000)", 5);
-//    }
+    @Test
+    @Description("Test filter software module by id")
+    public void testFilterByParameterId() {
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==" + ah.getId(), 1);
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + ah.getId(), 5);
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==" + -1, 0);
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + -1, 6);
+
+        // Not supported for numbers
+        if (Database.POSTGRESQL.equals(getDatabase())) {
+            return;
+        }
+
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==*", 6);
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==noexist*", 0);
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "=in=(" + ah.getId() + ",1000000)", 1);
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "=out=(" + ah.getId() + ",1000000)", 5);
+    }
 
     @Test
     @Description("Test filter software module by name")
     public void testFilterByParameterName() {
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub", 1);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub", 5);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub*", 2);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub*", 4);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==noExist*", 0);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=in=(agent-hub,notexist)", 1);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=out=(agent-hub,notexist)", 5);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub", 5);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub*", 2);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub*", 4);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==noExist*", 0);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=in=(agent-hub,notexist)", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=out=(agent-hub,notexist)", 5);
 
         //wildcard entries
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*$*", 1);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*§*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*$*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*§*", 1);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ö*", 1);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ä*", 1);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ü*", 1);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*@*", 1);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*/*", 1);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*&*", 1);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==***", 6);
-//        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*\\**", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*@*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*/*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*&*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==***", 6);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*\\**", 1);
     }
 
-//    @Test
-//    @Description("Test filter software module by description")
-//    public void testFilterByParameterDescription() {
-//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==''", 1);
-//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=''", 5);
-//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==agent-hub", 1);
-//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=agent-hub", 5);
-//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==noExist*", 0);
-//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=in=(agent-hub,notexist)", 1);
-//        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=out=(agent-hub,notexist)", 5);
-//    }
-//
-//    @Test
-//    @Description("Test filter software module by version")
-//    public void testFilterByParameterVersion() {
-//        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "==1.0.1", 2);
-//        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "!=v1.0", 6);
-//        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=in=(1.0.1,1.0.2)", 2);
-//        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=out=(1.0.1)", 4);
-//    }
-//
-//    @Test
-//    @Description("Test filter software module by type key")
-//    public void testFilterByType() {
-//        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==" + TestdataFactory.SM_TYPE_APP, 2);
-//        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "!=" + TestdataFactory.SM_TYPE_APP, 4);
-//        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==noExist*", 0);
-//        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=in=(" + TestdataFactory.SM_TYPE_APP + ")", 2);
-//        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=out=(" + TestdataFactory.SM_TYPE_APP + ")", 4);
-//    }
-//
-//    @Test
-//    @Description("Test filter software module by metadata")
-//    public void testFilterByMetadata() {
-//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==metaValue", 1);
-//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey!=metaValue", 1);
-//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey!=notexist", 2);
-//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==*v*", 2);
-//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==noExist*", 0);
-//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey=in=(metaValue,value)", 2);
-//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey=out=(metaValue,notexist)", 1);
-//        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".notExist==metaValue", 0);
-//
-//    }
+    @Test
+    @Description("Test filter software module by description")
+    public void testFilterByParameterDescription() {
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==''", 1);
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=''", 5);
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==agent-hub", 1);
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=agent-hub", 5);
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==noExist*", 0);
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=in=(agent-hub,notexist)", 1);
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=out=(agent-hub,notexist)", 5);
+    }
+
+    @Test
+    @Description("Test filter software module by version")
+    public void testFilterByParameterVersion() {
+        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "==1.0.1", 2);
+        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "!=v1.0", 6);
+        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=in=(1.0.1,1.0.2)", 2);
+        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=out=(1.0.1)", 4);
+    }
+
+    @Test
+    @Description("Test filter software module by type key")
+    public void testFilterByType() {
+        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==" + TestdataFactory.SM_TYPE_APP, 2);
+        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "!=" + TestdataFactory.SM_TYPE_APP, 4);
+        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==noExist*", 0);
+        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=in=(" + TestdataFactory.SM_TYPE_APP + ")", 2);
+        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=out=(" + TestdataFactory.SM_TYPE_APP + ")", 4);
+    }
+
+    @Test
+    @Description("Test filter software module by metadata")
+    public void testFilterByMetadata() {
+        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==metaValue", 1);
+        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey!=metaValue", 1);
+        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey!=notexist", 2);
+        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==*v*", 2);
+        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey==noExist*", 0);
+        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey=in=(metaValue,value)", 2);
+        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".metaKey=out=(metaValue,notexist)", 1);
+        assertRSQLQuery(SoftwareModuleFields.METADATA.name() + ".notExist==metaValue", 0);
+
+    }
 
     private void assertRSQLQuery(final String rsqlParam, final long expectedEntity) {
         final Page<SoftwareModule> find = softwareModuleManagement.findByRsql(PageRequest.of(0, 100), rsqlParam);
-        find.getContent().stream().forEach(softwareModule -> System.out.println(softwareModule.getName()));
         final long countAll = find.getTotalElements();
         assertThat(find).isNotNull();
         assertThat(countAll).isEqualTo(expectedEntity);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
@@ -41,6 +41,9 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
         softwareModuleManagement.create(
                 entityFactory.softwareModule().create().type(osType).name("poky").version("3.0.2").description("aa"));
         softwareModuleManagement
+                .create(entityFactory.softwareModule().create().type(osType).name("*§$%&/&%ÄÜ*Ö@").version("1.0.0")
+                        .description("wildcard testing"));
+        softwareModuleManagement
                 .create(entityFactory.softwareModule().create().type(osType).name("noDesc").version("noDesc"));
 
         final JpaSoftwareModule ah2 = (JpaSoftwareModule) softwareModuleManagement.create(entityFactory.softwareModule()
@@ -59,62 +62,77 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
     @Description("Test filter software module by id")
     public void testFilterByParameterId() {
         assertRSQLQuery(SoftwareModuleFields.ID.name() + "==" + ah.getId(), 1);
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + ah.getId(), 4);
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + ah.getId(), 5);
         assertRSQLQuery(SoftwareModuleFields.ID.name() + "==" + -1, 0);
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + -1, 5);
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "!=" + -1, 6);
 
         // Not supported for numbers
         if (Database.POSTGRESQL.equals(getDatabase())) {
             return;
         }
 
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==*", 5);
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "==*", 6);
         assertRSQLQuery(SoftwareModuleFields.ID.name() + "==noexist*", 0);
         assertRSQLQuery(SoftwareModuleFields.ID.name() + "=in=(" + ah.getId() + ",1000000)", 1);
-        assertRSQLQuery(SoftwareModuleFields.ID.name() + "=out=(" + ah.getId() + ",1000000)", 4);
+        assertRSQLQuery(SoftwareModuleFields.ID.name() + "=out=(" + ah.getId() + ",1000000)", 5);
     }
 
     @Test
     @Description("Test filter software module by name")
     public void testFilterByParameterName() {
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub", 4);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub", 5);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==agent-hub*", 2);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub*", 3);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "!=agent-hub*", 4);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==noExist*", 0);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=in=(agent-hub,notexist)", 1);
-        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=out=(agent-hub,notexist)", 4);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=out=(agent-hub,notexist)", 5);
+
+        String what = "*§$%&/&%ÄÜ*Ö@";
+        //wildcard entries
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*$*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*§*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ö*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ä*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*Ü*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*@*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*/*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*&*", 1);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==***", 6);
+        assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*\\**", 1);
+
+
     }
 
     @Test
     @Description("Test filter software module by description")
     public void testFilterByParameterDescription() {
         assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==''", 1);
-        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=''", 4);
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=''", 5);
         assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==agent-hub", 1);
-        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=agent-hub", 4);
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "!=agent-hub", 5);
         assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "==noExist*", 0);
         assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=in=(agent-hub,notexist)", 1);
-        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=out=(agent-hub,notexist)", 4);
+        assertRSQLQuery(SoftwareModuleFields.DESCRIPTION.name() + "=out=(agent-hub,notexist)", 5);
     }
 
     @Test
     @Description("Test filter software module by version")
     public void testFilterByParameterVersion() {
         assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "==1.0.1", 2);
-        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "!=v1.0", 5);
+        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "!=v1.0", 6);
         assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=in=(1.0.1,1.0.2)", 2);
-        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=out=(1.0.1)", 3);
+        assertRSQLQuery(SoftwareModuleFields.VERSION.name() + "=out=(1.0.1)", 4);
     }
 
     @Test
     @Description("Test filter software module by type key")
     public void testFilterByType() {
         assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==" + TestdataFactory.SM_TYPE_APP, 2);
-        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "!=" + TestdataFactory.SM_TYPE_APP, 3);
+        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "!=" + TestdataFactory.SM_TYPE_APP, 4);
         assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "==noExist*", 0);
         assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=in=(" + TestdataFactory.SM_TYPE_APP + ")", 2);
-        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=out=(" + TestdataFactory.SM_TYPE_APP + ")", 3);
+        assertRSQLQuery(SoftwareModuleFields.TYPE.name() + "=out=(" + TestdataFactory.SM_TYPE_APP + ")", 4);
     }
 
     @Test
@@ -131,10 +149,10 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
 
     }
 
-    private void assertRSQLQuery(final String rsqlParam, final long excpectedEntity) {
+    private void assertRSQLQuery(final String rsqlParam, final long expectedEntity) {
         final Page<SoftwareModule> find = softwareModuleManagement.findByRsql(PageRequest.of(0, 100), rsqlParam);
         final long countAll = find.getTotalElements();
         assertThat(find).isNotNull();
-        assertThat(countAll).isEqualTo(excpectedEntity);
+        assertThat(countAll).isEqualTo(expectedEntity);
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLSoftwareModuleFieldTest.java
@@ -88,7 +88,6 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=in=(agent-hub,notexist)", 1);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "=out=(agent-hub,notexist)", 5);
 
-        String what = "*§$%&/&%ÄÜ*Ö@";
         //wildcard entries
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*$*", 1);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*§*", 1);
@@ -100,8 +99,6 @@ public class RSQLSoftwareModuleFieldTest extends AbstractJpaIntegrationTest {
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*&*", 1);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==***", 6);
         assertRSQLQuery(SoftwareModuleFields.NAME.name() + "==*\\**", 1);
-
-
     }
 
     @Test


### PR DESCRIPTION
Wild card searches with a specific use case where the name has an asterisk(*) and searching by the single wildcard is now working as expected and only results in the specific results and not yielding all the results of the entity. 