### PR TITLE
Fix lastModifiedBy on modification perfomed by the JpaRolloutExecutor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ classpath-data.json
 # Intellij
 *.iml
 
+# local Spring configs
+application-local.properties
+
 # Maven
 maven.properties
 .flattened-pom.xml

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutHandler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutHandler.java
@@ -104,6 +104,8 @@ public class JpaRolloutHandler implements RolloutHandler {
         DeploymentHelper.runInNewTransaction(txManager, handlerId + "-" + rolloutId, status -> {
             rolloutManagement.get(rolloutId).ifPresentOrElse(
                     rollout -> {
+                        // auditor is retrieved and set on transaction commit
+                        // if not overridden, the system user will be the auditor
                         rollout.getAccessControlContext().ifPresentOrElse(
                             context -> // has stored context - executes it with it
                                 contextAware.runInContext(

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SpringSecurityAuditorAware.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SpringSecurityAuditorAware.java
@@ -24,8 +24,17 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
  */
 public class SpringSecurityAuditorAware implements AuditorAware<String> {
 
+    // Sometimes 'system' need to override the auditor when do create/modify actions in context of a tenant and user.
+    // Though this could be made using runAsTenantAsUser sometimes (as in transaction) this override is needed
+    // after runAsTenantAsUser (because it seems that auditor is got in commit time).
+    // So this thread local variable provides option to override explicitly the auditor.
+    private static final ThreadLocal<String> AUDITOR_OVERRIDE = new ThreadLocal<>();
+
     @Override
     public Optional<String> getCurrentAuditor() {
+        if (AUDITOR_OVERRIDE.get() != null) {
+            return Optional.of(AUDITOR_OVERRIDE.get());
+        }
 
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
@@ -36,7 +45,20 @@ public class SpringSecurityAuditorAware implements AuditorAware<String> {
         return Optional.ofNullable(getCurrentAuditor(authentication));
     }
 
-    private static String getCurrentAuditor(final Authentication authentication) {
+    // Always shall be followed by {@link #clearAuditorOverride}
+    public static void setAuditorOverride(final String auditor) {
+        if (auditor == null) {
+            AUDITOR_OVERRIDE.remove();
+        } else {
+            AUDITOR_OVERRIDE.set(auditor);
+        }
+    }
+
+    public static void clearAuditorOverride() {
+        AUDITOR_OVERRIDE.remove();
+    }
+
+    protected String getCurrentAuditor(final Authentication authentication) {
         if (authentication.getPrincipal() instanceof UserDetails) {
             return ((UserDetails) authentication.getPrincipal()).getUsername();
         }


### PR DESCRIPTION
Fix lastModifiedBy on modification perfomed by the JpaRolloutExecutor

1. The auditor is got on transaction commit - so haven't used the tenant & user context until now - write system
2. The start/stop/delete are called by the user (saved in lastModifiedBy) but then executed in JpaRolloutExecutor

So the change is:
1. Fix auditor for actions taken by JpaRolloutExecutor to be the createdBy
2. for start/stop/delete the auditor is set to the lastModifiedBy for the transaction (hence all action taken)