### PR TITLE
Management API: Full representation of rollout group must expose totalTargetsPerStatus property

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
@@ -102,6 +102,31 @@ public interface RolloutGroupManagement {
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
     Page<RolloutGroup> findByRolloutAndRsql(@NotNull Pageable pageable, long rolloutId,
             @NotNull String rsqlParam);
+ 
+    
+    /**
+     * Retrieves a page of {@link RolloutGroup}s filtered by a given
+     * {@link Rollout} and a rsql filter with detailed status.
+     * 
+     * @param pageable
+     *            the page request to sort and limit the result
+     * @param rolloutId
+     *            the rollout to filter the {@link RolloutGroup}s
+     * @param rsqlParam
+     *            the specification to filter the result set based on attributes
+     *            of the {@link RolloutGroup}
+     * 
+     * @return a page of found {@link RolloutGroup}s
+     * 
+     * @throws RSQLParameterUnsupportedFieldException
+     *             if a field in the RSQL string is used but not provided by the
+     *             given {@code fieldNameProvider}
+     * @throws RSQLParameterSyntaxException
+     *             if the RSQL syntax is wrong
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
+    Page<RolloutGroup> findByRolloutAndRsqlWithDetailedStatus(@NotNull Pageable pageable, long rolloutId,
+            @NotNull String rsqlParam);
 
     /**
      * Retrieves a page of {@link RolloutGroup}s filtered by a given

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRolloutRestApi.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRolloutRestApi.java
@@ -180,6 +180,10 @@ public interface MgmtRolloutRestApi {
      * @param rsqlParam
      *            the search parameter in the request URL, syntax
      *            {@code q=name==abc}
+     * @param representationModeParam
+     *            the representation mode parameter specifying whether a compact
+     *            or a full representation shall be returned
+     * 
      * @return a list of all rollout groups referred to a rollout for a defined
      *         or default page request with status OK. The response is always
      *         paged. In any failure the JsonResponseExceptionHandler is
@@ -191,7 +195,8 @@ public interface MgmtRolloutRestApi {
             @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET) int pagingOffsetParam,
             @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT) int pagingLimitParam,
             @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SORTING, required = false) String sortParam,
-            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SEARCH, required = false) String rsqlParam);
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SEARCH, required = false) String rsqlParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE_DEFAULT) String representationModeParam);
 
     /**
      * Handles the GET request for retrieving a single rollout group.

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
@@ -105,7 +105,7 @@ final class MgmtRolloutMapper {
             body.add(linkTo(methodOn(MgmtRolloutRestApi.class).deny(rollout.getId(), null)).withRel("deny").expand());
             body.add(linkTo(methodOn(MgmtRolloutRestApi.class).getRolloutGroups(rollout.getId(),
                     MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
-                    MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null)).withRel("groups")
+                    MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null, null)).withRel("groups")
                             .expand());
 
             final DistributionSet distributionSet = rollout.getDistributionSet();
@@ -165,12 +165,12 @@ final class MgmtRolloutMapper {
     }
 
     static List<MgmtRolloutGroupResponseBody> toResponseRolloutGroup(final List<RolloutGroup> rollouts,
-            final boolean confirmationFlowEnabled) {
+            final boolean confirmationFlowEnabled, final boolean withDetails) {
         if (rollouts == null) {
             return Collections.emptyList();
         }
 
-        return rollouts.stream().map(group -> toResponseRolloutGroup(group, false, confirmationFlowEnabled))
+        return rollouts.stream().map(group -> toResponseRolloutGroup(group, withDetails, confirmationFlowEnabled))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
If the collection of rollout groups of a rollout is requested for representation mode 'full' (`/rest/v1/rollouts/<id>/deploygroups?representation=full`), the JSON representation of each group needs to expose the `totalTargetsPerStatus` property.
