### PR TITLE
Fixing missing API doc

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -7,7 +7,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #
 
-baseurl = "https://www.eclipse.dev/hawkbit/"
+baseurl = "https://eclipse.dev/hawkbit/"
 languageCode = "en-us"
 title = "Eclipse hawkBit"
 theme = "hugo-material-docs"
@@ -18,6 +18,8 @@ canonifyurls = false
 	[markup.goldmark]
 		[markup.goldmark.extensions]
 			typographer = true
+        [markup.goldmark.renderer]
+            unsafe = true
 
 [markup.highlight]
 	codeFences = false

--- a/docs/content/apis/ddi_api.md
+++ b/docs/content/apis/ddi_api.md
@@ -32,4 +32,4 @@ SCHEDULED                   | This can be used by the target to inform that it s
 RESUMED                     | This can be used by the target to inform that it continued to work on the action.                                                                                                                                                        | RUNNING
 
 
-<iframe width="100%" height="800px" frameborder="0" src="../../rest-api/rootcontroller-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../rest-api/rootcontroller-api-guide.html"></iframe>

--- a/docs/content/apis/mgmt/distributionsets.md
+++ b/docs/content/apis/mgmt/distributionsets.md
@@ -4,4 +4,4 @@ parent: Management API
 weight: -101
 ---
 
-<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/distributionsets-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/distributionsets-api-guide.html"></iframe>

--- a/docs/content/apis/mgmt/distributionsettag.md
+++ b/docs/content/apis/mgmt/distributionsettag.md
@@ -4,4 +4,4 @@ parent: Management API
 weight: -105
 ---
 
-<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/distributionsettag-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/distributionsettag-api-guide.html"></iframe>

--- a/docs/content/apis/mgmt/distributionsettypes.md
+++ b/docs/content/apis/mgmt/distributionsettypes.md
@@ -4,4 +4,4 @@ parent: Management API
 weight: -102
 ---
 
-<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/distributionsettypes-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/distributionsettypes-api-guide.html"></iframe>

--- a/docs/content/apis/mgmt/rollouts.md
+++ b/docs/content/apis/mgmt/rollouts.md
@@ -4,4 +4,4 @@ parent: Management API
 weight: -106
 ---
 
-<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/rollout-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/rollout-api-guide.html"></iframe>

--- a/docs/content/apis/mgmt/softwaremodules.md
+++ b/docs/content/apis/mgmt/softwaremodules.md
@@ -4,4 +4,4 @@ parent: Management API
 weight: -103
 ---
 
-<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/softwaremodules-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/softwaremodules-api-guide.html"></iframe>

--- a/docs/content/apis/mgmt/softwaremoduletypes.md
+++ b/docs/content/apis/mgmt/softwaremoduletypes.md
@@ -4,4 +4,4 @@ parent: Management API
 weight: -100
 ---
 
-<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/softwaremoduletypes-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/softwaremoduletypes-api-guide.html"></iframe>

--- a/docs/content/apis/mgmt/targetfilters.md
+++ b/docs/content/apis/mgmt/targetfilters.md
@@ -4,4 +4,4 @@ parent: Management API
 weight: -107
 ---
 
-<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/targetfilters-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/targetfilters-api-guide.html"></iframe>

--- a/docs/content/apis/mgmt/targets.md
+++ b/docs/content/apis/mgmt/targets.md
@@ -4,4 +4,4 @@ parent: Management API
 weight: -100
 ---
 
-<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/targets-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/targets-api-guide.html"></iframe>

--- a/docs/content/apis/mgmt/targettag.md
+++ b/docs/content/apis/mgmt/targettag.md
@@ -4,4 +4,4 @@ parent: Management API
 weight: -104
 ---
 
-<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/targettag-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/targettag-api-guide.html"></iframe>

--- a/docs/content/apis/mgmt/targettypes.md
+++ b/docs/content/apis/mgmt/targettypes.md
@@ -4,4 +4,4 @@ parent: Management API
 weight: -100
 ---
 
-<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/targettypes-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/targettypes-api-guide.html"></iframe>

--- a/docs/content/apis/mgmt/tenant.md
+++ b/docs/content/apis/mgmt/tenant.md
@@ -4,4 +4,4 @@ parent: Management API
 weight: -108
 ---
 
-<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/tenant-api-guide/"></iframe>
+<iframe width="100%" height="800px" frameborder="0" src="../../../rest-api/tenant-api-guide.html"></iframe>


### PR DESCRIPTION
fixed by adding
```
[markup]
	[markup.goldmark]
        [markup.goldmark.renderer]
            unsafe = true
```

otherwise hugo removes raw html (as the iframes) 
+ links points to concrete html files 
+ www removed from baseurl (otherwise some cors issues occur)