### PR TITLE
Enable specifying target type when created using DMF API

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -231,14 +231,18 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
             final URI amqpUri = IpUtil.createAmqpUri(virtualHost, replyTo);
             final Target target;
             if (isOptionalMessageBodyEmpty(message)) {
+                LOG.debug("Received \"THING_CREATED\" AMQP message for thing \"{}\" without body.", thingId);
                 target = controllerManagement.findOrRegisterTargetIfItDoesNotExist(thingId, amqpUri);
             } else {
                 checkContentTypeJson(message);
                 final DmfCreateThing thingCreateBody = convertMessage(message, DmfCreateThing.class);
                 final DmfAttributeUpdate thingAttributeUpdateBody = thingCreateBody.getAttributeUpdate();
 
+                LOG.debug("Received \"THING_CREATED\" AMQP message for thing \"{}\" with target name \"{}\" and type " +
+                                "\"{}\".", thingId, thingCreateBody.getName(), thingCreateBody.getType());
+
                 target = controllerManagement.findOrRegisterTargetIfItDoesNotExist(thingId, amqpUri,
-                        thingCreateBody.getName());
+                        thingCreateBody.getName(), thingCreateBody.getType());
 
                 if (thingAttributeUpdateBody != null) {
                     controllerManagement.updateControllerAttributes(thingId, thingAttributeUpdateBody.getAttributes(),

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/matcher/SoftwareModuleJsonMatcher.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/matcher/SoftwareModuleJsonMatcher.java
@@ -26,7 +26,7 @@ public final class SoftwareModuleJsonMatcher {
 
     /**
      * Creates a matcher that matches when the list of repository software
-     * modules arelogically equal to the specified JSON software modules.
+     * modules are logically equal to the specified JSON software modules.
      * <p>
      * If the specified repository software modules are <code>null</code> then
      * the created matcher will only match if the JSON software modules are

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfCreateThing.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfCreateThing.java
@@ -25,6 +25,9 @@ public class DmfCreateThing {
     private String name;
 
     @JsonProperty
+    private String type;
+
+    @JsonProperty
     private DmfAttributeUpdate attributeUpdate;
 
     public String getName() {
@@ -33,6 +36,14 @@ public class DmfCreateThing {
 
     public void setName(final String name) {
         this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(final String type) {
+        this.type = type;
     }
 
     public DmfAttributeUpdate getAttributeUpdate() {

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -223,7 +223,8 @@ public interface ControllerManagement {
     /**
      * Register new target in the repository (plug-and-play) and in case it
      * already exists updates {@link Target#getAddress()} and
-     * {@link Target#getLastTargetQuery()} and {@link Target#getName()} and
+     * {@link Target#getLastTargetQuery()} and {@link Target#getName()}
+     * and {@link Target#getTargetType()} and
      * switches if {@link TargetUpdateStatus#UNKNOWN} to
      * {@link TargetUpdateStatus#REGISTERED}.
      *
@@ -233,10 +234,13 @@ public interface ControllerManagement {
      *            the client IP address of the target, might be {@code null}
      * @param name
      *            the name of the target
+     * @param type
+     *            the target type name of the target
      * @return target reference
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    Target findOrRegisterTargetIfItDoesNotExist(@NotEmpty String controllerId, @NotNull URI address, String name);
+    Target findOrRegisterTargetIfItDoesNotExist(@NotEmpty String controllerId, @NotNull URI address, String name,
+            String type);
 
     /**
      * Retrieves last {@link Action} for a download of an artifact of given

--- a/site/content/apis/dmf_api.md
+++ b/site/content/apis/dmf_api.md
@@ -63,6 +63,7 @@ Payload Template (optional):
 ```json
 {
     "name": "String",
+    "type": "String",
     "attributeUpdate": {
         "attributes": {
             "exampleKey1" : "exampleValue1",
@@ -74,6 +75,18 @@ Payload Template (optional):
 ```
 
 The "name" property specifies the name of the thing, which by default is the thing ID. This property is optional.<br />
+<br />
+The "type" property specifies name of a target type which should be assigned to the created/updated target. The 
+target type with the specified name should be created in advance, otherwise it can't be assigned to the target,
+resulting in:
+* error is logged
+* if the target does not exist then it is created without any target type assigned
+* if it exists already then no changes to its target type assignment are made.
+
+If the "type" property is set to a blank string while updating an existing target then any eventual target type
+assignment is removed from the target. This property is optional and if omitted then no changes to the target type
+assignment are made.<br />
+<br />
 The "attributeUpdate" property provides the attributes of the thing, for details see UPDATE_ATTRIBUTES message. This property is optional.
 
 


### PR DESCRIPTION
Extension of DMF API with possibility of setting target type name when creating target. If a target type with the provided name is found (was created beforehand) then it is associated with the new target.

This change is backward compatible (target type parameter is not mandatory).

More info in docs/content/apis/dmf_api.md