### PR TITLE
Use random default gateway token

### DIFF
--- a/hawkbit-autoconfigure/src/main/resources/hawkbit-security-defaults.properties
+++ b/hawkbit-autoconfigure/src/main/resources/hawkbit-security-defaults.properties
@@ -17,4 +17,4 @@ hawkbit.server.ddi.security.authentication.header.authority=
 hawkbit.server.ddi.security.authentication.targettoken.enabled=false
 hawkbit.server.ddi.security.authentication.gatewaytoken.enabled=false
 hawkbit.server.download.anonymous.enabled=false
-hawkbit.server.ddi.security.authentication.gatewaytoken.key=
+hawkbit.server.ddi.security.authentication.gatewaytoken.key=${random.uuid}

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/AuthenticationConfigurationView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/tenantconfiguration/AuthenticationConfigurationView.java
@@ -165,17 +165,17 @@ public class AuthenticationConfigurationView extends BaseConfigurationView<Proxy
 
     @Override
     public void save() {
+        if (getBinderBean().isGatewaySecToken()) {
+            writeConfigOption(TenantConfigurationKey.AUTHENTICATION_MODE_GATEWAY_SECURITY_TOKEN_KEY,
+                    getBinderBean().getGatewaySecurityToken());
+        }
+
         writeConfigOption(TenantConfigurationKey.AUTHENTICATION_MODE_TARGET_SECURITY_TOKEN_ENABLED,
                 getBinderBean().isTargetSecToken());
         writeConfigOption(TenantConfigurationKey.AUTHENTICATION_MODE_GATEWAY_SECURITY_TOKEN_ENABLED,
                 getBinderBean().isGatewaySecToken());
         writeConfigOption(TenantConfigurationKey.ANONYMOUS_DOWNLOAD_MODE_ENABLED,
                 getBinderBean().isDownloadAnonymous());
-
-        if (getBinderBean().isGatewaySecToken()) {
-            writeConfigOption(TenantConfigurationKey.AUTHENTICATION_MODE_GATEWAY_SECURITY_TOKEN_KEY,
-                    getBinderBean().getGatewaySecurityToken());
-        }
 
         writeConfigOption(TenantConfigurationKey.AUTHENTICATION_MODE_HEADER_ENABLED,
                 getBinderBean().isCertificateAuth());


### PR DESCRIPTION
Autoconfigure default tenant configuration with a random gateway token. So, the default token won't be the empty string. If need to be set explicitly it could be made via
hawkbit.server.ddi.security.authentication.gatewaytoken.key or hawkbit.server.tenant.configuration.authentication-gatewaytoken-key.defaultValue properties.

To get/check the autogenerated random (skoped to the single hawkbit start) you could use:
```
curl --user admin:admin -X GET -i 'http://localhost:8080/rest/v1/system/configs/authentication.gatewaytoken.key'
```