### PR TITLE
Fixed DataIntegrityViolationException with OIDC 

### DIFF
--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SecurityContextTenantAware.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SecurityContextTenantAware.java
@@ -25,6 +25,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 /**
  * A {@link TenantAware} implementation which retrieves the ID of the tenant
@@ -74,6 +75,9 @@ public class SecurityContextTenantAware implements TenantAware {
             final Object principal = context.getAuthentication().getPrincipal();
             if (principal instanceof UserPrincipal) {
                 return ((UserPrincipal) principal).getUsername();
+            }
+            if (principal instanceof OidcUser) {
+                return ((OidcUser) principal).getPreferredUsername();
             }
         }
         return null;


### PR DESCRIPTION
Hi. This PR fixes the bug reported in #1348. Fix was originally pushed in #1122, but author could not comply to contributing guidelines.

In my case the issue was causing that it was not possible to trigger deployment in hawkBit UI when OIDC was configured.
![Screenshot 2023-10-22 162437](https://github.com/eclipse/hawkbit/assets/12064920/3d2becee-3e2c-41ca-b08e-efc62701e342)

After fixing I've manually tested that issue is not reproducible anymore and triggering deployments works as expected. There are no exceptions in log after fix.
