### PR TITLE
Provide artifact last modified timestamp on DMF API

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
@@ -568,6 +568,7 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
         artifact.setFilename(localArtifact.getFilename());
         artifact.setHashes(new DmfArtifactHash(localArtifact.getSha1Hash(), localArtifact.getMd5Hash()));
         artifact.setSize(localArtifact.getSize());
+        artifact.setLastModified(localArtifact.getLastModifiedAt());
         return artifact;
     }
 

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherServiceTest.java
@@ -212,6 +212,7 @@ class AmqpMessageDispatcherServiceTest extends AbstractIntegrationTest {
                 assertThat(found.get().getSize()).isEqualTo(dbArtifact.getSize());
                 assertThat(found.get().getHashes().getMd5()).isEqualTo(dbArtifact.getMd5Hash());
                 assertThat(found.get().getHashes().getSha1()).isEqualTo(dbArtifact.getSha1Hash());
+                assertThat(found.get().getLastModified()).isGreaterThan(0L);
             });
         }
     }


### PR DESCRIPTION
Currently the lastModified timestamp of DmfArtifact DTO is not set when it is served over AMQP which results in always getting 0L for this value over DMF API.

This change adds setting the lastModified filed of DmfArtifact according to the artifact's last modification timestamp so it is served over DMF accordingly.