### PR TITLE
Full representation with filtration

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
@@ -458,4 +458,14 @@ public interface RolloutManagement {
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_UPDATE)
     void triggerNextGroup(long rolloutId);
 
+    /**
+     * Enrich the rollouts Slice with additional details
+     *
+     * @param rollouts
+     *            the rollouts to be enriched.
+     *
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_UPDATE)
+    void setRolloutStatusDetails(final Slice<Rollout> rollouts);
+
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -575,8 +575,8 @@ public class JpaRolloutManagement implements RolloutManagement {
 
         return fromCache;
     }
-
-    private void setRolloutStatusDetails(final Slice<Rollout> rollouts) {
+    @Override
+    public void setRolloutStatusDetails(final Slice<Rollout> rollouts) {
         final List<Long> rolloutIds = rollouts.getContent().stream().map(Rollout::getId).collect(Collectors.toList());
         final Map<Long, List<TotalTargetCountActionStatus>> allStatesForRollout = getStatusCountItemForRollout(
                 rolloutIds);

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResource.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResource.java
@@ -103,26 +103,17 @@ public class MgmtRolloutResource implements MgmtRolloutRestApi {
         final boolean isFullMode = parseRepresentationMode(representationModeParam) == MgmtRepresentationMode.FULL;
 
         final Pageable pageable = new OffsetBasedPageRequest(sanitizedOffsetParam, sanitizedLimitParam, sorting);
-        final Slice<Rollout> rollouts;
         final long totalElements;
+        final Page<Rollout> rollouts;
         if (rsqlParam != null) {
-            if (isFullMode) {
-                rollouts = this.rolloutManagement.findByFiltersWithDetailedStatus(pageable, rsqlParam, false);
-                totalElements = this.rolloutManagement.countByFilters(rsqlParam);
-            } else {
-                final Page<Rollout> findRolloutsAll = this.rolloutManagement.findByRsql(pageable, rsqlParam, false);
-                totalElements = findRolloutsAll.getTotalElements();
-                rollouts = findRolloutsAll;
-            }
+            rollouts = this.rolloutManagement.findByRsql(pageable, rsqlParam, false);
         } else {
-            if (isFullMode) {
-                rollouts = this.rolloutManagement.findAllWithDetailedStatus(pageable, false);
-                totalElements = this.rolloutManagement.count();
-            } else {
-                final Page<Rollout> findRolloutsAll = this.rolloutManagement.findAll(pageable, false);
-                totalElements = findRolloutsAll.getTotalElements();
-                rollouts = findRolloutsAll;
-            }
+            rollouts = this.rolloutManagement.findAll(pageable, false);
+        }
+        totalElements = rollouts.getTotalElements();
+
+        if (isFullMode) {
+            this.rolloutManagement.setRolloutStatusDetails(rollouts);
         }
 
         final List<MgmtRolloutResponseBody> rest = MgmtRolloutMapper.toResponseRollout(rollouts.getContent(),

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResource.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResource.java
@@ -103,14 +103,14 @@ public class MgmtRolloutResource implements MgmtRolloutRestApi {
         final boolean isFullMode = parseRepresentationMode(representationModeParam) == MgmtRepresentationMode.FULL;
 
         final Pageable pageable = new OffsetBasedPageRequest(sanitizedOffsetParam, sanitizedLimitParam, sorting);
-        final long totalElements;
         final Page<Rollout> rollouts;
         if (rsqlParam != null) {
             rollouts = this.rolloutManagement.findByRsql(pageable, rsqlParam, false);
         } else {
             rollouts = this.rolloutManagement.findAll(pageable, false);
         }
-        totalElements = rollouts.getTotalElements();
+
+        final long totalElements = rollouts.getTotalElements();
 
         if (isFullMode) {
             this.rolloutManagement.setRolloutStatusDetails(rollouts);


### PR DESCRIPTION
When performing a GET request will RSQL filtration ("q" parameter) and representation=full. No results are being returned. 
/rest/v1/rollouts?q=id==1&representation==full. 

The RSQL is being parsed and matched only by the name and description of the Rollout.
What works is /rest/v1/rollouts?q=<rollout_name>&representation==full, but q=<rollout_name> is not a proper filtration.
