### PR TITLE
Increase TTL & refresh for DistributedLockTest

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/resources/jpa-test.properties
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/resources/jpa-test.properties
@@ -58,8 +58,8 @@ logging.level.org.eclipse.persistence=${NOISE_SUPPRESS_LEVEL}
 ## enable / disable case sensitiveness of the DB when playing around
 #hawkbit.ql.case-insensitive-db=true
 
-hawkbit.repository.cluster.lock.ttl=1000
-hawkbit.repository.cluster.lock.refreshOnRemainMS=200
+hawkbit.repository.cluster.lock.ttl=3000
+hawkbit.repository.cluster.lock.refreshOnRemainMS=2000
 hawkbit.repository.cluster.lock.refreshOnRemainPercent=10
 ## reduce scheduler tic period to speed up tests
 hawkbit.repository.cluster.lock.ticPeriodMS=10


### PR DESCRIPTION
When in integration environments the current gap of 200ms for refresh could not be enough sometimes. So increse the ttl to 3s and refresh on 2 in order to be sure that the test will pass in such cases.