### PR TITLE
[#1360] Fix ConfigurationManagement#getState

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ConfirmationManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ConfirmationManagement.java
@@ -61,7 +61,8 @@ public interface ConfirmationManagement {
      * @return instance of {@link AutoConfirmationStatus} wrapped in an
      *         {@link Optional}. Present if active and empty if disabled.
      */
-    @PreAuthorize(SpPermission.SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    @PreAuthorize(SpPermission.SpringEvalExpressions.IS_CONTROLLER + SpPermission.SpringEvalExpressions.HAS_AUTH_OR +
+            SpPermission.SpringEvalExpressions.HAS_AUTH_READ_TARGET)
     Optional<AutoConfirmationStatus> getStatus(@NotEmpty String controllerId);
 
     /**


### PR DESCRIPTION
Fix access control: HAS_AUTH_READ_TARGET -> IS_CONTROLLER  or HAS_AUTH_READ_TARGET (shall be accessibly by targets when confirmation base is requested)