### PR TITLE
Remove unused fields from JpaDistributionSet

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetFilter.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetFilter.java
@@ -28,6 +28,4 @@ public final class DistributionSetFilter {
     private final String searchText;
     private final Boolean selectDSWithNoTag;
     private final Collection<String> tagNames;
-    private final String assignedTargetId;
-    private final String installedTargetId;
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaDeploymentManagement.java
@@ -934,15 +934,16 @@ public class JpaDeploymentManagement extends JpaActionManagement implements Depl
 
     @Override
     public Optional<DistributionSet> getAssignedDistributionSet(final String controllerId) {
-        // target access checked in assertTargetReadAllowed
-        assertTargetReadAllowed(controllerId);
-        return distributionSetRepository.findAssignedToTarget(controllerId);
+        return targetRepository
+                .findOne(TargetSpecifications.hasControllerId(controllerId))
+                .map(JpaTarget::getAssignedDistributionSet);
     }
 
     @Override
     public Optional<DistributionSet> getInstalledDistributionSet(final String controllerId) {
-        assertTargetReadAllowed(controllerId);
-        return distributionSetRepository.findInstalledAtTarget(controllerId);
+        return targetRepository
+                .findOne(TargetSpecifications.hasControllerId(controllerId))
+                .map(JpaTarget::getInstalledDistributionSet);
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaDistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaDistributionSetManagement.java
@@ -574,7 +574,7 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
                         throw new InsufficientPermissionException("Target not accessible (or not found)!");
                     }
                     return distributionSetRepository
-                            .findOne(DistributionSetSpecification.byActionId(actionId))
+                            .findOne(DistributionSetSpecification.byId(action.getDistributionSet().getId()))
                             .orElseThrow(() ->
                                     new InsufficientPermissionException("DistributionSet not accessible (or not found)!"));
                 })
@@ -628,14 +628,6 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
         if (hasTagsFilterActive(distributionSetFilter)) {
             spec = DistributionSetSpecification.hasTags(distributionSetFilter.getTagNames(),
                     distributionSetFilter.getSelectDSWithNoTag());
-            specList.add(spec);
-        }
-        if (distributionSetFilter.getInstalledTargetId() != null) {
-            spec = DistributionSetSpecification.installedTarget(distributionSetFilter.getInstalledTargetId());
-            specList.add(spec);
-        }
-        if (distributionSetFilter.getAssignedTargetId() != null) {
-            spec = DistributionSetSpecification.assignedTarget(distributionSetFilter.getAssignedTargetId());
             specList.add(spec);
         }
         return specList;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSet.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSet.java
@@ -35,7 +35,6 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -46,13 +45,11 @@ import org.eclipse.hawkbit.repository.exception.DistributionSetTypeUndefinedExce
 import org.eclipse.hawkbit.repository.exception.IncompleteDistributionSetException;
 import org.eclipse.hawkbit.repository.exception.LockedException;
 import org.eclipse.hawkbit.repository.exception.UnsupportedSoftwareModuleForThisDistributionSetException;
-import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetMetadata;
 import org.eclipse.hawkbit.repository.model.DistributionSetTag;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
-import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.eclipse.hawkbit.repository.model.helper.EventPublisherHolder;
 import org.eclipse.persistence.annotations.CascadeOnDelete;
 import org.eclipse.persistence.descriptors.DescriptorEvent;
@@ -122,26 +119,6 @@ public class JpaDistributionSet extends AbstractJpaNamedVersionedEntity implemen
 
     @Column(name = "required_migration_step")
     private boolean requiredMigrationStep;
-
-    @ToString.Exclude
-    @Getter(AccessLevel.NONE)
-    @OneToMany(mappedBy = "autoAssignDistributionSet", targetEntity = JpaTargetFilterQuery.class, fetch = FetchType.LAZY)
-    private List<TargetFilterQuery> autoAssignFilters;
-
-    @ToString.Exclude
-    @Getter(AccessLevel.NONE)
-    @OneToMany(mappedBy = "assignedDistributionSet", targetEntity = JpaTarget.class, fetch = FetchType.LAZY)
-    private List<JpaTarget> assignedToTargets;
-
-    @ToString.Exclude
-    @Getter(AccessLevel.NONE)
-    @OneToMany(mappedBy = "installedDistributionSet", targetEntity = JpaTarget.class, fetch = FetchType.LAZY)
-    private List<JpaTarget> installedAtTargets;
-
-    @ToString.Exclude
-    @Getter(AccessLevel.NONE)
-    @OneToMany(mappedBy = "distributionSet", targetEntity = JpaAction.class, fetch = FetchType.LAZY)
-    private List<JpaAction> actions;
 
     /**
      * Parameterized constructor.
@@ -282,14 +259,6 @@ public class JpaDistributionSet extends AbstractJpaNamedVersionedEntity implemen
 
     public void setRequiredMigrationStep(final boolean isRequiredMigrationStep) {
         requiredMigrationStep = isRequiredMigrationStep;
-    }
-
-    public List<Action> getActions() {
-        if (actions == null) {
-            return Collections.emptyList();
-        }
-
-        return Collections.unmodifiableList(actions);
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/DistributionSetRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/DistributionSetRepository.java
@@ -121,12 +121,6 @@ public interface DistributionSetRepository
     @Query("select ra.distributionSet.id from JpaRollout ra where ra.distributionSet.id in :ids")
     List<Long> findAssignedToRolloutDistributionSetsById(@Param("ids") Collection<Long> ids);
 
-    @Query("select DISTINCT ds from JpaDistributionSet ds join fetch ds.modules join ds.assignedToTargets t where t.controllerId = :controllerId")
-    Optional<DistributionSet> findAssignedToTarget(@Param("controllerId") String controllerId);
-
-    @Query("select DISTINCT ds from JpaDistributionSet ds join fetch ds.modules join ds.installedAtTargets t where t.controllerId = :controllerId")
-    Optional<DistributionSet> findInstalledAtTarget(@Param("controllerId") String controllerId);
-
     /**
      * Counts {@link DistributionSet} instances of given type in the repository.
      * <p/>

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/DistributionSetSpecification.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/DistributionSetSpecification.java
@@ -117,15 +117,6 @@ public final class DistributionSetSpecification {
         };
     }
 
-    public static Specification<JpaDistributionSet> byActionId(final Long actionId) {
-        return (dsRoot, query, cb) -> {
-            final ListJoin<JpaDistributionSet, JpaAction> join = dsRoot.join(JpaDistributionSet_.actions,
-                    JoinType.LEFT);
-            query.distinct(true);
-            return cb.equal(join.get(JpaAction_.id), actionId);
-        };
-    }
-
     /**
      * {@link Specification} for retrieving {@link DistributionSet} with given
      * {@link DistributionSet#getId()}s.
@@ -248,36 +239,6 @@ public final class DistributionSetSpecification {
      */
     public static Specification<JpaDistributionSet> hasType(final Collection<Long> typeIds) {
         return (dsRoot, query, cb) -> dsRoot.get(JpaDistributionSet_.type).get(JpaDistributionSetType_.id).in(typeIds);
-    }
-
-    /**
-     * @param installedTargetId
-     *            the targetID which is installed to a distribution set to search
-     *            for.
-     * @return the specification to search for a distribution set which is installed
-     *         to the given targetId
-     */
-    public static Specification<JpaDistributionSet> installedTarget(final String installedTargetId) {
-        return (dsRoot, query, cb) -> {
-            final ListJoin<JpaDistributionSet, JpaTarget> installedTargetJoin = dsRoot
-                    .join(JpaDistributionSet_.installedAtTargets, JoinType.INNER);
-            return cb.equal(installedTargetJoin.get(JpaTarget_.controllerId), installedTargetId);
-        };
-    }
-
-    /**
-     * @param assignedTargetId
-     *            the targetID which is assigned to a distribution set to search
-     *            for.
-     * @return the specification to search for a distribution set which is assigned
-     *         to the given targetId
-     */
-    public static Specification<JpaDistributionSet> assignedTarget(final String assignedTargetId) {
-        return (dsRoot, query, cb) -> {
-            final ListJoin<JpaDistributionSet, JpaTarget> assignedTargetJoin = dsRoot
-                    .join(JpaDistributionSet_.assignedToTargets, JoinType.INNER);
-            return cb.equal(assignedTargetJoin.get(JpaTarget_.controllerId), assignedTargetId);
-        };
     }
 
     /**


### PR DESCRIPTION
These fields also could lead to big memory usage if the JPA provider doesn't get LAZY hint