### PR TITLE
ui: Use simple target filter as primary

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetView.java
@@ -109,7 +109,7 @@ public class TargetView extends TableView<TargetView.TargetWithDs, String> {
 
     public TargetView(final HawkbitMgmtClient hawkbitClient) {
         super(
-                new RawFilter(hawkbitClient), new SimpleFilter(hawkbitClient),
+                new SimpleFilter(hawkbitClient), new RawFilter(hawkbitClient),
                 new SelectionGrid.EntityRepresentation<>(TargetWithDs.class, TargetWithDs::getControllerId) {
 
                     @Override


### PR DESCRIPTION
This PR makes it easier to search targets by preferring the simple search and keeping the RSQL as backup.