### PR TITLE
Update documentation with a link to overview diagrams

### DIFF
--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -5,3 +5,5 @@ weight: 60
 
 Overview of hawkBit modules and used 3rd party technology:
 ![](../images/architecture/architecture.png)
+
+For a detailed repository overview please refer to [module, build, class and other diagrams](https://sourcespy.com/github/eclipsehawkbit/).

--- a/docs/layouts/partials/drawer.html
+++ b/docs/layouts/partials/drawer.html
@@ -66,6 +66,11 @@
               <img src="https://maven-badges.herokuapp.com/maven-central/org.eclipse.hawkbit/hawkbit-parent/badge.svg" />
             </a>
           </li>
+          <li>
+            <a href="https://sourcespy.com/github/eclipsehawkbit/" title="SourceSpy Project Architecture Diagrams" target="_blank">
+              <img src="https://sourcespy.com/shield.svg" />
+            </a>
+          </li>
         </ul>
         {{ end }}
       </div>


### PR DESCRIPTION
Adding a link to the high-level diagrams including module, library dependency and others (see https://sourcespy.com/github/eclipsehawkbit/). Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project.

I have consulted with eclipse/hawkbit Gitter.

In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.