### PR TITLE
[#1580] Software Module & Distribution Set lock: add lock at mgmt level

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSet.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSet.java
@@ -26,10 +26,40 @@ import java.util.Set;
 public interface DistributionSet extends NamedVersionedEntity {
 
     /**
-     * @return <code>true</code> if the set is deleted and only kept for history
+     * @return type of the {@link DistributionSet}.
+     */
+    DistributionSetType getType();
+
+    /**
+     *
+     * @return unmodifiableSet of {@link SoftwareModule}.
+     */
+    Set<SoftwareModule> getModules();
+
+    /**
+     * @return <code>true</code> if all defined
+     *         {@link DistributionSetType#getMandatoryModuleTypes()} of
+     *         {@link #getType()} are present in this {@link DistributionSet}.
+     */
+    boolean isComplete();
+
+    /**
+     * @return <code>true</code> if this {@link DistributionSet} is locked. If so it's 'functional'
+     *         properties (e.g. software modules) could not be modified anymore.
+     */
+    boolean isLocked();
+
+    /**
+     * @return <code>true</code> if this {@link DistributionSet} is deleted and only kept for history
      *         purposes.
      */
     boolean isDeleted();
+
+    /**
+     * @return <code>false</code> if this {@link DistributionSet} is
+     *         invalidated.
+     */
+    boolean isValid();
 
     /**
      * @return <code>true</code> if {@link DistributionSet} contains a mandatory
@@ -37,17 +67,6 @@ public interface DistributionSet extends NamedVersionedEntity {
      *         and not automatically canceled if overridden by a newer update.
      */
     boolean isRequiredMigrationStep();
-
-    /**
-     * @return the auto assign target filters
-     */
-    List<TargetFilterQuery> getAutoAssignFilters();
-
-    /**
-     *
-     * @return unmodifiableSet of {@link SoftwareModule}.
-     */
-    Set<SoftwareModule> getModules();
 
     /**
      * Searches through modules for the given type.
@@ -59,23 +78,4 @@ public interface DistributionSet extends NamedVersionedEntity {
     default Optional<SoftwareModule> findFirstModuleByType(final SoftwareModuleType type) {
         return getModules().stream().filter(module -> module.getType().equals(type)).findAny();
     }
-
-    /**
-     * @return type of the {@link DistributionSet}.
-     */
-    DistributionSetType getType();
-
-    /**
-     * @return <code>true</code> if all defined
-     *         {@link DistributionSetType#getMandatoryModuleTypes()} of
-     *         {@link #getType()} are present in this {@link DistributionSet}.
-     */
-    boolean isComplete();
-
-    /**
-     * @return <code>false</code> if this {@link DistributionSet} is
-     *         invalidated.
-     */
-    boolean isValid();
-
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/SoftwareModule.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/SoftwareModule.java
@@ -14,13 +14,46 @@ import java.util.Optional;
 
 /**
  * Software package as sub element of a {@link DistributionSet}.
- *
  */
 public interface SoftwareModule extends NamedVersionedEntity {
+
     /**
      * Maximum length of software vendor.
      */
     int VENDOR_MAX_SIZE = 256;
+
+    /**
+     * @return the type of the software module
+     */
+    SoftwareModuleType getType();
+
+    /**
+     * @return immutable list of all artifacts
+     */
+    List<Artifact> getArtifacts();
+
+    /**
+     * @return the vendor of this {@link SoftwareModule}.
+     */
+    String getVendor();
+
+    /**
+     * @return {@code true} if this software module is marked as encrypted
+     *         otherwise {@code false}
+     */
+    boolean isEncrypted();
+
+    /**
+     * @return <code>true</code> if this {@link SoftwareModule} is locked. If so it's 'functional'
+     *         properties (e.g. software modules) could not be modified anymore.
+     */
+    boolean isLocked();
+
+    /**
+     * @return {@code true} if this {@link SoftwareModule} is marked as deleted
+     *         otherwise {@code false}
+     */
+    boolean isDeleted();
 
     /**
      * @param artifactId
@@ -40,37 +73,4 @@ public interface SoftwareModule extends NamedVersionedEntity {
         return getArtifacts().stream().filter(artifact -> artifact.getFilename().equalsIgnoreCase(fileName.trim()))
                 .findAny();
     }
-
-    /**
-     * @return immutable list of all artifacts
-     */
-    List<Artifact> getArtifacts();
-
-    /**
-     * @return the vendor of this software module
-     */
-    String getVendor();
-
-    /**
-     * @return the type of the software module
-     */
-    SoftwareModuleType getType();
-
-    /**
-     * @return {@code true} if this software module is marked as deleted
-     *         otherwise {@code false}
-     */
-    boolean isDeleted();
-
-    /**
-     * @return immutable list of {@link DistributionSet}s the module is assigned
-     *         to
-     */
-    List<DistributionSet> getAssignedTo();
-
-    /**
-     * @return {@code true} if this software module is marked as encrypted
-     *         otherwise {@code false}
-     */
-    boolean isEncrypted();
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSet.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSet.java
@@ -123,6 +123,7 @@ public class JpaDistributionSet extends AbstractJpaNamedVersionedEntity implemen
     private boolean requiredMigrationStep;
 
     @ToString.Exclude
+    @Getter(AccessLevel.NONE)
     @OneToMany(mappedBy = "autoAssignDistributionSet", targetEntity = JpaTargetFilterQuery.class, fetch = FetchType.LAZY)
     private List<TargetFilterQuery> autoAssignFilters;
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModule.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModule.java
@@ -88,6 +88,9 @@ public class JpaSoftwareModule extends AbstractJpaNamedVersionedEntity implement
     @Size(max = SoftwareModule.VENDOR_MAX_SIZE)
     private String vendor;
 
+    @Column(name = "encrypted")
+    private boolean encrypted;
+
     @ToString.Exclude
     @CascadeOnDelete
     @OneToMany(mappedBy = "softwareModule", fetch = FetchType.LAZY, targetEntity = JpaSoftwareModuleMetadata.class)
@@ -98,9 +101,6 @@ public class JpaSoftwareModule extends AbstractJpaNamedVersionedEntity implement
 
     @Column(name = "deleted")
     private boolean deleted;
-
-    @Column(name = "encrypted")
-    private boolean encrypted;
 
     @ToString.Exclude
     @Getter(AccessLevel.NONE)
@@ -188,15 +188,6 @@ public class JpaSoftwareModule extends AbstractJpaNamedVersionedEntity implement
      */
     public void setEncrypted(final boolean encrypted) {
         this.encrypted = encrypted;
-    }
-
-    @Override
-    public List<DistributionSet> getAssignedTo() {
-        if (assignedTo == null) {
-            return Collections.emptyList();
-        }
-
-        return Collections.unmodifiableList(assignedTo);
     }
 
     @Override


### PR DESCRIPTION
Additionally, 

* removed DistributionSet.getAutoAssignFilters and
* removed SoftwareModule.getAssignedTo both are not used and exposed via Mgmt API. 
 
Maybe, if needed, they could be returned back along with exposing them via Mgmt API.