### PR TITLE
Fix Dockerfile for 0.3.0M8-mysql

### DIFF
--- a/hawkbit-runtime/docker/0.3.0M8-mysql/Dockerfile
+++ b/hawkbit-runtime/docker/0.3.0M8-mysql/Dockerfile
@@ -7,9 +7,9 @@ COPY KEY .
 RUN set -x \
     && apk add --no-cache --virtual build-dependencies gnupg unzip libressl wget \
     && gpg --import KEY \
-    && wget -O $JAVA_HOME/lib/ext/mariadb-java-client.jar --no-verbose https://downloads.mariadb.com/Connectors/java/connector-java-$MARIADB_DRIVER_VERSION/mariadb-java-client-$MARIADB_DRIVER_VERSION.jar \
-    && wget -O $JAVA_HOME/lib/ext/mariadb-java-client.jar.asc --no-verbose https://downloads.mariadb.com/Connectors/java/connector-java-$MARIADB_DRIVER_VERSION/mariadb-java-client-$MARIADB_DRIVER_VERSION.jar.asc \
-    && gpg --verify --batch $JAVA_HOME/lib/ext/mariadb-java-client.jar.asc $JAVA_HOME/lib/ext/mariadb-java-client.jar \
+    && wget -O mariadb-java-client.jar --no-verbose https://downloads.mariadb.com/Connectors/java/connector-java-$MARIADB_DRIVER_VERSION/mariadb-java-client-$MARIADB_DRIVER_VERSION.jar \
+    && wget -O mariadb-java-client.jar.asc --no-verbose https://downloads.mariadb.com/Connectors/java/connector-java-$MARIADB_DRIVER_VERSION/mariadb-java-client-$MARIADB_DRIVER_VERSION.jar.asc \
+    && gpg --verify --batch mariadb-java-client.jar.asc mariadb-java-client.jar \
     && apk del build-dependencies
 
-ENTRYPOINT ["java","-jar","hawkbit-update-server.jar","--spring.profiles.active=mysql","-Xms1024m -Xmx1024m -XX:MaxMetaspaceSize=250m -XX:MetaspaceSize=250m -Xss1024K -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseCompressedOops -XX:+HeapDumpOnOutOfMemoryError"]
+ENTRYPOINT ["java","--module-path=mariadb-java-client.jar","--add-modules=org.mariadb.jdbc","-jar","hawkbit-update-server.jar","--spring.profiles.active=mysql","-Xms1024m -Xmx1024m -XX:MaxMetaspaceSize=250m -XX:MetaspaceSize=250m -Xss1024K -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseCompressedOops -XX:+HeapDumpOnOutOfMemoryError"]


### PR DESCRIPTION
Fixes the Dockerfile for the MySql setup of 0.3.0M8. Declares the MariaDB Java Client as a module dependency (as required for JRE 11).