### PR TITLE
Upgrade docker base image and maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,13 +179,13 @@
       <docker.jvm.args>${docker.memory.size} ${docker.gc.settings} -XX:+HeapDumpOnOutOfMemoryError
          -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom
       </docker.jvm.args>
-      <docker.jre.version>11.0.15_10-jre-alpine</docker.jre.version>
+      <docker.jre.version>11.0.19_7-jre-alpine</docker.jre.version>
       <!-- Docker image build - END -->
       <maven.processor.plugin.version>3.3.3</maven.processor.plugin.version>
       <maven.scm.plugin.version>1.11.1</maven.scm.plugin.version>
       <maven.site.plugin.version>3.9.1</maven.site.plugin.version>
-      <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
-      <maven.failsafe.plugin.version>3.0.0-M7</maven.failsafe.plugin.version>
+      <maven.surefire.plugin.version>3.0.0</maven.surefire.plugin.version>
+      <maven.failsafe.plugin.version>3.0.0</maven.failsafe.plugin.version>
       <maven.enforcer.plugin.version>3.1.0</maven.enforcer.plugin.version>
       <!-- ************************ -->
       <!-- Maven Surefire settings -->


### PR DESCRIPTION
- Docker base image upgraded to 11.0.19_7-jre-alpine - vulnerability fixes (https://openjdk.org/groups/vulnerability/advisories/2023-04-18)
- maven failsafe and surefire plugins upgraded to 3.0.0