### PR TITLE
[#1510] Add Vaadin 8 UI discontinuation warning

### DIFF
--- a/hawkbit-ui/src/main/resources/hawkbit-ui-defaults.properties
+++ b/hawkbit-ui/src/main/resources/hawkbit-ui-defaults.properties
@@ -30,3 +30,5 @@ hawkbit.server.ui.links.documentation.distribution-set-invalidation=https://www.
 
 # UI Favicon disabled to use our Eclipse icon
 spring.mvc.favicon.enabled=false
+
+hawkbit.server.ui.notification.text=<div style='padding-top: 10px;'><div style='border: 1px solid black; padding: 10px; padding-left: 30px; padding-right: 30px; background-color: yellow; color: black; font-weight: bold;'>Vaadin 8 hawkBit UI (<i>this UI</i>) is deprecated and will be discontinued! For more information check <a target="_blank" rel="noopener noreferrer" href="https://eclipse.dev/hawkbit/blog/2023-11-22-vaadin8_ui_discontinuation">Vaadin 8 UI discontinuation</a> announcement.</div></div>


### PR DESCRIPTION
Adds a warning about Vaadin 8 UI discontinuation. It could be disabled by setting spring property _hawkbit.server.ui.notification.text_ to an empty value. For instance by setting environment property:
```shell
export HAWKBIT_SERVER_UI_NOTIFICATION_TEXT=
```
Default warning note is:
```
Vaadin 8 hawkBit UI (this UI) is deprecated and will be removed from hawkBit! For more information read [Vaadin 8 UI discontinuation](https://eclipse.dev/hawkbit/blog/2023-11-22-vaadin8_ui_discontinuation) announcement.
```