### PR TITLE
Remove deprecations

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionFields.java
@@ -20,10 +20,8 @@ import lombok.Getter;
 public enum ActionFields implements QueryField {
 
     ID("id"),
-    @Deprecated(since = "0.10.0", forRemoval = true) // use ACTIVE
-    STATUS("active"), // true if status is "pending", false if "finished", after removal, will deprecate DETAILSTATUS too and replace with STATUS
-    ACTIVE("active"), // true if st
-    DETAILSTATUS("status"), // real status
+    ACTIVE("active"),
+    STATUS("status"),
     LASTSTATUSCODE("lastActionStatusCode"),
     CREATEDAT("createdAt"),
     CREATEDBY("createdBy"),
@@ -47,20 +45,5 @@ public enum ActionFields implements QueryField {
     ActionFields(final String jpaEntityFieldName, final String... subEntityAttributes) {
         this.jpaEntityFieldName = jpaEntityFieldName;
         this.subEntityAttributes = List.of(subEntityAttributes);
-    }
-
-    /**
-     * @deprecated since 0.10.0 - use {@link #ACTIVE} instead of {@link #STATUS}
-     */
-    @Deprecated(since = "0.10.0", forRemoval = true) // remove together with STATUS (with active meaning)
-    public static Object convertStatusValue(final String value) {
-        final String trimmedValue = value.trim();
-        if (trimmedValue.equalsIgnoreCase("pending")) {
-            return true;
-        } else if (trimmedValue.equalsIgnoreCase("finished")) {
-            return false;
-        } else {
-            throw new IllegalArgumentException("field 'status' must be one of the following values {pending, finished}");
-        }
     }
 }

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionStatusFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/ActionStatusFields.java
@@ -18,9 +18,11 @@ import lombok.Getter;
 public enum ActionStatusFields implements QueryField {
 
     ID("id"),
-    @Deprecated
-    REPORTEDAT("createdAt"),
-    CREATEDAT("createdAt"),
+    // search fields in sync with entity specifics (timestamp & report time)
+    TIMESTAMP("timestamp"),
+    REPORTEDAT("createdAt"), // same as CREATEDAT
+    // fields for db records as in other fields - created at / by
+    CREATEDAT("createdAt"), // same as REPORTEDAT
     CREATEDBY("createdBy");
 
     private final String jpaEntityFieldName;

--- a/hawkbit-ddi/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-ddi/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -494,8 +494,7 @@ public class DdiRootController implements DdiRootControllerRestApi {
 
     private static ActionStatusCreate generateActionCancelStatus(
             final DdiActionFeedback feedback, final Target target, final Long actionId) {
-        final ActionStatusCreateBuilder actionStatusCreate = ActionStatusCreate.builder()
-                .actionId(actionId).occurredAt(feedback.getTimestamp());
+        final ActionStatusCreateBuilder actionStatusCreate = ActionStatusCreate.builder().actionId(actionId).timestamp(feedback.getTimestamp());
         final List<String> messages = new ArrayList<>();
         final Status status;
         switch (feedback.getStatus().getExecution()) {
@@ -601,7 +600,7 @@ public class DdiRootController implements DdiRootControllerRestApi {
 
     private ActionStatusCreate generateUpdateStatus(final DdiActionFeedback feedback, final String controllerId, final Long actionId) {
         final ActionStatusCreateBuilder actionStatusCreate = ActionStatusCreate.builder()
-                .actionId(actionId).occurredAt(feedback.getTimestamp());
+                .actionId(actionId).timestamp(feedback.getTimestamp());
         final List<String> messages = new ArrayList<>();
 
         if (!CollectionUtils.isEmpty(feedback.getStatus().getDetails())) {

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtAction.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtAction.java
@@ -37,8 +37,8 @@ import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtActionType;
           "lastModifiedBy" : "bumlux",
           "lastModifiedAt" : 1682408571265,
           "type" : "update",
+          "active" : false,
           "status" : "finished",
-          "detailStatus" : "finished",
           "rollout" : 1,
           "rolloutName" : "rollout",
           "_links" : {
@@ -74,35 +74,15 @@ public class MgmtAction extends MgmtBaseEntity {
      * API definition for action in canceling.
      */
     public static final String ACTION_CANCEL = "cancel";
-    /**
-     * API definition for action completed.
-     *
-     * @deprecated since 0.10.0 will be removed together with status field
-     */
-    @Deprecated(since = "0.10.0", forRemoval = true)
-    public static final String ACTION_FINISHED = "finished";
-    /**
-     * API definition for action still active.
-     *
-     * @deprecated since 0.10.0 will be removed together with status field
-     */
-    @Deprecated(since = "0.10.0", forRemoval = true)
-    public static final String ACTION_PENDING = "pending";
 
     @Schema(description = "ID of the action", example = "7")
     private Long id;
     @Schema(description = "Type of action", example = "update")
     private String type;
-    /**
-     * @deprecated since 0.10.0 - use {@link #active} instead of {@link #status}
-     */
-    @Deprecated(since = "0.10.0")
-    @Schema(description = "Status of action, use active", example = "finished", deprecated = true)
-    private String status;
-    @Schema(description = "Status of action")
+    @Schema(description = "If acton is active")
     private boolean active;
-    @Schema(description = "Detailed status of action", example = "finished")
-    private String detailStatus;
+    @Schema(description = "Status of action")
+    private String status;
     @Schema(example = "1691065903238")
     private Long forceTime;
     private MgmtActionType forceType;
@@ -117,8 +97,7 @@ public class MgmtAction extends MgmtBaseEntity {
     @Schema(description = "The name of the rollout this action was created for", example = "rollout")
     private String rolloutName;
 
-    @Schema(description = "(Optional) Code provided as part of the last status update that was sent by the device.",
-            example = "200")
+    @Schema(description = "(Optional) Code provided as part of the last status update that was sent by the device.", example = "200")
     private Integer lastStatusCode;
 
     @Schema(description = "If created by external system this field contains the external reference for the action")

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSetRequestBodyPost.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSetRequestBodyPost.java
@@ -32,17 +32,6 @@ import org.eclipse.hawkbit.mgmt.json.model.softwaremodule.MgmtSoftwareModuleAssi
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MgmtDistributionSetRequestBodyPost extends MgmtDistributionSetRequestBodyPut {
 
-    // deprecated format from the times where os, application and runtime where statically defined
-    @Schema(hidden = true)
-    private MgmtSoftwareModuleAssignment os;
-
-    @Schema(hidden = true)
-    private MgmtSoftwareModuleAssignment runtime;
-
-    @Schema(hidden = true)
-    private MgmtSoftwareModuleAssignment application;
-    // deprecated format - END
-
     private List<MgmtSoftwareModuleAssignment> modules;
 
     @Schema(description = "The type of the distribution set", example = "test_default_ds_type")

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtTargetTagRestApi.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtTargetTagRestApi.java
@@ -332,18 +332,6 @@ public interface MgmtTargetTagRestApi {
             @RequestParam(value = "onNotFoundPolicy", required = false, defaultValue = "FAIL") OnNotFoundPolicy onNotFoundPolicy);
 
     /**
-     * @deprecated since 0.9.0, use {@link #assignTargets(Long, List, OnNotFoundPolicy)} (POST) instead.
-     */
-    @Deprecated(forRemoval = true, since = "0.9.0")
-    @PutMapping(
-            value = MgmtRestConstants.TARGET_TAG_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_TAG_TARGETS_REQUEST_MAPPING,
-            consumes = { MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE })
-    ResponseEntity<Void> assignTargetsPut(
-            @PathVariable("targetTagId") Long targetTagId,
-            @RequestBody List<String> controllerIds,
-            @RequestParam(value = "onNotFoundPolicy", required = false, defaultValue = "FAIL") OnNotFoundPolicy onNotFoundPolicy);
-
-    /**
      * Handles the DELETE request to unassign one target from the given tag id.
      *
      * @param targetTagId the ID of the target tag

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResource.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResource.java
@@ -18,7 +18,6 @@ import org.eclipse.hawkbit.mgmt.json.model.action.MgmtAction;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtActionRestApi;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRepresentationMode;
 import org.eclipse.hawkbit.mgmt.rest.resource.mapper.MgmtActionMapper;
-import org.eclipse.hawkbit.mgmt.rest.resource.util.LogUtility;
 import org.eclipse.hawkbit.mgmt.rest.resource.util.PagingUtility;
 import org.eclipse.hawkbit.repository.DeploymentManagement;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
@@ -47,9 +46,6 @@ public class MgmtActionResource implements MgmtActionRestApi {
     public ResponseEntity<PagedList<MgmtAction>> getActions(
             final String rsqlParam, final int pagingOffsetParam, final int pagingLimitParam, final String sortParam,
             final String representationModeParam) {
-        LogUtility.logDeprecated(rsqlParam != null && rsqlParam.contains("status")
-                ? "Usage of getActions with RSQL that is up to modification: rsql=" + rsqlParam
-                : "Usage of getActions:result that is up to modification.");
         final Pageable pageable = PagingUtility.toPageable(pagingOffsetParam, pagingLimitParam, sanitizeActionSortParam(sortParam));
 
         final Slice<Action> actions;
@@ -68,7 +64,6 @@ public class MgmtActionResource implements MgmtActionRestApi {
 
     @Override
     public ResponseEntity<MgmtAction> getAction(final Long actionId) {
-        LogUtility.logDeprecated("Usage of getActions:result that is up to modification.");
         final Action action = deploymentManagement.findAction(actionId)
                 .orElseThrow(() -> new EntityNotFoundException(Action.class, actionId));
 

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResource.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResource.java
@@ -118,7 +118,7 @@ public class MgmtDistributionSetResource implements MgmtDistributionSetRestApi {
     public ResponseEntity<PagedList<MgmtDistributionSet>> getDistributionSets(
             final String rsqlParam, final int pagingOffsetParam, final int pagingLimitParam, final String sortParam) {
         if (rsqlParam != null && rsqlParam.toLowerCase().contains("complete")) {
-            LogUtility.logDeprecated("Usage of MgmtDistributionSetResource.getActions with 'complete': 'complete' distribution set search field may be removed.");
+            LogUtility.logDeprecated("Usage of MgmtDistributionSetResource.getActions with 'complete': 'complete' distribution set search field is limited and may be removed.");
         }
         final Pageable pageable = PagingUtility.toPageable(pagingOffsetParam, pagingLimitParam, sanitizeDistributionSetSortParam(sortParam));
         final Page<? extends DistributionSet> findDsPage;

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTagResource.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTagResource.java
@@ -24,7 +24,6 @@ import org.eclipse.hawkbit.mgmt.json.model.target.MgmtTarget;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtTargetTagRestApi;
 import org.eclipse.hawkbit.mgmt.rest.resource.mapper.MgmtTagMapper;
 import org.eclipse.hawkbit.mgmt.rest.resource.mapper.MgmtTargetMapper;
-import org.eclipse.hawkbit.mgmt.rest.resource.util.LogUtility;
 import org.eclipse.hawkbit.mgmt.rest.resource.util.PagingUtility;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.TargetTagManagement;
@@ -156,13 +155,6 @@ public class MgmtTargetTagResource implements MgmtTargetTagRestApi {
             }
         }
         return ResponseEntity.ok().build();
-    }
-
-    @Override
-    public ResponseEntity<Void> assignTargetsPut(
-            final Long targetTagId, final List<String> controllerIds, final OnNotFoundPolicy onNotFoundPolicy) {
-        LogUtility.logDeprecated("Deprecated usage of assignTargetsPut. Use assignTargetsPut (POST) instead.");
-        return assignTargets(targetTagId, controllerIds, onNotFoundPolicy);
     }
 
     @Override

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtDistributionSetMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtDistributionSetMapper.java
@@ -59,15 +59,6 @@ public class MgmtDistributionSetMapper {
             final String defaultDsKey, final Map<String, DistributionSetType> dsTypeKeyToDsType) {
         return sets.stream().<DistributionSetManagement.Create> map(dsRest -> {
             final Set<Long> modules = new HashSet<>();
-            if (dsRest.getOs() != null) {
-                modules.add(dsRest.getOs().getId());
-            }
-            if (dsRest.getApplication() != null) {
-                modules.add(dsRest.getApplication().getId());
-            }
-            if (dsRest.getRuntime() != null) {
-                modules.add(dsRest.getRuntime().getId());
-            }
             if (dsRest.getModules() != null) {
                 dsRest.getModules().forEach(module -> modules.add(module.getId()));
             }

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtTargetMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtTargetMapper.java
@@ -239,11 +239,8 @@ public final class MgmtTargetMapper {
         action.getWeight().ifPresent(result::setWeight);
         result.setForceType(MgmtRestModelMapper.convertActionType(action.getActionType()));
 
-        result.setStatus(action.isActive() ? MgmtAction.ACTION_PENDING : MgmtAction.ACTION_FINISHED);
-
         result.setActive(action.isActive());
-        result.setDetailStatus(action.getStatus().toString().toLowerCase());
-
+        result.setStatus(action.getStatus().toString().toLowerCase());
         action.getLastActionStatusCode().ifPresent(result::setLastStatusCode);
 
         final Rollout rollout = action.getRollout();
@@ -365,7 +362,7 @@ public final class MgmtTargetMapper {
 
         result.setMessages(messages);
         result.setReportedAt(actionStatus.getCreatedAt());
-        result.setTimestamp(actionStatus.getOccurredAt());
+        result.setTimestamp(actionStatus.getTimestamp());
         result.setId(actionStatus.getId());
         result.setType(MgmtActionStatus.Type.forValue(actionStatus.getStatus().name()));
         actionStatus.getCode().ifPresent(result::setCode);

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtActionResourceTest.java
@@ -10,8 +10,11 @@
 package org.eclipse.hawkbit.mgmt.rest.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants.ACTION_V1_REQUEST_MAPPING;
+import static org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants.REQUEST_PARAMETER_SEARCH;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -35,7 +38,6 @@ import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.rest.util.MockMvcResultPrinter;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 /**
@@ -84,32 +86,32 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         final DistributionSet dsA = testdataFactory.createDistributionSet("");
         assignDistributionSet(dsA, Collections.singletonList(testdataFactory.createTarget("knownTargetId")));
 
-        final String rsqlPendingStatus = "status==pending";
-        final String rsqlFinishedStatus = "status==finished";
+        final String rsqlPendingStatus = "active==true";
+        final String rsqlFinishedStatus = "active==false";
         final String rsqlPendingOrFinishedStatus = rsqlFinishedStatus + "," + rsqlPendingStatus;
 
         // pending status one result
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlPendingStatus))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlPendingStatus))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
                 .andExpect(jsonPath("size", equalTo(1)))
-                .andExpect(jsonPath("content[0].status", equalTo("pending")));
+                .andExpect(jsonPath("content[0].active", equalTo(true)));
 
         // finished status none result
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlFinishedStatus))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlFinishedStatus))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(0)))
                 .andExpect(jsonPath("size", equalTo(0)));
 
         // pending or finished status one result
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlPendingOrFinishedStatus))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlPendingOrFinishedStatus))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
                 .andExpect(jsonPath("size", equalTo(1)))
-                .andExpect(jsonPath("content[0].status", equalTo("pending")));
+                .andExpect(jsonPath("content[0].active", equalTo(true)));
 
     }
 
@@ -122,34 +124,34 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         final DistributionSet dsA = testdataFactory.createDistributionSet("");
         assignDistributionSet(dsA, Collections.singletonList(testdataFactory.createTarget("knownTargetId")));
 
-        final String rsqlPendingStatus = "detailStatus==running";
-        final String rsqlFinishedStatus = "detailStatus==finished";
+        final String rsqlPendingStatus = "status==running";
+        final String rsqlFinishedStatus = "status==finished";
         final String rsqlPendingOrFinishedStatus = rsqlFinishedStatus + "," + rsqlPendingStatus;
 
         // running status one result
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlPendingStatus))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlPendingStatus))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
                 .andExpect(jsonPath("size", equalTo(1)))
-                .andExpect(jsonPath("content[0].detailStatus", equalTo("running")))
-                .andExpect(jsonPath("content[0].status", equalTo("pending")));
+                .andExpect(jsonPath("content[0].active", equalTo(true)))
+                .andExpect(jsonPath("content[0].status", equalTo("running")));
 
         // finished status none result
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlFinishedStatus))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlFinishedStatus))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(0)))
                 .andExpect(jsonPath("size", equalTo(0)));
 
         // running or finished status one result
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlPendingOrFinishedStatus))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlPendingOrFinishedStatus))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
                 .andExpect(jsonPath("size", equalTo(1)))
-                .andExpect(jsonPath("content[0].detailStatus", equalTo("running")))
-                .andExpect(jsonPath("content[0].status", equalTo("pending")));
+                .andExpect(jsonPath("content[0].active", equalTo(true)))
+                .andExpect(jsonPath("content[0].status", equalTo("running")));
     }
 
     /**
@@ -175,7 +177,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         final String rsqlExtRefNoMatch = "externalref==234extRef";
 
         // pending status one result
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlExtRef))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlExtRef))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
@@ -183,14 +185,14 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(jsonPath("content[0].externalRef", equalTo(externalRefs.get(0))));
 
         // finished status none result
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlExtRefWildcard))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlExtRefWildcard))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(2)))
                 .andExpect(jsonPath("size", equalTo(2)));
 
         // pending or finished status one result
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlExtRefNoMatch))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlExtRefNoMatch))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(0)))
@@ -204,8 +206,8 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
     void filterActionsByLastStatusCode() throws Exception {
         // assign a distribution set to three targets
         final DistributionSet dsA = testdataFactory.createDistributionSet("");
-        final DistributionSetAssignmentResult assignmentResult = assignDistributionSet(dsA,
-                testdataFactory.createTargets("target1", "target2", "target3"));
+        final DistributionSetAssignmentResult assignmentResult = assignDistributionSet(
+                dsA, testdataFactory.createTargets("target1", "target2", "target3"));
         final List<Action> actions = assignmentResult.getAssignedEntity();
         assertThat(actions).hasSize(3);
 
@@ -216,7 +218,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
 
         // verify that one result is returned if the actions are filtered for status code 200
         final String rsqlStatusCode = "lastStatusCode==200";
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlStatusCode))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlStatusCode))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
@@ -225,7 +227,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
 
         // verify no result is returned if we filter for a non-existing status code
         final String rsqlWrongStatusCode = "lastStatusCode==999";
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlWrongStatusCode))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlWrongStatusCode))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(0)))
@@ -245,7 +247,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         final String rsqlDsVersion = "distributionSet.version==" + ds.getVersion();
         final String rsqlDsId = "distributionSet.id==" + ds.getId();
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlDsName)
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlDsName)
                         .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, MgmtRepresentationMode.FULL.toString()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
@@ -254,25 +256,25 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(jsonPath("content.[0]._links.distributionset.name",
                         equalTo(ds.getName() + ":" + ds.getVersion())));
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlDsVersion))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlDsVersion))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
                 .andExpect(jsonPath("size", equalTo(1)));
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlDsName + "," + rsqlDsVersion))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlDsName + "," + rsqlDsVersion))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
                 .andExpect(jsonPath("size", equalTo(1)));
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=distributionSet.name==FooBar"))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=distributionSet.name==FooBar"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(0)))
                 .andExpect(jsonPath("size", equalTo(0)));
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlDsId))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlDsId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
@@ -301,7 +303,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         final String rsqlRolloutName = "rollout.name==" + rollout.getName();
         final String rsqlRolloutId = "rollout.id==" + rollout.getId();
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlRolloutName)
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlRolloutName)
                         .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, MgmtRepresentationMode.FULL.toString()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
@@ -311,15 +313,14 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(jsonPath(
                         "content.[0]._links.distributionset.name", equalTo(ds.getName() + ":" + ds.getVersion())));
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlRolloutId)
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlRolloutId)
                         .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, MgmtRepresentationMode.FULL.toString()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
                 .andExpect(jsonPath("size", equalTo(1)))
                 .andExpect(jsonPath("content.[0]._links.target.name", equalTo(target1.getName())))
-                .andExpect(jsonPath(
-                        "content.[0]._links.distributionset.name", equalTo(ds.getName() + ":" + ds.getVersion())));
+                .andExpect(jsonPath("content.[0]._links.distributionset.name", equalTo(ds.getName() + ":" + ds.getVersion())));
     }
 
     /**
@@ -364,7 +365,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
 
         final Action action0 = actions.get(0);
         final Action action1 = actions.get(1);
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING)
                         .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC")
                         .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, MgmtRepresentationMode.FULL.toString()))
                 .andDo(MockMvcResultPrinter.print())
@@ -373,8 +374,8 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
                 // verify action 1
                 .andExpect(jsonPath("content.[1].id", equalTo(action1.getId().intValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("update")))
-                .andExpect(jsonPath("content.[1].status", equalTo("pending")))
-                .andExpect(jsonPath("content.[1].detailStatus", equalTo("running")))
+                .andExpect(jsonPath("content.[1].active", equalTo(true)))
+                .andExpect(jsonPath("content.[1].status", equalTo("running")))
                 .andExpect(jsonPath("content.[1]._links.self.href",
                         equalTo(generateActionLink(knownTargetId, action1.getId()))))
                 .andExpect(jsonPath("content.[1]._links.target.href", equalTo(generateTargetLink(knownTargetId))))
@@ -384,13 +385,12 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
                 // verify action 0
                 .andExpect(jsonPath("content.[0].id", equalTo(action0.getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("cancel")))
-                .andExpect(jsonPath("content.[0].status", equalTo("pending")))
-                .andExpect(jsonPath("content.[0].detailStatus", equalTo("canceling")))
+                .andExpect(jsonPath("content.[0].active", equalTo(true)))
+                .andExpect(jsonPath("content.[0].status", equalTo("canceling")))
                 .andExpect(jsonPath("content.[0]._links.self.href",
                         equalTo(generateActionLink(knownTargetId, action0.getId()))))
                 .andExpect(jsonPath("content.[0]._links.target.href", equalTo(generateTargetLink(knownTargetId))))
-                .andExpect(jsonPath("content.[0]._links.distributionset.href",
-                        equalTo(generateDistributionSetLink(action0))))
+                .andExpect(jsonPath("content.[0]._links.distributionset.href", equalTo(generateDistributionSetLink(action0))))
 
                 // verify collection properties
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
@@ -403,7 +403,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void getActionsWithEmptyResult() throws Exception {
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("size", equalTo(0)))
@@ -421,7 +421,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
 
         // page 1: one entry
         final Action action0 = actions.get(0);
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING)
                         .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
                         .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
                 .andDo(MockMvcResultPrinter.print())
@@ -430,8 +430,8 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
                 // verify action 0
                 .andExpect(jsonPath("content.[0].id", equalTo(action0.getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("cancel")))
-                .andExpect(jsonPath("content.[0].status", equalTo("pending")))
-                .andExpect(jsonPath("content.[0].detailStatus", equalTo(action0.getStatus().toString().toLowerCase())))
+                .andExpect(jsonPath("content.[0].active", equalTo(true)))
+                .andExpect(jsonPath("content.[0].status", equalTo(action0.getStatus().toString().toLowerCase())))
                 .andExpect(jsonPath("content.[0]._links.self.href",
                         equalTo(generateActionLink(knownTargetId, action0.getId()))))
 
@@ -442,7 +442,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
 
         // page 2: one entry
         final Action action1 = actions.get(1);
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING)
                         .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
                         .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1))
                         .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1))
@@ -453,10 +453,9 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
                 // verify action 1
                 .andExpect(jsonPath("content.[0].id", equalTo(action1.getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("update")))
-                .andExpect(jsonPath("content.[0].status", equalTo("pending")))
-                .andExpect(jsonPath("content.[0].detailStatus", equalTo(action1.getStatus().toString().toLowerCase())))
-                .andExpect(jsonPath("content.[0]._links.self.href",
-                        equalTo(generateActionLink(knownTargetId, action1.getId()))))
+                .andExpect(jsonPath("content.[0].active", equalTo(true)))
+                .andExpect(jsonPath("content.[0].status", equalTo(action1.getStatus().toString().toLowerCase())))
+                .andExpect(jsonPath("content.[0]._links.self.href", equalTo(generateActionLink(knownTargetId, action1.getId()))))
 
                 // verify collection properties
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
@@ -474,12 +473,8 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
 
         // not allowed methods
-        mvc.perform(post(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING))
-                .andDo(MockMvcResultPrinter.print())
-                .andExpect(status().isMethodNotAllowed());
-        mvc.perform(put(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING))
-                .andDo(MockMvcResultPrinter.print())
-                .andExpect(status().isMethodNotAllowed());
+        mvc.perform(post(ACTION_V1_REQUEST_MAPPING)).andDo(MockMvcResultPrinter.print()).andExpect(status().isMethodNotAllowed());
+        mvc.perform(put(ACTION_V1_REQUEST_MAPPING)).andDo(MockMvcResultPrinter.print()).andExpect(status().isMethodNotAllowed());
     }
 
     /**
@@ -492,7 +487,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
         final Long actionId = actions.get(0).getId();
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "/" + actionId))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "/" + actionId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath(JSON_PATH_ACTION_ID, equalTo(actionId.intValue())));
@@ -503,9 +498,7 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void requestActionThatDoesNotExistsLeadsToNotFound() throws Exception {
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "/" + 101))
-                .andDo(MockMvcResultPrinter.print())
-                .andExpect(status().isNotFound());
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "/" + 101)).andDo(MockMvcResultPrinter.print()).andExpect(status().isNotFound());
     }
 
     @Test
@@ -514,20 +507,18 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         Action action1 = assignmentResults.get(0).getAssignedEntity().get(0);
         Action action2 = assignmentResults.get(1).getAssignedEntity().get(0);
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)
-                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING).param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
-
                 // verify action 1
                 .andExpect(jsonPath("content.[0].id", equalTo(action1.getId().intValue())))
                 .andExpect(jsonPath("content.[1].id", equalTo(action2.getId().intValue())));
 
-        mvc.perform(delete(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "/" + action1.getId()))
+        mvc.perform(delete(ACTION_V1_REQUEST_MAPPING + "/" + action1.getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "/" + action1.getId()))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "/" + action1.getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
     }
@@ -536,11 +527,9 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
     void shouldSuccessfullyDeleteMultipleActions() throws Exception {
         final List<DistributionSetAssignmentResult> assignmentResults = createTargetsAndPerformAssignment(4);
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)
-                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING).param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
-
                 // verify action 1
                 .andExpect(jsonPath("content.[0].id", equalTo(assignmentResults.get(0).getAssignedEntity().get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[1].id", equalTo(assignmentResults.get(1).getAssignedEntity().get(0).getId().intValue())))
@@ -548,33 +537,31 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(jsonPath("content.[3].id", equalTo(assignmentResults.get(3).getAssignedEntity().get(0).getId().intValue())));
 
         final List<Long> actionIdsToDelete = new ArrayList<>();
-        long deletedActionId1 = assignmentResults.get(2).getAssignedEntity().get(0).getId();
+        final long deletedActionId1 = assignmentResults.get(2).getAssignedEntity().get(0).getId();
         actionIdsToDelete.add(deletedActionId1);
-        long deletedActionId2 = assignmentResults.get(3).getAssignedEntity().get(0).getId();
+        final long deletedActionId2 = assignmentResults.get(3).getAssignedEntity().get(0).getId();
         actionIdsToDelete.add(deletedActionId2);
 
-        mvc.perform(delete(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)
-                .content(toJson(actionIdsToDelete)).contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(delete(ACTION_V1_REQUEST_MAPPING).content(toJson(actionIdsToDelete)).contentType(APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "/" + deletedActionId1))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "/" + deletedActionId1))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "/" + deletedActionId2))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "/" + deletedActionId2))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
-        Action deletedAction3 = assignmentResults.get(1).getAssignedEntity().get(0);
-        String rsql = "target.name==" + deletedAction3.getTarget().getName();
+        final Action deletedAction3 = assignmentResults.get(1).getAssignedEntity().get(0);
+        final String rsql = "target.name==" + deletedAction3.getTarget().getName();
 
-        mvc.perform(delete(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)
-                        .param(MgmtRestConstants.REQUEST_PARAMETER_SEARCH, rsql).contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(delete(ACTION_V1_REQUEST_MAPPING).param(REQUEST_PARAMETER_SEARCH, rsql).contentType(APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "/" + deletedAction3.getId()))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "/" + deletedAction3.getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
 
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "/" + assignmentResults.get(0).getAssignedEntity().get(0).getId()))
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "/" + assignmentResults.get(0).getAssignedEntity().get(0).getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
     }
@@ -582,14 +569,13 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
     @Test
     void shouldReceiveBadRequestWhenNeeded() throws Exception {
         // bad request on both empty parameters
-        mvc.perform(delete(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+        mvc.perform(delete(ACTION_V1_REQUEST_MAPPING).contentType(APPLICATION_JSON)).andExpect(status().isBadRequest());
 
         // bad request when both parameters are present
-        mvc.perform(delete(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING).contentType(MediaType.APPLICATION_JSON)
-                        .param(MgmtRestConstants.REQUEST_PARAMETER_SEARCH, "target.name==test")
-                        .content(toJson(List.of(1,2,3)))
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(delete(ACTION_V1_REQUEST_MAPPING).contentType(APPLICATION_JSON)
+                        .param(REQUEST_PARAMETER_SEARCH, "target.name==test")
+                        .content(toJson(List.of(1, 2, 3)))
+                        .contentType(APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }
 
@@ -623,15 +609,14 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
     private void verifyResultsByTargetPropertyFilter(final Target target, final DistributionSet ds, final String rsqlTargetFilter)
             throws Exception {
         // pending status one result
-        mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlTargetFilter)
+        mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "?q=" + rsqlTargetFilter)
                         .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, MgmtRepresentationMode.FULL.toString()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
                 .andExpect(jsonPath("size", equalTo(1)))
                 .andExpect(jsonPath("content.[0]._links.target.name", equalTo(target.getName())))
-                .andExpect(jsonPath(
-                        "content.[0]._links.distributionset.name", equalTo(ds.getName() + ":" + ds.getVersion())));
+                .andExpect(jsonPath("content.[0]._links.distributionset.name", equalTo(ds.getName() + ":" + ds.getVersion())));
     }
 
     private void getActions(final boolean withExternalRef) throws Exception {
@@ -650,26 +635,22 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
         }
 
         final ResultActions resultActions =
-                mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING)
-                                .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
+                mvc.perform(get(ACTION_V1_REQUEST_MAPPING).param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
                         .andDo(MockMvcResultPrinter.print())
                         .andExpect(status().isOk())
                         // verify action 1
                         .andExpect(jsonPath("content.[1].id", equalTo(action1.getId().intValue())))
                         .andExpect(jsonPath("content.[1].type", equalTo("update")))
-                        .andExpect(jsonPath("content.[1].status", equalTo("pending")))
-                        .andExpect(jsonPath("content.[1].detailStatus", equalTo("running")))
+                        .andExpect(jsonPath("content.[1].active", equalTo(true)))
+                        .andExpect(jsonPath("content.[1].status", equalTo("running")))
                         .andExpect(jsonPath("content.[1]._links.self.href",
                                 equalTo(generateActionLink(knownTargetId, action1.getId()))))
-
                         // verify action 0
                         .andExpect(jsonPath("content.[0].id", equalTo(action0.getId().intValue())))
                         .andExpect(jsonPath("content.[0].type", equalTo("cancel")))
-                        .andExpect(jsonPath("content.[0].status", equalTo("pending")))
-                        .andExpect(jsonPath("content.[1].detailStatus", equalTo("running")))
-                        .andExpect(jsonPath("content.[0]._links.self.href",
-                                equalTo(generateActionLink(knownTargetId, action0.getId()))))
-
+                        .andExpect(jsonPath("content.[0].active", equalTo(true)))
+                        .andExpect(jsonPath("content.[1].status", equalTo("running")))
+                        .andExpect(jsonPath("content.[0]._links.self.href", equalTo(generateActionLink(knownTargetId, action0.getId()))))
                         // verify collection properties
                         .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                         .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(2)))
@@ -700,10 +681,9 @@ class MgmtActionResourceTest extends AbstractManagementApiIntegrationTest {
             controllerManagement.updateActionExternalRef(actions.get(0).getId(), externalRef);
         }
 
-        final ResultActions resultActions =
-                mvc.perform(get(MgmtRestConstants.ACTION_V1_REQUEST_MAPPING + "/{actionId}", actions.get(0).getId()))
-                        .andDo(MockMvcResultPrinter.print())
-                        .andExpect(status().isOk());
+        final ResultActions resultActions = mvc.perform(get(ACTION_V1_REQUEST_MAPPING + "/{actionId}", actions.get(0).getId()))
+                .andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk());
 
         if (withExternalRef) {
             resultActions.andExpect(jsonPath("externalRef", equalTo(externalRef)));

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants.TARGET_V1_ACTIVATE_AUTO_CONFIRM;
 import static org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants.TARGET_V1_AUTO_CONFIRM;
 import static org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants.TARGET_V1_DEACTIVATE_AUTO_CONFIRM;
+import static org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants.TARGET_V1_REQUEST_MAPPING;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
@@ -22,6 +23,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -162,8 +164,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         targetManagement.create(Create.builder().controllerId(knownControllerId).name(knownNameNotModify)
                 .address(knownNewAddress).targetType(targetType).build());
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.controllerId", equalTo(knownControllerId)))
@@ -171,8 +172,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(jsonPath("$.name", equalTo(knownNameNotModify)))
                 .andExpect(jsonPath("$.targetType").exists());
 
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.controllerId", equalTo(knownControllerId)))
@@ -204,8 +204,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         targetManagement.create(Create.builder().controllerId(knownControllerId).name(knownNameNotModify)
                 .address(knownNewAddress).targetType(targetType).build());
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.controllerId", equalTo(knownControllerId)))
@@ -214,8 +213,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(jsonPath("$.targetType").exists());
 
         //check if controller name is updated AND target type is missing (not assigned)
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.controllerId", equalTo(knownControllerId)))
@@ -230,9 +228,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     @Test
     void getTargets() throws Exception {
         enableConfirmationFlow();
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING))
-                .andExpect(status().isOk())
-                .andDo(MockMvcResultPrinter.print());
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING)).andExpect(status().isOk()).andDo(MockMvcResultPrinter.print());
     }
 
     /**
@@ -240,7 +236,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void getTargetsWithParameters() throws Exception {
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "?limit=10&sort=name:ASC&offset=0&q=name==a"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "?limit=10&sort=name:ASC&offset=0&q=name==a"))
                 .andExpect(status().isOk())
                 .andDo(MockMvcResultPrinter.print());
     }
@@ -252,12 +248,10 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     void postActivateAutoConfirm() throws Exception {
         final Target testTarget = testdataFactory.createTarget("targetId");
 
-        final MgmtTargetAutoConfirmUpdate body = new MgmtTargetAutoConfirmUpdate("custom_initiator_value",
-                "custom_remark_value");
-
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + TARGET_V1_AUTO_CONFIRM + "/"
-                        + TARGET_V1_ACTIVATE_AUTO_CONFIRM, testTarget.getControllerId())
-                        .content(objectMapper.writeValueAsString(body)).contentType(MediaType.APPLICATION_JSON))
+        final MgmtTargetAutoConfirmUpdate body = new MgmtTargetAutoConfirmUpdate("custom_initiator_value", "custom_remark_value");
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + TARGET_V1_AUTO_CONFIRM + "/" + TARGET_V1_ACTIVATE_AUTO_CONFIRM,
+                        testTarget.getControllerId())
+                        .content(objectMapper.writeValueAsString(body)).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
     }
@@ -270,8 +264,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final Target testTarget = testdataFactory.createTarget("targetId");
         confirmationManagement.activateAutoConfirmation(testTarget.getControllerId(), null, null);
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + TARGET_V1_AUTO_CONFIRM + "/"
-                        + TARGET_V1_DEACTIVATE_AUTO_CONFIRM, testTarget.getControllerId()))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + TARGET_V1_AUTO_CONFIRM + "/" + TARGET_V1_DEACTIVATE_AUTO_CONFIRM,
+                        testTarget.getControllerId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
     }
@@ -343,14 +337,14 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     void testActionConfirmation(final String controllerId, final long actionId,
             final MgmtActionConfirmationRequestBodyPut.Confirmation payloadConfirmation, final int payloadCode, final String[] payloadMessages,
             final HttpStatus expectedHttpResponseStatus, final Status expectedGeneratedStatus) throws Exception {
-        String url = MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + controllerId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId + "/confirmation";
+        String url = TARGET_V1_REQUEST_MAPPING + "/" + controllerId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId + "/confirmation";
         mvc.perform(put(url).content(String.format("{\"confirmation\":\"%s\",\"details\":[\"%s\",\"%s\"],\"code\":%d}",
                                 payloadConfirmation.getName(),
                                 payloadMessages[0],
                                 payloadMessages[1],
                                 payloadCode
                         ))
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().is(expectedHttpResponseStatus.value()));
 
@@ -396,8 +390,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final ActionStatus status = deploymentManagement.findActionStatusByAction(action.getId(), PAGE).getContent()
                 .stream().sorted((e1, e2) -> Long.compare(e2.getId(), e1.getId())).toList().get(0);
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actions.get(0).getId() + "/status")
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS +
+                        "/" + actions.get(0).getId() + "/status")
                         .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(limitSize))
                         .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:DESC"))
                 .andExpect(status().isOk())
@@ -421,7 +415,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
 
         final String knownControllerId = "knownControllerId";
         testdataFactory.createTarget(knownControllerId);
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}", knownControllerId))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}", knownControllerId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("securityToken").doesNotExist());
@@ -437,7 +431,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
 
         final String knownControllerId = "knownControllerId";
         final Target createTarget = testdataFactory.createTarget(knownControllerId);
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}", knownControllerId))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}", knownControllerId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("securityToken", equalTo(createTarget.getSecurityToken())));
@@ -456,15 +450,13 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         createTarget(knownControllerId2);
 
         // test
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(2)))
                 .andExpect(jsonPath("size", equalTo(2)))
-                .andExpect(jsonPath("$.content.[?(@.controllerId=='" + knownControllerId1 + "')].ipAddress",
-                        contains("127.0.0.1")))
-                .andExpect(jsonPath("$.content.[?(@.controllerId=='" + knownControllerId2 + "')].ipAddress",
-                        contains("127.0.0.1")))
+                .andExpect(jsonPath("$.content.[?(@.controllerId=='" + knownControllerId1 + "')].ipAddress", contains("127.0.0.1")))
+                .andExpect(jsonPath("$.content.[?(@.controllerId=='" + knownControllerId2 + "')].ipAddress", contains("127.0.0.1")))
                 .andExpect(jsonPath("$.content.[?(@.controllerId=='" + knownControllerId1 + "')].address",
                         contains(IpUtil.createHttpUri("127.0.0.1").toString())))
                 .andExpect(jsonPath("$.content.[?(@.controllerId=='" + knownControllerId2 + "')].address",
@@ -476,27 +468,25 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void searchActionsRsql() throws Exception {
-
         // prepare test
         final DistributionSet dsA = testdataFactory.createDistributionSet("");
         final Target createTarget = testdataFactory.createTarget("knownTargetId");
 
         assignDistributionSet(dsA, Collections.singletonList(createTarget));
 
-        final String rsqlPendingStatus = "status==pending";
-        final String rsqlFinishedStatus = "status==finished";
+        final String rsqlPendingStatus = "active==true";
+        final String rsqlFinishedStatus = "active==false";
         final String rsqlPendingOrFinishedStatus = rsqlFinishedStatus + "," + rsqlPendingStatus;
         // pending status one result
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions?q=" + rsqlPendingStatus,
-                        createTarget.getControllerId()))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions?q=" + rsqlPendingStatus, createTarget.getControllerId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
                 .andExpect(jsonPath("size", equalTo(1)))
-                .andExpect(jsonPath("content[0].status", equalTo("pending")));
+                .andExpect(jsonPath("content[0].active", equalTo(true)));
 
         // finished status none result
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions?q=" + rsqlFinishedStatus,
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions?q=" + rsqlFinishedStatus,
                         createTarget.getControllerId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
@@ -505,13 +495,13 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
 
         // pending or finished status one result
         mvc.perform(get(
-                        MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions?q=" + rsqlPendingOrFinishedStatus,
+                        TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions?q=" + rsqlPendingOrFinishedStatus,
                         createTarget.getControllerId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)))
                 .andExpect(jsonPath("size", equalTo(1)))
-                .andExpect(jsonPath("content[0].status", equalTo("pending")));
+                .andExpect(jsonPath("content[0].active", equalTo(true)));
     }
 
     /**
@@ -523,22 +513,18 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final Target tA = createTargetAndStartAction();
 
         // test - cancel the active action
-        mvc.perform(
-                        delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}",
-                                tA.getControllerId(), deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE)
-                                        .getContent().get(0).getId()))
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}",
+                        tA.getControllerId(), deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE)
+                                .getContent().get(0).getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNoContent());
 
         final Action action = deploymentManagement.findAction(
                 deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE).getContent().get(0).getId()).get();
-        // still active because in "canceling" state and waiting for controller
-        // feedback
+        // still active because in "canceling" state and waiting for controller feedback
         assertThat(action.isActive()).isTrue();
 
-        // action has not been cancelled confirmed from controller, so DS
-        // remains assigned until
-        // confirmation
+        // action has not been cancelled confirmed from controller, so DS remains assigned until confirmation
         assertThat(deploymentManagement.findAssignedDistributionSet(tA.getControllerId())).isPresent();
         assertThat(deploymentManagement.findInstalledDistributionSet(tA.getControllerId())).isNotPresent();
     }
@@ -552,16 +538,15 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final Target tA = createTargetAndStartAction();
 
         // cancel the active action
-        deploymentManagement.cancelAction(
-                deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE).getContent().get(0).getId());
+        deploymentManagement.cancelAction(deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE).getContent().get(0).getId());
 
         // find the current active action
-        final List<Action> cancelActions = deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE)
-                .getContent().stream().filter(Action::isCancelingOrCanceled).toList();
+        final List<Action> cancelActions = deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE).getContent().stream()
+                .filter(Action::isCancelingOrCanceled).toList();
         assertThat(cancelActions).hasSize(1);
 
         // test - cancel an cancel action returns forbidden
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}",
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}",
                         tA.getControllerId(), cancelActions.get(0).getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isMethodNotAllowed());
@@ -572,21 +557,19 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void forceQuitAnCanceledActionReturnsOk() throws Exception {
-
         final Target tA = createTargetAndStartAction();
 
         // cancel the active action
-        deploymentManagement.cancelAction(
-                deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE).getContent().get(0).getId());
+        deploymentManagement.cancelAction(deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE).getContent().get(0).getId());
 
         // find the current active action
-        final List<Action> cancelActions = deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE)
-                .getContent().stream().filter(Action::isCancelingOrCanceled).toList();
+        final List<Action> cancelActions = deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE).getContent().stream()
+                .filter(Action::isCancelingOrCanceled).toList();
         assertThat(cancelActions).hasSize(1);
         assertThat(cancelActions.get(0).isCancelingOrCanceled()).isTrue();
 
         // test - force quit: Canceled actions should return 204
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}?force=true",
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}?force=true",
                         tA.getControllerId(), cancelActions.get(0).getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNoContent());
@@ -597,14 +580,12 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void forceQuitAnNotCanceledActionReturnsMethodNotAllowed() throws Exception {
-
         final Target tA = createTargetAndStartAction();
 
         // test - cancel an cancel action returns forbidden
-        mvc.perform(
-                        delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}?force=true",
-                                tA.getControllerId(), deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE)
-                                        .getContent().get(0).getId()))
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}?force=true",
+                        tA.getControllerId(), deploymentManagement.findActionsByTarget(tA.getControllerId(), PAGE)
+                                .getContent().get(0).getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isMethodNotAllowed());
     }
@@ -617,8 +598,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String knownControllerId = "knownControllerIdDelete";
         testdataFactory.createTarget(knownControllerId);
 
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId))
-                .andExpect(status().isOk());
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId)).andExpect(status().isOk());
 
         assertThat(targetManagement.findByControllerId(knownControllerId)).isNotPresent();
     }
@@ -629,9 +609,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     @Test
     void deleteTargetWhichDoesNotExistsLeadsToNotFound() throws Exception {
         final String knownControllerId = "knownControllerIdDelete";
-
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId))
-                .andExpect(status().isNotFound());
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId)).andExpect(status().isNotFound());
     }
 
     /**
@@ -640,8 +618,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     @Test
     void updateTargetWhichDoesNotExistsLeadsToNotFound() throws Exception {
         final String knownControllerId = "knownControllerIdUpdate";
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content("{}")
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content("{}").contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
     }
@@ -660,8 +637,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         targetManagement.create(
                 Create.builder().controllerId(knownControllerId).name(knownNameNotModify).description("old description").build());
 
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.controllerId", equalTo(knownControllerId)))
@@ -688,8 +664,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         targetManagement.create(
                 Create.builder().controllerId(knownControllerId).name(knownNameNotModify).description("old description").build());
 
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest());
 
@@ -709,8 +684,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         // prepare
         targetManagement.create(Create.builder().controllerId(knownControllerId).name(knownNameNotModify).build());
 
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body)
+                        .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.controllerId", equalTo(knownControllerId)))
@@ -736,8 +711,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         // prepare
         targetManagement.create(Create.builder().controllerId(knownControllerId).name(knownNameNotModify).address(knownNewAddress).build());
 
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId).content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.controllerId", equalTo(knownControllerId)))
@@ -761,7 +735,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String idC = "c";
         final String linksHrefPrefix = "http://localhost/rest/v1/targets/";
         createTargetsAlphabetical(knownTargetAmount);
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING))
                 .andExpect(status().isOk())
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(knownTargetAmount)))
@@ -786,8 +760,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idB + "')].updateStatus", contains("registered")))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idA + "')].lastControllerRequestAt", notNullValue()))
                 // idC
-                .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')]._links.self.href",
-                        contains(linksHrefPrefix + idC)))
+                .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')]._links.self.href", contains(linksHrefPrefix + idC)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')].name", contains(idC)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')].description", contains(idC)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')].controllerId", contains(idC)))
@@ -807,16 +780,14 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String idA = "a";
         final String linksHrefPrefix = "http://localhost/rest/v1/targets/";
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING)
-                        .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(limitSize)))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING).param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(limitSize)))
                 .andExpect(status().isOk())
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(knownTargetAmount)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(limitSize)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(limitSize)))
                 // idA
-                .andExpect(jsonPath("$.content.[?(@.name=='" + idA + "')]._links.self.href",
-                        contains(linksHrefPrefix + idA)))
+                .andExpect(jsonPath("$.content.[?(@.name=='" + idA + "')]._links.self.href", contains(linksHrefPrefix + idA)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idA + "')].name", contains(idA)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idA + "')].description", contains(idA)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idA + "')].controllerId", contains(idA)))
@@ -838,7 +809,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String linksHrefPrefix = "http://localhost/rest/v1/targets/";
 
         createTargetsAlphabetical(knownTargetAmount);
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING)
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING)
                         .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(offsetParam))
                         .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(knownTargetAmount)))
                 .andExpect(status().isOk())
@@ -847,24 +818,21 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(expectedSize)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(expectedSize)))
                 // idA
-                .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')]._links.self.href",
-                        contains(linksHrefPrefix + idC)))
+                .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')]._links.self.href", contains(linksHrefPrefix + idC)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')].name", contains(idC)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')].description", contains(idC)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')].controllerId", contains(idC)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')].createdBy", contains("bumlux")))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idC + "')].updateStatus", contains("registered")))
                 // idB
-                .andExpect(jsonPath("$.content.[?(@.name=='" + idD + "')]._links.self.href",
-                        contains(linksHrefPrefix + idD)))
+                .andExpect(jsonPath("$.content.[?(@.name=='" + idD + "')]._links.self.href", contains(linksHrefPrefix + idD)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idD + "')].name", contains(idD)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idD + "')].description", contains(idD)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idD + "')].controllerId", contains(idD)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idD + "')].createdBy", contains("bumlux")))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idD + "')].updateStatus", contains("registered")))
                 // idC
-                .andExpect(jsonPath("$.content.[?(@.name=='" + idE + "')]._links.self.href",
-                        contains(linksHrefPrefix + idE)))
+                .andExpect(jsonPath("$.content.[?(@.name=='" + idE + "')]._links.self.href", contains(linksHrefPrefix + idE)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idE + "')].name", contains(idE)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idE + "')].description", contains(idE)))
                 .andExpect(jsonPath("$.content.[?(@.name=='" + idE + "')].controllerId", contains(idE)))
@@ -883,7 +851,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final Target target = createSingleTarget(knownControllerId, knownName);
         final String hrefPrefix = "http://localhost/rest/v1/targets/" + knownControllerId + "/";
         // test
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath(JSON_PATH_NAME, equalTo(knownName)))
@@ -895,8 +863,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(jsonPath("$.pollStatus.overdue", equalTo(false)))
                 .andExpect(jsonPath("$._links.assignedDS.href", equalTo(hrefPrefix + "assignedDS")))
                 .andExpect(jsonPath("$._links.installedDS.href", equalTo(hrefPrefix + "installedDS")))
-                .andExpect(jsonPath("$._links.actions.href",
-                        equalTo(hrefPrefix + "actions" + "?offset=0&limit=50&sort=id%3ADESC")));
+                .andExpect(jsonPath("$._links.actions.href", equalTo(hrefPrefix + "actions" + "?offset=0&limit=50&sort=id%3ADESC")));
     }
 
     /**
@@ -904,18 +871,15 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void getSingleTargetNoExistsResponseNotFound() throws Exception {
-
         final String targetIdNotExists = "bubu";
 
         // test
-        final MvcResult mvcResult = mvc
-                .perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + targetIdNotExists))
+        final MvcResult mvcResult = mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + targetIdNotExists))
                 .andExpect(status().isNotFound())
                 .andReturn();
 
         // verify response json exception message
-        final ExceptionInfo exceptionInfo = ResourceUtility
-                .convertException(mvcResult.getResponse().getContentAsString());
+        final ExceptionInfo exceptionInfo = ResourceUtility.convertException(mvcResult.getResponse().getContentAsString());
         assertThat(exceptionInfo.getErrorCode()).isEqualTo(SpServerError.SP_REPO_ENTITY_NOT_EXISTS.getKey());
     }
 
@@ -930,7 +894,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         createSingleTarget(knownControllerId, knownName);
 
         // test
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId + "/assignedDS"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId + "/assignedDS"))
                 .andExpect(status().isNoContent())
                 .andExpect(content().string(""));
 
@@ -949,51 +913,36 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         assignDistributionSet(ds.getId(), knownControllerId);
 
         // test
-
         final SoftwareModule os = findFirstModuleByType(ds, osType).orElseThrow();
         final SoftwareModule jvm = findFirstModuleByType(ds, runtimeType).orElseThrow();
         final SoftwareModule bApp = findFirstModuleByType(ds, appType).orElseThrow();
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId + "/assignedDS"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId + "/assignedDS"))
                 .andExpect(status().isOk())
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(jsonPath(JSON_PATH_ID, equalTo(ds.getId().intValue())))
                 .andExpect(jsonPath(JSON_PATH_NAME, equalTo(ds.getName())))
                 .andExpect(jsonPath(JSON_PATH_DESCRIPTION, equalTo(ds.getDescription())))
                 // os
-                .andExpect(jsonPath("$.modules.[?(@.type=='" + osType.getKey() + "')].id",
-                        contains(os.getId().intValue())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + osType.getKey() + "')].id", contains(os.getId().intValue())))
                 .andExpect(jsonPath("$.modules.[?(@.type=='" + osType.getKey() + "')].name", contains(os.getName())))
-                .andExpect(jsonPath("$.modules.[?(@.type=='" + osType.getKey() + "')].description",
-                        contains(os.getDescription())))
-                .andExpect(
-                        jsonPath("$.modules.[?(@.type=='" + osType.getKey() + "')].version", contains(os.getVersion())))
-                .andExpect(
-                        jsonPath("$.modules.[?(@.type=='" + osType.getKey() + "')].vendor", contains(os.getVendor())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + osType.getKey() + "')].description", contains(os.getDescription())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + osType.getKey() + "')].version", contains(os.getVersion())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + osType.getKey() + "')].vendor", contains(os.getVendor())))
                 .andExpect(jsonPath("$.modules.[?(@.type=='" + osType.getKey() + "')].type", contains("os")))
                 // jvm
-                .andExpect(jsonPath("$.modules.[?(@.type=='" + runtimeType.getKey() + "')].id",
-                        contains(jvm.getId().intValue())))
-                .andExpect(
-                        jsonPath("$.modules.[?(@.type=='" + runtimeType.getKey() + "')].name", contains(jvm.getName())))
-                .andExpect(jsonPath("$.modules.[?(@.type=='" + runtimeType.getKey() + "')].description",
-                        contains(jvm.getDescription())))
-                .andExpect(jsonPath("$.modules.[?(@.type=='" + runtimeType.getKey() + "')].version",
-                        contains(jvm.getVersion())))
-                .andExpect(jsonPath("$.modules.[?(@.type=='" + runtimeType.getKey() + "')].vendor",
-                        contains(jvm.getVendor())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + runtimeType.getKey() + "')].id", contains(jvm.getId().intValue())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + runtimeType.getKey() + "')].name", contains(jvm.getName())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + runtimeType.getKey() + "')].description", contains(jvm.getDescription())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + runtimeType.getKey() + "')].version", contains(jvm.getVersion())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + runtimeType.getKey() + "')].vendor", contains(jvm.getVendor())))
                 .andExpect(jsonPath("$.modules.[?(@.type=='" + runtimeType.getKey() + "')].type", contains("runtime")))
                 // baseApp
-                .andExpect(jsonPath("$.modules.[?(@.type=='" + appType.getKey() + "')].id",
-                        contains(bApp.getId().intValue())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + appType.getKey() + "')].id", contains(bApp.getId().intValue())))
                 .andExpect(jsonPath("$.modules.[?(@.type=='" + appType.getKey() + "')].name", contains(bApp.getName())))
-                .andExpect(jsonPath("$.modules.[?(@.type=='" + appType.getKey() + "')].description",
-                        contains(bApp.getDescription())))
-                .andExpect(jsonPath("$.modules.[?(@.type=='" + appType.getKey() + "')].version",
-                        contains(bApp.getVersion())))
-                .andExpect(jsonPath("$.modules.[?(@.type=='" + appType.getKey() + "')].vendor",
-                        contains(bApp.getVendor())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + appType.getKey() + "')].description", contains(bApp.getDescription())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + appType.getKey() + "')].version", contains(bApp.getVersion())))
+                .andExpect(jsonPath("$.modules.[?(@.type=='" + appType.getKey() + "')].vendor", contains(bApp.getVendor())))
                 .andExpect(jsonPath("$.modules.[?(@.type=='" + appType.getKey() + "')].type", contains("application")));
-
     }
 
     /**
@@ -1006,7 +955,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String knownName = "someName";
         createSingleTarget(knownControllerId, knownName);
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId + "/installedDS"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownControllerId + "/installedDS"))
                 .andExpect(status().isNoContent())
                 .andExpect(content().string(""));
     }
@@ -1017,15 +966,11 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     @Test
     void createTargetWithEmptyNameAndLongControllerId() throws Exception {
         final String randomString = randomString(JpaTarget.CONTROLLER_ID_MAX_SIZE);
-
         final Create target = Create.builder().controllerId(randomString).build();
-
         final String targetList = JsonBuilder.targets(List.of(target), false);
-
         final String expectedTargetName = randomString.substring(0, Math.min(JpaTarget.CONTROLLER_ID_MAX_SIZE, NamedEntity.NAME_MAX_SIZE));
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).content(targetList)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING).content(targetList).contentType(APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("[0].controllerId", equalTo(randomString)))
                 .andExpect(jsonPath("[0].name", equalTo(expectedTargetName)));
@@ -1038,9 +983,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void createTargetWithoutPayloadBadRequest() throws Exception {
-
         final MvcResult mvcResult = mvc
-                .perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).contentType(MediaType.APPLICATION_JSON))
+                .perform(post(TARGET_V1_REQUEST_MAPPING).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest())
                 .andReturn();
@@ -1048,8 +992,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         assertThat(targetManagement.count()).isZero();
 
         // verify response json exception message
-        final ExceptionInfo exceptionInfo = ResourceUtility
-                .convertException(mvcResult.getResponse().getContentAsString());
+        final ExceptionInfo exceptionInfo = ResourceUtility.convertException(mvcResult.getResponse().getContentAsString());
         assertThat(exceptionInfo.getErrorCode()).isEqualTo(SpServerError.SP_REST_BODY_NOT_READABLE.getKey());
         assertThat(exceptionInfo.getMessage()).isEqualTo(SpServerError.SP_REST_BODY_NOT_READABLE.getMessage());
     }
@@ -1062,8 +1005,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String notJson = "abc";
 
         final MvcResult mvcResult = mvc
-                .perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).content(notJson)
-                        .contentType(MediaType.APPLICATION_JSON))
+                .perform(post(TARGET_V1_REQUEST_MAPPING).content(notJson).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest())
                 .andReturn();
@@ -1071,8 +1013,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         assertThat(targetManagement.count()).isZero();
 
         // verify response json exception message
-        final ExceptionInfo exceptionInfo = ResourceUtility
-                .convertException(mvcResult.getResponse().getContentAsString());
+        final ExceptionInfo exceptionInfo = ResourceUtility.convertException(mvcResult.getResponse().getContentAsString());
         assertThat(exceptionInfo.getExceptionClass()).isEqualTo(MessageNotReadableException.class.getName());
         assertThat(exceptionInfo.getErrorCode()).isEqualTo(SpServerError.SP_REST_BODY_NOT_READABLE.getKey());
     }
@@ -1083,8 +1024,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     @Test
     void createTargetWithMissingMandatoryPropertyBadRequest() throws Exception {
         final MvcResult mvcResult = mvc
-                .perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).content("[{\"name\":\"id1\"}]")
-                        .contentType(MediaType.APPLICATION_JSON))
+                .perform(post(TARGET_V1_REQUEST_MAPPING).content("[{\"name\":\"id1\"}]").contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest())
                 .andReturn();
@@ -1092,8 +1032,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         assertThat(targetManagement.count()).isZero();
 
         // verify response json exception message
-        final ExceptionInfo exceptionInfo = ResourceUtility
-                .convertException(mvcResult.getResponse().getContentAsString());
+        final ExceptionInfo exceptionInfo = ResourceUtility.convertException(mvcResult.getResponse().getContentAsString());
         assertThat(exceptionInfo.getExceptionClass()).isEqualTo(ConstraintViolationException.class.getName());
         assertThat(exceptionInfo.getErrorCode()).isEqualTo(SpServerError.SP_REPO_CONSTRAINT_VIOLATION.getKey());
     }
@@ -1106,9 +1045,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final Create test1 = Create.builder().controllerId("id1").name(randomString(NamedEntity.NAME_MAX_SIZE + 1)).build();
 
         final MvcResult mvcResult = mvc
-                .perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING)
-                        .content(JsonBuilder.targets(List.of(test1), true))
-                        .contentType(MediaType.APPLICATION_JSON))
+                .perform(post(TARGET_V1_REQUEST_MAPPING).content(JsonBuilder.targets(List.of(test1), true)).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest())
                 .andReturn();
@@ -1138,7 +1075,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
 
         final MvcResult mvcResult = mvc
                 .perform(post("/rest/v1/targets").content(JsonBuilder.targets(targets, true))
-                        .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -1187,8 +1124,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String knownDescription = "someDescription";
         final String createTargetsJson = getCreateTargetsListJsonString(knownControllerId, knownName, knownDescription);
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).content(createTargetsJson)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING).content(createTargetsJson).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().is2xxSuccessful());
 
@@ -1212,14 +1148,11 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
 
         // create a taret first to provoke a already exists error
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).content(createTargetsJson)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING).content(createTargetsJson).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().is2xxSuccessful());
         // create another one to retrieve the entity already exists exception
-        final MvcResult mvcResult = mvc
-                .perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).content(createTargetsJson)
-                        .contentType(MediaType.APPLICATION_JSON))
+        final MvcResult mvcResult = mvc.perform(post(TARGET_V1_REQUEST_MAPPING).content(createTargetsJson).contentType(APPLICATION_JSON))
                 .andExpect(status().is(HttpStatus.CONFLICT.value()))
                 .andReturn();
 
@@ -1227,8 +1160,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         assertThat(targetManagement.count()).isEqualTo(1);
 
         // verify response json exception message
-        final ExceptionInfo exceptionInfo = ResourceUtility
-                .convertException(mvcResult.getResponse().getContentAsString());
+        final ExceptionInfo exceptionInfo = ResourceUtility.convertException(mvcResult.getResponse().getContentAsString());
         assertThat(exceptionInfo.getExceptionClass()).isEqualTo(EntityAlreadyExistsException.class.getName());
         assertThat(exceptionInfo.getErrorCode()).isEqualTo(SpServerError.SP_REPO_ENTITY_ALREADY_EXISTS.getKey());
         assertThat(exceptionInfo.getMessage()).isEqualTo(SpServerError.SP_REPO_ENTITY_ALREADY_EXISTS.getMessage());
@@ -1242,8 +1174,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String knownTargetId = "targetId";
         testdataFactory.createTarget(knownTargetId);
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("size", equalTo(0)))
@@ -1259,21 +1190,18 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String knownTargetId = "targetId";
         final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actions.get(1).getId()))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING +
+                        "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actions.get(1).getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("id", equalTo(actions.get(1).getId().intValue())))
                 .andExpect(jsonPath("type", equalTo("update")))
-                .andExpect(jsonPath("status", equalTo("pending")))
+                .andExpect(jsonPath("active", equalTo(true)))
                 .andExpect(jsonPath("forceType", equalTo("forced")))
                 .andExpect(jsonPath("maintenanceWindow").doesNotExist())
-                .andExpect(jsonPath("_links.self.href",
-                        equalTo(generateActionSelfLink(knownTargetId, actions.get(1).getId()))))
-                .andExpect(jsonPath("_links.distributionset.href",
-                        equalTo(generateActionDsLink(actions.get(1).getDistributionSet().getId()))))
-                .andExpect(jsonPath("_links.status.href",
-                        equalTo(generateStatusreferenceLink(knownTargetId, actions.get(1).getId()))));
+                .andExpect(jsonPath("_links.self.href", equalTo(generateActionSelfLink(knownTargetId, actions.get(1).getId()))))
+                .andExpect(jsonPath("_links.distributionset.href", equalTo(generateActionDsLink(actions.get(1).getDistributionSet().getId()))))
+                .andExpect(jsonPath("_links.status.href", equalTo(generateStatusreferenceLink(knownTargetId, actions.get(1).getId()))));
     }
 
     /**
@@ -1285,28 +1213,25 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String schedule = getTestSchedule(10);
         final String duration = getTestDuration(10);
         final String timezone = getTestTimeZone();
-        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverrideWithMaintenanceWindow(knownTargetId,
-                schedule, duration, timezone);
+        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverrideWithMaintenanceWindow(
+                knownTargetId, schedule, duration, timezone);
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actions.get(1).getId()))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING +
+                        "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actions.get(1).getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("id", equalTo(actions.get(1).getId().intValue())))
                 .andExpect(jsonPath("type", equalTo("update")))
-                .andExpect(jsonPath("status", equalTo("pending")))
+                .andExpect(jsonPath("active", equalTo(true)))
                 .andExpect(jsonPath("forceType", equalTo("forced")))
                 .andExpect(jsonPath("maintenanceWindow.schedule", equalTo(schedule)))
                 .andExpect(jsonPath("maintenanceWindow.duration", equalTo(duration)))
                 .andExpect(jsonPath("maintenanceWindow.timezone", equalTo(timezone)))
                 .andExpect(jsonPath("maintenanceWindow.nextStartAt",
                         equalTo(actions.get(1).getMaintenanceWindowStartTime().get().toInstant().toEpochMilli())))
-                .andExpect(jsonPath("_links.self.href",
-                        equalTo(generateActionSelfLink(knownTargetId, actions.get(1).getId()))))
-                .andExpect(jsonPath("_links.distributionset.href",
-                        equalTo(generateActionDsLink(actions.get(1).getDistributionSet().getId()))))
-                .andExpect(jsonPath("_links.status.href",
-                        equalTo(generateStatusreferenceLink(knownTargetId, actions.get(1).getId()))));
+                .andExpect(jsonPath("_links.self.href", equalTo(generateActionSelfLink(knownTargetId, actions.get(1).getId()))))
+                .andExpect(jsonPath("_links.distributionset.href", equalTo(generateActionDsLink(actions.get(1).getDistributionSet().getId()))))
+                .andExpect(jsonPath("_links.status.href", equalTo(generateStatusreferenceLink(knownTargetId, actions.get(1).getId()))));
     }
 
     /**
@@ -1317,21 +1242,18 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String knownTargetId = "targetId";
         final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actions.get(0).getId()))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING +
+                        "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actions.get(0).getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("id", equalTo(actions.get(0).getId().intValue())))
                 .andExpect(jsonPath("type", equalTo("cancel")))
-                .andExpect(jsonPath("status", equalTo("pending")))
+                .andExpect(jsonPath("active", equalTo(true)))
                 .andExpect(jsonPath("forceType", equalTo("forced")))
                 .andExpect(jsonPath("maintenanceWindow").doesNotExist())
-                .andExpect(jsonPath("_links.self.href",
-                        equalTo(generateActionSelfLink(knownTargetId, actions.get(0).getId()))))
-                .andExpect(jsonPath("_links.canceledaction.href",
-                        equalTo(generateCanceledactionreferenceLink(knownTargetId, actions.get(0)))))
-                .andExpect(jsonPath("_links.status.href",
-                        equalTo(generateStatusreferenceLink(knownTargetId, actions.get(0).getId()))));
+                .andExpect(jsonPath("_links.self.href", equalTo(generateActionSelfLink(knownTargetId, actions.get(0).getId()))))
+                .andExpect(jsonPath("_links.canceledaction.href", equalTo(generateCanceledactionreferenceLink(knownTargetId, actions.get(0)))))
+                .andExpect(jsonPath("_links.status.href", equalTo(generateStatusreferenceLink(knownTargetId, actions.get(0).getId()))));
     }
 
     /**
@@ -1343,28 +1265,25 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String schedule = getTestSchedule(10);
         final String duration = getTestDuration(10);
         final String timezone = getTestTimeZone();
-        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverrideWithMaintenanceWindow(knownTargetId,
-                schedule, duration, timezone);
+        final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverrideWithMaintenanceWindow(
+                knownTargetId, schedule, duration, timezone);
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actions.get(0).getId()))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING +
+                        "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actions.get(0).getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("id", equalTo(actions.get(0).getId().intValue())))
                 .andExpect(jsonPath("forceType", equalTo("forced")))
                 .andExpect(jsonPath("type", equalTo("cancel")))
-                .andExpect(jsonPath("status", equalTo("pending")))
+                .andExpect(jsonPath("active", equalTo(true)))
                 .andExpect(jsonPath("maintenanceWindow.schedule", equalTo(schedule)))
                 .andExpect(jsonPath("maintenanceWindow.duration", equalTo(duration)))
                 .andExpect(jsonPath("maintenanceWindow.timezone", equalTo(timezone)))
                 .andExpect(jsonPath("maintenanceWindow.nextStartAt",
                         equalTo(actions.get(0).getMaintenanceWindowStartTime().get().toInstant().toEpochMilli())))
-                .andExpect(jsonPath("_links.self.href",
-                        equalTo(generateActionSelfLink(knownTargetId, actions.get(0).getId()))))
-                .andExpect(jsonPath("_links.canceledaction.href",
-                        equalTo(generateCanceledactionreferenceLink(knownTargetId, actions.get(0)))))
-                .andExpect(jsonPath("_links.status.href",
-                        equalTo(generateStatusreferenceLink(knownTargetId, actions.get(0).getId()))));
+                .andExpect(jsonPath("_links.self.href", equalTo(generateActionSelfLink(knownTargetId, actions.get(0).getId()))))
+                .andExpect(jsonPath("_links.canceledaction.href", equalTo(generateCanceledactionreferenceLink(knownTargetId, actions.get(0)))))
+                .andExpect(jsonPath("_links.status.href", equalTo(generateStatusreferenceLink(knownTargetId, actions.get(0).getId()))));
     }
 
     /**
@@ -1395,30 +1314,28 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverrideWithMaintenanceWindow(knownTargetId,
                 schedule, duration, timezone);
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS).param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS)
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("content.[1].id", equalTo(actions.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("update")))
-                .andExpect(jsonPath("content.[1].status", equalTo("pending")))
+                .andExpect(jsonPath("content.[1].active", equalTo(true)))
                 .andExpect(jsonPath("content.[1].maintenanceWindow.schedule", equalTo(schedule)))
                 .andExpect(jsonPath("content.[1].maintenanceWindow.duration", equalTo(duration)))
                 .andExpect(jsonPath("content.[1].maintenanceWindow.timezone", equalTo(timezone)))
                 .andExpect(jsonPath("content.[1].maintenanceWindow.nextStartAt",
                         equalTo(actions.get(1).getMaintenanceWindowStartTime().get().toInstant().toEpochMilli())))
-                .andExpect(jsonPath("content.[1]._links.self.href",
-                        equalTo(generateActionSelfLink(knownTargetId, actions.get(1).getId()))))
+                .andExpect(jsonPath("content.[1]._links.self.href", equalTo(generateActionSelfLink(knownTargetId, actions.get(1).getId()))))
                 .andExpect(jsonPath("content.[0].id", equalTo(actions.get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("cancel")))
-                .andExpect(jsonPath("content.[0].status", equalTo("pending")))
+                .andExpect(jsonPath("content.[0].active", equalTo(true)))
                 .andExpect(jsonPath("content.[0].maintenanceWindow.schedule", equalTo(schedule)))
                 .andExpect(jsonPath("content.[0].maintenanceWindow.duration", equalTo(duration)))
                 .andExpect(jsonPath("content.[0].maintenanceWindow.timezone", equalTo(timezone)))
                 .andExpect(jsonPath("content.[0].maintenanceWindow.nextStartAt",
                         equalTo(actions.get(0).getMaintenanceWindowStartTime().get().toInstant().toEpochMilli())))
-                .andExpect(jsonPath("content.[0]._links.self.href",
-                        equalTo(generateActionSelfLink(knownTargetId, actions.get(0).getId()))))
+                .andExpect(jsonPath("content.[0]._links.self.href", equalTo(generateActionSelfLink(knownTargetId, actions.get(0).getId()))))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)));
@@ -1431,21 +1348,20 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     void getActionsStatus() throws Exception {
         final String knownTargetId = "targetId";
         final Action action = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId).get(0);
-        // retrieve list in default descending order for actionstaus entries
+        // retrieve list in default descending order for action status entries
         final List<ActionStatus> actionStatus = deploymentManagement.findActionStatusByAction(action.getId(), PAGE)
                 .getContent().stream().sorted((e1, e2) -> Long.compare(e2.getId(), e1.getId()))
                 .toList();
 
         // sort is default descending order, latest status first
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
                         + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/"
                         + MgmtRestConstants.TARGET_V1_ACTION_STATUS))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
-                .andExpect(jsonPath("content.[0].messages",
-                        hasItem("Update Server: cancel obsolete action due to new update")))
+                .andExpect(jsonPath("content.[0].messages", hasItem("Update Server: cancel obsolete action due to new update")))
                 .andExpect(jsonPath("content.[0].reportedAt", equalTo(actionStatus.get(0).getCreatedAt())))
                 .andExpect(jsonPath("content.[1].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("running")))
@@ -1467,16 +1383,15 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .toList();
 
         // descending order
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
                         + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTION_STATUS).param(MgmtRestConstants.REQUEST_PARAMETER_SORTING,
-                        "CREATEDAT:DESC"))
+                        + MgmtRestConstants.TARGET_V1_ACTION_STATUS)
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "CREATEDAT:DESC"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
-                .andExpect(jsonPath("content.[0].messages",
-                        hasItem("Update Server: cancel obsolete action due to new update")))
+                .andExpect(jsonPath("content.[0].messages", hasItem("Update Server: cancel obsolete action due to new update")))
                 .andExpect(jsonPath("content.[0].reportedAt", equalTo(actionStatus.get(1).getCreatedAt())))
                 .andExpect(jsonPath("content.[1].id", equalTo(actionStatus.get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[1].type", equalTo("running")))
@@ -1486,7 +1401,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(2)));
 
         // ascending order
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
                         + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/"
                         + MgmtRestConstants.TARGET_V1_ACTION_STATUS).param(MgmtRestConstants.REQUEST_PARAMETER_SORTING,
                         "CREATEDAT:ASC"))
@@ -1518,7 +1433,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .toList();
 
         // Page 1
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
                         + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/"
                         + MgmtRestConstants.TARGET_V1_ACTION_STATUS).param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT,
                         String.valueOf(1)))
@@ -1526,15 +1441,14 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actionStatus.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("canceling")))
-                .andExpect(jsonPath("content.[0].messages",
-                        hasItem("Update Server: cancel obsolete action due to new update")))
+                .andExpect(jsonPath("content.[0].messages", hasItem("Update Server: cancel obsolete action due to new update")))
                 .andExpect(jsonPath("content.[0].reportedAt", equalTo(actionStatus.get(1).getCreatedAt())))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(1)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(1)));
 
         // Page 2
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
                         + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + action.getId() + "/"
                         + MgmtRestConstants.TARGET_V1_ACTION_STATUS)
                         .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
@@ -1558,7 +1472,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
 
         // page 1: one entry
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
                         + MgmtRestConstants.TARGET_V1_ACTIONS)
                         .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
                         .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
@@ -1566,15 +1480,14 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actions.get(0).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("cancel")))
-                .andExpect(jsonPath("content.[0].status", equalTo("pending")))
-                .andExpect(jsonPath("content.[0]._links.self.href",
-                        equalTo(generateActionSelfLink(knownTargetId, actions.get(0).getId()))))
+                .andExpect(jsonPath("content.[0].active", equalTo(true)))
+                .andExpect(jsonPath("content.[0]._links.self.href", equalTo(generateActionSelfLink(knownTargetId, actions.get(0).getId()))))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(1)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(1)));
 
         // page 2: one entry
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
                         + MgmtRestConstants.TARGET_V1_ACTIONS)
                         .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT, String.valueOf(1))
                         .param(MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET, String.valueOf(1))
@@ -1584,9 +1497,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].id", equalTo(actions.get(1).getId().intValue())))
                 .andExpect(jsonPath("content.[0].type", equalTo("update")))
-                .andExpect(jsonPath("content.[0].status", equalTo("pending")))
-                .andExpect(jsonPath("content.[0]._links.self.href",
-                        equalTo(generateActionSelfLink(knownTargetId, actions.get(1).getId()))))
+                .andExpect(jsonPath("content.[0].active", equalTo(true)))
+                .andExpect(jsonPath("content.[0]._links.self.href", equalTo(generateActionSelfLink(knownTargetId, actions.get(1).getId()))))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_SIZE, equalTo(1)))
                 .andExpect(jsonPath(JSON_PATH_PAGED_LIST_CONTENT, hasSize(1)));
@@ -1599,26 +1511,22 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     void updateAction() throws Exception {
         final Target target = testdataFactory.createTarget();
         final DistributionSet set = testdataFactory.createDistributionSet();
-        final Long actionId = getFirstAssignedActionId(
-                assignDistributionSet(set.getId(), target.getControllerId(), ActionType.SOFT));
+        final Long actionId = getFirstAssignedActionId(assignDistributionSet(set.getId(), target.getControllerId(), ActionType.SOFT));
         assertThat(deploymentManagement.findAction(actionId).get().getActionType()).isEqualTo(ActionType.SOFT);
 
         final String body = new JSONObject().put("forceType", "forced").toString();
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/"
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/"
                         + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId).content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("id", equalTo(actionId.intValue())))
                 .andExpect(jsonPath("type", equalTo("update")))
-                .andExpect(jsonPath("status", equalTo("pending")))
+                .andExpect(jsonPath("active", equalTo(true)))
                 .andExpect(jsonPath("forceType", equalTo("forced")))
-                .andExpect(jsonPath("_links.self.href",
-                        equalTo(generateActionSelfLink(target.getControllerId(), actionId))))
-                .andExpect(jsonPath("_links.distributionset.href",
-                        equalTo("http://localhost/rest/v1/distributionsets/" + set.getId())))
-                .andExpect(jsonPath("_links.status.href",
-                        equalTo(generateStatusreferenceLink(target.getControllerId(), actionId))));
+                .andExpect(jsonPath("_links.self.href", equalTo(generateActionSelfLink(target.getControllerId(), actionId))))
+                .andExpect(jsonPath("_links.distributionset.href", equalTo("http://localhost/rest/v1/distributionsets/" + set.getId())))
+                .andExpect(jsonPath("_links.status.href", equalTo(generateStatusreferenceLink(target.getControllerId(), actionId))));
 
         assertThat(deploymentManagement.findAction(actionId).get().getActionType()).isEqualTo(ActionType.FORCED);
     }
@@ -1632,8 +1540,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         Target target = testdataFactory.createTarget();
         final DistributionSet set = testdataFactory.createDistributionSet("one");
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
-                        .content("{\"id\":" + set.getId() + "}").contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
+                        .content("{\"id\":" + set.getId() + "}").contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("assigned", equalTo(1)))
@@ -1645,8 +1553,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         target = targetManagement.getByControllerId(target.getControllerId());
 
         // repeating DS assignment leads again to OK
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
-                        .content("{\"id\":" + set.getId() + "}").contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
+                        .content("{\"id\":" + set.getId() + "}").contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("assigned", equalTo(0)))
@@ -1662,8 +1570,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @ParameterizedTest
     @MethodSource("confirmationOptions")
-    void assignDistributionSetToTargetWithConfirmationOptions(final boolean confirmationFlowActive,
-            final Boolean confirmationRequired) throws Exception {
+    void assignDistributionSetToTargetWithConfirmationOptions(final boolean confirmationFlowActive, final Boolean confirmationRequired)
+            throws Exception {
         final Target target = testdataFactory.createTarget();
         final DistributionSet set = testdataFactory.createDistributionSet("one");
 
@@ -1677,8 +1585,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
             jsonPayload.put("confirmationRequired", confirmationRequired);
         }
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
-                        .content(jsonPayload.toString()).contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
+                        .content(jsonPayload.toString()).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("assigned", equalTo(1)))
@@ -1688,15 +1596,14 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
 
         assertThat(deploymentManagement.findAssignedDistributionSet(target.getControllerId()).get()).isEqualTo(set);
 
-        assertThat(
-                actionRepository
-                        .findAll(byDistributionSetId(set.getId()), PAGE)
-                        .map(Action.class::cast).getContent()).hasSize(1)
+        assertThat(actionRepository.findAll(byDistributionSetId(set.getId()), PAGE).map(Action.class::cast).getContent())
+                .hasSize(1)
                 .allMatch(action -> {
                     if (!confirmationFlowActive) {
                         return !action.isWaitingConfirmation();
                     }
-                    return confirmationRequired == null ? action.isWaitingConfirmation()
+                    return confirmationRequired == null
+                            ? action.isWaitingConfirmation()
                             : confirmationRequired == action.isWaitingConfirmation();
                 });
     }
@@ -1709,9 +1616,9 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final Target target = testdataFactory.createTarget();
         final DistributionSet set = testdataFactory.createDistributionSet("one");
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
                         .content("{\"id\":" + set.getId() + ",\"type\": \"downloadonly\"}")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("assigned", equalTo(1)))
@@ -1734,9 +1641,9 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         Target target = testdataFactory.createTarget();
         final DistributionSet set = testdataFactory.createDistributionSet("one");
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId()
-                        + "/assignedDS?offline=true").content("{\"id\":" + set.getId() + "}")
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS?offline=true")
+                        .content("{\"id\":" + set.getId() + "}")
+                        .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("assigned", equalTo(1)))
@@ -1750,9 +1657,9 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         assertThat(target.getUpdateStatus()).isEqualTo(TargetUpdateStatus.IN_SYNC);
 
         // repeating DS assignment leads again to OK
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId()
-                        + "/assignedDS?offline=true").content("{\"id\":" + set.getId() + "}")
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS?offline=true")
+                        .content("{\"id\":" + set.getId() + "}")
+                        .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("assigned", equalTo(0)))
@@ -1769,11 +1676,12 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final DistributionSet set = testdataFactory.createDistributionSet("one");
 
         final long forceTime = System.currentTimeMillis();
-        final String body = new JSONObject().put("id", set.getId()).put("type", "timeforced")
-                .put("forcetime", forceTime).toString();
+        final String body = new JSONObject()
+                .put("id", set.getId())
+                .put("type", "timeforced").put("forcetime", forceTime)
+                .toString();
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS").content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS").content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
         implicitLock(set);
@@ -1791,15 +1699,17 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void assignDistributionSetToTargetWithMaintenanceWindowStartTimeOnly() throws Exception {
-
         final Target target = testdataFactory.createTarget("fsdfsd");
         final DistributionSet set = testdataFactory.createDistributionSet("one");
 
-        final String body = new JSONObject().put("id", set.getId()).put("type", "forced")
-                .put("maintenanceWindow", new JSONObject().put("schedule", getTestSchedule(0))).toString();
+        final String body = new JSONObject()
+                .put("id", set.getId())
+                .put("type", "forced")
+                .put("maintenanceWindow", new JSONObject().put("schedule", getTestSchedule(0)))
+                .toString();
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
-                        .content(body).contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
+                        .content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest());
     }
@@ -1809,14 +1719,15 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void assignDistributionSetToTargetWithMaintenanceWindowEndTimeOnly() throws Exception {
-
         final Target target = testdataFactory.createTarget("fsdfsd");
         final DistributionSet set = testdataFactory.createDistributionSet("one");
 
-        final String body = new JSONObject().put("id", set.getId()).put("type", "forced")
-                .put("maintenanceWindow", new JSONObject().put("duration", getTestDuration(10))).toString();
+        final String body = new JSONObject().put("id", set.getId())
+                .put("type", "forced")
+                .put("maintenanceWindow", new JSONObject().put("duration", getTestDuration(10)))
+                .toString();
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
                         .content(body).contentType(MediaTypes.HAL_JSON_VALUE))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest());
@@ -1827,17 +1738,21 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void assignDistributionSetToTargetWithValidMaintenanceWindow() throws Exception {
-
         final Target target = testdataFactory.createTarget("fsdfsd");
         final DistributionSet set = testdataFactory.createDistributionSet("one");
 
-        final String body = new JSONObject().put("id", set.getId()).put("type", "forced").put("forcetime", "0")
-                .put("maintenanceWindow", new JSONObject().put("schedule", getTestSchedule(10))
-                        .put("duration", getTestDuration(10)).put("timezone", getTestTimeZone()))
+        final String body = new JSONObject()
+                .put("id", set.getId())
+                .put("type", "forced")
+                .put("forcetime", "0")
+                .put("maintenanceWindow", new JSONObject()
+                        .put("schedule", getTestSchedule(10))
+                        .put("duration", getTestDuration(10))
+                        .put("timezone", getTestTimeZone()))
                 .toString();
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
-                        .content(body).contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
+                        .content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
     }
@@ -1847,22 +1762,24 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void assignDistributionSetToTargetWithMaintenanceWindowNextExecutionStart() throws Exception {
-
         final Target target = testdataFactory.createTarget("fsdfsd");
         final DistributionSet set = testdataFactory.createDistributionSet("one");
         final long nextExecutionStart = System.currentTimeMillis();
 
         final String body = new JSONObject().put("id", set.getId()).put("maintenanceWindow",
-                        new JSONObject().put("schedule", getTestSchedule(10)).put("duration", getTestDuration(10))
-                                .put("timezone", getTestTimeZone()).put("nextStartAt", String.valueOf(nextExecutionStart)))
+                        new JSONObject()
+                                .put("schedule", getTestSchedule(10))
+                                .put("duration", getTestDuration(10))
+                                .put("timezone", getTestTimeZone())
+                                .put("nextStartAt", String.valueOf(nextExecutionStart)))
                 .toString();
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
-                        .content(body).contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
+                        .content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/"
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/"
                         + MgmtRestConstants.TARGET_V1_ACTIONS))
                 .andExpect(status().isOk())
                 .andDo(MockMvcResultPrinter.print())
@@ -1874,53 +1791,54 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void assignDistributionSetToTargetWithMaintenanceWindowEndTimeBeforeStartTime() throws Exception {
-
         final Target target = testdataFactory.createTarget("fsdfsd");
         final DistributionSet set = testdataFactory.createDistributionSet("one");
 
-        final String body = new JSONObject().put("id", set.getId()).put("type", "forced")
-                .put("maintenanceWindow", new JSONObject().put("schedule", getTestSchedule(-30))
-                        .put("duration", getTestDuration(5)).put("timezone", getTestTimeZone()))
+        final String body = new JSONObject()
+                .put("id", set.getId())
+                .put("type", "forced")
+                .put("maintenanceWindow", new JSONObject()
+                        .put("schedule", getTestSchedule(-30))
+                        .put("duration", getTestDuration(5))
+                        .put("timezone", getTestTimeZone()))
                 .toString();
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
-                        .content(body).contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + target.getControllerId() + "/assignedDS")
+                        .content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest());
     }
 
     @Test
     void invalidRequestsOnAssignDistributionSetToTarget() throws Exception {
-
         final DistributionSet set = testdataFactory.createDistributionSet("one");
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS")
-                        .content("{\"id\":" + set.getId() + "}").contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS")
+                        .content("{\"id\":" + set.getId() + "}").contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
 
         testdataFactory.createTarget("fsdfsd");
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS")
-                        .content("{\"id\":" + set.getId() + "}").contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS")
+                        .content("{\"id\":" + set.getId() + "}").contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
 
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS")
-                        .content("{\"id\":12345678}").contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS")
+                        .content("{\"id\":12345678}").contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
 
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS")
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS")
+                        .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isMethodNotAllowed());
 
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS")
-                        .content("{\"id\":" + set.getId() + "}").contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/fsdfsd/assignedDS")
+                        .content("{\"id\":" + set.getId() + "}").contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isMethodNotAllowed());
-
     }
 
     @Test
@@ -1928,34 +1846,26 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String knownTargetId = "targetId";
 
         // target does not exist
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
         final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
         final Long actionId = actions.get(0).getId();
 
         // should work now
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
-
         // action does not exist
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/12321"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/12321"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
-
         // not allowed methods
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isMethodNotAllowed());
-
         // Invalid content
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isUnsupportedMediaType());
     }
@@ -1965,36 +1875,34 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String knownTargetId = "targetId";
 
         // target does not exist
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/1/status"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/1/status"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
         final List<Action> actions = generateTargetWithTwoUpdatesWithOneOverride(knownTargetId);
         final Long actionId = actions.get(0).getId();
 
         // should work now
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId + "/status"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING +
+                        "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId + "/status"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
 
         // action does not exist
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/12321/status"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/12321/status"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
 
         // not allowed methods
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId + "/status"))
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING +
+                        "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId + "/status"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isMethodNotAllowed());
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId + "/status"))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING +
+                        "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId + "/status"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isMethodNotAllowed());
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                        + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId + "/status"))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING +
+                        "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId + "/status"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isMethodNotAllowed());
     }
@@ -2010,7 +1918,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         controllerManagement.updateControllerAttributes(knownTargetId, knownControllerAttrs, null);
 
         // test query target over rest resource
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/attributes"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/attributes"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(jsonPath("$.a", equalTo("1")))
@@ -2024,7 +1932,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         testdataFactory.createTarget(knownTargetId);
 
         // test query target over rest resource
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/attributes"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/attributes"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().is(HttpStatus.NO_CONTENT.value()));
     }
@@ -2055,7 +1963,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
 
         final String rsqlFindAOrB = "controllerId==a,controllerId==b";
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "?q=" + rsqlFindAOrB))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "?q=" + rsqlFindAOrB))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("size", equalTo(2)))
@@ -2071,7 +1979,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final Target target = testdataFactory.createTarget(knownTargetId);
 
         // test query target over rest resource with no tags - expect OK with empty list
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/tags"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/tags"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", Matchers.hasSize(0)));
@@ -2084,7 +1992,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         }
 
         // test query target over rest resource with 2 tags - expect OK with 2 tags the target is tagged with
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/tags"))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/tags"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", Matchers.hasSize(2)))
@@ -2110,8 +2018,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         metaData1.put(new JSONObject().put(JSON_PATH_KEY, knownKey1).put(JSON_PATH_VALUE, knownValue1));
         metaData1.put(new JSONObject().put(JSON_PATH_KEY, knownKey2).put(JSON_PATH_VALUE, knownValue2));
 
-        mvc.perform(post("/rest/v1/targets/{targetId}/metadata", knownControllerId).accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON).content(metaData1.toString()))
+        mvc.perform(post("/rest/v1/targets/{targetId}/metadata", knownControllerId).accept(APPLICATION_JSON)
+                        .contentType(APPLICATION_JSON).content(metaData1.toString()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isCreated())
                 .andExpect(content().string(""));
@@ -2128,8 +2036,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         }
 
         mvc.perform(post("/rest/v1/targets/{targetId}/metadata", knownControllerId)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON).content(metaData2.toString()))
+                        .accept(APPLICATION_JSON)
+                        .contentType(APPLICATION_JSON).content(metaData2.toString()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isForbidden());
 
@@ -2150,7 +2058,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final JSONObject jsonObject = new JSONObject().put(JSON_PATH_KEY, KNOWN_KEY).put(JSON_PATH_VALUE, updateValue);
 
         mvc.perform(put("/rest/v1/targets/{targetId}/metadata/{key}", knownControllerId, KNOWN_KEY)
-                        .accept(MediaType.APPLICATION_JSON).contentType(MediaType.APPLICATION_JSON)
+                        .accept(APPLICATION_JSON).contentType(APPLICATION_JSON)
                         .content(jsonObject.toString()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
@@ -2267,7 +2175,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         dsIds.forEach(id -> body.put(getAssignmentObject(id, MgmtActionType.FORCED, 67)));
 
         mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(body.toString())
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest());
     }
@@ -2281,8 +2189,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final Long dsId = testdataFactory.createDistributionSet().getId();
 
         final JSONArray body = new JSONArray().put(getAssignmentObject(dsId, MgmtActionType.FORCED));
-        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(body.toString())
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(body.toString()).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
     }
@@ -2298,8 +2205,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final JSONObject assignment = getAssignmentObject(dsId, MgmtActionType.FORCED);
         final JSONArray body = new JSONArray().put(assignment).put(assignment);
 
-        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(body.toString())
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(body.toString()).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(1)));
@@ -2311,15 +2217,13 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     @Test
     void multiAssignment() throws Exception {
         final String targetId = testdataFactory.createTarget().getControllerId();
-        final List<Long> dsIds = testdataFactory.createDistributionSets(2).stream().map(DistributionSet::getId)
-                .toList();
+        final List<Long> dsIds = testdataFactory.createDistributionSets(2).stream().map(DistributionSet::getId).toList();
 
         final JSONArray body = new JSONArray();
         dsIds.forEach(id -> body.put(getAssignmentObject(id, MgmtActionType.FORCED, 76)));
 
         enableMultiAssignments();
-        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(body.toString())
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(body.toString()).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("total", equalTo(2)));
@@ -2338,13 +2242,11 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final JSONObject bodyInvalid = getAssignmentObject(dsId, MgmtActionType.FORCED, Action.WEIGHT_MIN - 1);
 
         enableMultiAssignments();
-        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(bodyInvalid.toString())
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(bodyInvalid.toString()).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode", equalTo("hawkbit.server.error.repo.constraintViolation")));
-        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(bodyValid.toString())
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(bodyValid.toString()).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
 
@@ -2363,8 +2265,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
 
         final JSONObject bodyValid = getAssignmentObject(dsId, MgmtActionType.FORCED, 98);
 
-        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(bodyValid.toString())
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(bodyValid.toString()).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
     }
@@ -2381,8 +2282,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final JSONObject bodyValid = getAssignmentObject(dsId, MgmtActionType.FORCED, weight);
 
         enableMultiAssignments();
-        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(bodyValid.toString())
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(bodyValid.toString()).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
 
@@ -2419,14 +2319,13 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void getActionWithRolloutInfo() throws Exception {
-
         // setup
         final int amountTargets = 10;
         final List<Target> targets = testdataFactory.createTargets(amountTargets, "trg", "trg");
         final DistributionSet ds = testdataFactory.createDistributionSet("");
 
-        final Rollout rollout = testdataFactory.createRolloutByVariables("My Rollout", "My Rollout Description", 1,
-                "name==trg*", ds, "50", "5");
+        final Rollout rollout = testdataFactory.createRolloutByVariables(
+                "My Rollout", "My Rollout Description", 1, "name==trg*", ds, "50", "5");
         rolloutManagement.start(rollout.getId());
         rolloutHandler.handleAll();
 
@@ -2443,14 +2342,12 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final Slice<Action> action = deploymentManagement.findActionsByTarget(target.getControllerId(),
                 PageRequest.of(0, 100));
         assertThat(action.getContent()).hasSize(1);
-        mvc.perform(get("/rest/v1/targets/{targetId}/actions/{actionId}", target.getControllerId(),
-                        action.getContent().get(0).getId()))
+        mvc.perform(get("/rest/v1/targets/{targetId}/actions/{actionId}", target.getControllerId(), action.getContent().get(0).getId()))
                 .andExpect(status().isOk())
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(jsonPath("$.rollout", equalTo(rollout.getId().intValue())))
                 .andExpect(jsonPath("$.rolloutName", equalTo(rollout.getName())))
-                .andExpect(jsonPath(
-                        "$._links.rollout.href", containsString("/rest/v1/rollouts/" + rollout.getId().intValue())));
+                .andExpect(jsonPath("$._links.rollout.href", containsString("/rest/v1/rollouts/" + rollout.getId().intValue())));
     }
 
     /**
@@ -2471,9 +2368,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
 
         final List<Create> targets = List.of(test1, test2, test3);
 
-        mvc
-                .perform(post("/rest/v1/targets").content(JsonBuilder.targets(targets, true))
-                        .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+        mvc.perform(post("/rest/v1/targets").content(JsonBuilder.targets(targets, true)).contentType(APPLICATION_JSON).accept(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -2500,7 +2395,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
                 .andExpect(jsonPath("[2].targetType", equalTo(type2.getId().intValue())))
                 .andReturn();
 
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + test2.getControllerId()))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + test2.getControllerId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath(JSON_PATH_NAME, equalTo("targetOfType1")))
@@ -2536,8 +2431,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String targetList = JsonBuilder.targets(List.of(target), false);
 
         // test query target over rest resource
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).content(targetList)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING).content(targetList).contentType(APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("[0].controllerId", equalTo("targetcontroller")))
                 .andExpect(jsonPath("[0].targetType", equalTo(targetTypes.get(0).getId().intValue())));
@@ -2563,8 +2457,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         // update target over rest resource
         final String body = new JSONObject().put("targetType", targetTypes.get(1).getId().intValue()).toString();
 
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + controllerId).content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + controllerId).content(body).contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("controllerId", equalTo(controllerId)))
                 .andExpect(jsonPath("targetType", equalTo(targetTypes.get(1).getId().intValue())));
@@ -2587,7 +2480,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String targetList = JsonBuilder.targets(List.of(target), false, unknownTargetTypeId);
 
         // post target over rest resource
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING).content(targetList).contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING).content(targetList).contentType(APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("message", Matchers.containsString(errorMsg)));
     }
@@ -2607,8 +2500,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         assertThat(target).isNotNull();
 
         // assign target type over rest resource
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + targetControllerId + "/targettype")
-                        .content("{\"id\":" + targetType.getId() + "}").contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + targetControllerId + "/targettype")
+                        .content("{\"id\":" + targetType.getId() + "}").contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
 
@@ -2629,17 +2522,17 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         assertThat(target).isNotNull();
 
         // assign invalid target type over rest resource
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + targetControllerId + "/targettype")
-                        .content("{\"id\":" + invalidTargetTypeId + "}").contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + "/" + targetControllerId + "/targettype")
+                        .content("{\"id\":" + invalidTargetTypeId + "}").contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
 
         // verify response json exception message if body does not include id
         // field
         final MvcResult mvcResult = mvc
-                .perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + targetControllerId + "/targettype")
+                .perform(post(TARGET_V1_REQUEST_MAPPING + "/" + targetControllerId + "/targettype")
                         .content("{\"unknownfield\":" + invalidTargetTypeId + "}")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest())
                 .andReturn();
@@ -2666,8 +2559,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         assertThat(target.getTargetType().getId()).isEqualTo(targetTypes.get(0).getId());
 
         // unassign target type over rest resource
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + targetControllerId + "/targettype")
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/" + targetControllerId + "/targettype").contentType(APPLICATION_JSON))
                 .andExpect(status().isOk());
 
         assertThat(targetManagement.getByControllerId(targetControllerId).getTargetType()).isNull();
@@ -2680,42 +2572,33 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         testdataFactory.createTargetType("targettype", Set.of());
 
         // GET is not allowed
-        mvc.perform(get(
-                        MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING,
-                        knownTargetId))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING, knownTargetId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isMethodNotAllowed());
 
         // PUT is not allowed
-        mvc.perform(put(
-                        MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING,
-                        knownTargetId))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING, knownTargetId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isMethodNotAllowed());
 
         // POST does not exist with path parameter targettype
-        mvc.perform(post(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING
-                        + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING + "/123", knownTargetId))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING + "/123", knownTargetId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
 
         // DELETE does not exist with path parameter targettype
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING
-                        + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING + "/123", knownTargetId))
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING + "/123", knownTargetId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
 
         // Invalid content
-        mvc.perform(post(
-                        MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING,
-                        knownTargetId))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING, knownTargetId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isUnsupportedMediaType());
 
         // Bad request if id field is missing
-        mvc.perform(post(
-                        MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING,
-                        knownTargetId).content("{\"unknownfield\":123}").contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(post(TARGET_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_TARGET_TYPE_V1_REQUEST_MAPPING, knownTargetId)
+                        .content("{\"unknownfield\":123}").contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest());
     }
@@ -2728,13 +2611,11 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         confirmationManagement.activateAutoConfirmation(knownTargetId, initiator, remark);
 
         // GET with all possible responses
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + TARGET_V1_AUTO_CONFIRM,
-                        knownTargetId))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + TARGET_V1_AUTO_CONFIRM, knownTargetId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("active", equalTo(Boolean.TRUE)))
-                .andExpect(initiator == null ? jsonPath("initiator").doesNotExist()
-                        : jsonPath("initiator", equalTo(initiator)))
+                .andExpect(jsonPath("active", equalTo(true)))
+                .andExpect(initiator == null ? jsonPath("initiator").doesNotExist() : jsonPath("initiator", equalTo(initiator)))
                 .andExpect(remark == null ? jsonPath("remark").doesNotExist() : jsonPath("remark", equalTo(remark)))
                 .andExpect(jsonPath("_links.deactivate").exists())
                 .andExpect(jsonPath("_links.activate").doesNotExist());
@@ -2746,7 +2627,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         testdataFactory.createTarget(knownTargetId);
 
         // GET if active
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("content.[0].autoConfirmActive").doesNotExist());
@@ -2754,18 +2635,18 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         enableConfirmationFlow();
 
         // GET if not active
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("content.[0].autoConfirmActive", equalTo(Boolean.FALSE)));
+                .andExpect(jsonPath("content.[0].autoConfirmActive", equalTo(false)));
 
         confirmationManagement.activateAutoConfirmation(knownTargetId, "test", "remark");
 
         // GET if active
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("content.[0].autoConfirmActive", equalTo(Boolean.TRUE)));
+                .andExpect(jsonPath("content.[0].autoConfirmActive", equalTo(true)));
     }
 
     @Test
@@ -2773,19 +2654,17 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final String knownTargetId = "targetId";
 
         // GET for not existing target
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + TARGET_V1_AUTO_CONFIRM,
-                        knownTargetId))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + TARGET_V1_AUTO_CONFIRM, knownTargetId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isNotFound());
 
         testdataFactory.createTarget(knownTargetId);
 
         // GET for auto-confirm not active
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + TARGET_V1_AUTO_CONFIRM,
-                        knownTargetId))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}/" + TARGET_V1_AUTO_CONFIRM, knownTargetId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("active", equalTo(Boolean.FALSE)))
+                .andExpect(jsonPath("active", equalTo(false)))
                 .andExpect(jsonPath("initiator").doesNotExist())
                 .andExpect(jsonPath("remark").doesNotExist())
                 .andExpect(jsonPath("_links.activate").exists());
@@ -2797,7 +2676,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         testdataFactory.createTarget(knownTargetId);
 
         // GET with confirmation flow not active should not expose
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}", knownTargetId))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}", knownTargetId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("autoConfirmActive").doesNotExist())
@@ -2806,7 +2685,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         enableConfirmationFlow();
 
         // GET with confirmation flow active should expose
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}", knownTargetId))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}", knownTargetId))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("autoConfirmActive").exists())
@@ -2818,45 +2697,40 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
      */
     @Test
     void lastActionStatusCode() throws Exception {
-
         // prepare test
         final DistributionSet dsA = testdataFactory.createDistributionSet("");
         final Target target = testdataFactory.createTarget("knownTargetId");
         final Action action = getFirstAssignedAction(assignDistributionSet(dsA, Collections.singletonList(target)));
 
         // no status update yet -> no status code
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}",
-                        target.getControllerId(), action.getId()))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}", target.getControllerId(), action.getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("lastStatusCode").doesNotExist());
 
         // update action status with status code
         updateActionStatus(action, Status.RUNNING, 100);
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}",
-                        target.getControllerId(), action.getId()))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}", target.getControllerId(), action.getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("lastStatusCode", equalTo(100)))
-                .andExpect(jsonPath("detailStatus", equalTo("running")));
+                .andExpect(jsonPath("status", equalTo("running")));
 
         // update action status without a status code
         updateActionStatus(action, Status.RUNNING, null);
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}",
-                        target.getControllerId(), action.getId()))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}", target.getControllerId(), action.getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("lastStatusCode").doesNotExist())
-                .andExpect(jsonPath("detailStatus", equalTo("running")));
+                .andExpect(jsonPath("status", equalTo("running")));
 
         // update action status with status code
         updateActionStatus(action, Status.ERROR, 432);
-        mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}",
-                        target.getControllerId(), action.getId()))
+        mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions/{actionId}", target.getControllerId(), action.getId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("lastStatusCode", equalTo(432)))
-                .andExpect(jsonPath("detailStatus", equalTo("error")));
+                .andExpect(jsonPath("status", equalTo("error")));
     }
 
     @Test
@@ -2872,8 +2746,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         Assertions.assertEquals(10, actionsPerTarget);
         List<Action> oldActions = deploymentManagement.findActionsByTarget(testTarget.getControllerId(), PAGE).getContent();
 
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions", testTarget.getControllerId())
-                .param("keepLast", "5"))
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions", testTarget.getControllerId()).param("keepLast", "5"))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
 
@@ -2890,15 +2763,15 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     void testThatDeletionOfLastNTargetActionsReturnsBadRequestWhenNeeded() throws Exception {
         final Target testTarget = testdataFactory.createTarget();
         // either numberOfActions or actionIds list should be present
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions", testTarget.getControllerId()))
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions", testTarget.getControllerId()))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest());
 
         // both parameters present should also lead to bad request
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions", testTarget.getControllerId())
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions", testTarget.getControllerId())
                         .param("keepLast", "5")
-                        .content(toJson(List.of(1,2,3)))
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .content(toJson(List.of(1, 2, 3)))
+                        .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest());
     }
@@ -2913,13 +2786,13 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         }
 
         final List<Long> evenActionIds = deploymentManagement.findActionsByTarget(testTarget.getControllerId(), PAGE).getContent()
-                        .stream()
-                        .filter(action -> action.getId() % 2 == 0)
+                .stream()
+                .filter(action -> action.getId() % 2 == 0)
                 .map(Identifiable::getId).toList();
 
-        mvc.perform(delete(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions", testTarget.getControllerId())
+        mvc.perform(delete(TARGET_V1_REQUEST_MAPPING + "/{targetId}/actions", testTarget.getControllerId())
                         .content(toJson(evenActionIds))
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
 
@@ -2964,18 +2837,18 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         }
 
         final ResultActions resultActions =
-                mvc.perform(get(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                                + MgmtRestConstants.TARGET_V1_ACTIONS).param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
+                mvc.perform(get(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS)
+                                .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
                         .andDo(MockMvcResultPrinter.print())
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("content.[1].id", equalTo(actions.get(1).getId().intValue())))
                         .andExpect(jsonPath("content.[1].type", equalTo("update")))
-                        .andExpect(jsonPath("content.[1].status", equalTo("pending")))
+                        .andExpect(jsonPath("content.[1].active", equalTo(true)))
                         .andExpect(jsonPath("content.[1]._links.self.href",
                                 equalTo(generateActionSelfLink(knownTargetId, actions.get(1).getId()))))
                         .andExpect(jsonPath("content.[0].id", equalTo(actions.get(0).getId().intValue())))
                         .andExpect(jsonPath("content.[0].type", equalTo("cancel")))
-                        .andExpect(jsonPath("content.[0].status", equalTo("pending")))
+                        .andExpect(jsonPath("content.[0].active", equalTo(true)))
                         .andExpect(jsonPath("content.[0]._links.self.href",
                                 equalTo(generateActionSelfLink(knownTargetId, actions.get(0).getId()))))
                         .andExpect(jsonPath(JSON_PATH_PAGED_LIST_TOTAL, equalTo(2)))
@@ -2990,8 +2863,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     }
 
     private String generateActionSelfLink(final String knownTargetId, final Long actionId) {
-        return "http://localhost" + MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId;
+        return "http://localhost" + TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId;
     }
 
     private String generateActionDsLink(final Long dsId) {
@@ -2999,12 +2871,11 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     }
 
     private String generateCanceledactionreferenceLink(final String knownTargetId, final Action action) {
-        return "http://localhost" + MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
-                + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + action.getId();
+        return "http://localhost" + TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/" + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + action.getId();
     }
 
     private String generateStatusreferenceLink(final String knownTargetId, final Long actionId) {
-        return "http://localhost" + MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
+        return "http://localhost" + TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId + "/"
                 + MgmtRestConstants.TARGET_V1_ACTIONS + "/" + actionId + "/" + MgmtRestConstants.TARGET_V1_ACTION_STATUS
                 + "?offset=0&limit=50&sort=id%3ADESC";
     }
@@ -3013,8 +2884,8 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         return generateTargetWithTwoUpdatesWithOneOverrideWithMaintenanceWindow(knownTargetId, null, null, null);
     }
 
-    private List<Action> generateTargetWithTwoUpdatesWithOneOverrideWithMaintenanceWindow(final String knownTargetId,
-            final String schedule, final String duration, final String timezone) {
+    private List<Action> generateTargetWithTwoUpdatesWithOneOverrideWithMaintenanceWindow(
+            final String knownTargetId, final String schedule, final String duration, final String timezone) {
         final Target target = testdataFactory.createTarget(knownTargetId);
 
         final Iterator<DistributionSet> sets = testdataFactory.createDistributionSets(2).iterator();
@@ -3030,19 +2901,17 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
             await().until(() -> updatedTargets.stream().allMatch(t -> t.getLastModifiedAt() > 0L));
             assignDistributionSet(two, updatedTargets);
         } else {
-            final List<Target> updatedTargets = assignDistributionSetWithMaintenanceWindow(one.getId(),
-                    target.getControllerId(), schedule, duration, timezone).getAssignedEntity().stream()
+            final List<Target> updatedTargets = assignDistributionSetWithMaintenanceWindow(
+                    one.getId(), target.getControllerId(), schedule, duration, timezone).getAssignedEntity().stream()
                     .map(Action::getTarget).toList();
             // 2nd update
             // sleep 10ms to ensure that we can sort by reportedAt
             await().until(() -> updatedTargets.stream().allMatch(t -> t.getLastModifiedAt() > 0L));
-            assignDistributionSetWithMaintenanceWindow(two.getId(), updatedTargets.get(0).getControllerId(), schedule,
-                    duration, timezone);
+            assignDistributionSetWithMaintenanceWindow(two.getId(), updatedTargets.get(0).getControllerId(), schedule, duration, timezone);
         }
 
         // two updates, one cancellation
-        final List<Action> actions = deploymentManagement.findActionsByTarget(target.getControllerId(), PAGE)
-                .getContent();
+        final List<Action> actions = deploymentManagement.findActionsByTarget(target.getControllerId(), PAGE).getContent();
 
         assertThat(actions).hasSize(2);
         return actions;
@@ -3051,8 +2920,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     private void verifyAttributeUpdateCanBeRequested(final String knownTargetId) throws Exception {
         final String body = new JSONObject().put("requestAttributes", true).toString();
 
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId).content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId).content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
 
@@ -3062,8 +2930,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     private void verifyRequestAttributesAttributeIsOptional(final String knownTargetId) throws Exception {
         final String body = new JSONObject().put("description", "verify attribute can be missing").toString();
 
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId).content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId).content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
     }
@@ -3071,8 +2938,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
     private void verifyResettingRequestAttributesIsNotAllowed(final String knownTargetId) throws Exception {
         final String body = new JSONObject().put("requestAttributes", false).toString();
 
-        mvc.perform(put(MgmtRestConstants.TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId).content(body)
-                        .contentType(MediaType.APPLICATION_JSON))
+        mvc.perform(put(TARGET_V1_REQUEST_MAPPING + "/" + knownTargetId).content(body).contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest());
 
@@ -3130,9 +2996,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         return updateActionStatus(action, status, statusCode, null);
     }
 
-    private Action updateActionStatus(final Action action, final Status status, final Integer statusCode,
-            final String message) {
-
+    private Action updateActionStatus(final Action action, final Status status, final Integer statusCode, final String message) {
         assertThat(action).isNotNull();
         assertThat(status).isNotNull();
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -284,7 +284,7 @@ public interface ControllerManagement {
      * allowed number of action status messages from history; messageCount equal zero, does not retrieve any message; and messageCount larger
      * than zero, retrieves the specified number of messages, limited by maximum allowed number. A controller sends the feedback for an
      * {@link ActionStatus} as a list of messages; while returning the messages, even though the messages from multiple {@link ActionStatus}
-     * are retrieved in descending order by the reported time ({@link ActionStatus#getOccurredAt()}), i.e. latest ActionStatus first, the
+     * are retrieved in descending order by the reported time ({@link ActionStatus#getTimestamp()}), i.e. latest ActionStatus first, the
      * sub-ordering of messages from within single {@link ActionStatus} is unspecified.
      *
      * @param actionId to be filtered on

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Action.java
@@ -336,6 +336,6 @@ public interface Action extends TenantAwareBaseEntity {
         private Integer code;
         private Collection<@ValidString String> messages;
 
-        private Long occurredAt;
+        private Long timestamp;
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/ActionStatus.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/ActionStatus.java
@@ -23,7 +23,7 @@ public interface ActionStatus extends TenantAwareBaseEntity {
     /**
      * @return time in {@link TimeUnit#MILLISECONDS} when the status was reported.
      */
-    long getOccurredAt();
+    long getTimestamp();
 
     /**
      * @return {@link Action} this {@link ActionStatus} belongs to.

--- a/hawkbit-repository/hawkbit-repository-jpa-ql/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/legacy/JpaQueryRsqlVisitor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa-ql/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/legacy/JpaQueryRsqlVisitor.java
@@ -42,7 +42,6 @@ import cz.jirutka.rsql.parser.ast.OrNode;
 import cz.jirutka.rsql.parser.ast.RSQLVisitor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.eclipse.hawkbit.repository.ActionFields;
 import org.eclipse.hawkbit.repository.QueryField;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterSyntaxException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterUnsupportedFieldException;
@@ -297,9 +296,6 @@ public class JpaQueryRsqlVisitor<A extends Enum<A> & QueryField, T> extends Abst
         final Class<?> javaType = fieldPath.getJavaType();
         if (javaType != null && javaType.isEnum()) {
             return transformEnumValue(node, value, javaType);
-        }
-        if (fieldName == ActionFields.STATUS) {
-            return ActionFields.convertStatusValue(value);
         }
 
         if (Boolean.TYPE.equals(javaType)) {

--- a/hawkbit-repository/hawkbit-repository-jpa-ql/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/legacy/JpaQueryRsqlVisitorG2.java
+++ b/hawkbit-repository/hawkbit-repository-jpa-ql/src/main/java/org/eclipse/hawkbit/repository/jpa/rsql/legacy/JpaQueryRsqlVisitorG2.java
@@ -40,7 +40,6 @@ import cz.jirutka.rsql.parser.ast.RSQLOperators;
 import cz.jirutka.rsql.parser.ast.RSQLVisitor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.eclipse.hawkbit.repository.ActionFields;
 import org.eclipse.hawkbit.repository.QueryField;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterSyntaxException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterUnsupportedFieldException;
@@ -363,10 +362,6 @@ public class JpaQueryRsqlVisitorG2<A extends Enum<A> & QueryField, T>
 
         if (javaType != null && javaType.isEnum()) {
             return toEnumValue(node, javaType, value);
-        }
-
-        if (enumValue == ActionFields.STATUS) {
-            return ActionFields.convertStatusValue(value);
         }
 
         if (boolean.class.equals(javaType) || Boolean.class.equals(javaType)) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRepositoryConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRepositoryConfiguration.java
@@ -22,7 +22,6 @@ import org.aopalliance.intercept.MethodInvocation;
 import org.eclipse.hawkbit.artifact.encryption.ArtifactEncryption;
 import org.eclipse.hawkbit.artifact.encryption.ArtifactEncryptionSecretsStorage;
 import org.eclipse.hawkbit.artifact.encryption.ArtifactEncryptionService;
-import org.eclipse.hawkbit.repository.ActionFields;
 import org.eclipse.hawkbit.repository.AutoAssignExecutor;
 import org.eclipse.hawkbit.repository.DeploymentManagement;
 import org.eclipse.hawkbit.repository.PropertiesQuotaManagement;
@@ -42,7 +41,6 @@ import org.eclipse.hawkbit.repository.event.ApplicationEventFilter;
 import org.eclipse.hawkbit.repository.event.remote.EventEntityManager;
 import org.eclipse.hawkbit.repository.event.remote.EventEntityManagerHolder;
 import org.eclipse.hawkbit.repository.event.remote.TargetPollEvent;
-import org.eclipse.hawkbit.repository.exception.RSQLParameterUnsupportedFieldException;
 import org.eclipse.hawkbit.repository.jpa.acm.AccessController;
 import org.eclipse.hawkbit.repository.jpa.aspects.ExceptionMappingAspectHandler;
 import org.eclipse.hawkbit.repository.jpa.autocleanup.AutoActionCleanup;
@@ -474,39 +472,6 @@ public class JpaRepositoryConfiguration {
             protected <T extends Enum<T> & QueryField> Object transformValueElement(
                     final Object value, final Comparison comparison, final Class<T> queryFieldType) {
                 return value instanceof String strValue ? resolver.replace(strValue) : value;
-            }
-        };
-    }
-
-    /**
-     * @deprecated since 0.10.0, will be removed in future releases. Use "active" for querying active status instead of "status".
-     */
-    @Deprecated(since = "0.10.0", forRemoval = true)
-    @Bean
-    public NodeTransformer actionStatusTransformer() {
-        return new NodeTransformer.Abstract() {
-
-            // just extension points for subclasses
-            @Override
-            protected <T extends Enum<T> & QueryField> Object transformValueElement(
-                    final Object value, final Comparison comparison, final Class<T> queryFieldType) {
-                return queryFieldType == (Class<?>) ActionFields.class && "active".equalsIgnoreCase(comparison.getKey())
-                        ? mapActionStatus(value)
-                        : value;
-            }
-
-            private static Object mapActionStatus(final Object value) {
-                final String strValue = String.valueOf(value);
-                if ("true".equalsIgnoreCase(strValue) || "false".equalsIgnoreCase(strValue)) {
-                    return value;
-                } else {
-                    // handle custom action fields status
-                    try {
-                        return ActionFields.convertStatusValue(strValue);
-                    } catch (final IllegalArgumentException e) {
-                        throw new RSQLParameterUnsupportedFieldException(e.getMessage());
-                    }
-                }
             }
         };
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/AbstractDsAssignmentStrategy.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/AbstractDsAssignmentStrategy.java
@@ -119,7 +119,7 @@ public abstract class AbstractDsAssignmentStrategy {
     public JpaActionStatus createActionStatus(final JpaAction action, final String actionMessage) {
         final JpaActionStatus actionStatus = new JpaActionStatus();
         actionStatus.setAction(action);
-        actionStatus.setOccurredAt(action.getCreatedAt());
+        actionStatus.setTimestamp(action.getCreatedAt());
 
         if (StringUtils.hasText(actionMessage)) {
             actionStatus.addMessage(actionMessage);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaActionManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaActionManagement.java
@@ -67,7 +67,7 @@ public class JpaActionManagement {
     protected static JpaActionStatus buildJpaActionStatus(final ActionStatusCreate create) {
         final JpaActionStatus actionStatus = new JpaActionStatus(
                 create.getStatus(),
-                Optional.ofNullable(create.getOccurredAt()).orElseGet(System::currentTimeMillis));
+                Optional.ofNullable(create.getTimestamp()).orElseGet(System::currentTimeMillis));
         Optional.ofNullable(create.getMessages()).ifPresent(messages -> messages.forEach(actionStatus::addMessage));
         actionStatus.setCode(create.getCode());
         return actionStatus;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaDeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaDeploymentManagement.java
@@ -1048,7 +1048,7 @@ public class JpaDeploymentManagement extends JpaActionManagement implements Depl
     private void setSkipActionStatus(final JpaAction action) {
         final JpaActionStatus actionStatus = new JpaActionStatus();
         actionStatus.setAction(action);
-        actionStatus.setOccurredAt(action.getCreatedAt());
+        actionStatus.setTimestamp(action.getCreatedAt());
         actionStatus.setStatus(Status.RUNNING);
         actionStatus.addMessage(RepositoryConstants.SERVER_MESSAGE_PREFIX + "Distribution Set is already assigned. Skipping this action.");
         actionStatusRepository.save(actionStatus);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaDistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaDistributionSetManagement.java
@@ -142,7 +142,7 @@ public class JpaDistributionSetManagement
                         DistributionSetFields.class));
             }
             if (completedComparison.get() != null) { // really a comparison
-                log.warn("Usage of 'complete' in RSQL is deprecated and will be removed in future: {}", node);
+                log.warn("Usage of 'complete' is limited and may be removed: {}", node);
                 final boolean completed = completeComparison(completedComparison);
                 return filter(JpaManagementHelper.findAllWithCountBySpec(jpaRepository, specList, pageable), completed);
             }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaRolloutManagement.java
@@ -568,7 +568,7 @@ public class JpaRolloutManagement implements RolloutManagement {
             JpaActionStatus actionStatus = new JpaActionStatus();
             actionStatus.setAction(action);
             actionStatus.setStatus(status);
-            actionStatus.setOccurredAt(currentTimestamp);
+            actionStatus.setTimestamp(currentTimestamp);
             actionStatus.addMessage(RepositoryConstants.SERVER_MESSAGE_PREFIX + "A " + typeOfCancellation + " has been performed by server.");
             cancellingStatuses.add(actionStatus);
         });

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaActionStatus.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaActionStatus.java
@@ -60,7 +60,7 @@ public class JpaActionStatus extends AbstractJpaTenantAwareBaseEntity implements
     @Setter
     @Getter
     @Column(name = "target_occurred_at", nullable = false, updatable = false)
-    private long occurredAt;
+    private long timestamp;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(
@@ -97,12 +97,12 @@ public class JpaActionStatus extends AbstractJpaTenantAwareBaseEntity implements
      *
      * @param action the action for this action status
      * @param status the status for this action status
-     * @param occurredAt the occurred timestamp
+     * @param timestamp the occurred timestamp
      */
-    public JpaActionStatus(final Action action, final Status status, final long occurredAt) {
+    public JpaActionStatus(final Action action, final Status status, final long timestamp) {
         this.action = (JpaAction) action;
         this.status = status;
-        this.occurredAt = occurredAt;
+        this.timestamp = timestamp;
     }
 
     /**
@@ -110,13 +110,13 @@ public class JpaActionStatus extends AbstractJpaTenantAwareBaseEntity implements
      *
      * @param action the action for this action status
      * @param status the status for this action status
-     * @param occurredAt the occurred timestamp
+     * @param timestamp the occurred timestamp
      * @param message the message which should be added to this action status
      */
-    public JpaActionStatus(final JpaAction action, final Status status, final long occurredAt, final String message) {
+    public JpaActionStatus(final JpaAction action, final Status status, final long timestamp, final String message) {
         this.action = action;
         this.status = status;
-        this.occurredAt = occurredAt;
+        this.timestamp = timestamp;
         addMessage(message);
     }
 
@@ -124,11 +124,11 @@ public class JpaActionStatus extends AbstractJpaTenantAwareBaseEntity implements
      * Creates a new {@link ActionStatus} object.
      *
      * @param status the status for this action status
-     * @param occurredAt the occurred timestamp
+     * @param timestamp the occurred timestamp
      */
-    public JpaActionStatus(final Status status, final long occurredAt) {
+    public JpaActionStatus(final Status status, final long timestamp) {
         this.status = status;
-        this.occurredAt = occurredAt;
+        this.timestamp = timestamp;
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/ControllerManagementTest.java
@@ -203,12 +203,12 @@ class ControllerManagementTest extends AbstractJpaIntegrationTest {
         final Long actionId = getFirstAssignedActionId(assignDistributionSet(testDs, testTarget));
 
         controllerManagement.addUpdateActionStatus(ActionStatusCreate.builder().actionId(actionId)
-                .status(Action.Status.RUNNING).occurredAt(System.currentTimeMillis()).messages(List.of("proceeding message 1"))
+                .status(Action.Status.RUNNING).timestamp(System.currentTimeMillis()).messages(List.of("proceeding message 1"))
                 .build());
 
         waitNextMillis();
         controllerManagement.addUpdateActionStatus(ActionStatusCreate.builder().actionId(actionId)
-                .status(Action.Status.RUNNING).occurredAt(System.currentTimeMillis()).messages(List.of("proceeding message 2"))
+                .status(Action.Status.RUNNING).timestamp(System.currentTimeMillis()).messages(List.of("proceeding message 2"))
                 .build());
 
         final List<String> messages = controllerManagement.getActionHistoryMessages(actionId, 2);
@@ -242,7 +242,7 @@ class ControllerManagementTest extends AbstractJpaIntegrationTest {
         assertThat(actionId1).isNotNull();
         final ActionStatusCreateBuilder status = ActionStatusCreate.builder().actionId(actionId1).status(Status.WARNING);
         for (int i = 0; i < maxStatusEntries; i++) {
-            controllerManagement.addInformationalActionStatus(status.messages(List.of("Msg " + i)).occurredAt(System.currentTimeMillis()).build());
+            controllerManagement.addInformationalActionStatus(status.messages(List.of("Msg " + i)).timestamp(System.currentTimeMillis()).build());
         }
         final ActionStatusCreate actionStatusCreate = status.build();
         assertThatExceptionOfType(AssignmentQuotaExceededException.class)
@@ -254,7 +254,7 @@ class ControllerManagementTest extends AbstractJpaIntegrationTest {
         assertThat(actionId2).isNotEqualTo(actionId1);
         final ActionStatusCreateBuilder statusWarning = ActionStatusCreate.builder().actionId(actionId2).status(Status.WARNING);
         for (int i = 0; i < maxStatusEntries; i++) {
-            controllerManagement.addUpdateActionStatus(statusWarning.messages(List.of("Msg " + i)).occurredAt(System.currentTimeMillis()).build());
+            controllerManagement.addUpdateActionStatus(statusWarning.messages(List.of("Msg " + i)).timestamp(System.currentTimeMillis()).build());
         }
         final ActionStatusCreate actionStatusCreateQE = statusWarning.build();
         assertThatExceptionOfType(AssignmentQuotaExceededException.class)

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlActionFieldsTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlActionFieldsTest.java
@@ -66,6 +66,20 @@ class RsqlActionFieldsTest extends AbstractJpaIntegrationTest {
 
         assertRSQLQuery(ActionFields.ID.name() + "=in=(" + action.getId() + ",10000000)", 1);
         assertRSQLQuery(ActionFields.ID.name() + "=out=(" + action.getId() + ",10000000)", 10);
+    }/**
+     * Test action by status
+     */
+    @Test
+    void testFilterByParameterActive() {
+        assertRSQLQuery(ActionFields.ACTIVE.name() + "==" + true, 5);
+        assertRSQLQuery(ActionFields.ACTIVE.name() + "!=" + true, 6);
+        assertRSQLQuery(ActionFields.ACTIVE.name() + "=in=(" + true + ")", 5);
+        assertRSQLQuery(ActionFields.ACTIVE.name() + "=out=(" + true +")", 6);
+
+        final String rsql = ActionFields.ACTIVE.name() + "==true2";
+        assertThatExceptionOfType(QueryException.class)
+                .as("RSQLParameterUnsupportedFieldException because active cannot be compared with 'true2'")
+                .isThrownBy(() -> assertRSQLQuery(rsql, 5));
     }
 
     /**
@@ -73,14 +87,14 @@ class RsqlActionFieldsTest extends AbstractJpaIntegrationTest {
      */
     @Test
     void testFilterByParameterStatus() {
-        assertRSQLQuery(ActionFields.STATUS.name() + "==pending", 5);
-        assertRSQLQuery(ActionFields.STATUS.name() + "!=pending", 6);
-        assertRSQLQuery(ActionFields.STATUS.name() + "=in=(pending)", 5);
-        assertRSQLQuery(ActionFields.STATUS.name() + "=out=(pending)", 6);
+        assertRSQLQuery(ActionFields.STATUS.name() + "==" + Status.RUNNING, 5);
+        assertRSQLQuery(ActionFields.STATUS.name() + "!=" + Status.RUNNING, 6);
+        assertRSQLQuery(ActionFields.STATUS.name() + "=in=(" + Status.RUNNING + ")", 5);
+        assertRSQLQuery(ActionFields.STATUS.name() + "=out=(" + Status.RUNNING +")", 6);
 
-        final String rsql = ActionFields.STATUS.name() + "==true2";
+        final String rsql = ActionFields.STATUS.name() + "==not_a_status";
         assertThatExceptionOfType(QueryException.class)
-                .as("RSQLParameterUnsupportedFieldException because status cannot be compared with 'true'")
+                .as("RSQLParameterUnsupportedFieldException because status cannot be compared with 'not_a_status'")
                 .isThrownBy(() -> assertRSQLQuery(rsql, 5));
     }
 
@@ -99,7 +113,7 @@ class RsqlActionFieldsTest extends AbstractJpaIntegrationTest {
         newAction.setActionType(ActionType.SOFT);
         newAction.setDistributionSet(dsA);
         newAction.setActive(active);
-        newAction.setStatus(Status.RUNNING);
+        newAction.setStatus(active ? Status.RUNNING : Status.FINISHED);
         newAction.setTarget(target);
         newAction.setWeight(45);
         newAction.setInitiatedBy(tenantAware.getCurrentUsername());

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
@@ -147,10 +147,6 @@ public final class SpPermission {
         allPermissions.add(APPROVE_ROLLOUT);
         allPermissions.add(HANDLE_ROLLOUT);
 
-        // coarse-grained - maybe to be deprecated
-        for (final String access_prefix : new String[] { CREATE_PREFIX, READ_PREFIX, UPDATE_PREFIX, DELETE_PREFIX }) {
-            allPermissions.add(access_prefix + "REPOSITORY");
-        }
         allPermissions.add(TENANT_CONFIGURATION);
 
         if (!tenant) {

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/component/TargetActionsHistory.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/component/TargetActionsHistory.java
@@ -132,7 +132,7 @@ public class TargetActionsHistory extends Grid<TargetActionsHistory.ActionStatus
                     icon = Utils.tooltip(VaadinIcon.ADJUST.create(), "Pending Update");
                     icon.setColor("orange");
                 }// todo getDetailStatus should return an enum from src/main/java/org/eclipse/hawkbit/repository/model/Action.java
-            } else if (action.getType().equals(MgmtAction.ACTION_UPDATE) && action.getDetailStatus().equals("finished")) {
+            } else if (action.getType().equals(MgmtAction.ACTION_UPDATE) && action.getStatus().equals("finished")) {
                 icon = Utils.tooltip(VaadinIcon.CHECK_CIRCLE.create(), "Updated");
                 icon.setColor("green");
             } else {


### PR DESCRIPTION
* ActionFields.DETAILSTATUS removed and replaces with STATUS (so status is with changed semantic - not active but real status)
* ActionStatusFields.REPORTEDAT removed - use CREATEDAT
* MgmtAction.detailStatus removed and replaced with status (so status is with changed semantic - not active but real status)
* MgmtTargetTagRestApi.assignTargetsPut removed - use POST method