### PR TITLE
Fix applying createdat less or equal to rollout group filter

### DIFF
--- a/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/RolloutHelper.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/RolloutHelper.java
@@ -110,7 +110,7 @@ public final class RolloutHelper {
      */
     public static String getTargetFilterQuery(final String targetFilter, final Long createdAt) {
         if (createdAt != null) {
-            return targetFilter + ";createdat=le=" + createdAt.toString();
+            return "(" + targetFilter + ");createdat=le=" + createdAt;
         }
         return targetFilter;
     }


### PR DESCRIPTION
in case of x OR y, and createdAt <= was applied to y condition

More detailed:

The problem was that createdAt < rollout.getCreatedAt() was applied to the query with:
```java
query + ";createdat=le=" + createdAt
```
But if you have 'attrib.x = 1 OR attrib.y = 2' the actual condition becomes 
'attrib.x = 1 OR attrib.y = 2;createdat=le=132423'. Then the created at is applied to the attrib.y = 2 with priority. Thus 
* first breaks the expectations - could involve targets with createdAt > 132423 if match 'attrib.x = 1'
* than it leads to joining sp_target_attributes twice with OR witch could severely impact performance