### PR TITLE
Fixes fine-grained permissions config

### DIFF
--- a/hawkbit-ddi/hawkbit-ddi-server/src/test/java/org/eclipse/hawkbit/app/ddi/PreAuthorizeEnabledTest.java
+++ b/hawkbit-ddi/hawkbit-ddi-server/src/test/java/org/eclipse/hawkbit/app/ddi/PreAuthorizeEnabledTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.context.TestPropertySource;
  * Feature: Integration Test - Security<br/>
  * Story: PreAuthorized enabled
  */
-@TestPropertySource(properties = { "spring.flyway.enabled=true" })
+@TestPropertySource(properties = { "spring.flyway.enabled=true", "hawkbit.acm.access-controller.enabled=false" })
 class PreAuthorizeEnabledTest extends AbstractSecurityTest {
 
     /**

--- a/hawkbit-mgmt/hawkbit-mgmt-server/src/test/java/org/eclipse/hawkbit/app/mgmt/PreAuthorizeEnabledTest.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-server/src/test/java/org/eclipse/hawkbit/app/mgmt/PreAuthorizeEnabledTest.java
@@ -21,11 +21,13 @@ import org.eclipse.hawkbit.im.authentication.SpRole;
 import org.eclipse.hawkbit.repository.test.util.WithUser;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * Feature: Integration Test - Security<br/>
  * Story: PreAuthorized enabled
  */
+@TestPropertySource(properties = "hawkbit.acm.access-controller.enabled=true")
 class PreAuthorizeEnabledTest extends AbstractSecurityTest {
 
     /**

--- a/hawkbit-monolith/hawkbit-update-server/src/test/java/org/eclipse/hawkbit/app/PreAuthorizeEnabledTest.java
+++ b/hawkbit-monolith/hawkbit-update-server/src/test/java/org/eclipse/hawkbit/app/PreAuthorizeEnabledTest.java
@@ -21,11 +21,13 @@ import org.eclipse.hawkbit.im.authentication.SpRole;
 import org.eclipse.hawkbit.repository.test.util.WithUser;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * Feature: Integration Test - Security<br/>
  * Story: PreAuthorized enabled
  */
+@TestPropertySource(properties = "hawkbit.acm.access-controller.enabled=true")
 class PreAuthorizeEnabledTest extends AbstractSecurityTest {
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.eclipse.hawkbit.repository.jpa.acm.AccessControllerConfiguration

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/ActionAccessControllerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/ActionAccessControllerTest.java
@@ -25,8 +25,10 @@ import org.eclipse.hawkbit.repository.model.TargetType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
-@ContextConfiguration(classes = { DefaultAccessControllerConfiguration.class })
+@ContextConfiguration(classes = { AccessControllerConfiguration.class })
+@TestPropertySource(properties = "hawkbit.acm.access-controller.enabled=true")
 class ActionAccessControllerTest extends AbstractJpaIntegrationTest {
 
     private TargetType targetType1;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/DistributionSetAccessControllerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/DistributionSetAccessControllerTest.java
@@ -38,6 +38,7 @@ import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * Note: Still all test gets READ_REPOSITORY since find methods are inherited with request for READ_REPOSITORY. However,
@@ -46,7 +47,8 @@ import org.springframework.test.context.ContextConfiguration;
  * Feature: Component Tests - Access Control<br/>
  * Story: Test Distribution Set Access Controller
  */
-@ContextConfiguration(classes = { DefaultAccessControllerConfiguration.class })
+@ContextConfiguration(classes = { AccessControllerConfiguration.class })
+@TestPropertySource(properties = "hawkbit.acm.access-controller.enabled=true")
 class DistributionSetAccessControllerTest extends AbstractJpaIntegrationTest {
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/TargetAccessControllerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/TargetAccessControllerTest.java
@@ -44,12 +44,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * Feature: Component Tests - Access Control<br/>
  * Story: Test Target Access Controller
  */
-@ContextConfiguration(classes = { DefaultAccessControllerConfiguration.class, AcmTestConfiguration.class })
+@ContextConfiguration(classes = { AccessControllerConfiguration.class, AcmTestConfiguration.class })
+@TestPropertySource(properties = "hawkbit.acm.access-controller.enabled=true")
 class TargetAccessControllerTest extends AbstractJpaIntegrationTest {
 
     @Autowired

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/TargetTypeAccessControllerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/TargetTypeAccessControllerTest.java
@@ -37,8 +37,8 @@ import org.springframework.test.context.TestPropertySource;
  * Feature: Component Tests - Access Control<br/>
  * Story: Test Target Type Access Controller
  */
-@ContextConfiguration(classes = { DefaultAccessControllerConfiguration.class })
-@TestPropertySource(properties = { "hawkbit.acm.access-controller.target-type.enabled=true" })
+@ContextConfiguration(classes = { AccessControllerConfiguration.class })
+@TestPropertySource(properties = { "hawkbit.acm.access-controller.target-type.enabled=true", "hawkbit.acm.access-controller.enabled=true" })
 class TargetTypeAccessControllerTest extends AbstractJpaIntegrationTest {
 
     /**


### PR DESCRIPTION
* disabled by default
* evaluaton context considers fine-grained only when acm is enabled