### PR TITLE
[#1651] Fix tenant level config for DistributionSet implicit lock

### DIFF
--- a/hawkbit-repository/hawkbit-repository-core/src/main/resources/hawkbit-repository-defaults.properties
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/resources/hawkbit-repository-defaults.properties
@@ -107,7 +107,7 @@ hawkbit.server.tenant.configuration.user-confirmation-enabled.defaultValue=false
 hawkbit.server.tenant.configuration.user-confirmation-enabled.dataType=java.lang.Boolean
 hawkbit.server.tenant.configuration.user-confirmation-enabled.validator=org.eclipse.hawkbit.tenancy.configuration.validator.TenantConfigurationBooleanValidator
 
-hawkbit.server.tenant.configuration.implicit-lock-enabled.keyName=user.confirmation.flow.enabled
+hawkbit.server.tenant.configuration.implicit-lock-enabled.keyName=implicit.lock.enabled
 hawkbit.server.tenant.configuration.implicit-lock-enabled.defaultValue=true
 hawkbit.server.tenant.configuration.implicit-lock-enabled.dataType=java.lang.Boolean
 hawkbit.server.tenant.configuration.implicit-lock-enabled.validator=org.eclipse.hawkbit.tenancy.configuration.validator.TenantConfigurationBooleanValidator


### PR DESCRIPTION
enabled by default
fix the configuration for new tenant config key