### PR TITLE
Set license name to EPL-2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,9 @@
 
    <licenses>
       <license>
-         <name>Eclipse Public License - v 2.0</name>
+         <name>EPL-2.0</name>
          <url>https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt</url>
+         <comments>Eclipse Public License - Version 2.0</comments>
       </license>
    </licenses>
 


### PR DESCRIPTION
Change license name in root pom.xml to EPL-2.0 ([SPDX format](https://spdx.org/licenses/)) as advised in [Maven Metadata Best Practices](https://gitlab.eclipse.org/eclipsefdn/emo-team/sbom/-/blob/main/docs/sbom.adoc#sbom-maven-practices)