### PR TITLE
Do not retry AMQP messages which violates a quota

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -39,6 +39,7 @@ import org.eclipse.hawkbit.repository.RepositoryConstants;
 import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
 import org.eclipse.hawkbit.repository.UpdateMode;
 import org.eclipse.hawkbit.repository.builder.ActionStatusCreate;
+import org.eclipse.hawkbit.repository.exception.AssignmentQuotaExceededException;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Action.Status;
@@ -183,6 +184,8 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
             default:
                 logAndThrowMessageError(message, "No handle method was found for the given message type.");
             }
+        } catch(AssignmentQuotaExceededException ex) {
+            throw new AmqpRejectAndDontRequeueException("Could not handle message due to quota violation!", ex);
         } catch (final IllegalArgumentException ex) {
             throw new AmqpRejectAndDontRequeueException("Invalid message!", ex);
         } finally {


### PR DESCRIPTION
We had a case where a remote device sent an action state update, that violated the quota defined in `hawkbit.server.security.dos.maxStatusEntriesPerAction`. This caused an `AssignmentQuotaExceededException`to be thrown, so AMQP message consumption was blocked (and thereby the Device Management Federation API not functional anymore) until a manual cleanup in the database.
This changes the behavior so messages which violate a quota are ignored so Device Management Federation API remains functional.