### PR TITLE
Fix MgmtBaseEntity deserialization

### DIFF
--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtBaseEntity.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtBaseEntity.java
@@ -12,6 +12,7 @@ package org.eclipse.hawkbit.mgmt.json.model;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.RepresentationModel;
 
@@ -23,24 +24,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public abstract class MgmtBaseEntity extends RepresentationModel<MgmtBaseEntity> {
 
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonProperty
     @Schema(description = "Entity was originally created by (User, AMQP-Controller, anonymous etc.)",
-            accessMode = Schema.AccessMode.READ_WRITE, example = "bumlux")
+            accessMode = Schema.AccessMode.READ_ONLY, example = "bumlux")
     private String createdBy;
 
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonProperty
     @Schema(description = "Entity was originally created at (timestamp UTC in milliseconds)",
             accessMode = Schema.AccessMode.READ_ONLY, example = "1691065905897")
     private Long createdAt;
 
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonProperty
     @Schema(description = "Entity was last modified by (User, AMQP-Controller, anonymous etc.)",
             accessMode = Schema.AccessMode.READ_ONLY, example = "bumlux")
     private String lastModifiedBy;
 
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonProperty
     @Schema(description = "Entity was last modified at (timestamp UTC in milliseconds)",
             accessMode = Schema.AccessMode.READ_ONLY, example = "1691065906407")
     private Long lastModifiedAt;

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtNamedEntity.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtNamedEntity.java
@@ -13,12 +13,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * A json annotated rest model for NamedEntity to RESTful API representation.
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public abstract class MgmtNamedEntity extends MgmtBaseEntity {
 
     @JsonProperty(required = true)

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTarget.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTarget.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(description = """

--- a/hawkbit-rest/hawkbit-mgmt-api/src/test/java/org/eclipse/hawkbit/mgmt/json/model/AuditFieldSerializationTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/test/java/org/eclipse/hawkbit/mgmt/json/model/AuditFieldSerializationTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.mgmt.json.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+import org.eclipse.hawkbit.mgmt.json.model.target.MgmtTarget;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Feature("Unit Tests - Management API")
+@Story("Serialization")
+public class AuditFieldSerializationTest {
+
+    @Test
+    public void assertAuditingFields() throws JsonProcessingException {
+        final MgmtTarget mgmtTarget = new MgmtTarget();
+        mgmtTarget.setCreatedBy("user");
+        mgmtTarget.setCreatedAt(System.currentTimeMillis() - 1_000_000);
+        mgmtTarget.setLastModifiedBy("user2");
+        mgmtTarget.setLastModifiedAt(System.currentTimeMillis());
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final String serialized = objectMapper.writeValueAsString(mgmtTarget);
+        final MgmtTarget mgmtTargetDeserialization = objectMapper.readValue(serialized, MgmtTarget.class);
+        assertThat(mgmtTargetDeserialization).isEqualTo(mgmtTarget);
+    }
+}


### PR DESCRIPTION
Before REST refactoring MgmtBaseEntity was able to deserialize fields like createdBy. After refactoring, with READ_ONLY access it was dropped and these fields become null. While this could be a good change, it is not backward compatible (is that needed) and most importantly will lead to the fact that Feign client won't be able to access that data. So, at least for now, I return deserialization back