### PR TITLE
Add PostgreSQL-specific indexes to improve query performance

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_30__add_indexes___POSTGRESQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_30__add_indexes___POSTGRESQL.sql
@@ -1,0 +1,11 @@
+CREATE INDEX sp_idx_rollouttargetgroup_target_id
+    ON sp_rollouttargetgroup
+    USING BTREE (target_id);
+
+CREATE INDEX sp_idx_target_attributes_target_id
+    ON sp_target_attributes
+    USING BTREE (target_id);
+
+CREATE INDEX sp_idx_action_target
+    ON sp_action
+    USING BTREE (target);


### PR DESCRIPTION
This commit fixes #1761 by adding **three** new **PostgreSQL-specific**  **indexes** to the **sp_rollouttargetgroup**, **sp_target_attributes**, and **sp_action** tables to address performance issues identified in dynamic rollout queries handling over 300k+ targets. The added indexes aim to optimize the execution time of complex joins and conditions stated in the issue:

1. sp_rollouttargetgroup.target_id
2. sp_target_attributes.target_id
3. sp_action.target