### PR TITLE
Fix flatten mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>flatten-maven-plugin</artifactId>
             <configuration>
-               <flattenMode>ossrh</flattenMode>
+               <flattenMode>resolveCiFriendliesOnly</flattenMode>
                <updatePomFile>true</updatePomFile>
             </configuration>
             <executions>


### PR DESCRIPTION
change flatten mode to do not remove dependency management thus allowing inheritance with keeping hawkbit dependencies