### PR TITLE
Fix platform-specific new line in confirmation status

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaAutoConfirmationStatus.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaAutoConfirmationStatus.java
@@ -77,8 +77,8 @@ public class JpaAutoConfirmationStatus extends AbstractJpaTenantAwareBaseEntity 
         final String remarkMessage = StringUtils.hasText(remark) ? remark : "n/a";
         final String formattedInitiator = StringUtils.hasText(initiator) ? initiator : "n/a";
         final String createdByRolloutsUser = StringUtils.hasText(getCreatedBy()) ? getCreatedBy() : "n/a";
-        return String.format("Assignment automatically confirmed by initiator '%s'. %n%n" //
-                + "Auto confirmation activated by system user: '%s' %n%n" //
+        return String.format("Assignment automatically confirmed by initiator '%s'. \n\n"
+                + "Auto confirmation activated by system user: '%s' \n\n"
                 + "Remark: %s", formattedInitiator, createdByRolloutsUser, remarkMessage);
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/DeploymentManagementTest.java
@@ -797,9 +797,9 @@ class DeploymentManagementTest extends AbstractJpaIntegrationTest {
                                     // auto-confirmation will perform the confirmation
                                     assertThat(actionStatus.getMessages())
                                             .contains("Assignment initiated by user 'bumlux'")
-                                            .contains("Assignment automatically confirmed by initiator 'not_bumlux'. \n"
-                                                    + "\n" + "Auto confirmation activated by system user: 'bumlux' \n"
-                                                    + "\n" + "Remark: my personal remark");
+                                            .contains("Assignment automatically confirmed by initiator 'not_bumlux'. \n\n"
+                                                    + "Auto confirmation activated by system user: 'bumlux' \n\n"
+                                                    + "Remark: my personal remark");
                                 } else {
                                     // assignment never required confirmation, auto-confirmation will not be
                                     // applied.


### PR DESCRIPTION
In the JpaAutoConfirmationStatus#constructActionMessage format uses platform-specific new line. DeploymentManagementTest#assignmentWithAutoConfirmationWillBeHandledCorrectly test however expected "\n" - Linux new line. Thus it fails, for instance, on Windows.

This commit fixes the new line to "\n" in order to:
* have predictability and platform independence
* test to pass on all systems

The alternative is to use platform-specific new line in the test - but this would make the status a little bit indeterministic (platform dependent).