### PR TITLE
Add support for dynamic rollout group template

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/DynamicRolloutGroupTemplate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/DynamicRolloutGroupTemplate.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.repository.builder;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+import org.eclipse.hawkbit.repository.model.RolloutGroupConditions;
+
+/**
+ * Builder to create a new dynamic rollout group secret
+ */
+@Data
+@Builder
+public class DynamicRolloutGroupTemplate {
+
+    /**
+     * The name suffix, by default "" is used.
+     */
+    @NotNull
+    private String nameSuffix = "";
+
+    /**
+     * The count of matching Targets that should be assigned to this Group
+     */
+    private long targetCount;
+
+    /**
+     * The group conditions
+     */
+    private RolloutGroupConditions conditions;
+
+    /**
+     * If confirmation is required for this rollout group (considered with confirmation flow active)
+     */
+    private boolean confirmationRequired;
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/RolloutGroupBuilder.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/RolloutGroupBuilder.java
@@ -13,7 +13,6 @@ import org.eclipse.hawkbit.repository.model.Rollout;
 
 /**
  * Builder for {@link Rollout}.
- *
  */
 @FunctionalInterface
 public interface RolloutGroupBuilder {
@@ -22,5 +21,4 @@ public interface RolloutGroupBuilder {
      * @return builder instance
      */
     RolloutGroupCreate create();
-
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/RolloutGroupCreate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/RolloutGroupCreate.java
@@ -24,49 +24,41 @@ import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
  * Builder to create a new {@link RolloutGroup} entry. Defines all fields that
  * can be set at creation time. Other fields are set by the repository
  * automatically, e.g. {@link BaseEntity#getCreatedAt()}.
- *
  */
 public interface RolloutGroupCreate {
     /**
-     * @param name
-     *            for {@link Rollout#getName()}
+     * @param name for {@link Rollout#getName()}
      * @return updated builder instance
      */
     RolloutGroupCreate name(@Size(min = 1, max = NamedEntity.NAME_MAX_SIZE) @NotNull String name);
 
     /**
-     * @param description
-     *            for {@link Rollout#getDescription()}
+     * @param description for {@link Rollout#getDescription()}
      * @return updated builder instance
      */
     RolloutGroupCreate description(@Size(max = NamedEntity.DESCRIPTION_MAX_SIZE) String description);
 
     /**
-     * @param targetFilterQuery
-     *            for {@link Rollout#getTargetFilterQuery()}
+     * @param targetFilterQuery for {@link Rollout#getTargetFilterQuery()}
      * @return updated builder instance
      */
     RolloutGroupCreate targetFilterQuery(
             @Size(min = 1, max = TargetFilterQuery.QUERY_MAX_SIZE) @NotNull String targetFilterQuery);
 
     /**
-     * @param targetPercentage
-     *            the percentage of matching Targets that should be assigned to
-     *            this Group
+     * @param targetPercentage the percentage of matching Targets that should be assigned to this Group
      * @return updated builder instance
      */
     RolloutGroupCreate targetPercentage(Float targetPercentage);
 
     /**
-     * @param conditions
-     *            as created by {@link RolloutGroupConditionBuilder}.
+     * @param conditions as created by {@link RolloutGroupConditionBuilder}.
      * @return updated builder instance
      */
     RolloutGroupCreate conditions(RolloutGroupConditions conditions);
 
     /**
-     * @param confirmationRequired
-     *            if confirmation is required for this rollout group (considered
+     * @param confirmationRequired if confirmation is required for this rollout group (considered
      *            with confirmation flow active)
      * @return updated builder instance
      */
@@ -76,5 +68,4 @@ public interface RolloutGroupCreate {
      * @return peek on current state of {@link RolloutGroup} in the builder
      */
     RolloutGroup build();
-
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/RolloutUpdate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/RolloutUpdate.java
@@ -12,15 +12,12 @@ package org.eclipse.hawkbit.repository.builder;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import org.eclipse.hawkbit.repository.model.Action;
-import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.NamedEntity;
 import org.eclipse.hawkbit.repository.model.Rollout;
 
 /**
  * Builder to update an existing {@link Rollout} entry. Defines all fields that
  * can be updated.
- *
  */
 public interface RolloutUpdate {
     /**

--- a/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/RolloutHelper.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/RolloutHelper.java
@@ -78,7 +78,7 @@ public final class RolloutHelper {
      */
     public static void verifyRolloutGroupParameter(final int amountGroup, final QuotaManagement quotaManagement) {
         if (amountGroup <= 0) {
-            throw new ValidationException("The amount of groups cannot be lower than zero");
+            throw new ValidationException("The amount of groups cannot be lower than or equal to zero for static rollouts");
         } else if (amountGroup > quotaManagement.getMaxRolloutGroupsPerRollout()) {
             throw new AssignmentQuotaExceededException(
                     "The amount of groups cannot be greater than " + quotaManagement.getMaxRolloutGroupsPerRollout());

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/AbstractJpaIntegrationTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/AbstractJpaIntegrationTest.java
@@ -174,28 +174,28 @@ public abstract class AbstractJpaIntegrationTest extends AbstractIntegrationTest
 
     protected void assertRollout(final Rollout rollout, final boolean dynamic, final Rollout.RolloutStatus status, final int groupCreated, final long totalTargets) {
         final Rollout refreshed = refresh(rollout);
-        assertThat(refreshed.isDynamic()).isEqualTo(dynamic);
-        assertThat(refreshed.getStatus()).isEqualTo(status);
-        assertThat(refreshed.getRolloutGroupsCreated()).isEqualTo(groupCreated);
-        assertThat(refreshed.getTotalTargets()).isEqualTo(totalTargets);
+        assertThat(refreshed.isDynamic()).as("Is dynamic").isEqualTo(dynamic);
+        assertThat(refreshed.getStatus()).as("Status").isEqualTo(status);
+        assertThat(refreshed.getRolloutGroupsCreated()).as("Groups created").isEqualTo(groupCreated);
+        assertThat(refreshed.getTotalTargets()).as("Total targets").isEqualTo(totalTargets);
     }
 
     protected void assertGroup(final RolloutGroup group, final boolean dynamic, final RolloutGroup.RolloutGroupStatus status, final long totalTargets) {
         final RolloutGroup refreshed = refresh(group);
-        assertThat(refreshed.isDynamic()).isEqualTo(dynamic);
-        assertThat(refreshed.getStatus()).isEqualTo(status);
-        assertThat(refreshed.getTotalTargets()).isEqualTo(totalTargets);
+        assertThat(refreshed.isDynamic()).as("Is dynamic").isEqualTo(dynamic);
+        assertThat(refreshed.getStatus()).as("Status").isEqualTo(status);
+        assertThat(refreshed.getTotalTargets()).as("Total targets").isEqualTo(totalTargets);
     }
 
     protected Page<JpaAction> assertAndGetRunning(final Rollout rollout, final int count) {
         final Page<JpaAction> running = actionRepository.findByRolloutIdAndStatus(PAGE, rollout.getId(), Action.Status.RUNNING);
-        assertThat(running.getTotalElements()).isEqualTo(count);
+        assertThat(running.getTotalElements()).as("Action count").isEqualTo(count);
         return running;
     }
 
     protected void assertScheduled(final Rollout rollout, final int count) {
         final Page<JpaAction> running = actionRepository.findByRolloutIdAndStatus(PAGE, rollout.getId(), Action.Status.SCHEDULED);
-        assertThat(running.getTotalElements()).isEqualTo(count);
+        assertThat(running.getTotalElements()).as("Action count").isEqualTo(count);
     }
 
     protected void finishAction(final Action action) {

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/TestdataFactory.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/TestdataFactory.java
@@ -45,6 +45,7 @@ import org.eclipse.hawkbit.repository.TargetFilterQueryManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TargetTagManagement;
 import org.eclipse.hawkbit.repository.TargetTypeManagement;
+import org.eclipse.hawkbit.repository.builder.DynamicRolloutGroupTemplate;
 import org.eclipse.hawkbit.repository.builder.TagCreate;
 import org.eclipse.hawkbit.repository.builder.TargetCreate;
 import org.eclipse.hawkbit.repository.builder.TargetTypeCreate;
@@ -1239,6 +1240,14 @@ public class TestdataFactory {
             final int groupSize, final String filterQuery, final DistributionSet distributionSet,
             final String successCondition, final String errorCondition, final Action.ActionType actionType,
             final Integer weight, final boolean confirmationRequired, final boolean dynamic) {
+        return createRolloutByVariables(rolloutName, rolloutDescription, groupSize, filterQuery, distributionSet,
+                successCondition, errorCondition, actionType, weight, confirmationRequired, dynamic, null);
+    }
+    public Rollout createRolloutByVariables(final String rolloutName, final String rolloutDescription,
+            final int groupSize, final String filterQuery, final DistributionSet distributionSet,
+            final String successCondition, final String errorCondition, final Action.ActionType actionType,
+            final Integer weight, final boolean confirmationRequired, final boolean dynamic,
+            final DynamicRolloutGroupTemplate dynamicRolloutGroupTemplate) {
         final RolloutGroupConditions conditions = new RolloutGroupConditionBuilder().withDefaults()
                 .successCondition(RolloutGroupSuccessCondition.THRESHOLD, successCondition)
                 .errorCondition(RolloutGroupErrorCondition.THRESHOLD, errorCondition)
@@ -1248,7 +1257,7 @@ public class TestdataFactory {
                 entityFactory.rollout().create().name(rolloutName).description(rolloutDescription)
                         .targetFilterQuery(filterQuery).distributionSetId(distributionSet).actionType(actionType).weight(weight)
                         .dynamic(dynamic),
-                groupSize, confirmationRequired, conditions);
+                groupSize, confirmationRequired, conditions, dynamicRolloutGroupTemplate);
 
         // Run here, because Scheduler is disabled during tests
         rolloutHandler.handleAll();

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutRestRequestBodyPost.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutRestRequestBodyPost.java
@@ -17,6 +17,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtActionType;
+import org.eclipse.hawkbit.mgmt.json.model.rolloutgroup.MgmtDynamicRolloutGroupTemplate;
 import org.eclipse.hawkbit.mgmt.json.model.rolloutgroup.MgmtRolloutGroup;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -86,6 +87,10 @@ public class MgmtRolloutRestRequestBodyPost extends AbstractMgmtRolloutCondition
     @JsonProperty
     @Schema(example = "true")
     private boolean dynamic;
+
+    @JsonProperty
+    @Schema(description = "Template for dynamic groups (only if dynamic flag is true)")
+    private MgmtDynamicRolloutGroupTemplate dynamicGroupTemplate;
 
     @JsonProperty
     @Schema(description = """

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rolloutgroup/MgmtDynamicRolloutGroupTemplate.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rolloutgroup/MgmtDynamicRolloutGroupTemplate.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.mgmt.json.model.rolloutgroup;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Model for defining the Attributes of a Rollout Group
+ */
+@Data
+@Accessors(chain = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MgmtDynamicRolloutGroupTemplate {
+
+    @Schema(description = "The name suffix of the dynamic groups", example = "-dynamic")
+    private String nameSuffix;
+
+    @Schema(description = "Count of targets a dynamic group shall include", example = "20")
+    private Long targetCount;
+}

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
@@ -14,6 +14,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.eclipse.hawkbit.mgmt.json.model.rollout.AbstractMgmtRolloutConditionsEntity;
@@ -26,12 +27,14 @@ import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutRestRequestBodyPos
 import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutRestRequestBodyPut;
 import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutSuccessAction;
 import org.eclipse.hawkbit.mgmt.json.model.rollout.MgmtRolloutSuccessAction.SuccessAction;
+import org.eclipse.hawkbit.mgmt.json.model.rolloutgroup.MgmtDynamicRolloutGroupTemplate;
 import org.eclipse.hawkbit.mgmt.json.model.rolloutgroup.MgmtRolloutGroup;
 import org.eclipse.hawkbit.mgmt.json.model.rolloutgroup.MgmtRolloutGroupResponseBody;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtDistributionSetRestApi;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRolloutRestApi;
 import org.eclipse.hawkbit.repository.EntityFactory;
+import org.eclipse.hawkbit.repository.builder.DynamicRolloutGroupTemplate;
 import org.eclipse.hawkbit.repository.builder.RolloutCreate;
 import org.eclipse.hawkbit.repository.builder.RolloutGroupCreate;
 import org.eclipse.hawkbit.repository.builder.RolloutUpdate;
@@ -157,10 +160,19 @@ final class MgmtRolloutMapper {
     }
 
     static RolloutGroupCreate fromRequest(final EntityFactory entityFactory, final MgmtRolloutGroup restRequest) {
-
         return entityFactory.rolloutGroup().create().name(restRequest.getName())
                 .description(restRequest.getDescription()).targetFilterQuery(restRequest.getTargetFilterQuery())
                 .targetPercentage(restRequest.getTargetPercentage()).conditions(fromRequest(restRequest, false));
+    }
+
+    static DynamicRolloutGroupTemplate fromRequest(final MgmtDynamicRolloutGroupTemplate restRequest) {
+        if (restRequest == null) {
+            return null;
+        }
+        return DynamicRolloutGroupTemplate.builder()
+                .nameSuffix(Optional.ofNullable(restRequest.getNameSuffix()).orElse(""))
+                .targetCount(restRequest.getTargetCount())
+                .build();
     }
 
     static RolloutGroupConditions fromRequest(final AbstractMgmtRolloutConditionsEntity restRequest,


### PR DESCRIPTION
1. Add support in REST and Mgmt API for dynamic group template
2. If present - groups follows the pattern of this template, otherwise - the last static group
3. This allows to create pure dynamic rollout with 0 static groups - auto assignment equivalent with groups