### PR TITLE
ui: Quote tags since they could contain whitespace

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetView.java
@@ -204,7 +204,7 @@ public class TargetView extends TableView<TargetView.TargetWithDs, String> {
                             List.of("controllerid", "name"), textFilter.getOptionalValue().map(s -> "*" + s + "*"),
                             "targettype.name", type.getSelectedItems().stream().map(MgmtTargetType::getName)
                                     .toList(),
-                            "tag", tag.getSelectedItems().stream().map(MgmtTag::getName).toList()));
+                            "tag", tag.getSelectedItems().stream().map(t -> "\"" + t.getName() + "\"").toList()));
         }
     }
 


### PR DESCRIPTION
Tags can contain whitespace which cause a RSL 400 error. This MR fixes this by quoting the selected tags.