### PR TITLE
Extend get module artifacts API by download URL

### DIFF
--- a/hawkbit-repository/hawkbit-repository-test/src/main/resources/hawkbit-test-defaults.properties
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/resources/hawkbit-test-defaults.properties
@@ -57,7 +57,7 @@ hawkbit.artifact.url.protocols.download-cdn-http.ip=127.0.0.1
 hawkbit.artifact.url.protocols.download-cdn-http.protocol=http
 hawkbit.artifact.url.protocols.download-cdn-http.port=8080
 hawkbit.artifact.url.protocols.download-cdn-http.supports=MGMT
-hawkbit.artifact.url.protocols.download-cdn-http.ref={protocol}://external-cdn.com/artifacts/{artifactFileName}/download
+hawkbit.artifact.url.protocols.download-cdn-http.ref={protocol}://download-cdn.com/artifacts/{artifactFileName}/download
 ## Download URL Generation - END
 
 # Quota - START

--- a/hawkbit-repository/hawkbit-repository-test/src/main/resources/hawkbit-test-defaults.properties
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/resources/hawkbit-test-defaults.properties
@@ -43,7 +43,7 @@ hawkbit.artifact.url.protocols.download-http.ip=127.0.0.1
 hawkbit.artifact.url.protocols.download-http.protocol=http
 hawkbit.artifact.url.protocols.download-http.port=8080
 hawkbit.artifact.url.protocols.download-http.supports=DMF,DDI
-hawkbit.artifact.url.protocols.download-http.ref={protocol}://{hostnameRequest}:{portRequest}/{tenant}/controller/v1/{controllerId}/softwaremodules/{softwareModuleId}/artifacts/{artifactFileName}
+hawkbit.artifact.url.protocols.download-http.ref={protocol}://{hostnameRequest}:{portRequest}/{tenant}/controller/v1/{controllerId}/softwaremodules/{softwareModuleId}/artifacts/{artifactFileName}/download
 hawkbit.artifact.url.protocols.md5sum-http.rel=md5sum-http
 hawkbit.artifact.url.protocols.md5sum-http.protocol=${hawkbit.artifact.url.protocols.download-http.protocol}
 hawkbit.artifact.url.protocols.md5sum-http.hostname=${hawkbit.artifact.url.protocols.download-http.hostname}
@@ -57,7 +57,7 @@ hawkbit.artifact.url.protocols.download-cdn-http.ip=127.0.0.1
 hawkbit.artifact.url.protocols.download-cdn-http.protocol=http
 hawkbit.artifact.url.protocols.download-cdn-http.port=8080
 hawkbit.artifact.url.protocols.download-cdn-http.supports=MGMT
-hawkbit.artifact.url.protocols.download-cdn-http.ref={protocol}://{hostnameRequest}:{portRequest}/rest/v1/softwaremodules/{softwareModuleId}/artifacts/{artifactFileName}
+hawkbit.artifact.url.protocols.download-cdn-http.ref={protocol}://external-cdn.com/artifacts/{artifactFileName}/download
 ## Download URL Generation - END
 
 # Quota - START

--- a/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/AbstractDDiApiIntegrationTest.java
+++ b/hawkbit-rest/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/AbstractDDiApiIntegrationTest.java
@@ -208,11 +208,12 @@ public abstract class AbstractDDiApiIntegrationTest extends AbstractRestIntegrat
                         contains(artifact.getSha256Hash())))
                 .andExpect(jsonPath(prefix + ".chunks[?(@.part=='os')].artifacts[0]._links.download-http.href",
                         contains(HTTP_LOCALHOST + tenantAware.getCurrentTenant() + "/controller/v1/" + controllerId
-                                + "/softwaremodules/" + osModuleId + "/artifacts/" + artifact.getFilename())))
+                                + "/softwaremodules/" + osModuleId + "/artifacts/" + artifact.getFilename()
+                                + "/download")))
                 .andExpect(jsonPath(prefix + ".chunks[?(@.part=='os')].artifacts[0]._links.md5sum-http.href",
                         contains(HTTP_LOCALHOST + tenantAware.getCurrentTenant() + "/controller/v1/" + controllerId
                                 + "/softwaremodules/" + osModuleId + "/artifacts/" + artifact.getFilename()
-                                + ".MD5SUM")))
+                                + "/download.MD5SUM")))
                 .andExpect(jsonPath(prefix + ".chunks[?(@.part=='os')].artifacts[1].size", contains(ARTIFACT_SIZE)))
                 .andExpect(jsonPath(prefix + ".chunks[?(@.part=='os')].artifacts[1].filename",
                         contains(artifactSignature.getFilename())))
@@ -224,11 +225,12 @@ public abstract class AbstractDDiApiIntegrationTest extends AbstractRestIntegrat
                         contains(artifactSignature.getSha256Hash())))
                 .andExpect(jsonPath(prefix + ".chunks[?(@.part=='os')].artifacts[1]._links.download-http.href",
                         contains(HTTP_LOCALHOST + tenantAware.getCurrentTenant() + "/controller/v1/" + controllerId
-                                + "/softwaremodules/" + osModuleId + "/artifacts/" + artifactSignature.getFilename())))
+                                + "/softwaremodules/" + osModuleId + "/artifacts/" + artifactSignature.getFilename()
+                                + "/download")))
                 .andExpect(jsonPath(prefix + ".chunks[?(@.part=='os')].artifacts[1]._links.md5sum-http.href",
                         contains(HTTP_LOCALHOST + tenantAware.getCurrentTenant() + "/controller/v1/" + controllerId
                                 + "/softwaremodules/" + osModuleId + "/artifacts/" + artifactSignature.getFilename()
-                                + ".MD5SUM")))
+                                + "/download.MD5SUM")))
                 .andExpect(jsonPath(prefix + ".chunks[?(@.part=='bApp')].version",
                         contains(ds.findFirstModuleByType(appType).get().getVersion())))
                 .andExpect(jsonPath(prefix + ".chunks[?(@.part=='bApp')].metadata").doesNotExist())

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
@@ -275,7 +275,6 @@ public final class MgmtRestConstants {
      * Request parameter if the artifact url handler should be used
      */
     public static final String REQUEST_PARAMETER_USE_ARTIFACT_URL_HANDLER = "useartifacturlhandler";
-    public static final String REQUEST_PARAMETER_WITH_DOWNLOAD_URL = "withdownloadurl";
 
     // constant class, private constructor.
     private MgmtRestConstants() {

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
@@ -275,7 +275,7 @@ public final class MgmtRestConstants {
      * Request parameter if the artifact url handler should be used
      */
     public static final String REQUEST_PARAMETER_USE_ARTIFACT_URL_HANDLER = "useartifacturlhandler";
-
+    public static final String REQUEST_PARAMETER_WITH_DOWNLOAD_URL = "withdownloadurl";
 
     // constant class, private constructor.
     private MgmtRestConstants() {

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtSoftwareModuleRestApi.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtSoftwareModuleRestApi.java
@@ -83,7 +83,8 @@ public interface MgmtSoftwareModuleRestApi {
             + "/{softwareModuleId}/artifacts", produces = { MediaTypes.HAL_JSON_VALUE,
                     MediaType.APPLICATION_JSON_VALUE })
     ResponseEntity<List<MgmtArtifact>> getArtifacts(@PathVariable("softwareModuleId") final Long softwareModuleId,
-            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_WITH_DOWNLOAD_URL, required = false) final Boolean withDownloadUrl);
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, defaultValue = MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE_DEFAULT) String representationModeParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_USE_ARTIFACT_URL_HANDLER, required = false) final Boolean useArtifactUrlHandler);
 
     /**
      * Handles the GET request of retrieving a single Artifact meta data

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtSoftwareModuleRestApi.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtSoftwareModuleRestApi.java
@@ -82,7 +82,8 @@ public interface MgmtSoftwareModuleRestApi {
     @GetMapping(value = MgmtRestConstants.SOFTWAREMODULE_V1_REQUEST_MAPPING
             + "/{softwareModuleId}/artifacts", produces = { MediaTypes.HAL_JSON_VALUE,
                     MediaType.APPLICATION_JSON_VALUE })
-    ResponseEntity<List<MgmtArtifact>> getArtifacts(@PathVariable("softwareModuleId") final Long softwareModuleId);
+    ResponseEntity<List<MgmtArtifact>> getArtifacts(@PathVariable("softwareModuleId") final Long softwareModuleId,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_WITH_DOWNLOAD_URL, required = false) final Boolean withDownloadUrl);
 
     /**
      * Handles the GET request of retrieving a single Artifact meta data

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleMapper.java
@@ -124,7 +124,7 @@ public final class MgmtSoftwareModuleMapper {
     }
 
     static void addLinks(final SoftwareModule softwareModule, final MgmtSoftwareModule response) {
-        response.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class).getArtifacts(response.getModuleId()))
+        response.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class).getArtifacts(response.getModuleId(), null))
                 .withRel(MgmtRestConstants.SOFTWAREMODULE_V1_ARTIFACT).expand());
 
         response.add(linkTo(
@@ -172,12 +172,4 @@ public final class MgmtSoftwareModuleMapper {
         urls.forEach(entry -> response.add(Link.of(entry.getRef()).withRel(entry.getRel()).expand()));
     }
 
-    static List<MgmtArtifact> artifactsToResponse(final Collection<Artifact> artifacts) {
-        if (artifacts == null) {
-            return Collections.emptyList();
-        }
-
-        return new ResponseList<>(
-                artifacts.stream().map(MgmtSoftwareModuleMapper::toResponse).collect(Collectors.toList()));
-    }
 }

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleMapper.java
@@ -124,7 +124,7 @@ public final class MgmtSoftwareModuleMapper {
     }
 
     static void addLinks(final SoftwareModule softwareModule, final MgmtSoftwareModule response) {
-        response.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class).getArtifacts(response.getModuleId(), null))
+        response.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class).getArtifacts(response.getModuleId(), null, null))
                 .withRel(MgmtRestConstants.SOFTWAREMODULE_V1_ARTIFACT).expand());
 
         response.add(linkTo(

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResource.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResource.java
@@ -39,6 +39,7 @@ import org.eclipse.hawkbit.repository.model.ArtifactUpload;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleMetadata;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
+import org.eclipse.hawkbit.rest.data.ResponseList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -105,7 +106,7 @@ public class MgmtSoftwareModuleResource implements MgmtSoftwareModuleRestApi {
             fileName = file.getOriginalFilename();
         }
 
-        try (InputStream in = file.getInputStream()) {
+        try (final InputStream in = file.getInputStream()) {
             final Artifact result = artifactManagement.create(new ArtifactUpload(in, softwareModuleId, fileName,
                     md5Sum == null ? null : md5Sum.toLowerCase(), sha1Sum == null ? null : sha1Sum.toLowerCase(),
                     sha256Sum == null ? null : sha256Sum.toLowerCase(), false, file.getContentType(), file.getSize()));
@@ -122,10 +123,19 @@ public class MgmtSoftwareModuleResource implements MgmtSoftwareModuleRestApi {
 
     @Override
     public ResponseEntity<List<MgmtArtifact>> getArtifacts(
-            @PathVariable("softwareModuleId") final Long softwareModuleId) {
+            @PathVariable("softwareModuleId") final Long softwareModuleId,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_WITH_DOWNLOAD_URL, required = false) final Boolean withDownloadUrl) {
 
         final SoftwareModule module = findSoftwareModuleWithExceptionIfNotFound(softwareModuleId, null);
-        return ResponseEntity.ok(MgmtSoftwareModuleMapper.artifactsToResponse(module.getArtifacts()));
+
+        final List<MgmtArtifact> response = module.getArtifacts().stream().map(artifact -> {
+            final MgmtArtifact mgmtArtifact = MgmtSoftwareModuleMapper.toResponse(artifact);
+            if (!module.isDeleted() && Boolean.TRUE.equals(withDownloadUrl)) {
+                MgmtSoftwareModuleMapper.addLinks(artifact, mgmtArtifact, artifactUrlHandler, systemManagement);
+            }
+            return mgmtArtifact;
+        }).toList();
+        return ResponseEntity.ok(new ResponseList<>(response));
     }
 
     @Override
@@ -141,7 +151,7 @@ public class MgmtSoftwareModuleResource implements MgmtSoftwareModuleRestApi {
 
         final MgmtArtifact response = MgmtSoftwareModuleMapper.toResponse(module.getArtifact(artifactId).get());
         if (!module.isDeleted()) {
-            if(useArtifactUrlHandler != null && useArtifactUrlHandler) {
+            if (Boolean.TRUE.equals(useArtifactUrlHandler)) {
                 MgmtSoftwareModuleMapper.addLinks(module.getArtifact(artifactId).get(), response, artifactUrlHandler,
                         systemManagement);
             } else {
@@ -177,7 +187,7 @@ public class MgmtSoftwareModuleResource implements MgmtSoftwareModuleRestApi {
         final Pageable pageable = new OffsetBasedPageRequest(sanitizedOffsetParam, sanitizedLimitParam, sorting);
 
         final Slice<SoftwareModule> findModulesAll;
-        long countModulesAll;
+        final long countModulesAll;
         if (rsqlParam != null) {
             findModulesAll = softwareModuleManagement.findByRsql(pageable, rsqlParam);
             countModulesAll = ((Page<SoftwareModule>) findModulesAll).getTotalElements();

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
@@ -41,6 +41,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
 import org.eclipse.hawkbit.exception.SpServerError;
 import org.eclipse.hawkbit.mgmt.json.model.artifact.MgmtArtifact;
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtRepresentationMode;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
 import org.eclipse.hawkbit.repository.Constants;
 import org.eclipse.hawkbit.repository.exception.AssignmentQuotaExceededException;
@@ -691,7 +692,7 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
     @Description("Verifies the listing of all artifacts assigned to a software module. That includes the artifact metadata and download links.")
-    void getArtifactsWithCdnDownloadParameter(final boolean withDownloadUrl) throws Exception {
+    void getArtifactsWithCdnDownloadParameter(final boolean useArtifactUrlHandler) throws Exception {
         final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
 
         final int artifactSize = 5 * 1024;
@@ -703,7 +704,8 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
                 .create(new ArtifactUpload(new ByteArrayInputStream(random), sm.getId(), "file2", false, artifactSize));
 
         mvc.perform(get("/rest/v1/softwaremodules/{smId}/artifacts", sm.getId())
-                .param("withdownloadurl", String.valueOf(withDownloadUrl))
+                .param("representation", MgmtRepresentationMode.FULL.toString())
+                .param("useartifacturlhandler", String.valueOf(useArtifactUrlHandler))
                 .accept(MediaType.APPLICATION_JSON)).andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.[0].id", equalTo(artifact.getId().intValue())))
@@ -712,12 +714,10 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
                 .andExpect(jsonPath("$.[0].hashes.sha1", equalTo(artifact.getSha1Hash())))
                 .andExpect(jsonPath("$.[0].hashes.sha256", equalTo(artifact.getSha256Hash())))
                 .andExpect(jsonPath("$.[0].providedFilename", equalTo("file1")))
-                .andExpect(
-                        withDownloadUrl
-                                ? jsonPath("$.[0]._links.download.href",
-                                        equalTo("http://external-cdn.com/artifacts/%s/download"
-                                                .formatted(artifact.getFilename())))
-                                : jsonPath("$.[0]._links", Matchers.not(Matchers.hasKey("download"))))
+                .andExpect(jsonPath("$.[0]._links.download.href", useArtifactUrlHandler
+                        ? equalTo("http://external-cdn.com/artifacts/%s/download".formatted(artifact.getFilename()))
+                        : equalTo("http://localhost/rest/v1/softwaremodules/%s/artifacts/%s/download"
+                                .formatted(sm.getId(), artifact.getId()))))
                 .andExpect(jsonPath("$.[0]._links.self.href",
                         equalTo("http://localhost/rest/v1/softwaremodules/" + sm.getId() + "/artifacts/"
                                 + artifact.getId())))
@@ -726,12 +726,10 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
                 .andExpect(jsonPath("$.[1].hashes.sha1", equalTo(artifact2.getSha1Hash())))
                 .andExpect(jsonPath("$.[1].hashes.sha256", equalTo(artifact2.getSha256Hash())))
                 .andExpect(jsonPath("$.[1].providedFilename", equalTo("file2")))
-                .andExpect(
-                        withDownloadUrl
-                                ? jsonPath("$.[1]._links.download.href",
-                                        equalTo("http://external-cdn.com/artifacts/%s/download"
-                                                .formatted(artifact2.getFilename())))
-                                : jsonPath("$.[1]._links", Matchers.not(Matchers.hasKey("download"))))
+                .andExpect(jsonPath("$.[1]._links.download.href", useArtifactUrlHandler
+                        ? equalTo("http://external-cdn.com/artifacts/%s/download".formatted(artifact2.getFilename()))
+                        : equalTo("http://localhost/rest/v1/softwaremodules/%s/artifacts/%s/download"
+                                .formatted(sm.getId(), artifact2.getId()))))
                 .andExpect(jsonPath("$.[1]._links.self.href",
                         equalTo("http://localhost/rest/v1/softwaremodules/%s/artifacts/%s".formatted(sm.getId(),
                                 artifact2.getId()))));

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
@@ -597,7 +597,7 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
     @Description("Verifies the listing of one defined artifact assigned to a given software module. That includes the artifact metadata and cdn download links.")
-    void getArtifactWithCdnDownloadParameter(final boolean useArtifactUrlHandler) throws Exception {
+    void getArtifactWithUseArtifactUrlHandlerParameter(final boolean useArtifactUrlHandler) throws Exception {
         // prepare data for test
         final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
 
@@ -692,7 +692,7 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
     @Description("Verifies the listing of all artifacts assigned to a software module. That includes the artifact metadata and download links.")
-    void getArtifactsWithCdnDownloadParameter(final boolean useArtifactUrlHandler) throws Exception {
+    void getArtifactsWithUseArtifactUrlHandlerParameter(final boolean useArtifactUrlHandler) throws Exception {
         final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
 
         final int artifactSize = 5 * 1024;

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
@@ -619,7 +619,7 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
                 .andExpect(jsonPath("$.hashes.sha256", equalTo(artifact.getSha256Hash())))
                 .andExpect(jsonPath("$.providedFilename", equalTo("file1")))
                 .andExpect(jsonPath("$._links.download.href", useArtifactUrlHandler
-                        ? equalTo("http://external-cdn.com/artifacts/%s/download".formatted(artifact.getFilename()))
+                        ? equalTo("http://download-cdn.com/artifacts/%s/download".formatted(artifact.getFilename()))
                         : equalTo("http://localhost/rest/v1/softwaremodules/%s/artifacts/%s/download"
                                 .formatted(sm.getId(), artifact.getId()))))
                 .andExpect(jsonPath("$._links.self.href", equalTo(
@@ -715,7 +715,7 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
                 .andExpect(jsonPath("$.[0].hashes.sha256", equalTo(artifact.getSha256Hash())))
                 .andExpect(jsonPath("$.[0].providedFilename", equalTo("file1")))
                 .andExpect(jsonPath("$.[0]._links.download.href", useArtifactUrlHandler
-                        ? equalTo("http://external-cdn.com/artifacts/%s/download".formatted(artifact.getFilename()))
+                        ? equalTo("http://download-cdn.com/artifacts/%s/download".formatted(artifact.getFilename()))
                         : equalTo("http://localhost/rest/v1/softwaremodules/%s/artifacts/%s/download"
                                 .formatted(sm.getId(), artifact.getId()))))
                 .andExpect(jsonPath("$.[0]._links.self.href",
@@ -727,7 +727,7 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
                 .andExpect(jsonPath("$.[1].hashes.sha256", equalTo(artifact2.getSha256Hash())))
                 .andExpect(jsonPath("$.[1].providedFilename", equalTo("file2")))
                 .andExpect(jsonPath("$.[1]._links.download.href", useArtifactUrlHandler
-                        ? equalTo("http://external-cdn.com/artifacts/%s/download".formatted(artifact2.getFilename()))
+                        ? equalTo("http://download-cdn.com/artifacts/%s/download".formatted(artifact2.getFilename()))
                         : equalTo("http://localhost/rest/v1/softwaremodules/%s/artifacts/%s/download"
                                 .formatted(sm.getId(), artifact2.getId()))))
                 .andExpect(jsonPath("$.[1]._links.self.href",

--- a/hawkbit-rest/hawkbit-rest-docs/src/main/asciidoc/softwaremodules-api-guide.adoc
+++ b/hawkbit-rest/hawkbit-rest-docs/src/main/asciidoc/softwaremodules-api-guide.adoc
@@ -271,6 +271,10 @@ include::{snippets}/softwaremodules/get-artifacts/http-request.adoc[]
 
 include::{snippets}/softwaremodules/get-artifacts/path-parameters.adoc[]
 
+==== Request query parameter
+
+include::{snippets}/softwaremodules/get-artifacts-with-parameters/request-parameters.adoc[]
+
 === Response (Status 200)
 
 ==== Response fields 

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/SoftwaremodulesDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/SoftwaremodulesDocumentationTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.hawkbit.im.authentication.SpPermission;
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtRepresentationMode;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
 import org.eclipse.hawkbit.repository.Constants;
 import org.eclipse.hawkbit.repository.model.Artifact;
@@ -279,7 +280,7 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
     }
 
     @Test
-    @Description("Handles the GET request of retrieving all meta data of artifacts assigned to a software module (including a download URL by the artifact provider). Required Permission: "
+    @Description("Handles the GET request of retrieving all meta data of artifacts assigned to a software module (in full representation mode including a download URL by the artifact provider). Required Permission: "
             + SpPermission.READ_REPOSITORY)
     public void getArtifactsWithParameters() throws Exception {
         final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
@@ -290,11 +291,15 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
 
         mockMvc.perform(
                 get(MgmtRestConstants.SOFTWAREMODULE_V1_REQUEST_MAPPING + "/{softwareModuleId}/artifacts", sm.getId())
-                        .param("withdownloadurl", "true"))
+                        .param("representation", MgmtRepresentationMode.FULL.toString())
+                        .param("useartifacturlhandler", Boolean.TRUE.toString()))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(content().contentType(MediaTypes.HAL_JSON))
-                .andDo(this.document.document(requestParameters(parameterWithName("withdownloadurl")
-                        .description(MgmtApiModelProperties.ARTIFACT_DOWNLOAD_USE_URL_HANDLER))));
+                .andDo(this.document.document(requestParameters(
+                        parameterWithName("representation").description(MgmtApiModelProperties.REPRESENTATION_MODE)
+                                .optional(),
+                        parameterWithName("useartifacturlhandler")
+                                .description(MgmtApiModelProperties.ARTIFACT_DOWNLOAD_USE_URL_HANDLER).optional())));
     }
 
     @Test
@@ -422,13 +427,12 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
                 .create(new ArtifactUpload(new ByteArrayInputStream(random), sm.getId(), "file1", false, 0));
 
         mockMvc.perform(
-                        get(MgmtRestConstants.SOFTWAREMODULE_V1_REQUEST_MAPPING + "/{softwareModuleId}/artifacts/{artifactId}",
-                                sm.getId(), artifact.getId()).param("useartifacturlhandler", "true"))
+                get(MgmtRestConstants.SOFTWAREMODULE_V1_REQUEST_MAPPING + "/{softwareModuleId}/artifacts/{artifactId}",
+                        sm.getId(), artifact.getId()).param("useartifacturlhandler", "true"))
                 .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
                 .andExpect(content().contentType(MediaTypes.HAL_JSON))
-                .andDo(this.document.document(
-                        requestParameters(
-                                parameterWithName("useartifacturlhandler").description(MgmtApiModelProperties.ARTIFACT_DOWNLOAD_USE_URL_HANDLER))));
+                .andDo(this.document.document(requestParameters(parameterWithName("useartifacturlhandler")
+                        .description(MgmtApiModelProperties.ARTIFACT_DOWNLOAD_USE_URL_HANDLER).optional())));
     }
 
     @Test

--- a/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/SoftwaremodulesDocumentationTest.java
+++ b/hawkbit-rest/hawkbit-rest-docs/src/test/java/org/eclipse/hawkbit/rest/mgmt/documentation/SoftwaremodulesDocumentationTest.java
@@ -249,7 +249,7 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
     public void getArtifacts() throws Exception {
         final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
 
-        final byte random[] = RandomStringUtils.random(5).getBytes();
+        final byte[] random = RandomStringUtils.random(5).getBytes();
 
         artifactManagement.create(new ArtifactUpload(new ByteArrayInputStream(random), sm.getId(), "file1", false, 0));
 
@@ -279,12 +279,31 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
     }
 
     @Test
+    @Description("Handles the GET request of retrieving all meta data of artifacts assigned to a software module (including a download URL by the artifact provider). Required Permission: "
+            + SpPermission.READ_REPOSITORY)
+    public void getArtifactsWithParameters() throws Exception {
+        final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
+
+        final byte[] random = RandomStringUtils.random(5).getBytes();
+
+        artifactManagement.create(new ArtifactUpload(new ByteArrayInputStream(random), sm.getId(), "file1", false, 0));
+
+        mockMvc.perform(
+                get(MgmtRestConstants.SOFTWAREMODULE_V1_REQUEST_MAPPING + "/{softwareModuleId}/artifacts", sm.getId())
+                        .param("withdownloadurl", "true"))
+                .andDo(MockMvcResultPrinter.print()).andExpect(status().isOk())
+                .andExpect(content().contentType(MediaTypes.HAL_JSON))
+                .andDo(this.document.document(requestParameters(parameterWithName("withdownloadurl")
+                        .description(MgmtApiModelProperties.ARTIFACT_DOWNLOAD_USE_URL_HANDLER))));
+    }
+
+    @Test
     @Description("Handles POST request for artifact upload. Required Permission: " + SpPermission.CREATE_REPOSITORY)
     public void postArtifact() throws Exception {
         final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
 
         // create test file
-        final byte random[] = RandomStringUtils.random(5).getBytes();
+        final byte[] random = RandomStringUtils.random(5).getBytes();
         final MockMultipartFile file = new MockMultipartFile("file", "origFilename", null, random);
 
         mockMvc.perform(
@@ -320,7 +339,7 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
 
         final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
 
-        final byte random[] = RandomStringUtils.random(5).getBytes();
+        final byte[] random = RandomStringUtils.random(5).getBytes();
         final MockMultipartFile file = new MockMultipartFile("file", "origFilename", null, random);
 
         mockMvc.perform(
@@ -342,7 +361,7 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
     public void deleteArtifact() throws Exception {
         final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
 
-        final byte random[] = RandomStringUtils.random(5).getBytes();
+        final byte[] random = RandomStringUtils.random(5).getBytes();
 
         final Artifact artifact = artifactManagement
                 .create(new ArtifactUpload(new ByteArrayInputStream(random), sm.getId(), "file1", false, 0));
@@ -361,7 +380,7 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
     public void getArtifact() throws Exception {
         final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
 
-        final byte random[] = RandomStringUtils.random(5).getBytes();
+        final byte[] random = RandomStringUtils.random(5).getBytes();
 
         final Artifact artifact = artifactManagement
                 .create(new ArtifactUpload(new ByteArrayInputStream(random), sm.getId(), "file1", false, 0));
@@ -397,7 +416,7 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
     public void getArtifactWithParameters() throws Exception {
         final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
 
-        final byte random[] = RandomStringUtils.random(5).getBytes();
+        final byte[] random = RandomStringUtils.random(5).getBytes();
 
         final Artifact artifact = artifactManagement
                 .create(new ArtifactUpload(new ByteArrayInputStream(random), sm.getId(), "file1", false, 0));
@@ -419,7 +438,7 @@ public class SoftwaremodulesDocumentationTest extends AbstractApiRestDocumentati
 
         final SoftwareModule sm = testdataFactory.createSoftwareModuleOs();
 
-        final byte random[] = RandomStringUtils.random(5).getBytes();
+        final byte[] random = RandomStringUtils.random(5).getBytes();
 
         final Artifact artifact = artifactManagement
                 .create(new ArtifactUpload(new ByteArrayInputStream(random), sm.getId(), "file1", false, 0));


### PR DESCRIPTION
Introduce request parameter to request download URLs when retrieving list of artifacts for a specific software module.