### PR TITLE
Fix force quit actions to explicitly handle 0 active actions

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaRolloutManagement.java
@@ -561,6 +561,10 @@ public class JpaRolloutManagement implements RolloutManagement {
                 .getContent();
         log.info("Found {} active actions for rollout {}", actions.size(), rollout.getId());
 
+        if (actions.isEmpty()) {
+            return;
+        }
+        
         storeActionsAndStatuses(actions, Action.Status.CANCELED);
 
         // find next active actions - filter by targetId list and isActive

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
@@ -28,6 +28,7 @@ import jakarta.persistence.NamedAttributeNode;
 import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.NamedEntityGraphs;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.constraints.Max;
@@ -64,6 +65,7 @@ import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus;
 public class JpaRollout extends AbstractJpaNamedEntity implements Rollout, EventAwareEntity {
 
     @OneToMany(targetEntity = JpaRolloutGroup.class, fetch = FetchType.LAZY, cascade = { CascadeType.REMOVE }, mappedBy = "rollout")
+    @OrderBy("id ASC")
     private List<JpaRolloutGroup> rolloutGroups = new ArrayList<>();
 
     @Setter


### PR DESCRIPTION
Previously the database was left to handle this case, but this leads to incompatabilities with some databases (like postgre) 