### PR TITLE
ui: Make clearer which target's detail is currently open

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetView.java
@@ -342,8 +342,9 @@ public class TargetView extends TableView<TargetView.TargetWithDs, String> {
         }
     }
 
-    protected static class TargetDetailedView extends TabSheet {
+    protected static class TargetDetailedView extends VerticalLayout {
 
+        private final Span targetId;
         private final TargetDetails targetDetails;
         private final TargetAssignedInstalled targetAssignedInstalled;
         private final TargetTags targetTags;
@@ -351,6 +352,8 @@ public class TargetView extends TableView<TargetView.TargetWithDs, String> {
         private final TargetActionsHistoryLayout targetActionsHistoryLayout;
 
         private TargetDetailedView(final HawkbitMgmtClient hawkbitClient) {
+            final TabSheet tabSheet = new TabSheet();
+            targetId = new Span();
             targetDetails = new TargetDetails(hawkbitClient);
             targetAssignedInstalled = new TargetAssignedInstalled(hawkbitClient);
             targetTags = new TargetTags(hawkbitClient);
@@ -358,14 +361,17 @@ public class TargetView extends TableView<TargetView.TargetWithDs, String> {
             targetActionsHistoryLayout = new TargetActionsHistoryLayout(hawkbitClient);
             setWidthFull();
 
-            add("Details", targetDetails);
-            add("Assigned / Installed", targetAssignedInstalled);
-            add("Tags", targetTags);
-            add("Metadata", targetMetadata);
-            add("Action History", targetActionsHistoryLayout);
+            add(targetId);
+            tabSheet.add("Details", targetDetails);
+            tabSheet.add("Assigned / Installed", targetAssignedInstalled);
+            tabSheet.add("Tags", targetTags);
+            tabSheet.add("Metadata", targetMetadata);
+            tabSheet.add("Action History", targetActionsHistoryLayout);
+            add(tabSheet);
         }
 
         private void setItem(final MgmtTarget target) {
+            this.targetId.setText(target.getControllerId());
             this.targetDetails.setItem(target);
             this.targetAssignedInstalled.setItem(target);
             this.targetTags.setItem(target);

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/util/TableView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/util/TableView.java
@@ -82,7 +82,7 @@ public class TableView<T, ID> extends Div implements Constants, BeforeEnterObser
 
         if (detailsButtonHandler != null) {
             ComponentRenderer<Button, T> renderer = new ComponentRenderer<>(renderDetailsButton(detailsButtonHandler));
-            selectionGrid.addColumn(renderer).setHeader("Details").setAutoWidth(true).setFlexGrow(0);
+            selectionGrid.addColumn(renderer).setHeader("Details").setAutoWidth(true).setFlexGrow(0).setFrozenToEnd(true);
         }
 
         filter = new Filter(


### PR DESCRIPTION
This MR clarifies which target's details is currently displayed by:
- pining the action button (view/close)
- show the target name and ID in the details panel