### PR TITLE
Made implicit tenant meta data creation configurable

### DIFF
--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageDispatcherService.java
@@ -62,6 +62,7 @@ import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleMetadata;
 import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.repository.model.TenantMetaData;
 import org.eclipse.hawkbit.security.SystemSecurityContext;
 import org.eclipse.hawkbit.util.IpUtil;
 import org.slf4j.Logger;
@@ -557,9 +558,10 @@ public class AmqpMessageDispatcherService extends BaseAmqpService {
     private DmfArtifact convertArtifact(final Target target, final Artifact localArtifact) {
         final DmfArtifact artifact = new DmfArtifact();
 
+        final TenantMetaData metaData = systemManagement.getTenantMetadata();
         artifact.setUrls(artifactUrlHandler
-                .getUrls(new URLPlaceholder(systemManagement.getTenantMetadata().getTenant(),
-                        systemManagement.getTenantMetadata().getId(), target.getControllerId(), target.getId(),
+                .getUrls(new URLPlaceholder(metaData.getTenant(),
+                        metaData.getId(), target.getControllerId(), target.getId(),
                         new SoftwareData(localArtifact.getSoftwareModule().getId(), localArtifact.getFilename(),
                                 localArtifact.getId(), localArtifact.getSha1Hash())),
                         ApiType.DMF)

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RepositoryProperties.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RepositoryProperties.java
@@ -56,7 +56,7 @@ public class RepositoryProperties {
     private boolean eagerPollPersistence;
 
     /**
-     * If an {@link Action} has a weight of null this value is used as weight.
+     * If an {@link org.eclipse.hawkbit.repository.model.Action} has a weight of null this value is used as weight.
      */
     private int actionWeightIfAbsent = 1000;
 
@@ -65,6 +65,8 @@ public class RepositoryProperties {
      * (in seconds).
      */
     private long dsInvalidationLockTimeout = 5;
+
+    private boolean implicitTenantCreateAllowed;
 
     public boolean isEagerPollPersistence() {
         return eagerPollPersistence;
@@ -122,4 +124,11 @@ public class RepositoryProperties {
         this.dsInvalidationLockTimeout = dsInvalidationLockTimeout;
     }
 
+    public boolean isImplicitTenantCreateAllowed() {
+        return implicitTenantCreateAllowed;
+    }
+
+    public void setImplicitTenantCreateAllowed(final boolean implicitTenantCreateAllowed) {
+        this.implicitTenantCreateAllowed = implicitTenantCreateAllowed;
+    }
 }


### PR DESCRIPTION
In hawkBit up to 0.4.1 it was true - getTenantMetadate created implicitly a tenant metadata.  It was disable in latest commits - but now it is made optional - disabled by default