### PR TITLE
Ignore isEmpty methods in MgmtTargetAttributes and MgmtDistributionSetAssignments in order to avoid invalid schematic

### DIFF
--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtDistributionSetAssignments.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtDistributionSetAssignments.java
@@ -13,6 +13,7 @@ import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.NoArgsConstructor;
 
@@ -48,5 +49,11 @@ public class MgmtDistributionSetAssignments extends ArrayList<MgmtDistributionSe
      */
     public MgmtDistributionSetAssignments(final List<MgmtDistributionSetAssignment> assignments) {
         super(assignments);
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isEmpty() {
+        return super.isEmpty();
     }
 }

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTargetAttributes.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTargetAttributes.java
@@ -3,6 +3,8 @@
  */
 package org.eclipse.hawkbit.mgmt.json.model.target;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.io.Serial;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,4 +16,10 @@ public class MgmtTargetAttributes extends HashMap<String, String> {
 
     @Serial
     private static final long serialVersionUID = 1L;
+
+    @Override
+    @JsonIgnore
+    public boolean isEmpty() {
+        return super.isEmpty();
+    }
 }


### PR DESCRIPTION
The current generated schematic available here:
https://eclipse.dev/hawkbit/apis/management_api/
contains this part:
```
      "MgmtDistributionSetAssignments": {
        "type": "array",
        "properties": {
          "empty": {
            "type": "boolean"
          },
          "first": {
            "$ref": "#/components/schemas/MgmtDistributionSetAssignment"
          },
          "last": {
            "$ref": "#/components/schemas/MgmtDistributionSetAssignment"
          }
        },
        "items": {
          "$ref": "#/components/schemas/MgmtDistributionSetAssignment"
        }
      },
```

If you try to generate an client using openapi-generator-cli, you will have this following error: 

`[main] ERROR o.o.codegen.InlineModelResolver - Illegal schema found with non-object type combined with properties, no properties should be defined:`

And an invalid generated python code

This PR mark as ignored "isEmpty" (the only remaining on my side ???) on MgmtDistributionSetAssignments and MgmtTargetAttributes.java allowing to have a correct generated schema