### PR TITLE
Add REST API security filter chain customization

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.hawkbit.im.authentication.TenantAwareAuthenticationDetails;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
@@ -88,7 +89,7 @@ public class OidcUserManagementAutoConfiguration {
         return new JwtAuthoritiesOidcUserService(extractor);
     }
 
-    @Bean
+    @Bean("hawkbitOAuth2ResourceServerCustomizer")
     @ConditionalOnMissingBean
     Customizer<OAuth2ResourceServerConfigurer<HttpSecurity>> oauth2ResourceServerCustomizer(
             final InMemoryClientRegistrationRepository clientRegistrationRepository,


### PR DESCRIPTION
It is called just before the build and could be used for instance to set application provider. Note: implementation of customizers shall always take in account what is the already set by the hawkBit