### PR TITLE
Switch shutdown to shutdownNow in executors

### DIFF
--- a/hawkbit-sdk/hawkbit-sdk-device/src/main/java/org/eclipse/hawkbit/sdk/device/DdiController.java
+++ b/hawkbit-sdk/hawkbit-sdk-device/src/main/java/org/eclipse/hawkbit/sdk/device/DdiController.java
@@ -105,7 +105,7 @@ public class DdiController {
 
     public void stop() {
         if (executorService != null) {
-            executorService.shutdown();
+            executorService.shutdownNow();
         }
         executorService = null;
         lastActionId = null;
@@ -113,6 +113,7 @@ public class DdiController {
     }
 
     private void poll() {
+        log.debug(LOG_PREFIX + " Polling ...", tenantId, controllerId);
         Optional.ofNullable(executorService).ifPresent(executor ->
             getControllerBase().ifPresentOrElse(
                     controllerBase -> {


### PR DESCRIPTION
When invoking shutdown of executors this will leave all current scheduled tasks for execution. This means possibly there will be one last poll after that.
In the case of a device simulator for example this is not good because when clearing all the created demo devices sometimes some are left behind for this particular reason. 
When using shutdownNow() we ensure to not execute anything anymore in this point of time