### PR TITLE
[#2429] Add completeness property for software modules

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/DistributionSetFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/DistributionSetFields.java
@@ -32,7 +32,6 @@ public enum DistributionSetFields implements QueryField {
     LASTMODIFIEDAT("lastModifiedAt"),
     LASTMODIFIEDBY("lastModifiedBy"),
     VERSION("version"),
-    COMPLETE("complete"),
     MODULE("modules", SoftwareModuleFields.ID.getJpaEntityFieldName(), SoftwareModuleFields.NAME.getJpaEntityFieldName()),
     TAG("tags", "name"),
     METADATA("metadata"),

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSet.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSet.java
@@ -147,11 +147,6 @@ public class MgmtDistributionSet extends MgmtNamedEntity {
             example = "OS (FW) mandatory, runtime (FW) and app (SW) optional")
     private String typeName;
 
-    @Schema(description = """
-            True of the distribution set software module setup is complete as defined by the
-            distribution set type""", example = "true")
-    private Boolean complete;
-
     @Schema(description = "If the distribution set is locked", example = "true")
     private boolean locked;
 
@@ -167,4 +162,8 @@ public class MgmtDistributionSet extends MgmtNamedEntity {
     private boolean requiredMigrationStep;
 
     private List<MgmtSoftwareModule> modules = new ArrayList<>();
+
+    @Schema(description = "True of the distribution set software module setup is complete as defined by the distribution set type",
+            example = "true")
+    private Boolean complete;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModule.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModule.java
@@ -93,4 +93,7 @@ public class MgmtSoftwareModule extends MgmtNamedEntity {
 
     @Schema(description = "If the software module is deleted", example = "false")
     private boolean deleted;
+
+    @Schema(description = "True of the software module has sufficient number of artifacts", example = "true")
+    private Boolean complete;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleType.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleType.java
@@ -40,6 +40,7 @@ import org.eclipse.hawkbit.mgmt.json.model.MgmtTypeEntity;
           "description" : "Updated description.",
           "key" : "application",
           "maxAssignments" : 2147483647,
+          "minArtifacts": 1,
           "deleted" : false,
           "_links" : {
             "self" : {
@@ -54,7 +55,9 @@ public class MgmtSoftwareModuleType extends MgmtTypeEntity {
     @Schema(description = "The technical identifier of the entity", example = "83")
     private Long id;
 
-    @Schema(description = "Software modules of that type can be assigned at this maximum number " +
-            "(e.g. operating system only once)", example = "1")
+    @Schema(description = "The minimum number of artifacts a software module if this type should have in order to be completed", example = "1")
+    private int minArtifacts;
+
+    @Schema(description = "Software modules of this type can be assigned at this maximum number (e.g. operating system only once)", example = "1")
     private int maxAssignments;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleTypeRequestBodyPost.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleTypeRequestBodyPost.java
@@ -33,6 +33,9 @@ public class MgmtSoftwareModuleTypeRequestBodyPost extends MgmtSoftwareModuleTyp
     @Schema(example = "Example key")
     private String key;
 
+    @Schema(description = "The minimum number of artifacts a software module if this type should have in order to be completed", example = "1")
+    private int minArtifacts;
+
     @JsonProperty(required = true)
     @Schema(example = "1")
     private int maxAssignments;

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResource.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResource.java
@@ -45,6 +45,7 @@ import org.eclipse.hawkbit.mgmt.rest.resource.mapper.MgmtRestModelMapper;
 import org.eclipse.hawkbit.mgmt.rest.resource.mapper.MgmtSoftwareModuleMapper;
 import org.eclipse.hawkbit.mgmt.rest.resource.mapper.MgmtTargetFilterQueryMapper;
 import org.eclipse.hawkbit.mgmt.rest.resource.mapper.MgmtTargetMapper;
+import org.eclipse.hawkbit.mgmt.rest.resource.util.LogUtility;
 import org.eclipse.hawkbit.mgmt.rest.resource.util.PagingUtility;
 import org.eclipse.hawkbit.repository.DeploymentManagement;
 import org.eclipse.hawkbit.repository.DistributionSetInvalidationManagement;
@@ -116,6 +117,9 @@ public class MgmtDistributionSetResource implements MgmtDistributionSetRestApi {
     @Override
     public ResponseEntity<PagedList<MgmtDistributionSet>> getDistributionSets(
             final String rsqlParam, final int pagingOffsetParam, final int pagingLimitParam, final String sortParam) {
+        if (rsqlParam != null && rsqlParam.toLowerCase().contains("complete")) {
+            LogUtility.logDeprecated("Usage of MgmtDistributionSetResource.getActions with 'complete': 'complete' distribution set search field may be removed.");
+        }
         final Pageable pageable = PagingUtility.toPageable(pagingOffsetParam, pagingLimitParam, sanitizeDistributionSetSortParam(sortParam));
         final Page<? extends DistributionSet> findDsPage;
         if (rsqlParam != null) {

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtDistributionSetMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtDistributionSetMapper.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -33,9 +32,7 @@ import org.eclipse.hawkbit.mgmt.rest.api.MgmtDistributionSetTypeRestApi;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
 import org.eclipse.hawkbit.repository.DistributionSetManagement;
 import org.eclipse.hawkbit.repository.DistributionSetTagManagement;
-import org.eclipse.hawkbit.repository.DistributionSetTypeManagement;
 import org.eclipse.hawkbit.repository.SoftwareModuleManagement;
-import org.eclipse.hawkbit.repository.SystemManagement;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetAssignmentResult;
@@ -60,7 +57,7 @@ public class MgmtDistributionSetMapper {
     public List<DistributionSetManagement.Create> fromRequest(
             final Collection<MgmtDistributionSetRequestBodyPost> sets,
             final String defaultDsKey, final Map<String, DistributionSetType> dsTypeKeyToDsType) {
-        return sets.stream().<DistributionSetManagement.Create>map(dsRest -> {
+        return sets.stream().<DistributionSetManagement.Create> map(dsRest -> {
             final Set<Long> modules = new HashSet<>();
             if (dsRest.getOs() != null) {
                 modules.add(dsRest.getOs().getId());
@@ -195,7 +192,7 @@ public class MgmtDistributionSetMapper {
     }
 
     private Set<? extends SoftwareModule> findSoftwareModuleWithExceptionIfNotFound(final Set<Long> softwareModuleIds) {
-         if (CollectionUtils.isEmpty(softwareModuleIds)) {
+        if (CollectionUtils.isEmpty(softwareModuleIds)) {
             return Collections.emptySet();
         }
 

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtSoftwareModuleTypeMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtSoftwareModuleTypeMapper.java
@@ -13,7 +13,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import lombok.AccessLevel;
@@ -21,7 +20,7 @@ import lombok.NoArgsConstructor;
 import org.eclipse.hawkbit.mgmt.json.model.softwaremoduletype.MgmtSoftwareModuleType;
 import org.eclipse.hawkbit.mgmt.json.model.softwaremoduletype.MgmtSoftwareModuleTypeRequestBodyPost;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtSoftwareModuleTypeRestApi;
-import org.eclipse.hawkbit.repository.SoftwareModuleTypeManagement;
+import org.eclipse.hawkbit.repository.SoftwareModuleTypeManagement.Create;
 import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 import org.eclipse.hawkbit.rest.json.model.ResponseList;
 
@@ -31,41 +30,37 @@ import org.eclipse.hawkbit.rest.json.model.ResponseList;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MgmtSoftwareModuleTypeMapper {
 
-    public static List<SoftwareModuleTypeManagement.Create> smFromRequest(
-            final Collection<MgmtSoftwareModuleTypeRequestBodyPost> smTypesRest) {
-        if (smTypesRest == null) {
-            return Collections.emptyList();
+    public static List<Create> smFromRequest(final Collection<MgmtSoftwareModuleTypeRequestBodyPost> request) {
+        if (request == null) {
+            return List.of();
         }
-
-        return smTypesRest.stream().map(MgmtSoftwareModuleTypeMapper::fromRequest).toList();
+        return request.stream().map(MgmtSoftwareModuleTypeMapper::fromRequest).toList();
     }
 
     public static List<MgmtSoftwareModuleType> toTypesResponse(final Collection<? extends SoftwareModuleType> types) {
         if (types == null) {
-            return Collections.emptyList();
+            return List.of();
         }
-
         return new ResponseList<>(types.stream().map(MgmtSoftwareModuleTypeMapper::toResponse).toList());
     }
 
     public static MgmtSoftwareModuleType toResponse(final SoftwareModuleType type) {
         final MgmtSoftwareModuleType result = new MgmtSoftwareModuleType();
-
         MgmtRestModelMapper.mapTypeToType(result, type);
-        result.setMaxAssignments(type.getMaxAssignments());
-        result.setId(type.getId());
-
-        result.add(linkTo(methodOn(MgmtSoftwareModuleTypeRestApi.class).getSoftwareModuleType(result.getId()))
-                .withSelfRel().expand());
-
+        result
+                .setId(type.getId())
+                .setMinArtifacts(type.getMinArtifacts())
+                .setMaxAssignments(type.getMaxAssignments());
+        result.add(linkTo(methodOn(MgmtSoftwareModuleTypeRestApi.class).getSoftwareModuleType(result.getId())).withSelfRel().expand());
         return result;
     }
 
-    private static SoftwareModuleTypeManagement.Create fromRequest(final MgmtSoftwareModuleTypeRequestBodyPost smsRest) {
-        return SoftwareModuleTypeManagement.Create.builder()
-                .key(smsRest.getKey()).name(smsRest.getName())
-                .description(smsRest.getDescription()).colour(smsRest.getColour())
-                .maxAssignments(smsRest.getMaxAssignments())
+    private static Create fromRequest(final MgmtSoftwareModuleTypeRequestBodyPost request) {
+        return Create.builder()
+                .key(request.getKey()).name(request.getName())
+                .description(request.getDescription()).colour(request.getColour())
+                .minArtifacts(request.getMinArtifacts())
+                .maxAssignments(request.getMaxAssignments())
                 .build();
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SoftwareModuleTypeManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SoftwareModuleTypeManagement.java
@@ -63,6 +63,8 @@ public interface SoftwareModuleTypeManagement<T extends SoftwareModuleType>
 
         @Builder.Default
         private int maxAssignments = 1;
+        @Builder.Default
+        private int minArtifacts;
     }
 
     @SuperBuilder

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetUpdatedEvent.java
@@ -28,16 +28,7 @@ public class DistributionSetUpdatedEvent extends RemoteEntityEvent<DistributionS
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private boolean complete;
-
-    /**
-     * Constructor.
-     *
-     * @param distributionSet Distribution Set
-     * @param complete <code>true</code> if {@link DistributionSet} is after the update {@link DistributionSet#isComplete()}
-     */
-    public DistributionSetUpdatedEvent(final DistributionSet distributionSet, final boolean complete) {
+    public DistributionSetUpdatedEvent(final DistributionSet distributionSet) {
         super(distributionSet);
-        this.complete = complete;
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/IncompleteSoftwareModuleException.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/exception/IncompleteSoftwareModuleException.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.repository.exception;
+
+import java.io.Serial;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.eclipse.hawkbit.exception.AbstractServerRtException;
+import org.eclipse.hawkbit.exception.SpServerError;
+
+/**
+ * Thrown if a software module is being locked while incomplete (i.e. not enough artifacts are assigned).
+ */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class IncompleteSoftwareModuleException extends AbstractServerRtException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public IncompleteSoftwareModuleException() {
+        super(SpServerError.SP_DS_INCOMPLETE);
+    }
+
+    public IncompleteSoftwareModuleException(final Throwable cause) {
+        super(SpServerError.SP_DS_INCOMPLETE, cause);
+    }
+
+    public IncompleteSoftwareModuleException(final String message) {
+        super(SpServerError.SP_DS_INCOMPLETE, message);
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSet.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSet.java
@@ -40,12 +40,6 @@ public interface DistributionSet extends NamedVersionedEntity {
     Set<SoftwareModule> getModules();
 
     /**
-     * @return <code>true</code> if all defined {@link DistributionSetType#getMandatoryModuleTypes()} of {@link #getType()} are present in
-     *         this {@link DistributionSet}.
-     */
-    boolean isComplete();
-
-    /**
      * @return <code>true</code> if this {@link DistributionSet} is locked. If so it's 'functional' properties (e.g. software modules) could not
      *         be modified anymore.
      */
@@ -66,4 +60,12 @@ public interface DistributionSet extends NamedVersionedEntity {
      *         active and not automatically canceled if overridden by a newer update.
      */
     boolean isRequiredMigrationStep();
+
+    /**
+     * Returns if the distribution set could be assumed as completed. I.e. all requirements (e.g. mandatory software module types) are satisfied.
+     *
+     * @return <code>true</code> if all defined {@link DistributionSetType#getMandatoryModuleTypes()} of {@link #getType()} are present in
+     *         this {@link DistributionSet}.
+     */
+    boolean isComplete();
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetType.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetType.java
@@ -30,12 +30,6 @@ public interface DistributionSetType extends Type {
     Set<SoftwareModuleType> getOptionalModuleTypes();
 
     /**
-     * @param distributionSet to check for completeness
-     * @return <code>true</code> if the all mandatory software module types are in the system.
-     */
-    boolean checkComplete(DistributionSet distributionSet);
-
-    /**
      * Checks if the given {@link SoftwareModuleType} is in this {@link DistributionSetType}.
      *
      * @param softwareModuleType search for

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/SoftwareModule.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/SoftwareModule.java
@@ -71,6 +71,13 @@ public interface SoftwareModule extends NamedVersionedEntity {
     boolean isDeleted();
 
     /**
+     * Returns if the software module could be assumed as completed. I.e. all requirements (e.g. min artifacts) are satisfied.
+     *
+     * @return <code>true</code> if artifacts are more or equals to {@link SoftwareModuleType#getMinArtifacts()} if the software module type.
+     */
+    boolean isComplete();
+
+    /**
      * @param artifactId to look for
      * @return found {@link Artifact}
      */

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/SoftwareModuleType.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/SoftwareModuleType.java
@@ -16,7 +16,12 @@ package org.eclipse.hawkbit.repository.model;
 public interface SoftwareModuleType extends Type {
 
     /**
-     * @return maximum assignments of an {@link SoftwareModule} of this type to a {@link DistributionSet}.
+     * @return thet minimum number of artifacts a {@link SoftwareModule} of this type should have in order to be completed.
+     */
+    int getMinArtifacts();
+
+    /**
+     * @return the maximum assignments of a {@link SoftwareModule} of this type to a {@link DistributionSet}.
      */
     int getMaxAssignments();
 }

--- a/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/H2/V1_12_34__sm_type_min_artifacts__H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/H2/V1_12_34__sm_type_min_artifacts__H2.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sp_software_module_type ADD COLUMN min_artifacts integer default 0 NOT NULL;
+DROP INDEX sp_idx_distribution_set_01;
+CREATE INDEX sp_idx_distribution_set_01 ON sp_distribution_set (tenant, deleted);
+ALTER TABLE sp_distribution_set DROP COLUMN complete;

--- a/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/MYSQL/V1_12_34__sm_type_min_artifacts__MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/MYSQL/V1_12_34__sm_type_min_artifacts__MYSQL.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sp_software_module_type ADD COLUMN min_artifacts integer default 0 NOT NULL;
+ALTER TABLE sp_distribution_set DROP INDEX sp_idx_distribution_set_01;
+CREATE INDEX sp_idx_distribution_set_01 ON sp_distribution_set (tenant, deleted);
+ALTER TABLE sp_distribution_set DROP COLUMN complete;

--- a/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/POSTGRESQL/V1_12_35__sm_type_min_artifacts__POSTGRESQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/POSTGRESQL/V1_12_35__sm_type_min_artifacts__POSTGRESQL.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sp_software_module_type ADD COLUMN min_artifacts integer default 0 NOT NULL;
+DROP INDEX sp_idx_distribution_set_01;
+CREATE INDEX sp_idx_distribution_set_01 ON sp_distribution_set USING BTREE (tenant, deleted);
+ALTER TABLE sp_distribution_set DROP COLUMN complete;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaSoftwareModuleManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaSoftwareModuleManagement.java
@@ -28,6 +28,7 @@ import org.eclipse.hawkbit.repository.QuotaManagement;
 import org.eclipse.hawkbit.repository.SoftwareModuleFields;
 import org.eclipse.hawkbit.repository.SoftwareModuleManagement;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
+import org.eclipse.hawkbit.repository.exception.IncompleteSoftwareModuleException;
 import org.eclipse.hawkbit.repository.exception.LockedException;
 import org.eclipse.hawkbit.repository.jpa.JpaManagementHelper;
 import org.eclipse.hawkbit.repository.jpa.acm.AccessController;
@@ -142,6 +143,9 @@ public class JpaSoftwareModuleManagement extends
         if (jpaSoftwareModule.isLocked()) {
             return jpaSoftwareModule;
         } else {
+            if (!softwareModule.isComplete()) {
+                throw new IncompleteSoftwareModuleException("Could not be locked while incomplete!");
+            }
             jpaSoftwareModule.lock();
             return jpaRepository.save(jpaSoftwareModule);
         }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
@@ -113,15 +113,6 @@ public class JpaDistributionSetType extends AbstractJpaTypeEntity implements Dis
     }
 
     @Override
-    public boolean checkComplete(final DistributionSet distributionSet) {
-        final List<SoftwareModuleType> smTypes = distributionSet.getModules().stream()
-                .map(SoftwareModule::getType)
-                .distinct()
-                .toList();
-        return !smTypes.isEmpty() && new HashSet<>(smTypes).containsAll(getMandatoryModuleTypes());
-    }
-
-    @Override
     public String toString() {
         return "DistributionSetType [key=" + getKey() + ", isDeleted()=" + isDeleted() + ", getId()=" + getId() + "]";
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModule.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModule.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
@@ -144,6 +145,17 @@ public class JpaSoftwareModule
         } else {
             throw new UnsupportedOperationException("Only JpaArtifact is supported");
         }
+    }
+
+    @Override
+    public boolean isComplete() {
+        return Optional.ofNullable(type).map(smType -> {
+            if (smType.getMinArtifacts() > 0) {
+                return getArtifacts().size() >= smType.getMinArtifacts();
+            } else {
+                return true;
+            }
+        }).orElse(true);
     }
 
     public void removeArtifact(final Artifact artifact) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModuleType.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaSoftwareModuleType.java
@@ -46,6 +46,11 @@ public class JpaSoftwareModuleType extends AbstractJpaTypeEntity implements Soft
     private static final long serialVersionUID = 1L;
 
     @Setter(value = lombok.AccessLevel.PRIVATE) // used via reflection
+    @Column(name = "min_artifacts", nullable = false)
+    @Min(0)
+    private int minArtifacts;
+
+    @Setter(value = lombok.AccessLevel.PRIVATE) // used via reflection
     @Column(name = "max_ds_assignments", nullable = false)
     @Min(1)
     private int maxAssignments;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/DistributionSetSpecification.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/DistributionSetSpecification.java
@@ -58,26 +58,6 @@ public final class DistributionSetSpecification {
     }
 
     /**
-     * {@link Specification} for retrieving {@link DistributionSet}s by its COMPLETED attribute.
-     *
-     * @param isCompleted TRUE/FALSE are compared to the attribute COMPLETED. If NULL the attribute is ignored
-     * @return the {@link DistributionSet} {@link Specification}
-     */
-    public static Specification<JpaDistributionSet> isCompleted(final Boolean isCompleted) {
-        return (dsRoot, query, cb) -> cb.equal(dsRoot.get(JpaDistributionSet_.complete), isCompleted);
-    }
-
-    /**
-     * {@link Specification} for retrieving {@link DistributionSet}s by its VALID attribute.
-     *
-     * @param isValid TRUE/FALSE are compared to the attribute VALID. If NULL the attribute is ignored
-     * @return the {@link DistributionSet} {@link Specification}
-     */
-    public static Specification<JpaDistributionSet> isValid(final Boolean isValid) {
-        return (dsRoot, query, cb) -> cb.equal(dsRoot.get(JpaDistributionSet_.valid), isValid);
-    }
-
-    /**
      * {@link Specification} for retrieving {@link DistributionSet} with given {@link DistributionSet#getId()}s.
      *
      * @param distids to search

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetUpdatedEventTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/event/remote/entity/DistributionSetUpdatedEventTest.java
@@ -31,7 +31,7 @@ class DistributionSetUpdatedEventTest extends AbstractRemoteEntityEventTest<Dist
 
     @Override
     protected RemoteEntityEvent<?> createRemoteEvent(final DistributionSet baseEntity, final Class<? extends RemoteEntityEvent<?>> eventType) {
-        return new DistributionSetUpdatedEvent(baseEntity, true);
+        return new DistributionSetUpdatedEvent(baseEntity);
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DeploymentManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DeploymentManagementTest.java
@@ -1357,8 +1357,7 @@ class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         List<? extends DistributionSet> allFoundDS = distributionSetManagement.findAll(PAGE).getContent();
         assertThat(allFoundDS).as("no ds should be founded").isEmpty();
 
-        assertThat(distributionSetRepository.findAll(JpaManagementHelper.combineWithAnd(
-                List.of(DistributionSetSpecification.isDeleted(true), DistributionSetSpecification.isCompleted(true))), PAGE).getContent())
+        assertThat(distributionSetRepository.findAll(DistributionSetSpecification.isDeleted(true), PAGE).getContent())
                 .as("wrong size of founded ds").hasSize(noOfDistributionSets);
 
         IntStream.range(0, deploymentResult.getDistributionSets().size()).forEach(i -> testdataFactory.sendUpdateActionStatusToTargets(
@@ -1369,9 +1368,8 @@ class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         // verify that the result is the same, even though distributionSet dsA has been installed
         // successfully and no activeAction is referring to created distribution sets
         allFoundDS = distributionSetManagement.findAll(pageRequest).getContent();
-        assertThat(allFoundDS).as("no ds should be founded").isEmpty();
-        assertThat(distributionSetRepository.findAll(JpaManagementHelper.combineWithAnd(
-                List.of(DistributionSetSpecification.isDeleted(true), DistributionSetSpecification.isCompleted(true))), PAGE).getContent())
+        assertThat(allFoundDS).as("no ds should be found").isEmpty();
+        assertThat(distributionSetRepository.findAll(DistributionSetSpecification.isDeleted(true), PAGE).getContent())
                 .as("wrong size of founded ds").hasSize(noOfDistributionSets);
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DistributionSetTypeManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DistributionSetTypeManagementTest.java
@@ -109,18 +109,6 @@ class DistributionSetTypeManagementTest extends AbstractRepositoryManagementTest
     }
 
     /**
-     * Verifies that when no SoftwareModules are assigned to a Distribution then the DistributionSet is not complete.
-     */
-    @Test
-    void incompleteIfDistributionSetHasNoSoftwareModulesAssigned() {
-        final JpaDistributionSetType jpaDistributionSetType = (JpaDistributionSetType) distributionSetTypeManagement
-                .create(Create.builder().key("newType").name("new Type").build());
-        final DistributionSet distributionSet = testdataFactory.createDistributionSet(
-                "DistributionOne", "3.1.2", jpaDistributionSetType, new ArrayList<>());
-        assertThat(jpaDistributionSetType.checkComplete(distributionSet)).isFalse();
-    }
-
-    /**
      * Verifies that the quota for software module types per distribution set type is enforced as expected.
      */
     @Test


### PR DESCRIPTION
* add `min artifacts` requirement on the Software Module Type level for Software Module completeness
* removed `complete` Distribution Set property from DB - calculated runtime
* Distribution Set and Software Module completeness is calcualted on demand in memory (TODO: implement cache)
* locking of Software Module now requires the software module to be `completed`